### PR TITLE
Enabled documentation for activation profiles and fixed minor markup issue

### DIFF
--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -148,3 +148,18 @@ Partitions
    :members:
    :special-members: __str__
 
+.. _`Activation profiles`:
+
+Activation profile
+------------------
+
+.. automodule:: zhmcclient._activation_profile
+
+.. autoclass:: zhmcclient.ActivationProfileManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.ActivationProfile
+   :members:
+   :special-members: __str__
+

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 """
-
-**Activation Profiles ** are required for CPC (processor)
+**Activation profiles** are required for CPC (processor)
 and CPC image (partition) activation. They are used to tailor the operation
 of a CPC and are stored in the Support Element associated with the CPC.
+
 There are types of activation profiles:
 
 1. Reset:
@@ -36,7 +36,6 @@ There are types of activation profiles:
    the operating system will be loaded from.
 
 Activation Profiles are not provided when the CPC is enabled for DPM.
-
 """
 
 from __future__ import absolute_import


### PR DESCRIPTION
This was forgotten when the support for activation profiles was added.

Ready for review and merge.