### PR TITLE
Added get_notification_topics() and example7 for user wait for async op. completion

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -41,3 +41,5 @@ twine # Apache-2.0
 
 # Examples:
 PyYAML # MIT
+stomp.py # Apache
+

--- a/examples/example7.py
+++ b/examples/example7.py
@@ -53,8 +53,8 @@ if example7 is None:
 
 hmc = example7["hmc"]
 cpcname = example7["cpcname"]
-partitionname = example7["partitionname"]
-amq_port = example7['amq_port']
+partname = example7["partname"]
+amqport = example7['amqport']
 callback = None
 topic = None
 
@@ -107,37 +107,37 @@ try:
     cl = zhmcclient.Client(session)
 
     print("Retrieving notification topics ...")
-    topics = session.get_notfication_topics()
+    topics = session.get_notification_topics()
 
-    for entry in topics:
-        if entry['topic-type'] == 'job-notification':
-            job_topic = entry['topic-name']
+    for topic in topics:
+        if topic['topic-type'] == 'job-notification':
+            job_topic_name = topic['topic-name']
             break
 
-    conn = stomp.Connection([(session.host, amq_port)], use_ssl="SSL")
+    conn = stomp.Connection([(session.host, amqport)], use_ssl="SSL")
     conn.set_listener('', MyListener())
     conn.start()
     conn.connect(userid, password, wait=True)
 
     sub_id = 42  # subscription ID
 
-    print("Subscribing for job notifications using topic: %s" % job_topic)
-    conn.subscribe(destination="/topic/"+job_topic, id=sub_id, ack='auto')
+    print("Subscribing for job notifications using topic: %s" % job_topic_name)
+    conn.subscribe(destination="/topic/"+job_topic_name, id=sub_id, ack='auto')
 
     print("Finding CPC %s ..." % cpcname)
     cpc = cl.cpcs.find(name=cpcname)
     print("Status of CPC %s: %s" % (cpcname, cpc.get_property('status')))
 
-    print("Finding partition %s ..." % partitionname)
-    partition = cpc.partitions.find(name=partitionname)
+    print("Finding partition %s ..." % partname)
+    partition = cpc.partitions.find(name=partname)
     partition_status = partition.get_property('status')
-    print("Status of partition %s: %s" % (partitionname, partition_status))
+    print("Status of partition %s: %s" % (partname, partition_status))
 
     if partition_status == 'active':
-        print("Stopping partition %s asynchronously ..." % partitionname)
+        print("Stopping partition %s asynchronously ..." % partname)
         result = partition.stop(wait_for_completion=False)
