### PR TITLE
Improved documentation of resource modules and renaming of a method argument

### DIFF
--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -332,7 +332,7 @@ class PartitionTests(unittest.TestCase):
                 "/api/partitions/fake-part-id-1/operations/scsi-dump",
                 json=result)
             status = partition.dump_partition(
-                wait_for_completion=False, properties={})
+                wait_for_completion=False, parameters={})
             self.assertEqual(status, result)
 
     def test_psw_restart(self):

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 """
-An **Adapter** object represents a single adapter of a physical z Systems
-or LinuxONE computer that is in DPM mode (Dynamic Partition Manager mode).
-Objects of this class are not provided when the CPC is not in DPM mode.
+An **Adapter** resource represents a single adapter in a CPC.
+Most of the adapters are physical adapters which are installed in the I/O
+drawer of a CPC, but there also are not-physical adapters like HiperSockets.
 
-Most of the adapters are physical adapters which are installed
-in the I/O cage or drawer of a physical processor frame.
-But there also are not physical adapters like HiperSockets.
+Adapter resources resources are contained in CPC resources.
 
-There are four types of adapter types:
+Adapters only exist in CPCs that are in DPM mode.
+
+There are four types of Adapters:
 
 1. Network:
    Network adapters enable communication through different networking
@@ -71,8 +71,7 @@ __all__ = ['AdapterManager', 'Adapter']
 
 class AdapterManager(BaseManager):
     """
-    Manager object for Adapters. This manager object is scoped to the
-    adapters of a particular CPC.
+    Manager providing access to the Adapters in a particular CPC.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
@@ -83,21 +82,20 @@ class AdapterManager(BaseManager):
         Parameters:
 
           cpc (:class:`~zhmcclient.Cpc`):
-            CPC defining the scope for this manager object.
+            CPC defining the scope for this manager.
         """
         super(AdapterManager, self).__init__(cpc)
 
     @property
     def cpc(self):
         """
-        :class:`~zhmcclient.Cpc`: Parent object (CPC) defining the scope for
-        this manager object.
+        :class:`~zhmcclient.Cpc`: CPC defining the scope for this manager.
         """
         return self._parent
 
     def list(self, full_properties=False):
         """
-        List the adapters in scope of this manager object.
+        List the Adapters in this CPC.
 
         Parameters:
 
@@ -132,16 +130,13 @@ class AdapterManager(BaseManager):
 
     def create_hipersocket(self, properties):
         """
-        Create and configures a HiperSockets adapter
-        with the specified resource properties.
+        Create and configure a HiperSockets Adapter.
 
         Parameters:
 
-          properties (dict): Properties for the new adapter.
-            See the section in the :term:`HMC API` about the specific HMC
-            operation and about the 'Create Hipersocket'
-            description of the members of the passed properties
-            dict.
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create Hipersocket' in the :term:`HMC API` book.
 
         Returns:
 
@@ -172,9 +167,8 @@ class Adapter(BaseResource):
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
 
-    Properties of an Adapter:
-      See the sub-section 'Data model' of the section 'Adapter object'
-      in the :term:`HMC API`.
+    For the properties of an Adapter, see section 'Data model' in section
+    'Adapter object' in the :term:`HMC API` book.
     """
 
     def __init__(self, manager, uri, properties):
@@ -182,13 +176,13 @@ class Adapter(BaseResource):
         Parameters:
 
           manager (:class:`~zhmcclient.AdapterManager`):
-            Manager object for this resource.
+            Manager for this Adapter.
 
           uri (string):
-            Canonical URI path of the Adapter object.
+            Canonical URI path of this Adapter.
 
           properties (dict):
-            Properties to be set for this resource object.
+            Properties to be set for this Adapter.
             See initialization of :class:`~zhmcclient.BaseResource` for
             details.
         """
@@ -197,7 +191,7 @@ class Adapter(BaseResource):
 
     def delete(self):
         """
-        Deletes this adapter.
+        Delete this Adapter.
 
         Raises:
 
