### PR TITLE
Added support for Coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - pip install --upgrade pip
   - make develop
   - pip list
+  - pip install python-coveralls
 
 # commands to run builds & tests
 script:
@@ -27,3 +28,5 @@ script:
   - make builddoc
   - make test
 
+after_success:
+  - coveralls

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,9 @@
 zhmcclient - A pure Python client library for the z Systems HMC Web Services API
 ================================================================================
 
+.. image:: https://img.shields.io/coveralls/zhmcclient/python-zhmcclient.svg
+    :target: https://coveralls.io/r/zhmcclient/python-zhmcclient
+
 .. image:: https://img.shields.io/pypi/v/zhmcclient.svg?maxAge=2592000
     :target: https://pypi.python.org/pypi/zhmcclient/
     :alt: Latest Version


### PR DESCRIPTION
Details:
- Coveralls.io is service to publish your coverage stats online.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>