### PR TITLE
Add Adapter support

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -55,6 +55,22 @@ CPCs
    :special-members: __str__
 
 
+.. _`Activation profiles`:
+
+Activation profiles
+-------------------
+
+.. automodule:: zhmcclient._activation_profile
+
+.. autoclass:: zhmcclient.ActivationProfileManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.ActivationProfile
+   :members:
+   :special-members: __str__
+
+
 .. _`LPARs`:
 
 LPARs
@@ -87,17 +103,17 @@ Partitions
    :special-members: __str__
 
 
-.. _`Activation profiles`:
+.. _`Adapters`:
 
-Activation profiles
--------------------
+Adapters
+--------
 
-.. automodule:: zhmcclient._activation_profile
+.. automodule:: zhmcclient._adapter
 
-.. autoclass:: zhmcclient.ActivationProfileManager
+.. autoclass:: zhmcclient.AdapterManager
    :members:
    :special-members: __str__
 
-.. autoclass:: zhmcclient.ActivationProfile
+.. autoclass:: zhmcclient.Adapter
    :members:
    :special-members: __str__

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example 7: Using the Adapter interface.
+"""
+
+import sys
+import yaml
+import requests.packages.urllib3
+import time
+import pprint
+
+import zhmcclient
+
+requests.packages.urllib3.disable_warnings()
+
+if len(sys.argv) != 2:
+    print("Usage: %s hmccreds.yaml" % sys.argv[0])
+    sys.exit(2)
+hmccreds_file = sys.argv[1]
+
+with open(hmccreds_file, 'r') as fp:
+    hmccreds = yaml.load(fp)
+
+examples = hmccreds.get("examples", None)
+if examples is None:
+    print("examples not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+example7 = examples.get("example7", None)
+if example7 is None:
+    print("example7 not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+loglevel = example7.get("loglevel", None)
+if loglevel is not None:
+    level = getattr(logging, loglevel.upper(), None)
+    if level is None:
+        print("Invalid value for loglevel in credentials file %s: %s" % \
+              (hmccreds_file, loglevel))
+        sys.exit(1)
+    logging.basicConfig(level=level)
+
+hmc = example7["hmc"]
+
+cred = hmccreds.get(hmc, None)
+if cred is None:
+    print("Credentials for HMC %s not found in credentials file %s" % \
+          (hmc, hmccreds_file))
+    sys.exit(1)
+
+userid = cred['userid']
+password = cred['password']
+
+print(__doc__)
+
+try:
+    print("Using HMC %s with userid %s ..." % (hmc, userid))
+    session = zhmcclient.Session(hmc, userid, password)
+    cl = zhmcclient.Client(session)
+
+    timestats = example7.get("timestats", None)
+    if timestats:
+        session.time_stats_keeper.enable()
+
+    print("Listing CPCs ...")
+    cpcs = cl.cpcs.list()
+    for cpc in cpcs:
+        print(cpc)
+        print("\tListing Adapters for %s ..." % cpc.properties['name'])
+        adapters = cpc.adapters.list()
+        for i, adapter in enumerate(adapters):
+            print('\t' + str(adapter))
+
+    print("Logging off ...")
+    session.logoff()
+
+    if timestats:
+        print(session.time_stats_keeper)
+
+    print("Done.")
+
+except zhmcclient.Error as exc:
+    print("%s: %s" % (exc.__class__.__name__, exc))
+    sys.exit(1)

--- a/examples/example_hmccreds.yaml
+++ b/examples/example_hmccreds.yaml
@@ -42,6 +42,10 @@ examples:
       lparname: PART8
       #loglevel: debug
       #timestats: yes
+   example8:
+      hmc: "9.152.150.65"
+      #loglevel: debug
+      #timestats: yes
 
 "9.152.150.65":
    userid: ensadmin

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _adapter module.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+import requests_mock
+
+from zhmcclient import Session, Client
+
+
+class AdapterTests(unittest.TestCase):
+    """All tests for Adapter and AdapterManager classes."""
+
+    def setUp(self):
+        self.session = Session('adapter-dpm-host', 'adapter-user',
+                               'adapter-pwd')
+        self.client = Client(self.session)
+        with requests_mock.mock() as m:
+            # Because logon is deferred until needed, we perform it
+            # explicitly in order to keep mocking in the actual test simple.
+            m.post('/api/sessions', json={'api-session': 'adapter-session-id'})
+            self.session.logon()
+
+        self.cpc_mgr = self.client.cpcs
+        with requests_mock.mock() as m:
+            result = {
+                'cpcs': [
+                    {
+                        'object-uri': '/api/cpcs/adapter-cpc-id-1',
+                        'name': 'CPC',
+                        'status': 'service-required',
+                    }
+                ]
+            }
+            m.get('/api/cpcs', json=result)
+
+            cpcs = self.cpc_mgr.list()
+            self.cpc = cpcs[0]
+
+    def tearDown(self):
+        with requests_mock.mock() as m:
+            m.delete('/api/sessions/this-session', status_code=204)
+            self.session.logoff()
+
+    def test_init(self):
+        """Test __init__() on AdapterManager instance in CPC."""
+        adapter_mgr = self.cpc.adapters
+        self.assertEqual(adapter_mgr.cpc, self.cpc)
+
+    def test_list_short_ok(self):
+        """
+        Test successful list() with short set of properties on AdapterManager
+        instance in CPC.
+        """
+        adapter_mgr = self.cpc.adapters
+        with requests_mock.mock() as m:
+            result = {
+                'adapters': [
+                    {
+                        'adapter-family': 'ficon',
+                        'adapter-id': '18C',
+                        'type': 'fcp',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-1',
+                        'name': 'FCP Adapter 1'
+                    },
+                    {
+                        'adapter-family': 'osa',
+                        'adapter-id': '1C4',
+                        'type': 'osd',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-2',
+                        'name': 'OSD Adapter 1'
+                    }
+                ]
+            }
+
+            m.get('/api/cpcs/adapter-cpc-id-1/adapters', json=result)
+
+            adapters = adapter_mgr.list(full_properties=False)
+
+            self.assertEqual(len(adapters), len(result['adapters']))
+            for idx, adapter in enumerate(adapters):
+                self.assertEqual(
+                    adapter.properties,
+                    result['adapters'][idx])
+                self.assertEqual(
+                    adapter.uri,
+                    result['adapters'][idx]['object-uri'])
+                self.assertFalse(adapter.full_properties)
+                self.assertEqual(adapter.manager, adapter_mgr)
+
+    def test_list_full_ok(self):
+        """
+        Test successful list() with full set of properties on AdapterManager
+        instance in CPC.
+        """
+        adapter_mgr = self.cpc.adapters
+        with requests_mock.mock() as m:
+            result = {
+                'adapters': [
+                    {
+                        'adapter-family': 'ficon',
+                        'adapter-id': '18C',
+                        'type': 'fcp',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-1',
+                        'name': 'FCP Adapter 1'
+                    },
+                    {
+                        'adapter-family': 'osa',
+                        'adapter-id': '1C4',
+                        'type': 'osd',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-2',
+                        'name': 'OSD Adapter 1'
+                    }
+                ]
+            }
+
+            m.get('/api/cpcs/adapter-cpc-id-1/adapters', json=result)
+
+            mock_result_adapter1 = {
+                'adapter-family': 'ficon',
+                'adapter-id': '18C',
+                'type': 'fcp',
+                'status': 'active',
+                'object-uri': '/api/adapters/fake-adapter-id-1',
+                'name': 'FCP Adapter 1',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/adapters/fake-adapter-id-1',
+                  json=mock_result_adapter1)
+            mock_result_adapter2 = {
+                'adapter-family': 'osa',
+                'adapter-id': '1C4',
+                'type': 'osd',
+                'status': 'active',
+                'object-uri': '/api/adapters/fake-adapter-id-2',
+                'name': 'OSD Adapter 1',
+                'description': 'Test Adapter',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/adapters/fake-adapter-id-2',
+                  json=mock_result_adapter2)
+
+            adapters = adapter_mgr.list(full_properties=True)
+
+            self.assertEqual(len(adapters), len(result['adapters']))
+            for idx, adapter in enumerate(adapters):
+                self.assertEqual(adapter.properties['name'],
+                                 result['adapters'][idx]['name'])
+                self.assertEqual(
+                    adapter.uri,
+                    result['adapters'][idx]['object-uri'])
+                self.assertTrue(adapter.full_properties)
+                self.assertEqual(adapter.manager, adapter_mgr)
+
+    def test_create_hipersocket(self):
+        """
+        This tests the 'Create Hipersocket' operation.
+        """
+        adapter_mgr = self.cpc.adapters
+        with requests_mock.mock() as m:
+            result = {
+                'object-uri': '/api/adapters/fake-adapter-id-1'
+            }
+            m.post('/api/cpcs/adapter-cpc-id-1/adapters', json=result)
+
+            status = adapter_mgr.create_hipersocket(properties={})
+            self.assertEqual(status, result['object-uri'])
+
+    def test_delete(self):
+        """
+        This tests the 'Delete Adapter' operation.
+        """
+        adapter_mgr = self.cpc.adapters
+        with requests_mock.mock() as m:
+            result = {
+                'adapters': [
+                    {
+                        'adapter-family': 'ficon',
+                        'adapter-id': '18C',
+                        'type': 'fcp',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-1',
+                        'name': 'FCP Adapter 1'
+                    },
+                    {
+                        'adapter-family': 'osa',
+                        'adapter-id': '1C4',
+                        'type': 'osd',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-2',
+                        'name': 'OSD Adapter 1'
+                    }
+                ]
+            }
+            m.get('/api/cpcs/adapter-cpc-id-1/adapters', json=result)
+
+            adapters = adapter_mgr.list(full_properties=False)
+            adapter = adapters[0]
+            m.delete(
+                "/api/adapters/fake-adapter-id-1",
+                json=result)
+            status = adapter.delete()
+            self.assertEqual(status, None)
+
+    def test_update_properties(self):
+        """
+        This tests the 'Update Adapter Properties' operation.
+        """
+        adapter_mgr = self.cpc.adapters
+        with requests_mock.mock() as m:
+            result = {
+                'adapters': [
+                    {
+                        'adapter-family': 'ficon',
+                        'adapter-id': '18C',
+                        'type': 'fcp',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-1',
+                        'name': 'FCP Adapter 1'
+                    },
+                    {
+                        'adapter-family': 'osa',
+                        'adapter-id': '1C4',
+                        'type': 'osd',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-2',
+                        'name': 'OSD Adapter 1'
+                    }
+                ]
+            }
+            m.get('/api/cpcs/adapter-cpc-id-1/adapters', json=result)
+
+            adapters = adapter_mgr.list(full_properties=False)
+            adapter = adapters[0]
+            m.post(
+                "/api/adapters/fake-adapter-id-1",
+                json=result)
+            status = adapter.update_properties(properties={})
+            self.assertEqual(status, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -33,3 +33,4 @@ from ._cpc import *           # noqa: F401
 from ._lpar import *          # noqa: F401
 from ._partition import *     # noqa: F401
 from ._activation_profile import *     # noqa: F401
+from ._adapter import *       # noqa: F401

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -1,0 +1,227 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+An **Adapter** object represents a single adapter of a physical z Systems
+or LinuxONE computer that is in DPM mode (Dynamic Partition Manager mode).
+Objects of this class are not provided when the CPC is not in DPM mode.
+
+Most of the adapters are physical adapters which are installed
+in the I/O cage or drawer of a physical processor frame.
+But there also are not physical adapters like HiperSockets.
+
+There are four types of adapter types:
+
+1. Network:
+   Network adapters enable communication through different networking
+   transport protocols. These network adapters are OSA-Express,
+   HiperSockets and 10 GbE RoCE Express.
+   DPM automatically discovers OSA-Express and RoCE-Express adapters
+   because they are physical cards that are installed on the CPC.
+   In contrast, HiperSockets are not physical adapters and must be
+   installed and configured by an administrator using the 'Create Hipersocket'
+   operation (see create_hipersocket()).
+   Network interface cards (NICs) provide a partition with access to networks.
+   Each NIC represents a unique connection between the partition
+   and a specific network adapter.
+
+2. Storage:
+   Fibre Channel connections provide high-speed connections between CPCs
+   and storage devices.
+   DPM automatically discovers any storage adapters installed on the CPC.
+   Host bus adapters (HBAs) provide a partition with access to external
+   storage area networks (SANs) and devices that are connected to a CPC.
+   Each HBA represents a unique connection between the partition
+   and a specific storage adapter.
+
+3. Accelerators:
+   Accelerators are adapters that provide specialized functions to
+   improve performance or use of computer resource like the IBM System z
+   Enterprise Data Compression (zEDC) feature.
+   DPM automatically discovers accelerators that are installed on the CPC.
+   An accelerator virtual function provides a partition with access
+   to zEDC features that are installed on a CPC.
+   Each virtual function represents a unique connection between
+   the partition and a physical feature card.
+
+4. Cryptos:
+   Cryptos are adapters that provide cryptographic processing functions.
+   DPM automatically discovers cryptographic features that are installed
+   on the CPC.
+"""
+
+from __future__ import absolute_import
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+
+__all__ = ['AdapterManager', 'Adapter']
+
+
+class AdapterManager(BaseManager):
+    """
+    Manager object for Adapters. This manager object is scoped to the
+    adapters of a particular CPC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+    """
+
+    def __init__(self, cpc):
+        """
+        Parameters:
+
+          cpc (:class:`~zhmcclient.Cpc`):
+            CPC defining the scope for this manager object.
+        """
+        super(AdapterManager, self).__init__(cpc)
+
+    @property
+    def cpc(self):
+        """
+        :class:`~zhmcclient.Cpc`: Parent object (CPC) defining the scope for
+        this manager object.
+        """
+        return self._parent
+
+    def list(self, full_properties=False):
+        """
+        List the adapters in scope of this manager object.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.Adapter` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        cpc_uri = self.cpc.get_property('object-uri')
+        adapters_res = self.session.get(cpc_uri + '/adapters')
+        adapter_list = []
+        if adapters_res:
+            adapter_items = adapters_res['adapters']
+            for adapter_props in adapter_items:
+                adapter = Adapter(self, adapter_props['object-uri'],
+                                  adapter_props)
+                if full_properties:
+                    adapter.pull_full_properties()
+                adapter_list.append(adapter)
+        return adapter_list
+
+    def create_hipersocket(self, properties):
+        """
+        Create and configures a HiperSockets adapter
+        with the specified resource properties.
+
+        Parameters:
+
+          properties (dict): Properties for the new adapter.
+            See the section in the :term:`HMC API` about the specific HMC
+            operation and about the 'Create Hipersocket'
+            description of the members of the passed properties
+            dict.
+
+        Returns:
+
+          string: The resource URI of the new adapter.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        cpc_uri = self.cpc.get_property('object-uri')
+        result = self.session.post(cpc_uri + '/adapters', body=properties)
+        return result['object-uri']
+
+
+class Adapter(BaseResource):
+    """
+    Representation of an Adapter.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Properties of an Adapter:
+      See the sub-section 'Data model' of the section 'Adapter object'
+      in the :term:`HMC API`.
+    """
+
+    def __init__(self, manager, uri, properties):
+        """
+        Parameters:
+
+          manager (:class:`~zhmcclient.AdapterManager`):
+            Manager object for this resource.
+
+          uri (string):
+            Canonical URI path of the Adapter object.
+
+          properties (dict):
+            Properties to be set for this resource object.
+            See initialization of :class:`~zhmcclient.BaseResource` for
+            details.
+        """
+        assert isinstance(manager, AdapterManager)
+        super(Adapter, self).__init__(manager, uri, properties)
+
+    def delete(self):
+        """
+        Deletes this adapter.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        adapter_uri = self.get_property('object-uri')
+        self.manager.session.delete(adapter_uri)
+
+    def update_properties(self, properties):
+        """
+        Updates one or more of the writable properties of a adapter
+        with the specified resource properties.
+
+        Parameters:
+
+          properties (dict): Updated properties for the adapter.
+            See the section in the :term:`HMC API` about
+            the specific HMC operation 'Update Adapter Properties'
+            description of the members of the passed properties
+            dict.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        adapter_uri = self.get_property('object-uri')
+        self.manager.session.post(adapter_uri, body=properties)

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -45,6 +45,7 @@ from ._resource import BaseResource
 from ._lpar import LparManager
 from ._partition import PartitionManager
 from ._activation_profile import ActivationProfileManager
+from ._adapter import AdapterManager
 from ._logging import _log_call
 
 
@@ -134,6 +135,7 @@ class Cpc(BaseResource):
         # We do here some lazy loading.
         self._lpars = None
         self._partitions = None
+        self._adapters = None
         self._reset_activation_profiles = None
         self._image_activation_profiles = None
         self._load_activation_profiles = None
@@ -161,6 +163,18 @@ class Cpc(BaseResource):
         if not self._partitions:
             self._partitions = PartitionManager(self)
         return self._partitions
+
+    @property
+    @_log_call
+    def adapters(self):
+        """
+        :class:`~zhmcclient.AdapterManager`: Manager object for the
+        adapters in this CPC.
+        """
+        # We do here some lazy loading.
+        if not self._adapters:
+            self._adapters = AdapterManager(self)
+        return self._adapters
 
     @property
     @_log_call


### PR DESCRIPTION
Details:
- Add AdapterManager class.
- Add Adapter class.
- Add Unit Tests for AdapterManager and Adapter.
- Add AdapterManager to Cpc class.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>