### PR TITLE
Restructured and improved the documentation.

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -1,0 +1,112 @@
+.. Copyright 2016 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _`Appendix`:
+
+Appendix
+========
+
+This section contains information that is referenced from other sections,
+and that does not really need to be read in sequence.
+
+.. _'Special type names`:
+
+Special type names
+------------------
+
+This documentation uses a few special terms to refer to Python types:
+
+.. glossary::
+
+   string
+      a :term:`unicode string` or a :term:`byte string`
+
+   unicode string
+      a Unicode string type (:func:`unicode <py2:unicode>` in
+      Python 2, and :class:`py3:str` in Python 3)
+
+   byte string
+      a byte string type (:class:`py2:str` in Python 2, and
+      :class:`py3:bytes` in Python 3). Unless otherwise
+      indicated, byte strings in this package are always UTF-8 encoded.
+
+   number
+      one of the number types :class:`py:int`, :class:`py2:long` (Python 2
+      only), or :class:`py:float`.
+
+   integer
+      one of the integer types :class:`py:int` or :class:`py2:long` (Python 2
+      only).
+
+   json object
+      a :class:`py:dict` object that is a Python representation of a valid JSON
+      object. See :ref:`py:py-to-json-table` for details.
+
+   header dict
+      a :class:`py:dict` object that specifies HTTP header fields, as follows:
+
+        * `key` (:term:`string`): Name of the header field, in any lexical case.
+          Dictionary key lookup is case sensitive, however.
+        * `value` (:term:`string`): Value of the header field.
+
+   callable
+      a type for callable objects (e.g. a function, calling a class returns a
+      new instance, instances are callable if they have a
+      :meth:`~py:object.__call__` method).
+
+   DeprecationWarning
+      a standard Python warning that indicates the use of deprecated
+      functionality. See section :ref:`Deprecations` for details.
+
+.. _`Bibliography`:
+
+Bibliography
+------------
+
+.. glossary::
+
+   X.509
+      `ITU-T X.509, Information technology - Open Systems Interconnection - The Directory: Public-key and attribute certificate frameworks <http://www.itu.int/rec/T-REC-X.509/en>`_
+
+   RFC2616
+      `IETF RFC2616, Hypertext Transfer Protocol - HTTP/1.1, June 1999 <https://tools.ietf.org/html/rfc2616>`_
+
+   RFC2617
+      `IETF RFC2617, HTTP Authentication: Basic and Digest Access Authentication, June 1999 <https://tools.ietf.org/html/rfc2617>`_
+
+   RFC3986
+      `IETF RFC3986, Uniform Resource Identifier (URI): Generic Syntax, January 2005 <https://tools.ietf.org/html/rfc3986>`_
+
+   RFC6874
+      `IETF RFC6874, Representing IPv6 Zone Identifiers in Address Literals and Uniform Resource Identifiers, February 2013 <https://tools.ietf.org/html/rfc6874>`_
+
+   HMC API
+       The Web Services API of the z Systems Hardware Management Console, described in the following books:
+
+   HMC API 2.11.1
+       `IBM SC27-2616-01, z Systems Hardware Management Console Web Services API (Version 2.11.1) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/38BA3E47697D87E385257967006AB34E/>`_
+
+   HMC API 2.12.0
+       `IBM SC27-2617-01, z Systems Hardware Management Console Web Services API (Version 2.12.0) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/9B97F40675618BA085257A6A00777BEA/>`_
+
+   HMC API 2.12.1
+       `IBM SC27-2626-00a, z Systems Hardware Management Console Web Services API (Version 2.12.1) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/3DDB93B38680A72F85257BA600515AA7/>`_
+
+   HMC API 2.13.0
+       `IBM SC27-2627-00a, z Systems Hardware Management Console Web Services API (Version 2.13.0) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/7FA57A5A8A5297B185257DE7004E7144/>`_
+
+   HMC API 2.13.1
+       `IBM SC27-2634-01, z Systems Hardware Management Console Web Services API (Version 2.13.1) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/CB468B15654CA89B85257F7200746C16/>`_
+

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -13,9 +13,22 @@
 .. limitations under the License.
 ..
 