@@ -211,16 +205,15 @@ class Adapter(BaseResource):
 
     def update_properties(self, properties):
         """
-        Updates one or more of the writable properties of a adapter
-        with the specified resource properties.
+        Update writeable properties of this Adapter.
 
         Parameters:
 
-          properties (dict): Updated properties for the adapter.
-            See the section in the :term:`HMC API` about
-            the specific HMC operation 'Update Adapter Properties'
-            description of the members of the passed properties
-            dict.
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model' in section 'Adapter object' in the
+            :term:`HMC API` book.
 
         Raises:
 

--- a/zhmcclient/_client.py
+++ b/zhmcclient/_client.py
@@ -95,13 +95,11 @@ class Client(object):
         Returns:
 
           :term:`json object`:
-
-           A JSON object with members ``api-major-version``,
+            A JSON object with members ``api-major-version``,
            ``api-minor-version``, ``hmc-version`` and ``hmc-name``.
-
-            For details, see the sections in the :term:`HMC API` about the
-            "Query API Version" operation.
-
+            For details about these properties, see section
+            'Response body contents' in section 'Query API Version' in the
+            :term:`HMC API` book.
 
         Raises:
 

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -19,18 +19,18 @@ computer. A particular HMC can manage multiple CPCs.
 The HMC can manage a range of old and new CPC generations. Some older CPC
 generations are not capable of supporting the HMC Web Services API; these older
 CPCs can be managed using the GUI of the HMC, but not through its Web Services
-API. Therefore, such older CPCs will not show up at the HMC Web Services API,
-and thus will not show up in the API of this Python package.
+API. Therefore, such older CPCs will not be exposed at the HMC Web Services
+API, and thus will not show up in the API of this Python package.
 
 TODO: List earliest CPC generation that supports the HMC Web Services API.
 
 A CPC can be in any of the following three modes:
 
 - DPM mode: Dynamic Partition Manager is enabled for the CPC.
-- Ensemble mode: The CPC is member of an ensemble. This Python client
-  does not support the functionality that is specific to ensemble mode.
 - Classic mode: The CPC does not have Dynamic Partition Manager enabled,
   and is not member of an ensemble.
+- Ensemble mode: The CPC is member of an ensemble. This Python client
+  does not support the functionality that is specific to ensemble mode.
 
 The functionality supported at the HMC API and thus also for users of this
 Python client, depends on the mode in which the CPC currently is. If a
@@ -55,9 +55,8 @@ __all__ = ['CpcManager', 'Cpc']
 
 class CpcManager(BaseManager):
     """
-    Manager object for CPCs. This manager object is scoped to the HMC Web
-    Services API capable CPCs managed by the HMC that is associated with a
-    particular client.
+    Manager providing access to the CPCs exposed by the HMC this client is
+    connected to.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
@@ -76,7 +75,7 @@ class CpcManager(BaseManager):
     @_log_call
     def list(self, full_properties=False):
         """
-        List the CPCs in scope of this manager object.
+        List the CPCs exposed by the HMC this client is connected to.
 
         Parameters:
 
@@ -121,13 +120,13 @@ class Cpc(BaseResource):
         Parameters:
 
           manager (:class:`~zhmcclient.CpcManager`):
-            Manager object for this CPC.
+            Manager for this CPC.
 
           uri (string):
-            Canonical URI path of the CPC object.
+            Canonical URI path of this CPC.
 
           properties (dict):
-            Properties to be set for this resource object.
+            Properties to be set for this CPC.
             See initialization of :class:`~zhmcclient.BaseResource` for
             details.
         """
@@ -146,8 +145,7 @@ class Cpc(BaseResource):
     @_log_call
     def lpars(self):
         """
-        :class:`~zhmcclient.LparManager`: Manager object for the LPARs in this
-        CPC.
+        :class:`~zhmcclient.LparManager`: Access to the LPARs in this CPC.
         """
         # We do here some lazy loading.
         if not self._lpars:
@@ -158,8 +156,8 @@ class Cpc(BaseResource):
     @_log_call
     def partitions(self):
         """
-        :class:`~zhmcclient.PartitionManager`: Manager object for the
-        partitions in this CPC.
+        :class:`~zhmcclient.PartitionManager`: Access to the Partitions in this
+        CPC.
         """
         # We do here some lazy loading.
         if not self._partitions:
@@ -170,8 +168,8 @@ class Cpc(BaseResource):
     @_log_call
     def adapters(self):
         """
-        :class:`~zhmcclient.AdapterManager`: Manager object for the
-        adapters in this CPC.
+        :class:`~zhmcclient.AdapterManager`: Access to the Adapters in this
+        CPC.
         """
         # We do here some lazy loading.
         if not self._adapters:
@@ -182,8 +180,8 @@ class Cpc(BaseResource):
     @_log_call
     def vswitches(self):
         """
-        :class:`~zhmcclient.VirtualSwitchManager`: Manager object for the
-        Virtual Switches in this CPC.
+        :class:`~zhmcclient.VirtualSwitchManager`: Access to the Virtual
+        Switches in this CPC.
         """
         # We do here some lazy loading.
         if not self._vswitches:
