### PR TITLE
Addressed PyLint issues and added uri property to BaseResource class.

### DIFF
--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -83,7 +83,7 @@ class InitTests(ResourceTestCase):
         res = MyResource(self.mgr, self.uri, init_props)
 
         self.assertTrue(res.manager is self.mgr)
-        self.assertEqual(res._uri, self.uri)
+        self.assertEqual(res.uri, self.uri)
         self.assert_properties(res, init_props)
         self.assertTrue(int(time.time()) - res.properties_timestamp <= 1)
         self.assertEqual(res.full_properties, False)
@@ -98,7 +98,7 @@ class InitTests(ResourceTestCase):
         res = MyResource(self.mgr, self.uri, init_props)
 
         self.assertTrue(res.manager is self.mgr)
-        self.assertEqual(res._uri, self.uri)
+        self.assertEqual(res.uri, self.uri)
         self.assert_properties(res, init_props)
         self.assertTrue(int(time.time()) - res.properties_timestamp <= 1)
         self.assertEqual(res.full_properties, False)
@@ -113,7 +113,7 @@ class InitTests(ResourceTestCase):
         res = MyResource(self.mgr, self.uri, init_props)
 
         self.assertTrue(res.manager is self.mgr)
-        self.assertEqual(res._uri, self.uri)
+        self.assertEqual(res.uri, self.uri)
         self.assert_properties(res, init_props)
         self.assertTrue(int(time.time()) - res.properties_timestamp <= 1)
         self.assertEqual(res.full_properties, False)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -100,7 +100,8 @@ class SessionTests(unittest.TestCase):
 
         self.assertFalse(logged_on)
 
-    def test_delete_completed_job_status(self):
+    @staticmethod
+    def test_delete_completed_job_status():
         """
         This tests the 'Delete Completed Job Status' operation.
         """
@@ -120,7 +121,8 @@ class SessionTests(unittest.TestCase):
             m.delete('/api/sessions/this-session', status_code=204)
             session.logoff()
 
-    def test_query_job_status(self):
+    @staticmethod
+    def test_query_job_status():
         """
         This tests the 'Query Job Status' operation.
         """

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -92,6 +92,13 @@ class BaseResource(object):
         return self._properties
 
     @property
+    def uri(self):
+        """
+        string: The resource URI, in the format ``/api/cpcs/12345``.
+        """
+        return self._uri
+
+    @property
     def manager(self):
         """
         Subclass of :class:`~zhmcclient.BaseManager`:

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -20,11 +20,11 @@ from __future__ import absolute_import
 
 import json
 import time
-import requests
 try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
+import requests
 
 from ._exceptions import HTTPError, AuthError, ConnectionError
 from ._timestats import TimeStatsKeeper
@@ -249,14 +249,16 @@ class Session(object):
         self._session = None
         self._headers.pop('X-API-Session', None)
 
-    def _log_hmc_request_id(self, response):
+    @staticmethod
+    def _log_hmc_request_id(response):
         """
         Log the identifier the HMC uses to distinguish requests.
         """
         LOG.info("Returned HMC request ID: %r",
                  response.headers.get('X-Request-Id', ''))
 
-    def _log_http_method(self, http_method, uri):
+    @staticmethod
+    def _log_http_method(http_method, uri):
         """
         Log HTTP method name and target URI.
         """


### PR DESCRIPTION
The `uri` property was added for two reasons:
- in order to avoid access to the private `_uri` instance variable in the unit tests.
- because it is a rather important attribute for the resource and was not available otherwise yet.

ready for review and merge