### PR TITLE
Add Virtual Function Support

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -135,7 +135,7 @@ NICs
    :special-members: __str__
 
 
-.. _`NICs`:
+.. _`HBAs`:
 
 HBAs
 ----
@@ -147,5 +147,21 @@ HBAs
    :special-members: __str__
 
 .. autoclass:: zhmcclient.Hba
+   :members:
+   :special-members: __str__
+
+
+.. _`Virtual Functions`:
+
+Virtual Functions
+-----------------
+
+.. automodule:: zhmcclient._virtual_function
+
+.. autoclass:: zhmcclient.VirtualFunctionManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.VirtualFunction
    :members:
    :special-members: __str__

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Example 8: Using the Adapter, NIC and HBA interface.
+Example 8: Using the Adapter, NIC, HBA and Virtual Function interface.
 """
 
 import sys
@@ -102,6 +102,13 @@ try:
                 print('\t\t' + str(hba))
 #                hba.pull_full_properties()
 #                print('\t\t' + str(hba.properties))
+            vfs = partition.virtual_functions.list(full_properties=False)
+            for k, vf in enumerate(vfs):
+                if k == 0:
+                    print("\t\tListing Virtual Functions for %s ..." % partition.properties['name'])
+                print('\t\t' + str(vf))
+#                vf.pull_full_properties()
+#                print('\t\t' + str(vf.properties))
 
     print("Logging off ...")
     session.logoff()

--- a/tests/test_virtual_function.py
+++ b/tests/test_virtual_function.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _virtual_function module.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+import requests_mock
+
+from zhmcclient import Session, Client
+
+
+class VirtualFunctionTests(unittest.TestCase):
+    """
+    All tests for VirtualFunction and VirtualFunctionManager classes.
+    """
+
+    def setUp(self):
+        self.session = Session('test-dpm-host', 'test-user', 'test-id')
+        self.client = Client(self.session)
+        with requests_mock.mock() as m:
+            # Because logon is deferred until needed, we perform it
+            # explicitly in order to keep mocking in the actual test simple.
+            m.post('/api/sessions', json={'api-session': 'test-session-id'})
+            self.session.logon()
+
+        self.cpc_mgr = self.client.cpcs
+        with requests_mock.mock() as m:
+            result = {
+                'cpcs': [
+                    {
+                        'object-uri': '/api/cpcs/fake-cpc-id-1',
+                        'name': 'CPC1',
+                        'status': '',
+                    }
+                ]
+            }
+            m.get('/api/cpcs', json=result)
+#            self.cpc = self.cpc_mgr.find(name="CPC1", full_properties=False)
+            cpcs = self.cpc_mgr.list()
+            self.cpc = cpcs[0]
+
+        partition_mgr = self.cpc.partitions
+        with requests_mock.mock() as m:
+            result = {
+                'partitions': [
+                    {
+                        'status': 'active',
+                        'object-uri': '/api/partitions/fake-part-id-1',
+                        'name': 'PART1'
+                    },
+                    {
+                        'status': 'stopped',
+                        'object-uri': '/api/partitions/fake-part-id-2',
+                        'name': 'PART2'
+                    }
+                ]
+            }
+
+            m.get('/api/cpcs/fake-cpc-id-1/partitions', json=result)
+
+            mock_result_part1 = {
+                'status': 'active',
+                'object-uri': '/api/partitions/fake-part-id-1',
+                'name': 'PART1',
+                'description': 'Test Partition',
+                'more_properties': 'bliblablub',
+                'virtual-function-uris': [
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-1',
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-2'
+                ]
+            }
+            m.get('/api/partitions/fake-part-id-1',
+                  json=mock_result_part1)
+            mock_result_part2 = {
+                'status': 'stopped',
+                'object-uri': '/api/partitions/fake-lpar-id-2',
+                'name': 'PART2',
+                'description': 'Test Partition',
+                'more_properties': 'bliblablub',
+                'virtual-function-uris': [
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-1',
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-2'
+                ]
+            }
+            m.get('/api/partitions/fake-part-id-2',
+                  json=mock_result_part2)
+
+            partitions = partition_mgr.list(full_properties=True)
+            self.partition = partitions[0]
+
+    def tearDown(self):
+        with requests_mock.mock() as m:
+            m.delete('/api/sessions/this-session', status_code=204)
+            self.session.logoff()
+
+    def test_init(self):
+        """Test __init__() on VirtualFunctionManager instance in Partition."""
+        vf_mgr = self.partition.virtual_functions
+        self.assertEqual(vf_mgr.partition, self.partition)
+
+    def test_list_short_ok(self):
+        """
+        Test successful list() with short set of properties on
+        VirtualFunctionManager instance in partition.
+        """
+        vf_mgr = self.partition.virtual_functions
+        vfs = vf_mgr.list(full_properties=False)
+
+        self.assertEqual(
+            len(vfs),
+            len(self.partition.properties['virtual-function-uris']))
+        for idx, vf in enumerate(vfs):
+            self.assertEqual(
+                vf.properties['element-uri'],
+                self.partition.properties['virtual-function-uris'][idx])
+            self.assertEqual(
+                vf.uri,
+                self.partition.properties['virtual-function-uris'][idx])
+            self.assertFalse(vf.full_properties)
+            self.assertEqual(vf.manager, vf_mgr)
+
+    def test_list_full_ok(self):
+        """
+        Test successful list() with full set of properties on
+        VirtualFunctionManager instance in partition.
+        """
+        vf_mgr = self.partition.virtual_functions
+
+        with requests_mock.mock() as m:
+
+            mock_result_vf1 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'vf1',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-1',
+                'class': 'virtual-function',
+                'element-id': 'fake-vf-id-1',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/virtual-functions/'
+                  'fake-vf-id-1',
+                  json=mock_result_vf1)
+            mock_result_vf2 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'vf2',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-2',
+                'class': 'virtual-function',
+                'element-id': 'fake-vf-id-2',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/virtual-functions/'
+                  'fake-vf-id-2',
+                  json=mock_result_vf2)
+
+            vfs = vf_mgr.list(full_properties=True)
+
+            self.assertEqual(
+                len(vfs),
+                len(self.partition.properties['virtual-function-uris']))
+            for idx, vf in enumerate(vfs):
+                self.assertEqual(
+                    vf.properties['element-uri'],
+                    self.partition.properties['virtual-function-uris'][idx])
+                self.assertEqual(
+                    vf.uri,
+                    self.partition.properties['virtual-function-uris'][idx])
+                self.assertTrue(vf.full_properties)
+                self.assertEqual(vf.manager, vf_mgr)
+
+    def test_create(self):
+        """
+        This tests the 'Create Virtual Function' operation.
+        """
+        vf_mgr = self.partition.virtual_functions
+        with requests_mock.mock() as m:
+            result = {
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-1'
+            }
+            m.post('/api/partitions/fake-part-id-1/virtual-functions',
+                   json=result)
+
+            status = vf_mgr.create(properties={})
+            self.assertEqual(status, result['element-uri'])
+
+    def test_delete(self):
+        """
+        This tests the 'Delete Virtual Function' operation.
+        """
+        vf_mgr = self.partition.virtual_functions
+        vfs = vf_mgr.list(full_properties=False)
+        vf = vfs[0]
+        with requests_mock.mock() as m:
+            result = {}
+            m.delete(
+                '/api/partitions/fake-part-id-1/virtual-functions/'
+                'fake-vf-id-1',
+                json=result)
+            status = vf.delete()
+            self.assertEqual(status, None)
+
+    def test_update_properties(self):
+        """
+        This tests the 'Update Virtual Function Properties' operation.
+        """
+        vf_mgr = self.partition.virtual_functions
+        vfs = vf_mgr.list(full_properties=False)
+        vf = vfs[0]
+        with requests_mock.mock() as m:
+            result = {}
+            m.post(
+                '/api/partitions/fake-part-id-1/virtual-functions/'
+                'fake-vf-id-1',
+                json=result)
+            status = vf.update_properties(properties={})
+            self.assertEqual(status, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -36,3 +36,4 @@ from ._activation_profile import *     # noqa: F401
 from ._adapter import *       # noqa: F401
 from ._nic import *           # noqa: F401
 from ._hba import *           # noqa: F401
+from ._virtual_function import *       # noqa: F401

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -33,6 +33,7 @@ from ._manager import BaseManager
 from ._resource import BaseResource
 from ._nic import NicManager
 from ._hba import HbaManager
+from ._virtual_function import VirtualFunctionManager
 from ._logging import _log_call
 
 __all__ = ['PartitionManager', 'Partition']
@@ -150,6 +151,7 @@ class Partition(BaseResource):
         super(Partition, self).__init__(manager, uri, properties)
         self._nics = None
         self._hbas = None
+        self._virtual_functions = None
 
     @property
     @_log_call
@@ -174,6 +176,18 @@ class Partition(BaseResource):
         if not self._hbas:
             self._hbas = HbaManager(self)
         return self._hbas
+
+    @property
+    @_log_call
+    def virtual_functions(self):
+        """
+        :class:`~zhmcclient.VirtualFunctionManager`:
+        Manager object for the Virtual Functions in this Partition.
+        """
+        # We do here some lazy loading.
+        if not self._virtual_functions:
+            self._virtual_functions = VirtualFunctionManager(self)
+        return self._virtual_functions
 
     def start(self, wait_for_completion=True):
         """

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -1,0 +1,184 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A **Virtual Function** represents a unique connection between the partition
+and a accelerator adapter like System z Enterprise Data Compression (zEDC)
+that is configured on a physical z Systems or LinuxONE computer
+that is in DPM mode (Dynamic Partition Manager mode).
+Objects of this class are not provided when the CPC is not in DPM mode.
+
+A Virtual Function is always contained in a partition.
+"""
+
+from __future__ import absolute_import
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+
+__all__ = ['VirtualFunctionManager', 'VirtualFunction']
+
+
+class VirtualFunctionManager(BaseManager):
+    """
+    Manager object for Virtual Functions. This manager object is scoped
+    to the Virtual Functions of a particular Partition.
+
+    Derived from :class:`~zhmcclient.BaseManager`;
+    see there for common methods and attributes.
+    """
+
+    def __init__(self, partition):
+        """
+        Parameters:
+
+          partition (:class:`~zhmcclient.Partition`):
+            Partition defining the scope for this manager object.
+        """
+        super(VirtualFunctionManager, self).__init__(partition)
+
+    @property
+    def partition(self):
+        """
+        :class:`~zhmcclient.Partition`: Parent object (Partition)
+        defining the scope for this manager object.
+        """
+        return self._parent
+
+    def list(self, full_properties=False):
+        """
+        List the Virtual Functions in scope of this manager object.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.VirtualFunction` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        if not self.partition.full_properties:
+            self.partition.pull_full_properties()
+
+        vfs_res = self.partition.get_property('virtual-function-uris')
+        vf_list = []
+        if vfs_res:
+            for vf_uri in vfs_res:
+                vf = VirtualFunction(self, vf_uri, {'element-uri': vf_uri})
+                if full_properties:
+                    vf.pull_full_properties()
+                vf_list.append(vf)
+        return vf_list
+
+    def create(self, properties):
+        """
+        Create and configures a Virtual Function with
+        the specified resource properties.
+
+        Parameters:
+
+          properties (dict): Properties for the new Virtual Function.
+            See the section in the :term:`HMC API` about the specific HMC
+            operation and about the 'Create Virtual Function' description
+            of the members of the passed properties dict.
+
+        Returns:
+
+          string: The resource URI of the new Virtual Function.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        partition_uri = self.partition.get_property('object-uri')
+        result = self.session.post(partition_uri + '/virtual-functions',
+                                   body=properties)
+        return result['element-uri']
+
+
+class VirtualFunction(BaseResource):
+    """
+    Representation of a Virtual Function.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Properties of a VirtualFunction:
+      See the sub-section 'Data model - Virtual Function Element Object'
+      of the section 'Partition object' in the :term:`HMC API`.
+    """
+
+    def __init__(self, manager, uri, properties):
+        """
+        Parameters:
+
+          manager (:class:`~zhmcclient.VirtualFunctionManager`):
+            Manager object for this resource.
+
+          uri (string):
+            Canonical URI path of the VirtualFunction object.
+
+          properties (dict):
+            Properties to be set for this resource object.
+            See initialization of :class:`~zhmcclient.BaseResource` for
+            details.
+        """
+        assert isinstance(manager, VirtualFunctionManager)
+        super(VirtualFunction, self).__init__(manager, uri, properties)
+
+    def delete(self):
+        """
+        Deletes this Virtual Function.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.delete(self._uri)
+
+    def update_properties(self, properties):
+        """
+        Updates one or more of the writable properties of Virtual Function
+        with the specified resource properties.
+
+        Parameters:
+
+          properties (dict): Updated properties for the Virtual Function.
+            See the sub-section 'Data model - Virtual Function Element Object'
+            of the section 'Partition object' in the :term:`HMC API`.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self._uri, body=properties)


### PR DESCRIPTION
Details:
- Add VirtualFunctionManager class.
- Add VirtualFunction class.
- Add Unit Tests for VirtualFunctionManager
  and VirtualFunction.
- Add VirtualFunctionManager to Partition class.
- Add VirtualFunction to documentation reference.
- Add VirtualFunction example (example8.py).

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>