@@ -194,9 +192,8 @@ class Cpc(BaseResource):
     @_log_call
     def reset_activation_profiles(self):
         """
-        :class:`~zhmcclient.ActivationManager`: Manager object for the
-        Reset Activation Profiles in this CPC.
-        `None`, if the CPC is in DPM mode.
+        :class:`~zhmcclient.ActivationManager`: Access to the Reset
+        Activation Profiles in this CPC.
         """
         # We do here some lazy loading.
         if not self._reset_activation_profiles:
@@ -208,8 +205,8 @@ class Cpc(BaseResource):
     @_log_call
     def image_activation_profiles(self):
         """
-        :class:`~zhmcclient.ActivationManager`: Manager object for the
-        Image Activation Profiles in this CPC.
+        :class:`~zhmcclient.ActivationManager`: Access to the Image
+        Activation Profiles in this CPC.
         """
         # We do here some lazy loading.
         if not self._image_activation_profiles:
@@ -221,8 +218,8 @@ class Cpc(BaseResource):
     @_log_call
     def load_activation_profiles(self):
         """
-        :class:`~zhmcclient.ActivationManager`: Manager object for the
-        Load Activation Profiles in this CPC.
+        :class:`~zhmcclient.ActivationManager`: Access to the Load
+        Activation Profiles in this CPC.
         """
         # We do here some lazy loading.
         if not self._load_activation_profiles:
@@ -338,17 +335,17 @@ class Cpc(BaseResource):
     @_log_call
     def import_profiles(self, profile_area, wait_for_completion=True):
         """
-        Imports activation profiles and/or system activity profiles for the CPC
-        from the SE hard drive into the CPC object using the HMC operation
+        Import activation profiles and/or system activity profiles for this CPC
+        from the SE hard drive into the CPC using the HMC operation
         "Import Profiles".
 
-        This operation is not permitted when the CPC is enabled for DPM.
+        This operation is not permitted when the CPC is in DPM mode.
 
         Parameters:
 
           profile_area (int):
-             The numbered hard drive area (1-4) from which the profiles are
-             imported.
+            The numbered hard drive area (1-4) from which the profiles are
+            imported.
 
           wait_for_completion (bool):
             Boolean controlling whether this method should wait for completion
@@ -390,11 +387,10 @@ class Cpc(BaseResource):
     @_log_call
     def export_profiles(self, profile_area, wait_for_completion=True):
         """
-        Exports activation profiles and/or system activity profiles from the
-        CPC object designated to the SE hard drive using the HMC operation
-        "Export Profiles".
+        Export activation profiles and/or system activity profiles from this
+        CPC to the SE hard drive using the HMC operation "Export Profiles".
 
-        This operation is not permitted when the CPC is enabled for DPM.
+        This operation is not permitted when the CPC is in DPM mode.
 
         Parameters:
 

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -162,9 +162,10 @@ class HTTPError(Error):
         conjunction with the HTTP status code to determine the error condition.
 
         Standard HMC reason codes that apply across the entire API are
-        described in section "Common request validation reason codes" in the
-        HMC API book. Additional operation-specific reason codes may also be
-        documented in the description of the specific API operations.
+        described in section 'Common request validation reason codes' in the
+        :term:`HMC API` book. Additional operation-specific reason codes may
+        also be documented in the description of specific API operations in the
+        :term:`HMC API` book.
         """
         return self._body.get('reason', None)
 

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 """
-An **HBA** object represents a unique connection between a partition
-and a physical FICON channel that is configured on the CPC
-of a physical z Systems or LinuxONE computer that is in DPM mode
-(Dynamic Partition Manager mode).
-Host bus adapters (HBAs) provide a partition with access to external
-storage area networks (SANs) and devices that are connected to a CPC.
+A **Host Bus Adapter (HBA)** provides a Partition with access to external
+storage area networks (SANs) through a storage adapter.
 
-An HBA is always contained in a partition.
+HBA resources are contained in Partition resources.
+
+HBAs only exist in CPCs that are in DPM mode.
 """
 
 from __future__ import absolute_import
@@ -33,8 +31,7 @@ __all__ = ['HbaManager', 'Hba']
 
 class HbaManager(BaseManager):
     """
-    Manager object for HBAs. This manager object is scoped to the HBAs
-    of a particular Partition.
+    Manager providing access to the HBAs in a particular Partition.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
@@ -45,21 +42,21 @@ class HbaManager(BaseManager):
         Parameters:
 
           partition (:class:`~zhmcclient.Partition`):
