### PR TITLE
Fixed all flake8 issues and enforced issue-free flake8 in make check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ endif
 # TODO: Once Flake8 has no more errors, remove the dash "-"
 flake8.log: Makefile $(flake8_rc_file) $(check_py_files)
 	rm -fv $@
-	-bash -c "set -o pipefail; flake8 $(check_py_files) 2>&1 |tee $@.tmp"
+	bash -c "set -o pipefail; flake8 $(check_py_files) 2>&1 |tee $@.tmp"
 	mv -f $@.tmp $@
 	@echo 'Done: Created Flake8 log file: $@'
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -23,7 +23,6 @@ import requests
 import requests_mock
 
 from zhmcclient._session import Session
-from zhmcclient._client import Client
 
 
 class SessionTests(unittest.TestCase):
@@ -106,7 +105,6 @@ class SessionTests(unittest.TestCase):
         This tests the 'Delete Completed Job Status' operation.
         """
         session = Session('fake-host', 'fake-user', 'fake-id')
-        client = Client(session)  # contains CpcManager object
         with requests_mock.mock() as m:
             # Because logon is deferred until needed, we perform it
             # explicitly in order to keep mocking in the actual test simple.
@@ -127,7 +125,6 @@ class SessionTests(unittest.TestCase):
         This tests the 'Query Job Status' operation.
         """
         session = Session('fake-host', 'fake-user', 'fake-id')
-        client = Client(session)  # contains CpcManager object
         with requests_mock.mock() as m:
             # Because logon is deferred until needed, we perform it
             # explicitly in order to keep mocking in the actual test simple.

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -52,7 +52,8 @@ __all__ = ['ActivationProfileManager', 'ActivationProfile']
 class ActivationProfileManager(BaseManager):
     """
     Manager object for Activation Profiles.
-    This manager object is scoped to the Activation Profiles of a particular CPC.
+    This manager object is scoped to the Activation Profiles of a particular
+    CPC.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
@@ -122,9 +123,11 @@ class ActivationProfileManager(BaseManager):
         profiles_res = self.session.get(cpc_uri + '/' + activation_profile)
         profile_list = []
         if profiles_res:
-            profile_items = profiles_res[self._profile_type + '-activation-profiles']
+            profile_items = profiles_res[self._profile_type +
+                                         '-activation-profiles']
             for profile_props in profile_items:
-                profile = ActivationProfile(self, profile_props['element-uri'], profile_props)
+                profile = ActivationProfile(self, profile_props['element-uri'],
+                                            profile_props)
                 if full_properties:
                     profile.pull_full_properties()
                 profile_list.append(profile)

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -181,8 +181,8 @@ class Cpc(BaseResource):
             if self.dpm_enabled:
                 self._reset_activation_profiles = None
             else:
-                self._reset_activation_profiles = ActivationProfileManager(self,
-                    profile_type='reset')
+                self._reset_activation_profiles = \
+                    ActivationProfileManager(self, profile_type='reset')
         return self._reset_activation_profiles
 
     @property
@@ -198,8 +198,8 @@ class Cpc(BaseResource):
             if self.dpm_enabled:
                 self._image_activation_profiles = None
             else:
-                self._image_activation_profiles = ActivationProfileManager(self,
-                    profile_type='image')
+                self._image_activation_profiles = \
+                    ActivationProfileManager(self, profile_type='image')
         return self._image_activation_profiles
 
     @property
@@ -215,8 +215,8 @@ class Cpc(BaseResource):
             if self.dpm_enabled:
                 self._load_activation_profiles = None
             else:
-                self._load_activation_profiles = ActivationProfileManager(self,
-                    profile_type='load')
+                self._load_activation_profiles = \
+                    ActivationProfileManager(self, profile_type='load')
         return self._load_activation_profiles
 
     @property
@@ -278,7 +278,8 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         cpc_uri = self.get_property('object-uri')
-        result = self.manager.session.post(cpc_uri + '/operations/start',
+        result = self.manager.session.post(
+            cpc_uri + '/operations/start',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -318,7 +319,8 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         cpc_uri = self.get_property('object-uri')
-        result = self.manager.session.post(cpc_uri + '/operations/stop',
+        result = self.manager.session.post(
+            cpc_uri + '/operations/stop',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -368,16 +370,17 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         cpc_uri = self.get_property('object-uri')
-        body = { 'profile-area' : profile_area}
-        result = self.manager.session.post(cpc_uri + '/operations/import-profiles',
-            body, wait_for_completion=wait_for_completion)
+        body = {'profile-area': profile_area}
+        result = self.manager.session.post(
+            cpc_uri + '/operations/import-profiles', body,
+            wait_for_completion=wait_for_completion)
         return result
 
     @_log_call
     def export_profiles(self, profile_area, wait_for_completion=True):
         """
