### PR TITLE
Add Virtual Switch Support

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -165,3 +165,19 @@ Virtual Functions
 .. autoclass:: zhmcclient.VirtualFunction
    :members:
    :special-members: __str__
+
+
+.. _`Virtual Switches`:
+
+Virtual Switches
+----------------
+
+.. automodule:: zhmcclient._virtual_switch
+
+.. autoclass:: zhmcclient.VirtualSwitchManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.VirtualSwitch
+   :members:
+   :special-members: __str__

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 
 """
-Example 8: Using the Adapter, NIC, HBA and Virtual Function interface.
+Example 8: Using the Adapter, Virtual Switch, NIC, HBA
+           and Virtual Function interface.
 """
 
 import sys
@@ -85,6 +86,10 @@ try:
         adapters = cpc.adapters.list()
         for i, adapter in enumerate(adapters):
             print('\t' + str(adapter))
+        print("\tListing Virtual Switches for %s ..." % cpc.properties['name'])
+        vswitches = cpc.vswitches.list()
+        for i, vswitch in enumerate(vswitches):
+            print('\t' + str(vswitch))
         print("\tListing Partitions for %s ..." % cpc.properties['name'])
         partitions = cpc.partitions.list()
         for i, partition in enumerate(partitions):

--- a/tests/test_virtual_switch.py
+++ b/tests/test_virtual_switch.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _virtual_switch module.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+import requests_mock
+
+from zhmcclient import Session, Client
+
+
+class VirtualSwitchTests(unittest.TestCase):
+    """All tests for VirtualSwitch and VirtualSwitchManager classes."""
+
+    def setUp(self):
+        self.session = Session('vswitch-dpm-host', 'vswitch-user',
+                               'vswitch-pwd')
+        self.client = Client(self.session)
+        with requests_mock.mock() as m:
+            # Because logon is deferred until needed, we perform it
+            # explicitly in order to keep mocking in the actual test simple.
+            m.post('/api/sessions', json={'api-session': 'vswitch-session-id'})
+            self.session.logon()
+
+        self.cpc_mgr = self.client.cpcs
+        with requests_mock.mock() as m:
+            result = {
+                'cpcs': [
+                    {
+                        'object-uri': '/api/cpcs/vswitch-cpc-id-1',
+                        'name': 'CPC',
+                        'status': 'service-required',
+                    }
+                ]
+            }
+            m.get('/api/cpcs', json=result)
+
+            cpcs = self.cpc_mgr.list()
+            self.cpc = cpcs[0]
+
+    def tearDown(self):
+        with requests_mock.mock() as m:
+            m.delete('/api/sessions/this-session', status_code=204)
+            self.session.logoff()
+
+    def test_init(self):
+        """Test __init__() on VirtualSwitchManager instance in CPC."""
+        vswitch_mgr = self.cpc.vswitches
+        self.assertEqual(vswitch_mgr.cpc, self.cpc)
+
+    def test_list_short_ok(self):
+        """
+        Test successful list() with short set of properties
+        on VirtualSwitchManager instance in CPC.
+        """
+        vswitch_mgr = self.cpc.vswitches
+        with requests_mock.mock() as m:
+            result = {
+                'virtual-switches': [
+                    {
+                        'name': 'VSWITCH1',
+                        'object-uri': '/api/virtual-switches/fake-vswitch-id1',
+                        'type': 'osd'
+                    },
+                    {
+                        'name': 'VSWITCH2',
+                        'object-uri': '/api/virtual-switches/fake-vswitch-id2',
+                        'type': 'hpersockets'
+                    }
+                ]
+            }
+
+            m.get('/api/cpcs/vswitch-cpc-id-1/virtual-switches', json=result)
+
+            vswitches = vswitch_mgr.list(full_properties=False)
+
+            self.assertEqual(len(vswitches), len(result['virtual-switches']))
+            for idx, vswitch in enumerate(vswitches):
+                self.assertEqual(
+                    vswitch.properties,
+                    result['virtual-switches'][idx])
+                self.assertEqual(
+                    vswitch.uri,
+                    result['virtual-switches'][idx]['object-uri'])
+                self.assertFalse(vswitch.full_properties)
+                self.assertEqual(vswitch.manager, vswitch_mgr)
+
+    def test_list_full_ok(self):
+        """
+        Test successful list() with full set of properties on
+        VirtualSwitchManager instance in CPC.
+        """
+        vswitch_mgr = self.cpc.vswitches
+        with requests_mock.mock() as m:
+            result = {
+                'virtual-switches': [
+                    {
+                        'name': 'VSWITCH1',
+                        'object-uri': '/api/virtual-switches/fake-vswitch-id1',
+                        'type': 'osd'
+                    },
+                    {
+                        'name': 'VSWITCH2',
+                        'object-uri': '/api/virtual-switches/fake-vswitch-id2',
+                        'type': 'hipersockets'
+                    }
+                ]
+            }
+
+            m.get('/api/cpcs/vswitch-cpc-id-1/virtual-switches', json=result)
+
+            mock_result_virtual_switch1 = {
+                'name': 'VSWITCH1',
+                'object-uri': '/api/virtual-switches/fake-vswitch-id1',
+                'type': 'osd',
+                'class': 'virtual-switch',
+                'description': 'Test VirtualSwitch',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/virtual-switches/fake-vswitch-id1',
+                  json=mock_result_virtual_switch1)
+            mock_result_virtual_switch2 = {
+                'name': 'VSWITCH2',
+                'object-uri': '/api/virtual-switches/fake-vswitch-id2',
+                'type': 'hipersockets',
+                'class': 'virtual-switch',
+                'description': 'Test VirtualSwitch',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/virtual-switches/fake-vswitch-id2',
+                  json=mock_result_virtual_switch2)
+
+            vswitches = vswitch_mgr.list(full_properties=True)
+
+            self.assertEqual(len(vswitches), len(result['virtual-switches']))
+            for idx, vswitch in enumerate(vswitches):
+                self.assertEqual(vswitch.properties['name'],
+                                 result['virtual-switches'][idx]['name'])
+                self.assertEqual(
+                    vswitch.uri,
+                    result['virtual-switches'][idx]['object-uri'])
+                self.assertTrue(vswitch.full_properties)
+                self.assertEqual(vswitch.manager, vswitch_mgr)
+
+    def test_update_properties(self):
+        """
+        This tests the 'Update VirtualSwitch Properties' operation.
+        """
+        vswitch_mgr = self.cpc.vswitches
+        with requests_mock.mock() as m:
+            result = {
+                'virtual-switches': [
+                    {
+                        'name': 'VSWITCH1',
+                        'object-uri': '/api/virtual-switches/fake-vswitch-id1',
+                        'type': 'osd'
+                    },
+                    {
+                        'name': 'VSWITCH2',
+                        'object-uri': '/api/virtual-switches/fake-vswitch-id2',
+                        'type': 'hpersockets'
+                    }
+                ]
+            }
+            m.get('/api/cpcs/vswitch-cpc-id-1/virtual-switches', json=result)
+
+            vswitches = vswitch_mgr.list(full_properties=False)
+            vswitch = vswitches[0]
+            m.post(
+                "/api/virtual-switches/fake-vswitch-id1",
+                json=result)
+            status = vswitch.update_properties(properties={})
+            self.assertEqual(status, None)
+
+    def test_get_connected_vnics(self):
+        """
+        This tests the 'Get Connected VNICs of a Virtual Switch' operation.
+        """
+        vswitch_mgr = self.cpc.vswitches
+        with requests_mock.mock() as m:
+            result = {
+                'virtual-switches': [
+                    {
+                        'name': 'VSWITCH1',
+                        'object-uri': '/api/virtual-switches/fake-vswitch-id1',
+                        'type': 'osd'
+                    },
+                    {
+                        'name': 'VSWITCH2',
+                        'object-uri': '/api/virtual-switches/fake-vswitch-id2',
+                        'type': 'hpersockets'
+                    }
+                ]
+            }
+            m.get('/api/cpcs/vswitch-cpc-id-1/virtual-switches', json=result)
+
+            vswitches = vswitch_mgr.list(full_properties=False)
+            vswitch = vswitches[0]
+            result = {
+                'connected-vnic-uris': [
+                    '/api/partitions/fake-part-id1/nics/fake-nic-id1',
+                    '/api/partitions/fake-part-id1/nics/fake-nic-id2',
+                    '/api/partitions/fake-part-id1/nics/fake-nic-id3'
+                ]
+            }
+
+            m.get(
+                "/api/virtual-switches/fake-vswitch-id1/"
+                "operations/get-connected-vnics",
+                json=result)
+            status = vswitch.get_connected_vnics()
+            self.assertEqual(status, result['connected-vnic-uris'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -37,3 +37,4 @@ from ._adapter import *       # noqa: F401
 from ._nic import *           # noqa: F401
 from ._hba import *           # noqa: F401
 from ._virtual_function import *       # noqa: F401
+from ._virtual_switch import *         # noqa: F401

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -46,6 +46,7 @@ from ._lpar import LparManager
 from ._partition import PartitionManager
 from ._activation_profile import ActivationProfileManager
 from ._adapter import AdapterManager
+from ._virtual_switch import VirtualSwitchManager
 from ._logging import _log_call
 
 
@@ -136,6 +137,7 @@ class Cpc(BaseResource):
         self._lpars = None
         self._partitions = None
         self._adapters = None
+        self._vswitches = None
         self._reset_activation_profiles = None
         self._image_activation_profiles = None
         self._load_activation_profiles = None
@@ -175,6 +177,18 @@ class Cpc(BaseResource):
         if not self._adapters:
             self._adapters = AdapterManager(self)
         return self._adapters
+
+    @property
+    @_log_call
+    def vswitches(self):
+        """
+        :class:`~zhmcclient.VirtualSwitchManager`: Manager object for the
+        Virtual Switches in this CPC.
+        """
+        # We do here some lazy loading.
+        if not self._vswitches:
+            self._vswitches = VirtualSwitchManager(self)
+        return self._vswitches
 
     @property
     @_log_call

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -185,7 +185,7 @@ class BaseResource(object):
         status=service-required)
         """
         properties_keys = self._properties.keys()
-        search_keys = ['status', 'object-uri', 'element-uri', 'name']
+        search_keys = ['status', 'object-uri', 'element-uri', 'name', 'type']
         sorted_keys = sorted([k for k in properties_keys if k in search_keys])
         info = ", ".join("%s=%s" % (k, self._properties[k])
                          for k in sorted_keys)

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -1,0 +1,172 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A Virtual Switch object is a virtualized representation of
+networking vswitch and port of a physical z Systems or LinuxONE computer
+that is in DPM mode (Dynamic Partition Manager mode).
+Objects of this class are not provided when the CPC is not in DPM mode.
+Network vswitchs without a physical port, such as hipersockets
+or single port OSAs are virtualized to a single virtual switch.
+Network vswitchs with multiple ports are virtualized into multiple virtual
+switches one for each port. Virtual switches are generated automatically
+every time a new network vswitch is detected and configured.
+The virtual switch serves as the connection point for network interfaces
+(VNICs) created by the virtual server administrator.
+"""
+
+from __future__ import absolute_import
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+
+__all__ = ['VirtualSwitchManager', 'VirtualSwitch']
+
+
+class VirtualSwitchManager(BaseManager):
+    """
+    Manager object for Virtual Switches. This manager object is scoped to the
+    vswitchs of a particular CPC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+    """
+
+    def __init__(self, cpc):
+        """
+        Parameters:
+
+          cpc (:class:`~zhmcclient.Cpc`):
+            CPC defining the scope for this manager object.
+        """
+        super(VirtualSwitchManager, self).__init__(cpc)
+
+    @property
+    def cpc(self):
+        """
+        :class:`~zhmcclient.Cpc`: Parent object (CPC) defining the scope for
+        this manager object.
+        """
+        return self._parent
+
+    def list(self, full_properties=False):
+        """
+        List the Virtual Switches in scope of this manager object.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.VirtualSwitch` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        cpc_uri = self.cpc.get_property('object-uri')
+        vswitch_res = self.session.get(cpc_uri + '/virtual-switches')
+        vswitch_list = []
+        if vswitch_res:
+            vswitch_items = vswitch_res['virtual-switches']
+            for vswitch_props in vswitch_items:
+                vswitch = VirtualSwitch(self, vswitch_props['object-uri'],
+                                        vswitch_props)
+                if full_properties:
+                    vswitch.pull_full_properties()
+                vswitch_list.append(vswitch)
+        return vswitch_list
+
+
+class VirtualSwitch(BaseResource):
+    """
+    Representation of an VirtualSwitch.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Properties of an VirtualSwitch:
+      See the sub-section 'Data model' of the section 'VirtualSwitch object'
+      in the :term:`HMC API`.
+    """
+
+    def __init__(self, manager, uri, properties):
+        """
+        Parameters:
+
+          manager (:class:`~zhmcclient.VirtualSwitchManager`):
+            Manager object for this resource.
+
+          uri (string):
+            Canonical URI path of the VirtualSwitch object.
+
+          properties (dict):
+            Properties to be set for this resource object.
+            See initialization of :class:`~zhmcclient.BaseResource` for
+            details.
+        """
+        assert isinstance(manager, VirtualSwitchManager)
+        super(VirtualSwitch, self).__init__(manager, uri, properties)
+
+    def get_connected_vnics(self):
+        """
+        Retrieves the list of network interfaces (VNICs)
+        connected to a single Virtual VirtualSwitch.
+
+        Returns:
+
+          : A list of NIC URIs.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        vswitch_uri = self.get_property('object-uri')
+        status = self.manager.session.get(
+            vswitch_uri +
+            '/operations/get-connected-vnics')
+        return status['connected-vnic-uris']
+
+    def update_properties(self, properties):
+        """
+        Updates one or more of the writable properties of a vswitch
+        with the specified resource properties.
+
+        Parameters:
+
+          properties (dict): Updated properties for the vswitch.
+            See the section in the :term:`HMC API` about
+            the specific HMC operation 'Update VirtualSwitch Properties'
+            description of the members of the passed properties
+            dict.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        vswitch_uri = self.get_property('object-uri')
+        self.manager.session.post(vswitch_uri, body=properties)


### PR DESCRIPTION
Details:
- Add VirtualSwitchManager class.
- Add VirtualSwitch class.
- Add Unit Tests for VirtualSwitchManager
  and VirtualSwitch.
- Add VirtualSwitchManager to CPC class.
- Add Virtual Switch to documentation reference.
- Add Virtual Switch to example (example8.py).
- Add 'type' if available to __str__ of BaseResource.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>