-            Partition defining the scope for this manager object.
+            Partition defining the scope for this manager.
         """
         super(HbaManager, self).__init__(partition)
 
     @property
     def partition(self):
         """
-        :class:`~zhmcclient.Partition`: Parent object (Partition)
-        defining the scope for this manager object.
+        :class:`~zhmcclient.Partition`: Partition defining the scope for this
+        manager.
         """
         return self._parent
 
     def list(self, full_properties=False):
         """
-        List the HBAs in scope of this manager object.
+        List the HBAs in this Partition.
 
         Parameters:
 
@@ -91,14 +88,13 @@ class HbaManager(BaseManager):
 
     def create(self, properties):
         """
-        Create and configures an HBA with the specified resource properties.
+        Create and configure an HBA in this Partition.
 
         Parameters:
 
-          properties (dict): Properties for the new HBA.
-            See the section in the :term:`HMC API` about the specific HMC
-            operation and about the 'Create HBA' description of the members
-            of the passed properties dict.
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create HBA' in the :term:`HMC API` book.
 
         Returns:
 
@@ -129,9 +125,9 @@ class Hba(BaseResource):
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
 
-    Properties of a Hba:
-      See the sub-section 'Data model - HBA Element Object' of the section
-      'Partition object' in the :term:`HMC API`.
+    For the properties of an HBA resource, see section
+    'Data model - HBA Element Object' in section 'Partition object' in the
+    :term:`HMC API` book.
     """
 
     def __init__(self, manager, uri, properties):
@@ -139,13 +135,13 @@ class Hba(BaseResource):
         Parameters:
 
           manager (:class:`~zhmcclient.HbaManager`):
-            Manager object for this resource.
+            Manager for this HBA.
 
           uri (string):
-            Canohbaal URI path of the Hba object.
+            Canonical URI path of this HBA.
 
           properties (dict):
-            Properties to be set for this resource object.
+            Properties to be set for this HBA.
             See initialization of :class:`~zhmcclient.BaseResource` for
             details.
         """
@@ -154,7 +150,7 @@ class Hba(BaseResource):
 
     def delete(self):
         """
-        Deletes this HBA.
+        Delete this HBA.
 
         Raises:
 
@@ -167,14 +163,15 @@ class Hba(BaseResource):
 
     def update_properties(self, properties):
         """
-        Updates one or more of the writable properties of HBA
-        with the specified resource properties.
+        Update writeable properties of this HBA.
 
         Parameters:
 
-          properties (dict): Updated properties for the HBA.
-            See the sub-section 'Data model - HBA Element Object'
-            of the section 'Partition object' in the :term:`HMC API`.
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model - HBA Element Object' in the
+            :term:`HMC API` book.
 
         Raises:
 

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -13,13 +13,16 @@
 # limitations under the License.
 
 """
-A **Logical Partition (LPAR)** is a subset of a physical z Systems or LinuxONE
-computer that is not in DPM mode (Dynamic Partition Manager mode).
-Objects of this class are not provided when the CPC is in DPM mode.
-
-An LPAR is always contained in a CPC.
+A **Logical Partition (LPAR)** is a subset of the hardware resources of a
+:term:`CPC` in classic mode (or ensemble mode), virtualized as a separate
+computer.
 
 LPARs cannot be created or deleted by the user; they can only be listed.
+
+LPAR resources are contained in CPC resources.
+
+LPAR resources only exist in CPCs that are in classic mode (or ensemble mode).
+CPCs in DPM mode have :term:`Partition` resources, instead.
 """
 
 from __future__ import absolute_import
@@ -33,8 +36,7 @@ __all__ = ['LparManager', 'Lpar']
 
 class LparManager(BaseManager):
     """
-    Manager object for LPARs. This manager object is scoped to the LPARs of a
-    particular CPC.
+    Manager providing access to the LPARs in a particular CPC.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
@@ -45,22 +47,21 @@ class LparManager(BaseManager):
         Parameters:
 
           cpc (:class:`~zhmcclient.Cpc`):
-            CPC defining the scope for this manager object.
+            CPC defining the scope for this manager.
         """
         super(LparManager, self).__init__(cpc)
 
     @property
     def cpc(self):
         """
-        :class:`~zhmcclient.Cpc`: Parent object (CPC) defining the scope for
-        this manager object.
+        :class:`~zhmcclient.Cpc`: CPC defining the scope for this manager.
         """
         return self._parent
 
     @_log_call
     def list(self, full_properties=False):
         """
-        List the LPARs in scope of this manager object.
+        List the LPARs in this CPC.
 
         Parameters:
 