-.. _`Logging`:
+.. _`Concepts`:
 
-Logging
-=======
+Concepts
+========
 
-.. automodule:: zhmcclient._logging
+TODO: Write up some concepts:
+
+- Topology with client, HMC and managed CPCs
+- CPCs that are visible vs. not visible
+- Visibility dependent on access rights of the userid
+- Connecting to the HMC, and session vs. client
+- Failure handling
+- Dependency on CPC mode (classic, DPM, ensemble)
+- Basics about resource model
+
+  - How managers and resources play together
+  - Description of resource properties in HMC API book
+  - Mapping between data types used in the HMC API book and Python data types
+    used to represent them.

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -13,16 +13,16 @@
 .. limitations under the License.
 ..
 
-.. _`API Reference`:
+.. _`General features`:
 
-API Reference
-=============
+Reference: General features
+===========================
 
-.. _`Sessions`:
-.. _`Clients`:
 
-Sessions and clients
---------------------
+.. _`Session`:
+
+Session
+-------
 
 .. automodule:: zhmcclient._session
 
@@ -30,11 +30,18 @@ Sessions and clients
    :members:
    :special-members: __str__
 
+
+.. _`Client`:
+
+Client
+------
+
 .. automodule:: zhmcclient._client
 
 .. autoclass:: zhmcclient.Client
    :members:
    :special-members: __str__
+
 
 .. _`Time Statistics`:
 
@@ -50,6 +57,15 @@ Time Statistics
 .. autoclass:: zhmcclient.TimeStats
    :members:
    :special-members: __str__
+
+
+.. _`Logging`:
+
+Logging
+-------
+
+.. automodule:: zhmcclient._logging
+
 
 .. _`Exceptions`:
 
@@ -87,79 +103,3 @@ Exceptions
 .. autoclass:: zhmcclient.NoUniqueMatch
    :members:
    :special-members: __str__
-
-.. _`CPCs`:
-
-BaseManager and BaseResource
-----------------------------
-
-.. automodule:: zhmcclient._manager
-
-.. autoclass:: zhmcclient.BaseManager
-   :members:
-   :special-members: __str__
-
-.. automodule:: zhmcclient._resource
-
-.. autoclass:: zhmcclient.BaseResource
-   :members:
-   :special-members: __str__
-
-CPCs
-----
-
-.. automodule:: zhmcclient._cpc
-
-.. autoclass:: zhmcclient.CpcManager
-   :members:
-   :special-members: __str__
-
-.. autoclass:: zhmcclient.Cpc
-   :members:
-   :special-members: __str__
-
-.. _`LPARs`:
-
-LPARs
------
-
-.. automodule:: zhmcclient._lpar
-
-.. autoclass:: zhmcclient.LparManager
-   :members:
-   :special-members: __str__
-
-.. autoclass:: zhmcclient.Lpar
-   :members:
-   :special-members: __str__
-
-.. _`Partitions`:
-
-Partitions
-----------
-
-.. automodule:: zhmcclient._partition
-
-.. autoclass:: zhmcclient.PartitionManager
-   :members:
-   :special-members: __str__
-
-.. autoclass:: zhmcclient.Partition
-   :members:
-   :special-members: __str__
-
-.. _`Activation profiles`:
-
-Activation profile
-------------------
-
-.. automodule:: zhmcclient._activation_profile
-
-.. autoclass:: zhmcclient.ActivationProfileManager
-   :members:
-   :special-members: __str__
-
-.. autoclass:: zhmcclient.ActivationProfile
-   :members:
-   :special-members: __str__
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,11 +16,18 @@
 zhmcclient - A Pure python client library for the z Systems HMC Web Services API
 ********************************************************************************
 
