### PR TITLE
Fixed incorrect args/kwargs prototype generated when using _log_call

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@
 six # MIT
 pbr>=1.8 # Apache-2.0
 requests>=2.10.0 # Apache-2.0
+decorator # new BSD
 

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -65,9 +65,10 @@ Examples:
       logging.basicConfig(format=format_string, level=logging.WARNING)
 """
 
-import functools
 import logging
 import inspect
+
+from decorator import decorate
 
 
 def _get_logger(name):
@@ -116,8 +117,7 @@ def _log_call(func):
     else:
         raise TypeError("The _log_call decorator must be used on a function")
 
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(func, *args, **kwargs):
         """
         Log entry to and exit from the decorated function, at the debug level.
 
@@ -133,4 +133,4 @@ def _log_call(func):
         logger.debug("Leaving %s", where)
         return result
 
-    return wrapper
+    return decorate(func, wrapper)


### PR DESCRIPTION
This fixes the documentation (although code is changed).

Ready for review and merge.

Details:
- The documentation generated for methods or functions decorated with
  the `_log_call` decorator is incorrectly generated with a prototype
  of `*args, **kwargs`. This the prototype of the wrapper function
  of the decorator. This has been fixed by switching from using
  the `functools` package to using the `decorator` package.
  See also http://stackoverflow.com/a/14448445/1424462
  and https://pythonhosted.org/decorator/documentation.html#a-trace-decorator