@@ -106,13 +107,13 @@ class Lpar(BaseResource):
         Parameters:
 
           manager (:class:`~zhmcclient.LparManager`):
-            Manager object for this resource.
+            Manager object for this LPAR.
 
           uri (string):
-            Canonical URI path of the LPAR object.
+            Canonical URI path of this LPAR.
 
           properties (dict):
-            Properties to be set for this resource object.
+            Properties to be set for this LPAR.
             See initialization of :class:`~zhmcclient.BaseResource` for
             details.
         """

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 """
-A **NIC** object represents a single Network interface card (NIC)
-of a physical z Systems or LinuxONE computer that is in DPM mode
-(Dynamic Partition Manager mode).
-Objects of this class are not provided when the CPC is not in DPM mode.
-Each NIC represents a unique connection between a partition and
-a specific network adapter that is defined or installed on the CPC.
+A **Network Interface Card (NIC)** provides a Partition with access to external
+communication networks through a network adapter.
 
-A NIC is always contained in a partition.
+NIC resources are contained in Partition resources.
+
+NICs only exist in CPCs that are in DPM mode.
 """
 
 from __future__ import absolute_import
@@ -33,8 +31,7 @@ __all__ = ['NicManager', 'Nic']
 
 class NicManager(BaseManager):
     """
-    Manager object for NICs. This manager object is scoped to the NICs
-    of a particular Partition.
+    Manager providing access to the NICs in a particular Partition.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
@@ -45,21 +42,21 @@ class NicManager(BaseManager):
         Parameters:
 
           partition (:class:`~zhmcclient.Partition`):
-            Partition defining the scope for this manager object.
+            Partition defining the scope for this manager.
         """
         super(NicManager, self).__init__(partition)
 
     @property
     def partition(self):
         """
-        :class:`~zhmcclient.Partition`: Parent object (Partition)
-        defining the scope for this manager object.
+        :class:`~zhmcclient.Partition`: Partition defining the scope for this
+        manager.
         """
         return self._parent
 
     def list(self, full_properties=False):
         """
-        List the NICs in scope of this manager object.
+        List the NICs in this Partition.
 
         Parameters:
 
@@ -91,14 +88,13 @@ class NicManager(BaseManager):
 
     def create(self, properties):
         """
-        Create and configures a NIC with the specified resource properties.
+        Create and configure a NIC in this Partition.
 
         Parameters:
 
-          properties (dict): Properties for the new NIC.
-            See the section in the :term:`HMC API` about the specific HMC
-            operation and about the 'Create NIC' description of the members
-            of the passed properties dict.
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create NIC' in the :term:`HMC API` book.
 
         Returns:
 
@@ -124,14 +120,14 @@ class NicManager(BaseManager):
 
 class Nic(BaseResource):
     """
-    Representation of a NIC.
+    Representation of a NIC resource.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
 
-    Properties of a Nic:
-      See the sub-section 'Data model - NIC Element Object' of the section
-      'Partition object' in the :term:`HMC API`.
+    For the properties of a NIC resource, see section
+    'Data model - NIC Element Object' in section 'Partition object' in the
+    :term:`HMC API` book.
     """
 
     def __init__(self, manager, uri, properties):
@@ -139,13 +135,13 @@ class Nic(BaseResource):
         Parameters:
 
           manager (:class:`~zhmcclient.NicManager`):
-            Manager object for this resource.
+            Manager for this resource.
 
           uri (string):
-            Canonical URI path of the Nic object.
+            Canonical URI path of this resource.
 
           properties (dict):
-            Properties to be set for this resource object.
+            Properties to be set for this resource.
             See initialization of :class:`~zhmcclient.BaseResource` for
             details.
         """
@@ -154,7 +150,7 @@ class Nic(BaseResource):
 
     def delete(self):
         """
-        Deletes this NIC.
+        Delete this NIC resource.
 
         Raises:
 
@@ -167,14 +163,15 @@ class Nic(BaseResource):
 
     def update_properties(self, properties):
         """
-        Updates one or more of the writable properties of NIC
-        with the specified resource properties.
+        Update writeable properties of this NIC.
 
         Parameters:
 
-          properties (dict): Updated properties for the NIC.
-            See the sub-section 'Data model - NIC Element Object'
-            of the section 'Partition object' in the :term:`HMC API`.
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model - NIC Element Object' in the
+            :term:`HMC API` book.
 
         Raises:
 

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -46,10 +46,10 @@ class BaseResource(object):
             type in the scope of that manager).
 
           uri (string):