+This documentation is for *users* of the zhmcclient package. *Developers*
+should start on its `GitHub project page`_.
+
+.. _GitHub project page: https://github.com/zhmcclient/python-zhmcclient
+
 .. toctree::
    :maxdepth: 2
    :numbered:
 
    intro.rst
    tutorial.rst
-   operations.rst
-   logging.rst
+   concepts.rst
+   general.rst
+   resources.rst
+   appendix.rst

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -23,10 +23,9 @@ Introduction
 What this package provides
 --------------------------
 
-The **zhmcclient** Python package is a a Python client library that interacts
-with the Web Services API of the z Systems Hardware Management Console (HMC)
-(see :term:`HMC API`).
-This package is written in pure Python.
+zhmcclient is a Python client library that interacts with the Web Services API
+of the z Systems Hardware Management Console (HMC) (see :term:`HMC API`).
+This package is written in pure Python and runs on Python 2 and 3.
 
 The Web Services API of the HMC is the access point for any external tools to
 manage the z Systems platform; it supports management of the lifecycle and
@@ -45,6 +44,7 @@ The Web Services API of the HMC supports two protocols for its clients:
 This Python package currently supports only the REST API with a subset of the
 defined functionality. Support for JMS is intended to be added in the future,
 as well as completing the functionality of the REST API.
+
 
 .. _`Supported environments`:
 
@@ -73,136 +73,85 @@ HMC version  HMC API version  HMC API book            Machine generations
 2.13.1       1.7              :term:`HMC API 2.13.1`  up to z13/z13s/Emperor/Rockhopper
 ===========  ===============  ======================  =================================
 
-.. _`Deprecation policy`:
 
-Deprecation policy
-------------------
+.. _`Versioning`:
 
-This package attempts to be as backwards compatible as possible.
-
-However, occasionally functionality needs to be retired, because it is flawed and
-a better but incompatible replacement has emerged.
-Such changes are done by deprecating existing functionality,
-without removing it. The deprecated functionality is still supported throughout
-new minor releases. Eventually, a new major release will break compatibility and
-will remove the deprecated functionality.
-
-In order to prepare the users for that, deprecation of functionality
-is stated in the API documentation, and is made visible at runtime by issuing
-Python warnings of type ``DeprecationWarning`` (see the Python
-:mod:`py:warnings` module).
-
-Since Python 2.7, ``DeprecationWarning`` messages are suppressed by default.
-They can be shown for example in any of these ways:
-
-* By specifying the Python command line option: ``-W default``
-* By invoking Python with the environment variable: ``PYTHONWARNINGS=default``
-
-It is recommended that the users of this package run their test code with
-``DeprecationWarning`` messages being shown, so they become aware of any use of
-deprecated functionality.
-
-Here is a summary of the deprecation and compatibility policy used by
-this package, by release type:
-
-* New update release (M.N.U -> M.N.U+1): No new deprecations; fully backwards
-  compatible.
-* New minor release (M.N.U -> M.N+1.0): New deprecations may be added; as
-  backwards compatible as possible.
-* New major release (M.N.U -> M+1.0.0): Deprecated functionality may get
-  removed; backwards compatibility may be broken.
-
-Compatibility is always seen from the perspective of the user of this package, so
-a backwards compatible new release of this package means that the user can safely
-upgrade to that new release without encountering compatibility issues.
-
-.. _'Special type names`:
-
-Special type names
-------------------
-
-This documentation uses a few special terms to refer to Python types:
-
-.. glossary::
-
-   string
-      a :term:`unicode string` or a :term:`byte string`
-
-   unicode string
-      a Unicode string type (:func:`unicode <py2:unicode>` in
-      Python 2, and :class:`py3:str` in Python 3)
-
-   byte string
-      a byte string type (:class:`py2:str` in Python 2, and
-      :class:`py3:bytes` in Python 3). Unless otherwise
-      indicated, byte strings in this package are always UTF-8 encoded.
-
-   number
-      one of the number types :class:`py:int`, :class:`py2:long` (Python 2
-      only), or :class:`py:float`.
-
-   integer
-      one of the integer types :class:`py:int` or :class:`py2:long` (Python 2
-      only).
-
-   json object
-      a :class:`py:dict` object that is a Python representation of a valid JSON
-      object. See :ref:`py:py-to-json-table` for details.
-
-   header dict
-      a :class:`py:dict` object that specifies HTTP header fields, as follows:
-
-        * `key` (:term:`string`): Name of the header field, in any lexical case.
-          Dictionary key lookup is case sensitive, however.
-        * `value` (:term:`string`): Value of the header field.
-
-   callable
-      a type for callable objects (e.g. a function, calling a class returns a
-      new instance, instances are callable if they have a
-      :meth:`~py:object.__call__` method).
-
-   DeprecationWarning
-      a standard Python warning that indicates a deprecated functionality.
-      See section `Deprecation policy`_ and the standard Python module
-      :mod:`py:warnings` for details.
-
-.. _`References`:
-
-References
+Versioning
 ----------
 
