### PR TITLE
Add HBA Support

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -133,3 +133,19 @@ NICs
 .. autoclass:: zhmcclient.Nic
    :members:
    :special-members: __str__
+
+
+.. _`NICs`:
+
+HBAs
+----
+
+.. automodule:: zhmcclient._hba
+
+.. autoclass:: zhmcclient.HbaManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.Hba
+   :members:
+   :special-members: __str__

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Example 8: Using the Adapter and NIC interface.
+Example 8: Using the Adapter, NIC and HBA interface.
 """
 
 import sys
@@ -94,6 +94,14 @@ try:
                 if j == 0:
                     print("\t\tListing NICs for %s ..." % partition.properties['name'])
                 print('\t\t' + str(nic))
+
+            hbas = partition.hbas.list(full_properties=False)
+            for j, hba in enumerate(hbas):
+                if j == 0:
+                    print("\t\tListing HBAs for %s ..." % partition.properties['name'])
+                print('\t\t' + str(hba))
+#                hba.pull_full_properties()
+#                print('\t\t' + str(hba.properties))
 
     print("Logging off ...")
     session.logoff()

--- a/tests/test_hba.py
+++ b/tests/test_hba.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _hba module.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+import requests_mock
+
+from zhmcclient import Session, Client
+
+
+class HbaTests(unittest.TestCase):
+    """All tests for Hba and HbaManager classes."""
+
+    def setUp(self):
+        self.session = Session('test-dpm-host', 'test-user', 'test-id')
+        self.client = Client(self.session)
+        with requests_mock.mock() as m:
+            # Because logon is deferred until needed, we perform it
+            # explicitly in order to keep mocking in the actual test simple.
+            m.post('/api/sessions', json={'api-session': 'test-session-id'})
+            self.session.logon()
+
+        self.cpc_mgr = self.client.cpcs
+        with requests_mock.mock() as m:
+            result = {
+                'cpcs': [
+                    {
+                        'object-uri': '/api/cpcs/fake-cpc-id-1',
+                        'name': 'CPC1',
+                        'status': '',
+                    }
+                ]
+            }
+            m.get('/api/cpcs', json=result)
+#            self.cpc = self.cpc_mgr.find(name="CPC1", full_properties=False)
+            cpcs = self.cpc_mgr.list()
+            self.cpc = cpcs[0]
+
+        partition_mgr = self.cpc.partitions
+        with requests_mock.mock() as m:
+            result = {
+                'partitions': [
+                    {
+                        'status': 'active',
+                        'object-uri': '/api/partitions/fake-part-id-1',
+                        'name': 'PART1'
+                    },
+                    {
+                        'status': 'stopped',
+                        'object-uri': '/api/partitions/fake-part-id-2',
+                        'name': 'PART2'
+                    }
+                ]
+            }
+
+            m.get('/api/cpcs/fake-cpc-id-1/partitions', json=result)
+
+            mock_result_part1 = {
+                'status': 'active',
+                'object-uri': '/api/partitions/fake-part-id-1',
+                'name': 'PART1',
+                'description': 'Test Partition',
+                'more_properties': 'bliblablub',
+                'hba-uris': [
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-2'
+                ]
+            }
+            m.get('/api/partitions/fake-part-id-1',
+                  json=mock_result_part1)
+            mock_result_part2 = {
+                'status': 'stopped',
+                'object-uri': '/api/partitions/fake-lpar-id-2',
+                'name': 'PART2',
+                'description': 'Test Partition',
+                'more_properties': 'bliblablub',
+                'hba-uris': [
+                    '/api/partitions/fake-part-id-2/hbas/fake-hba-id-4',
+                    '/api/partitions/fake-part-id-2/hbas/fake-hba-id-6'
+                ]
+            }
+            m.get('/api/partitions/fake-part-id-2',
+                  json=mock_result_part2)
+
+            partitions = partition_mgr.list(full_properties=True)
+            self.partition = partitions[0]
+
+    def tearDown(self):
+        with requests_mock.mock() as m:
+            m.delete('/api/sessions/this-session', status_code=204)
+            self.session.logoff()
+
+    def test_init(self):
+        """Test __init__() on HbaManager instance in Partition."""
+        hba_mgr = self.partition.hbas
+        self.assertEqual(hba_mgr.partition, self.partition)
+
+    def test_list_short_ok(self):
+        """
+        Test successful list() with short set of properties on
+        HbaManager instance in partition.
+        """
+        hba_mgr = self.partition.hbas
+        hbas = hba_mgr.list(full_properties=False)
+
+        self.assertEqual(len(hbas), len(self.partition.properties['hba-uris']))
+        for idx, hba in enumerate(hbas):
+            self.assertEqual(
+                hba.properties['element-uri'],
+                self.partition.properties['hba-uris'][idx])
+            self.assertEqual(
+                hba.uri,
+                self.partition.properties['hba-uris'][idx])
+            self.assertFalse(hba.full_properties)
+            self.assertEqual(hba.manager, hba_mgr)
+
+    def test_list_full_ok(self):
+        """
+        Test successful list() with full set of properties on
+        HbaManager instance in partition.
+        """
+        hba_mgr = self.partition.hbas
+
+        with requests_mock.mock() as m:
+
+            mock_result_hba1 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'hba1',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                'class': 'hba',
+                'element-id': 'fake-hba-id-1',
+                'wwpn': 'AABBCCDDEC000082',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                  json=mock_result_hba1)
+            mock_result_hba2 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'hba2',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-2',
+                'class': 'hba',
+                'element-id': 'fake-hba-id-2',
+                'wwpn': 'AABBCCDDEC000083',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/hbas/fake-hba-id-2',
+                  json=mock_result_hba2)
+
+            hbas = hba_mgr.list(full_properties=True)
+
+            self.assertEqual(
+                len(hbas),
+                len(self.partition.properties['hba-uris']))
+            for idx, hba in enumerate(hbas):
+                self.assertEqual(
+                    hba.properties['element-uri'],
+                    self.partition.properties['hba-uris'][idx])
+                self.assertEqual(
+                    hba.uri,
+                    self.partition.properties['hba-uris'][idx])
+                self.assertTrue(hba.full_properties)
+                self.assertEqual(hba.manager, hba_mgr)
+
+    def test_create(self):
+        """
+        This tests the 'Create HBA' operation.
+        """
+        hba_mgr = self.partition.hbas
+        with requests_mock.mock() as m:
+            result = {
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1'
+            }
+            m.post('/api/partitions/fake-part-id-1/hbas', json=result)
+
+            status = hba_mgr.create(properties={})
+            self.assertEqual(status, result['element-uri'])
+
+    def test_delete(self):
+        """
+        This tests the 'Delete HBA' operation.
+        """
+        hba_mgr = self.partition.hbas
+        hbas = hba_mgr.list(full_properties=False)
+        hba = hbas[0]
+        with requests_mock.mock() as m:
+            result = {}
+            m.delete(
+                '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                json=result)
+            status = hba.delete()
+            self.assertEqual(status, None)
+
+    def test_update_properties(self):
+        """
+        This tests the 'Update HBA Properties' operation.
+        """
+        hba_mgr = self.partition.hbas
+        hbas = hba_mgr.list(full_properties=False)
+        hba = hbas[0]
+        with requests_mock.mock() as m:
+            result = {}
+            m.post(
+                '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                json=result)
+            status = hba.update_properties(properties={})
+            self.assertEqual(status, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -35,3 +35,4 @@ from ._partition import *     # noqa: F401
 from ._activation_profile import *     # noqa: F401
 from ._adapter import *       # noqa: F401
 from ._nic import *           # noqa: F401
+from ._hba import *           # noqa: F401

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -1,0 +1,183 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+An **HBA** object represents a unique connection between a partition
+and a physical FICON channel that is configured on the CPC
+of a physical z Systems or LinuxONE computer that is in DPM mode
+(Dynamic Partition Manager mode).
+Host bus adapters (HBAs) provide a partition with access to external
+storage area networks (SANs) and devices that are connected to a CPC.
+
+An HBA is always contained in a partition.
+"""
+
+from __future__ import absolute_import
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+
+__all__ = ['HbaManager', 'Hba']
+
+
+class HbaManager(BaseManager):
+    """
+    Manager object for HBAs. This manager object is scoped to the HBAs
+    of a particular Partition.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+    """
+
+    def __init__(self, partition):
+        """
+        Parameters:
+
+          partition (:class:`~zhmcclient.Partition`):
+            Partition defining the scope for this manager object.
+        """
+        super(HbaManager, self).__init__(partition)
+
+    @property
+    def partition(self):
+        """
+        :class:`~zhmcclient.Partition`: Parent object (Partition)
+        defining the scope for this manager object.
+        """
+        return self._parent
+
+    def list(self, full_properties=False):
+        """
+        List the HBAs in scope of this manager object.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.Hba` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        if not self.partition.full_properties:
+            self.partition.pull_full_properties()
+
+        hbas_res = self.partition.get_property('hba-uris')
+        hba_list = []
+        if hbas_res:
+            for hba_uri in hbas_res:
+                hba = Hba(self, hba_uri, {'element-uri': hba_uri})
+                if full_properties:
+                    hba.pull_full_properties()
+                hba_list.append(hba)
+        return hba_list
+
+    def create(self, properties):
+        """
+        Create and configures an HBA with the specified resource properties.
+
+        Parameters:
+
+          properties (dict): Properties for the new HBA.
+            See the section in the :term:`HMC API` about the specific HMC
+            operation and about the 'Create HBA' description of the members
+            of the passed properties dict.
+
+        Returns:
+
+          string: The resource URI of the new HBA.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        partition_uri = self.partition.get_property('object-uri')
+        result = self.session.post(partition_uri + '/hbas', body=properties)
+        return result['element-uri']
+
+
+class Hba(BaseResource):
+    """
+    Representation of an HBA.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Properties of a Hba:
+      See the sub-section 'Data model - HBA Element Object' of the section
+      'Partition object' in the :term:`HMC API`.
+    """
+
+    def __init__(self, manager, uri, properties):
+        """
+        Parameters:
+
+          manager (:class:`~zhmcclient.HbaManager`):
+            Manager object for this resource.
+
+          uri (string):
+            Canohbaal URI path of the Hba object.
+
+          properties (dict):
+            Properties to be set for this resource object.
+            See initialization of :class:`~zhmcclient.BaseResource` for
+            details.
+        """
+        assert isinstance(manager, HbaManager)
+        super(Hba, self).__init__(manager, uri, properties)
+
+    def delete(self):
+        """
+        Deletes this HBA.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.delete(self._uri)
+
+    def update_properties(self, properties):
+        """
+        Updates one or more of the writable properties of HBA
+        with the specified resource properties.
+
+        Parameters:
+
+          properties (dict): Updated properties for the HBA.
+            See the sub-section 'Data model - HBA Element Object'
+            of the section 'Partition object' in the :term:`HMC API`.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self._uri, body=properties)

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -32,6 +32,7 @@ from __future__ import absolute_import
 from ._manager import BaseManager
 from ._resource import BaseResource
 from ._nic import NicManager
+from ._hba import HbaManager
 from ._logging import _log_call
 
 __all__ = ['PartitionManager', 'Partition']
@@ -148,6 +149,7 @@ class Partition(BaseResource):
         assert isinstance(manager, PartitionManager)
         super(Partition, self).__init__(manager, uri, properties)
         self._nics = None
+        self._hbas = None
 
     @property
     @_log_call
@@ -160,6 +162,18 @@ class Partition(BaseResource):
         if not self._nics:
             self._nics = NicManager(self)
         return self._nics
+
+    @property
+    @_log_call
+    def hbas(self):
+        """
+        :class:`~zhmcclient.NicManager`: Manager object for the
+        HBAs in this Partition.
+        """
+        # We do here some lazy loading.
+        if not self._hbas:
+            self._hbas = HbaManager(self)
+        return self._hbas
 
     def start(self, wait_for_completion=True):
         """


### PR DESCRIPTION
Details:
- Add HbaManager class.
- Add Hba class.
- Add Unit Tests for HbaManager and Hba.
- Add HbaManager to Hba class.
- Add HBA to documentation reference.
- Add Hba example (example7.py).

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>