-            Canonical URI path of the BaseResource object.
+            Canonical URI path of the resource.
 
           properties (dict):
-            Properties to be set for this resource object.
+            Properties to be set for the resource.
 
             * Key: Name of the property.
             * Value: Value of the property.
@@ -62,8 +62,8 @@ class BaseResource(object):
             resource object. The properties on the resource object are
             mutable. Whether or not a particular property of the represented
             manageable resource can be updated is described in its property
-            qualifiers. See section "Property characteristics" in chapter 5 of
-            :term:`HMC API` for a description of the concept of property
+            qualifiers. See section "Property characteristics" in the
+            :term:`HMC API` book for a description of the concept of property
             qualifiers, and the respective sections describing the resources
             for their actual definitions of property qualifiers.
         """
@@ -77,24 +77,25 @@ class BaseResource(object):
     def properties(self):
         """
         dict:
-          The properties of this resource object.
+          The properties of this resource.
 
           * Key: Name of the property.
           * Value: Value of the property.
 
-          See the respective sections in :term:`HMC API` for a description
-          of the resources along with their properties.
+          See the respective 'Data model' sections in the :term:`HMC API` book
+          for a description of the resources along with their properties.
 
           The dictionary contains either the full set of resource properties,
-          or the short set of resource properties as obtained by list
-          operations.
+          or a subset thereof.
         """
         return self._properties
 
     @property
     def uri(self):
         """
-        string: The resource URI, in the format ``/api/cpcs/12345``.
+        string: The canonical URI path of the resource.
+
+        Example: ``/api/cpcs/12345``
         """
         return self._uri
 
@@ -121,7 +122,7 @@ class BaseResource(object):
     @property
     def properties_timestamp(self):
         """
-        The point in time of the last update of the resource properties
+        The point in time of the last update of the resource properties cached
         in this object, as Unix time (an integer that is the number of seconds
         since the Unix epoch).
         """
@@ -129,8 +130,8 @@ class BaseResource(object):
 
     def pull_full_properties(self):
         """
-        Retrieve the full set of properties for this resource (and store them
-        in :attr:`properties`).
+        Retrieve the full set of resource properties and cache them in this
+        object.
 
         Raises:
 
@@ -146,15 +147,17 @@ class BaseResource(object):
 
     def get_property(self, name):
         """
-        Return the value of a resource property. If the resource property
-        is not in the currently known set of properties, the full set of
-        resource properties is retrieved and the resource property is
-        again attempted to be returned.
+        Return the value of a resource property.
+
+        If the resource property is not cached in this object yet, the full set
+        of resource properties is retrieved and cached in this object, and the
+        resource property is again attempted to be returned.
 
         Parameters:
+
           name (:term:`string`):
             Name of the resource property, using the names defined in the
-            respective section of :term:`HMC API`.
+            respective 'Data model' sections in the :term:`HMC API` book.
 
         Returns:
 
@@ -179,12 +182,13 @@ class BaseResource(object):
 
     def __str__(self):
         """
-        Convert a BaseResource object to a string.
+        Return a human readable representation of this resource.
 
-        example:
-        Cpc(name=P0000S12,
-        object-uri=/api/cpcs/f1bc49af-f71a-3467-8def-3c186b5d9352,
-        status=service-required)
+        Example::
+
+            Cpc(name=P0000S12,
+                object-uri=/api/cpcs/f1bc49af-f71a-3467-8def-3c186b5d9352,
+                status=service-required)
         """
         properties_keys = self._properties.keys()
         search_keys = ['status', 'object-uri', 'element-uri', 'name', 'type']
@@ -195,6 +199,7 @@ class BaseResource(object):
 
     def __repr__(self):
         """
-        Convert a BaseResource object to a string.
+        Return a representation of this resource suitable for debugging its
+        state.
         """
         return self.__str__()

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -414,8 +414,8 @@ class Session(object):
             determine the status of the job and the result of the original
             operation, once the job has completed.
 
-            See the section in the :term:`HMC API` about the specific HMC
-            operation and about the "Query Job Status" operation, for a
+            See the section in the :term:`HMC API` book about the specific HMC
+            operation and about the 'Query Job Status' operation, for a
             description of the members of the returned JSON objects.
 
         Raises:
@@ -595,9 +595,8 @@ class Session(object):
             with members ``job-status-code``, ``job-reason-code``, and
             optionally ``job-results``.
 
-            For details, see the sections in the :term:`HMC API` about the
-            "Query Job Status" operation and about the original operation that
-            was performed asynchronously.
+            For details, see section 'Response body contents' in section
+            'Query Job Status' in the :term:`HMC API` book.
 
         Raises:
 

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 """
-A **Virtual Function** represents a unique connection between the partition
-and a accelerator adapter like System z Enterprise Data Compression (zEDC)
-that is configured on a physical z Systems or LinuxONE computer
-that is in DPM mode (Dynamic Partition Manager mode).
-Objects of this class are not provided when the CPC is not in DPM mode.
+A **Virtual Function** provides a Partition with access to accelerator Adapters
+like the System z Enterprise Data Compression (zEDC) adapter.
 
