### PR TITLE
Fixed links to Jupyter notebooks in tutorial section.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -472,7 +472,7 @@ intersphinx_cache_limit = 5
 # results in the link caption "this issue".
 
 extlinks = {
-  'nbview': ('http://nbviewer.jupyter.org/github/zhmc/zhmcclient/blob/master/docs/notebooks/%s', 'View '),
-  'nbdown': ('https://github.com/zhmc/zhmcclient/raw/master/docs/notebooks/%s', '')
+  'nbview': ('http://nbviewer.jupyter.org/github/zhmcclient/python-zhmcclient/blob/master/docs/notebooks/%s', 'View '),
+  'nbdown': ('https://github.com/zhmcclient/python-zhmcclient/raw/master/docs/notebooks/%s', '')
 }
 


### PR DESCRIPTION
This should now show the notebooks in the tutorial page in the notebook viewer on nbview.jupyter.org. 

Ready for review and merge.