### PR TITLE
Fixes #50: Changed create...() to return resource object instead of URI.

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import unittest
 import requests_mock
 
-from zhmcclient import Session, Client
+from zhmcclient import Session, Client, Adapter
 
 
 class AdapterTests(unittest.TestCase):
@@ -184,8 +184,11 @@ class AdapterTests(unittest.TestCase):
             }
             m.post('/api/cpcs/adapter-cpc-id-1/adapters', json=result)
 
-            status = adapter_mgr.create_hipersocket(properties={})
-            self.assertEqual(status, result['object-uri'])
+            adapter = adapter_mgr.create_hipersocket(properties={})
+
+            self.assertTrue(isinstance(adapter, Adapter))
+            self.assertEqual(adapter.properties, result)
+            self.assertEqual(adapter.uri, result['object-uri'])
 
     def test_delete(self):
         """

--- a/tests/test_hba.py
+++ b/tests/test_hba.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import unittest
 import requests_mock
 
-from zhmcclient import Session, Client
+from zhmcclient import Session, Client, Hba
 
 
 class HbaTests(unittest.TestCase):
@@ -194,8 +194,11 @@ class HbaTests(unittest.TestCase):
             }
             m.post('/api/partitions/fake-part-id-1/hbas', json=result)
 
-            status = hba_mgr.create(properties={})
-            self.assertEqual(status, result['element-uri'])
+            hba = hba_mgr.create(properties={})
+
+            self.assertTrue(isinstance(hba, Hba))
+            self.assertEqual(hba.properties, result)
+            self.assertEqual(hba.uri, result['element-uri'])
 
     def test_delete(self):
         """

--- a/tests/test_nic.py
+++ b/tests/test_nic.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import unittest
 import requests_mock
 
-from zhmcclient import Session, Client
+from zhmcclient import Session, Client, Nic
 
 
 class NicTests(unittest.TestCase):
@@ -194,8 +194,11 @@ class NicTests(unittest.TestCase):
             }
             m.post('/api/partitions/fake-part-id-1/nics', json=result)
 
-            status = nic_mgr.create(properties={})
-            self.assertEqual(status, result['element-uri'])
+            nic = nic_mgr.create(properties={})
+
+            self.assertTrue(isinstance(nic, Nic))
+            self.assertEqual(nic.properties, result)
+            self.assertEqual(nic.uri, result['element-uri'])
 
     def test_delete(self):
         """

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import unittest
 import requests_mock
 
-from zhmcclient import Session, Client
+from zhmcclient import Session, Client, Partition
 
 
 class PartitionTests(unittest.TestCase):
@@ -165,8 +165,11 @@ class PartitionTests(unittest.TestCase):
             }
             m.post('/api/cpcs/fake-cpc-id-1/partitions', json=result)
 
-            status = partition_mgr.create(properties={})
-            self.assertEqual(status, result['object-uri'])
+            partition = partition_mgr.create(properties={})
+
+            self.assertTrue(isinstance(partition, Partition))
+            self.assertEqual(partition.properties, result)
+            self.assertEqual(partition.uri, result['object-uri'])
 
     def test_start(self):
         """

--- a/tests/test_virtual_function.py
+++ b/tests/test_virtual_function.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import unittest
 import requests_mock
 
-from zhmcclient import Session, Client
+from zhmcclient import Session, Client, VirtualFunction
 
 
 class VirtualFunctionTests(unittest.TestCase):
@@ -206,8 +206,11 @@ class VirtualFunctionTests(unittest.TestCase):
             m.post('/api/partitions/fake-part-id-1/virtual-functions',
                    json=result)
 
-            status = vf_mgr.create(properties={})
-            self.assertEqual(status, result['element-uri'])
+            vf = vf_mgr.create(properties={})
+
+            self.assertTrue(isinstance(vf, VirtualFunction))
+            self.assertEqual(vf.properties, result)
+            self.assertEqual(vf.uri, result['element-uri'])
 
     def test_delete(self):
         """

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -145,7 +145,9 @@ class AdapterManager(BaseManager):
 
         Returns:
 
-          string: The resource URI of the new adapter.
+          Adapter: The resource object for the new HiperSockets adapter.
+            The object will have its 'object-uri' property set as returned by
+            the HMC, and will also have the input properties set.
 
         Raises:
 
@@ -156,7 +158,11 @@ class AdapterManager(BaseManager):
         """
         cpc_uri = self.cpc.get_property('object-uri')
         result = self.session.post(cpc_uri + '/adapters', body=properties)
-        return result['object-uri']
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = properties.copy()
+        props.update(result)
+        return Adapter(self, props['object-uri'], props)
 
 
 class Adapter(BaseResource):

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -110,7 +110,9 @@ class PartitionManager(BaseManager):
 
         Returns:
 
-          string: The resource URI of the new partition.
+          Partition: The resource object for the new partition.
+            The object will have its 'object-uri' property set as returned by
+            the HMC, and will also have the input properties set.
 
         Raises:
 
@@ -121,7 +123,11 @@ class PartitionManager(BaseManager):
         """
         cpc_uri = self.cpc.get_property('object-uri')
         result = self.session.post(cpc_uri + '/partitions', body=properties)
-        return result['object-uri']
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = properties.copy()
+        props.update(result)
+        return Partition(self, props['object-uri'], props)
 
 
 class Partition(BaseResource):

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -110,9 +110,11 @@ class BaseResource(object):
     @property
     def full_properties(self):
         """
-        A boolean indicating whether the resource properties in this object
-        are the full set of resource properties, vs. just the short set of
-        resource properties as obtained by list functions.
+        A boolean indicating whether or not the resource properties in this
+        object are the full set of resource properties.
+
+        Note that listing resources and creating new resources produces objects
+        that have less than the full set of properties.
         """
         return self._full_properties
 
@@ -170,7 +172,7 @@ class BaseResource(object):
         try:
             return self._properties[name]
         except KeyError:
-            if self.full_properties:
+            if self._full_properties:
                 raise
             self.pull_full_properties()
             return self._properties[name]

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -78,9 +78,6 @@ class VirtualFunctionManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        if not self.partition.full_properties:
-            self.partition.pull_full_properties()
-
         vfs_res = self.partition.get_property('virtual-function-uris')
         vf_list = []
         if vfs_res:
@@ -105,7 +102,9 @@ class VirtualFunctionManager(BaseManager):
 
         Returns:
 
-          string: The resource URI of the new Virtual Function.
+          VirtualFunction: The resource object for the new virtual function.
+            The object will have its 'element-uri' property set as returned by
+            the HMC, and will also have the input properties set.
 
         Raises:
 
@@ -117,7 +116,11 @@ class VirtualFunctionManager(BaseManager):
         partition_uri = self.partition.get_property('object-uri')
         result = self.session.post(partition_uri + '/virtual-functions',
                                    body=properties)
-        return result['element-uri']
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = properties.copy()
+        props.update(result)
+        return VirtualFunction(self, props['element-uri'], props)
 
 
 class VirtualFunction(BaseResource):


### PR DESCRIPTION
Please review.

Details:

- Removed unnecessary check for full properties in list() for Adapter, Nic, Hba.
- Changed returned object from any create...() methods to be the resource object, filled with the input properties and the returned properties.
- Adjusted testcases to the changed return value.

What was NOT done:

- The full_properties property still exists, and is tested by the test cases. We could remove it in the future, but for now I left it in.
- I did NOT add any additional state w.r.t. the filled properties, because I think the only relevant information is whether the set is complete or not complete. Distinguishing between created (which does NOT just have the URI property filled, but also the input properties!) and the properties returned by list() did not seem necessary.