-        Exports activation profiles and/or system activity profiles from the CPC
-        object designated to the SE hard drive using the HMC operation
+        Exports activation profiles and/or system activity profiles from the
+        CPC object designated to the SE hard drive using the HMC operation
         "Export Profiles".
 
         This operation is not permitted when the CPC is enabled for DPM.
@@ -419,7 +422,8 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         cpc_uri = self.get_property('object-uri')
-        body = { 'profile-area' : profile_area}
-        result = self.manager.session.post(cpc_uri + '/operations/export-profiles',
-            body, wait_for_completion=wait_for_completion)
+        body = {'profile-area': profile_area}
+        result = self.manager.session.post(
+            cpc_uri + '/operations/export-profiles', body,
+            wait_for_completion=wait_for_completion)
         return result

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -159,8 +159,9 @@ class Lpar(BaseResource):
         """
         lpar_uri = self.get_property('object-uri')
         body = {}
-        result = self.manager.session.post(lpar_uri + '/operations/activate',
-            body, wait_for_completion=wait_for_completion)
+        result = self.manager.session.post(
+            lpar_uri + '/operations/activate', body,
+            wait_for_completion=wait_for_completion)
         return result
 
     @_log_call
@@ -203,8 +204,9 @@ class Lpar(BaseResource):
         """
         lpar_uri = self.get_property('object-uri')
         body = {'force': True}
-        result = self.manager.session.post(lpar_uri + '/operations/deactivate',
-            body, wait_for_completion=wait_for_completion)
+        result = self.manager.session.post(
+            lpar_uri + '/operations/deactivate', body,
+            wait_for_completion=wait_for_completion)
         return result
 
     @_log_call
@@ -249,6 +251,7 @@ class Lpar(BaseResource):
         """
         lpar_uri = self.get_property('object-uri')
         body = {'load-address': load_address}
-        result = self.manager.session.post(lpar_uri + '/operations/load',
-            body, wait_for_completion=wait_for_completion)
+        result = self.manager.session.post(
+            lpar_uri + '/operations/load', body,
+            wait_for_completion=wait_for_completion)
         return result

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -187,7 +187,8 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         partition_uri = self.get_property('object-uri')
-        result = self.manager.session.post(partition_uri + '/operations/start',
+        result = self.manager.session.post(
+            partition_uri + '/operations/start',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -229,7 +230,8 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         partition_uri = self.get_property('object-uri')
-        result = self.manager.session.post(partition_uri + '/operations/stop',
+        result = self.manager.session.post(
+            partition_uri + '/operations/stop',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -265,4 +267,3 @@ class Partition(BaseResource):
         """
         partition_uri = self.get_property('object-uri')
         self.manager.session.post(partition_uri, body=properties)
-


### PR DESCRIPTION
This PR removes the ignoring of the flake8 error code in `make check`, so that an issue-free flake8 is now enforced. Any future flake8 issues will cause the Travis CI build to fail.

Because PyLint messages are harder to map to good or bad, PyLint issues are still ignored in `make check`, and PyLint issues need to be resolved on a voluntary basis.

Ready for review and merge.