-A Virtual Function is always contained in a partition.
+Virtual Function resources are contained in Partition resources.
+
+Virtual Functions only exist in CPCs that are in DPM mode.
 """
 
 from __future__ import absolute_import
@@ -32,8 +31,8 @@ __all__ = ['VirtualFunctionManager', 'VirtualFunction']
 
 class VirtualFunctionManager(BaseManager):
     """
-    Manager object for Virtual Functions. This manager object is scoped
-    to the Virtual Functions of a particular Partition.
+    Manager providing access to the Virtual Functions in a particular
+    Partition.
 
     Derived from :class:`~zhmcclient.BaseManager`;
     see there for common methods and attributes.
@@ -44,21 +43,21 @@ class VirtualFunctionManager(BaseManager):
         Parameters:
 
           partition (:class:`~zhmcclient.Partition`):
-            Partition defining the scope for this manager object.
+            Partition defining the scope for this manager.
         """
         super(VirtualFunctionManager, self).__init__(partition)
 
     @property
     def partition(self):
         """
-        :class:`~zhmcclient.Partition`: Parent object (Partition)
-        defining the scope for this manager object.
+        :class:`~zhmcclient.Partition`: Partition defining the scope for this
+        manager.
         """
         return self._parent
 
     def list(self, full_properties=False):
         """
-        List the Virtual Functions in scope of this manager object.
+        List the Virtual Functions of this Partition.
 
         Parameters:
 
@@ -90,15 +89,13 @@ class VirtualFunctionManager(BaseManager):
 
     def create(self, properties):
         """
-        Create and configures a Virtual Function with
-        the specified resource properties.
+        Create a Virtual Function in this Partition.
 
         Parameters:
 
-          properties (dict): Properties for the new Virtual Function.
-            See the section in the :term:`HMC API` about the specific HMC
-            operation and about the 'Create Virtual Function' description
-            of the members of the passed properties dict.
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create Virtual Function' in the :term:`HMC API` book.
 
         Returns:
 
@@ -130,9 +127,9 @@ class VirtualFunction(BaseResource):
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
 
-    Properties of a VirtualFunction:
-      See the sub-section 'Data model - Virtual Function Element Object'
-      of the section 'Partition object' in the :term:`HMC API`.
+    For the properties of a Virtual Function, see section
+    'Data model - Virtual Function Element Object' in section
+    'Partition object' in the :term:`HMC API` book.
     """
 
     def __init__(self, manager, uri, properties):
@@ -140,13 +137,13 @@ class VirtualFunction(BaseResource):
         Parameters:
 
           manager (:class:`~zhmcclient.VirtualFunctionManager`):
-            Manager object for this resource.
+            Manager object for this Virtual Function.
 
           uri (string):
-            Canonical URI path of the VirtualFunction object.
+            Canonical URI path of this Virtual Function.
 
           properties (dict):
-            Properties to be set for this resource object.
+            Properties to be set for this Virtual Function.
             See initialization of :class:`~zhmcclient.BaseResource` for
             details.
         """
@@ -155,7 +152,7 @@ class VirtualFunction(BaseResource):
 
     def delete(self):
         """
-        Deletes this Virtual Function.
+        Delete this Virtual Function.
 
         Raises:
 
@@ -168,14 +165,15 @@ class VirtualFunction(BaseResource):
 
     def update_properties(self, properties):
         """
-        Updates one or more of the writable properties of Virtual Function
-        with the specified resource properties.
+        Update writeable properties of this Virtual Function.
 
         Parameters:
 
-          properties (dict): Updated properties for the Virtual Function.
-            See the sub-section 'Data model - Virtual Function Element Object'
-            of the section 'Partition object' in the :term:`HMC API`.
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model - Virtual Function element object' in the
+            :term:`HMC API` book.
 
         Raises:
 

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -13,17 +13,14 @@
 # limitations under the License.
 
 """