-.. glossary::
+This documentation applies to package version |release|. You can also see that
+version in the top left corner of this page.
 
-   X.509
-      `ITU-T X.509, Information technology - Open Systems Interconnection - The Directory: Public-key and attribute certificate frameworks <http://www.itu.int/rec/T-REC-X.509/en>`_
+This package uses the rules of `Semantic Versioning 2.0.0`_ for its package
+version.
 
-   RFC2616
-      `IETF RFC2616, Hypertext Transfer Protocol - HTTP/1.1, June 1999 <https://tools.ietf.org/html/rfc2616>`_
+.. _Semantic Versioning 2.0.0: http://semver.org/spec/v2.0.0.html
 
-   RFC2617
-      `IETF RFC2617, HTTP Authentication: Basic and Digest Access Authentication, June 1999 <https://tools.ietf.org/html/rfc2617>`_
+The package version can be accessed by programs using the
+``zhmcclient.__version__`` variable [#]_:
 
-   RFC3986
-      `IETF RFC3986, Uniform Resource Identifier (URI): Generic Syntax, January 2005 <https://tools.ietf.org/html/rfc3986>`_
+.. autodata:: zhmcclient._version.__version__
 
-   RFC6874
-      `IETF RFC6874, Representing IPv6 Zone Identifiers in Address Literals and Uniform Resource Identifiers, February 2013 <https://tools.ietf.org/html/rfc6874>`_
+This documentation may have been built from a development level of the
+package. You can recognize a development version of this package by the
+presence of a ".devDDD" suffix in the version string. Development versions are
+pre-versions of the next assumed version that is not yet released. For example,
+version 0.1.2.dev25 is development pre-version #25 of the next version to be
+released after 0.1.1. This is an assumed next version, because the actually
+released next version might be 0.2.0 or even 1.0.0.
 
-   HMC API
-       One of the following HMC API books:
+.. [#] For tooling reasons, that variable is shown as
+   ``zhmcclient._version.__version__`` in this documentation, but it should be
+   accessed as ``zhmcclient.__version__``.
 
-   HMC API 2.11.1
-       `IBM SC27-2616-01, z Systems Hardware Management Console Web Services API (Version 2.11.1) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/38BA3E47697D87E385257967006AB34E/>`_
 
-   HMC API 2.12.0
-       `IBM SC27-2617-01, z Systems Hardware Management Console Web Services API (Version 2.12.0) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/9B97F40675618BA085257A6A00777BEA/>`_
+.. _`Compatibility`:
 
-   HMC API 2.12.1
-       `IBM SC27-2626-00a, z Systems Hardware Management Console Web Services API (Version 2.12.1) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/3DDB93B38680A72F85257BA600515AA7/>`_
+Compatibility
+-------------
 
-   HMC API 2.13.0
-       `IBM SC27-2627-00a, z Systems Hardware Management Console Web Services API (Version 2.13.0) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/7FA57A5A8A5297B185257DE7004E7144/>`_
+In this package, compatibility is always seen from the perspective of the user
+of the package. Thus, a backwards compatible new version of this package means
+that the user can safely upgrade to that new version without encountering
+compatibility issues.
 
-   HMC API 2.13.1
-       `IBM SC27-2634-01, z Systems Hardware Management Console Web Services API (Version 2.13.1) <https://www-304.ibm.com/servers/resourcelink/lib03010.nsf/0/CB468B15654CA89B85257F7200746C16/>`_
+This package uses the rules of `Semantic Versioning 2.0.0`_ for compatibility
+between package versions, and for :ref:`deprecations <Deprecations>`.
 
+The public API of this package that is subject to the semantic versioning
+rules (and specificically to its compatibility rules) is the API described in
+this documentation.
+
+.. _`Deprecations`:
+
+Deprecations
+------------
+
+Deprecated functionality is marked accordingly in this documentation, and is
+made visible at runtime by issuing Python warnings of type
+:exc:`~py:exceptions.DeprecationWarning` (see :mod:`py:warnings` for details).
+
+Since Python 2.7, :exc:`~py:exceptions.DeprecationWarning` warnings are
+suppressed by default. They can be shown for example in any of these ways:
+
+* by specifying the Python command line option:
+
+  ``-W default``
+
+* by invoking Python with the environment variable:
+
+  ``PYTHONWARNINGS=default``
+
+* by issuing in your program:
+
+  ::
+
+      warnings.filterwarnings(action='default', category=DeprecationWarning)
+
+It is recommended that users of this package run their test code with
+:exc:`~py:exceptions.DeprecationWarning` warnings being shown, so they become
+aware of any use of deprecated functionality.
+
+It is even possible to raise an exception instead of issuing a warning message
+upon the use of deprecated functionality, by setting the action to ``'error'``
+instead of ``'default'``.

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1,0 +1,103 @@
+.. Copyright 2016 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _`Resources`:
+
+Reference: Resources
+====================
+
+
+.. _`BaseManager`:
+.. _`BaseResource`:
+.. _`Base classes for resources`:
+
+Base classes for resources
+--------------------------
+
+.. automodule:: zhmcclient._manager
+
+.. autoclass:: zhmcclient.BaseManager
+   :members:
+   :special-members: __str__
+
+.. automodule:: zhmcclient._resource
+
+.. autoclass:: zhmcclient.BaseResource
+   :members:
+   :special-members: __str__
+
+
+.. _`CPCs`:
+
+CPCs
+----
+
+.. automodule:: zhmcclient._cpc
+
+.. autoclass:: zhmcclient.CpcManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.Cpc
+   :members:
+   :special-members: __str__
+
+
+.. _`LPARs`:
+
+LPARs
+-----
+
+.. automodule:: zhmcclient._lpar
+
+.. autoclass:: zhmcclient.LparManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.Lpar
+   :members:
+   :special-members: __str__
+
+
+.. _`Partitions`:
+
+Partitions
+----------
+
+.. automodule:: zhmcclient._partition
+
+.. autoclass:: zhmcclient.PartitionManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.Partition
+   :members:
+   :special-members: __str__
+
+
+.. _`Activation profiles`:
+
+Activation profiles
+-------------------
+
+.. automodule:: zhmcclient._activation_profile
+
+.. autoclass:: zhmcclient.ActivationProfileManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.ActivationProfile
+   :members:
+   :special-members: __str__

--- a/zhmcclient/_version.py
+++ b/zhmcclient/_version.py
@@ -24,6 +24,14 @@ import pbr.version
 
 __all__ = ['__version__']
 
+#: The full version of this package including any development levels, as a
+#: :term:`string`.
+#:
+#: Possible formats for this version string are:
+#:
+#: * "M.N.P.devD": Development level D of a not yet released assumed M.N.P
+#:   version
+#: * "M.N.P": A released M.N.P version
 __version__ = pbr.version.VersionInfo('zhmcclient').release_string()
 
 # Check supported Python versions


### PR DESCRIPTION
For details, see the commit message.

Ready for review and merge. Best way to review is to build the documentation locally via `make builddoc`.