-    elif partition_status == 'inactive':
-        print("Starting partition %s asynchronously ..." % partitionname)
+    elif partition_status in ('inactive', 'stopped'):
+        print("Starting partition %s asynchronously ..." % partname)
         result = partition.start(wait_for_completion=False)
     else:
         raise zhmcclient.Error("Cannot deal with partition status: %s" % \

--- a/examples/example7.py
+++ b/examples/example7.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example 7: Using stomp to receive job completion JMS notifications from HMC
+"""
+
+import sys
+import yaml
+import requests.packages.urllib3
+import stomp
+
+
+import zhmcclient
+__callback = None
+
+requests.packages.urllib3.disable_warnings()
+
+if len(sys.argv) != 2:
+    print("Usage: %s hmccreds.yaml" % sys.argv[0])
+    sys.exit(2)
+hmccreds_file = sys.argv[1]
+
+with open(hmccreds_file, 'r') as fp:
+    hmccreds = yaml.load(fp)
+
+examples = hmccreds.get("examples", None)
+if examples is None:
+    print("examples not found in credentials file %s" %
+          (hmccreds_file))
+    sys.exit(1)
+
+example7 = examples.get("example7", None)
+if example7 is None:
+    print("example7 not found in credentials file %s" %
+          (hmccreds_file))
+    sys.exit(1)
+
+hmc = example7["hmc"]
+cpcname = example7["cpcname"]
+partitionname = example7["partitionname"]
+amq_port = example7['amq_port']
+callback = None
+topic = None
+
+cred = hmccreds.get(hmc, None)
+if cred is None:
+    print("Credentials for HMC %s not found in credentials file %s" %
+          (hmc, hmccreds_file))
+    sys.exit(1)
+
+userid = cred['userid']
+password = cred['password']
+
+messages = []
+
+
+class MyListener():
+
+    def on_connecting(self, host_and_port):
+        print ("Attempting to connect to message broker...")
+
+    def on_connected(self, headers, message):
+        print ("Connected to broker: %s" % message)
+
+    def on_disconnected(self, headers, message):
+        print ("No longer connected to broker: %s" % message)
+
+    def on_error(self, headers, message):
+        print('received an error "%s"' % message)
+
+    def on_message(self, headers, message):
+        print ('received a message')
+        messages.append(headers)
+
+try:
+    print("Using HMC %s with userid %s ..." % (hmc, userid))
+    session = zhmcclient.Session(hmc, userid, password)
+    cl = zhmcclient.Client(session)
+
+    topics = session.get_notfication_topics()
+
+    for entry in topics:
+        if entry['topic-type'] == 'job-notification':
+            dest = entry['topic-name']
+            break
+    print("destination: %s" % dest)
+
+    conn = stomp.Connection([(session.host, amq_port)], use_ssl="SSL")
+    conn.set_listener('', MyListener())
+    conn.start()
+    conn.connect(userid, password, wait=True)
+    conn.subscribe(destination="/topic/" + dest, id=1, ack='auto')
+
+    cpc = cl.cpcs.find(name=cpcname)
+    cpc.pull_full_properties()
+    print("Status of CPC %s: %s" %
+          (cpc.properties['name'], cpc.properties['status']))
+    partition = cpc.partitions.find(name=partitionname)
+    print("Status of Partition %s: %s" %
+          (partition.properties['name'], partition.properties['status']))
+    print("Stopping partition %s ..." % partition.properties['name'])
+    status = partition.stop(wait_for_completion=False)
+    while True:
+        if messages != []:
+            print ("received messages are ", messages)
+            break
+    print ("Done printing the messages...")
+    conn.disconnect()
+
+except zhmcclient.Error as exc:
+    print("%s: %s" % (exc.__class__.__name__, exc))
+    sys.exit(1)

--- a/examples/example_hmccreds.yaml
+++ b/examples/example_hmccreds.yaml
@@ -46,7 +46,7 @@ examples:
       hmc: "9.152.133.209"
       cpcname: DPMSE2
       cpcstatus: Active
-      partitionname: sree_test
+      partname: sree_test
       amq_port: 61612
    example8:
       hmc: "9.152.150.65"

--- a/examples/example_hmccreds.yaml
+++ b/examples/example_hmccreds.yaml
@@ -42,6 +42,12 @@ examples:
       lparname: PART8
       #loglevel: debug
       #timestats: yes
+   example7:
+      hmc: "9.152.133.209"
+      cpcname: DPMSE2
+      cpcstatus: Active
+      partitionname: sree_test
+      amq_port: 61612
    example8:
       hmc: "9.152.150.65"
       #loglevel: debug
@@ -56,5 +62,9 @@ examples:
    password: 1234
 
 "9.152.133.140":
+   userid: ensadmin
+   password: 1234
+
+"9.152.133.209":
    userid: ensadmin
    password: 1234

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -145,3 +145,45 @@ class SessionTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.delete('/api/sessions/this-session', status_code=204)
             session.logoff()
+
+    def test_get_notification_topics(self):
+        """
+        This tests the 'Get Notification Topics' operation.
+        """
+        session = Session('fake-host', 'fake-user', 'fake-id')
+        with requests_mock.mock() as m:
+            # Because logon is deferred until needed, we perform it
+            # explicitly in order to keep mocking in the actual test simple.
+            m.post('/api/sessions', json={'api-session': 'fake-session-id'})
+            session.logon()
+        gnt_uri = "/api/sessions/operations/get-notification-topics"
+        with requests_mock.mock() as m:
+            gnt_result = {
+                "topics": [
+                    {
+                        'topic-name': 'ensadmin.145',
+                        'topic-type': 'object-notification',
+                    },
+                    {
+                        'topic-name': 'ensadmin.145job',
+                        'topic-type': 'job-notification',
+                    },
+                    {
+                        'topic-name': 'ensadmin.145aud',
+                        'topic-type': 'audit-notification',
+                    },
+                    {
+                        'topic-name': 'ensadmin.145sec',
+                        'topic-type': 'security-notification',
+                    }
+                ]
+            }
+            m.get(gnt_uri, json=gnt_result)
+
+            result = session.get_notification_topics()
+
+            self.assertEqual(result, gnt_result['topics'])
+
+        with requests_mock.mock() as m:
+            m.delete('/api/sessions/this-session', status_code=204)
+            session.logoff()

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -652,4 +652,3 @@ class Session(object):
         topics_uri = '/api/sessions/operations/get-notification-topics'
         response = self.get(topics_uri)
         return response['topics']
-

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -637,17 +637,26 @@ class Session(object):
         self.delete(job_uri)
 
     @_log_call
-    def get_notfication_topics(self):
+    def get_notification_topics(self):
         """
-        The Get Notification Topics operation returns a structure that
+        The 'Get Notification Topics' operation returns a structure that
         describes the JMS notification topics associated with the
-        API session
+        API session.
 
         Returns:
 
-            The return value is a array of nested topic-info objects, which
-            contains the fields - topic-type, topic-name, object-uri and
-            include-refresh-messages
+            : List with one item for each notification topic. The dictionary
+            has the following keys:
+
+            * topic-type (string): Topic type, e.g. "job-notification".
+            * topic-name (string): Topic name; can be used for subscriptions.
+            * object-uri (string): When topic-type is
+              "os-message-notification", this item is the canonical URI path
+              of the Partition for which this topic exists.
+              This field does not exist for the other topic types.
+            * include-refresh-messages (bool): When the topic-type is
+              "os-message-notification", this item indicates whether refresh
+              operating system messages will be sent on this topic.
         """
         topics_uri = '/api/sessions/operations/get-notification-topics'
         response = self.get(topics_uri)

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -627,8 +627,6 @@ class Session(object):
             by the job.
             Must not be `None`.
 
-        Returns:
-
         Raises:
 
           :exc:`~zhmcclient.HTTPError`
@@ -637,3 +635,21 @@ class Session(object):
           :exc:`~zhmcclient.ConnectionError`
         """
         self.delete(job_uri)
+
+    @_log_call
+    def get_notfication_topics(self):
+        """
+        The Get Notification Topics operation returns a structure that
+        describes the JMS notification topics associated with the
+        API session
+
+        Returns:
+
+            The return value is a array of nested topic-info objects, which
+            contains the fields - topic-type, topic-name, object-uri and
+            include-refresh-messages
+        """
+        topics_uri = '/api/sessions/operations/get-notification-topics'
+        response = self.get(topics_uri)
+        return response['topics']
+


### PR DESCRIPTION
This PR is ready to be merged.

Details:

* Added the method `get_notification_topics()` which returns the per-session JMS destination names for the logged in user.
* Added example7 which demonstrates how a user can wait for completion of an asynchronous operation (stopping or starting a partition) using JMS notifications from the HMC.