-A Virtual Switch object is a virtualized representation of
-networking vswitch and port of a physical z Systems or LinuxONE computer
-that is in DPM mode (Dynamic Partition Manager mode).
-Objects of this class are not provided when the CPC is not in DPM mode.
-Network vswitchs without a physical port, such as hipersockets
-or single port OSAs are virtualized to a single virtual switch.
-Network vswitchs with multiple ports are virtualized into multiple virtual
-switches one for each port. Virtual switches are generated automatically
-every time a new network vswitch is detected and configured.
-The virtual switch serves as the connection point for network interfaces
-(VNICs) created by the virtual server administrator.
+A **Virtual Switch** is a virtualized networking switch connecting
+the NICs in Partitions with a Port on a Network Adapter.
+Virtual Switches are generated automatically every time a new Adapter
+is detected and configured.
+
+Virtual Switch resources are contained in CPC resources.
+
+Virtual Switches only exist in CPCs that are in DPM mode.
 """
 
 from __future__ import absolute_import
@@ -36,8 +33,7 @@ __all__ = ['VirtualSwitchManager', 'VirtualSwitch']
 
 class VirtualSwitchManager(BaseManager):
     """
-    Manager object for Virtual Switches. This manager object is scoped to the
-    vswitchs of a particular CPC.
+    Manager providing access to the Virtual Switches in a particular CPC.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
@@ -48,21 +44,20 @@ class VirtualSwitchManager(BaseManager):
         Parameters:
 
           cpc (:class:`~zhmcclient.Cpc`):
-            CPC defining the scope for this manager object.
+            CPC defining the scope for this manager.
         """
         super(VirtualSwitchManager, self).__init__(cpc)
 
     @property
     def cpc(self):
         """
-        :class:`~zhmcclient.Cpc`: Parent object (CPC) defining the scope for
-        this manager object.
+        :class:`~zhmcclient.Cpc`: CPC defining the scope for this manager.
         """
         return self._parent
 
     def list(self, full_properties=False):
         """
-        List the Virtual Switches in scope of this manager object.
+        List the Virtual Switches in this CPC.
 
         Parameters:
 
@@ -98,14 +93,13 @@ class VirtualSwitchManager(BaseManager):
 
 class VirtualSwitch(BaseResource):
     """
-    Representation of an VirtualSwitch.
+    Representation of a Virtual Switch.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
 
-    Properties of an VirtualSwitch:
-      See the sub-section 'Data model' of the section 'VirtualSwitch object'
-      in the :term:`HMC API`.
+    For the properties of a Virtual Switch, see section 'Data model'
+    in section 'Virtual Switch object' in the :term:`HMC API` book.
     """
 
     def __init__(self, manager, uri, properties):
@@ -113,13 +107,13 @@ class VirtualSwitch(BaseResource):
         Parameters:
 
           manager (:class:`~zhmcclient.VirtualSwitchManager`):
-            Manager object for this resource.
+            Manager object for this Virtual Switch.
 
           uri (string):
-            Canonical URI path of the VirtualSwitch object.
+            Canonical URI path of this Virtual Switch.
 
           properties (dict):
-            Properties to be set for this resource object.
+            Properties to be set for this Virtual Switch.
             See initialization of :class:`~zhmcclient.BaseResource` for
             details.
         """
@@ -128,8 +122,7 @@ class VirtualSwitch(BaseResource):
 
     def get_connected_vnics(self):
         """
-        Retrieves the list of network interfaces (VNICs)
-        connected to a single Virtual VirtualSwitch.
+        List the NICs connected to this Virtual Switch.
 
         Returns:
 
@@ -150,16 +143,15 @@ class VirtualSwitch(BaseResource):
 
     def update_properties(self, properties):
         """
-        Updates one or more of the writable properties of a vswitch
-        with the specified resource properties.
+        Update writeable properties of this Virtual Switch.
 
         Parameters:
 
-          properties (dict): Updated properties for the vswitch.
-            See the section in the :term:`HMC API` about
-            the specific HMC operation 'Update VirtualSwitch Properties'
-            description of the members of the passed properties
-            dict.
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model' in section 'Virtual Switch object' in the
+            :term:`HMC API` book.
 
         Raises:
 


### PR DESCRIPTION
Please review.

Details on documentation changes:

- Updated all references to specific sections of the HMC API book to be consistent, and to use section names that can be search in the HMC API book's PDF file.
- Updated descriptions of all resource modules (module level, manager classes, resource classes, and their methods and properties) to be consistent, and to improve the description quality.

Code changes:

- Renamed the 'properties' argument of `Partition.dump_partition()` to 'parameters', and adjusted the test case accordingly.