### PR TITLE
Add Port Support

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -99,6 +99,22 @@ Adapters
    :special-members: __str__
 
 
+.. _`Ports`:
+
+Ports
+-----
+
+.. automodule:: zhmcclient._port
+
+.. autoclass:: zhmcclient.PortManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.Port
+   :members:
+   :special-members: __str__
+
+
 .. _`NICs`:
 
 NICs

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Example 8: Using the Adapter, Virtual Switch, NIC, HBA
+Example 8: Using the Adapter, Port, Virtual Switch, NIC, HBA
            and Virtual Function interface.
 """
 
@@ -86,6 +86,12 @@ try:
         adapters = cpc.adapters.list()
         for i, adapter in enumerate(adapters):
             print('\t' + str(adapter))
+            ports = adapter.ports.list(full_properties=False)
+            for p, port in enumerate(ports):
+                if p == 0:
+                    print("\t\tListing Ports for %s ..." % adapter.properties['name'])
+#                port.pull_full_properties()
+                print('\t\t' + str(port))
         print("\tListing Virtual Switches for %s ..." % cpc.properties['name'])
         vswitches = cpc.vswitches.list()
         for i, vswitch in enumerate(vswitches):

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _port module.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+import requests_mock
+
+from zhmcclient import Session, Client
+
+
+class PortTests(unittest.TestCase):
+    """All tests for Port and PortManager classes."""
+
+    def setUp(self):
+        self.session = Session('port-dpm-host', 'port-user',
+                               'port-pwd')
+        self.client = Client(self.session)
+        with requests_mock.mock() as m:
+            # Because logon is deferred until needed, we perform it
+            # explicitly in order to keep mocking in the actual test simple.
+            m.post('/api/sessions', json={'api-session': 'port-session-id'})
+            self.session.logon()
+
+        self.cpc_mgr = self.client.cpcs
+        with requests_mock.mock() as m:
+            result = {
+                'cpcs': [
+                    {
+                        'object-uri': '/api/cpcs/port-cpc-id-1',
+                        'name': 'CPC',
+                        'status': 'service-required',
+                    }
+                ]
+            }
+            m.get('/api/cpcs', json=result)
+
+            cpcs = self.cpc_mgr.list()
+            self.cpc = cpcs[0]
+
+        adapter_mgr = self.cpc.adapters
+        with requests_mock.mock() as m:
+            self.result = {
+                'adapters': [
+                    {
+                        'adapter-family': 'ficon',
+                        'adapter-id': '18C',
+                        'type': 'fcp',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-1',
+                        'name': 'FCP Adapter 1',
+                        'port-count': 1,
+                        'storage-port-uris': [
+                            '/api/adapters/fake-adapter-id-1/storage-ports/0'
+                        ]
+                    },
+                    {
+                        'adapter-family': 'osa',
+                        'adapter-id': '1C4',
+                        'type': 'osd',
+                        'status': 'active',
+                        'object-uri': '/api/adapters/fake-adapter-id-2',
+                        'name': 'OSD Adapter 1',
+                        'port-count': 2,
+                        'network-port-uris': [
+                            '/api/adapters/fake-adapter-id-2/network-ports/0',
+                            '/api/adapters/fake-adapter-id-2/network-ports/1'
+                        ]
+                    },
+                    {
+                        'status': 'not-active',
+                        'configured-capacity': 3,
+                        'description': '',
+                        'parent': '/api/cpcs//port-cpc-id-1',
+                        'object-id': 'fake-adapter-id-3',
+                        'detected-card-type': 'zedc-express',
+                        'class': 'adapter',
+                        'name': 'zEDC 01CC Z15B-23',
+                        'used-capacity': 0,
+                        'adapter-id': '1CC',
+                        'maximum-total-capacity': 15,
+                        'adapter-family': 'accelerator',
+                        'allowed-capacity': 15,
+                        'state': 'reserved',
+                        'object-uri': '/api/adapters/fake-adapter-id-3',
+                        'card-location': 'Z15B-LG23',
+                        'type': 'zedc'
+                    }
+                ]
+            }
+
+            m.get('/api/cpcs/port-cpc-id-1/adapters', json=self.result)
+
+            adapters = adapter_mgr.list(full_properties=False)
+            self.adapters = adapters
+
+    def tearDown(self):
+        with requests_mock.mock() as m:
+            m.delete('/api/sessions/this-session', status_code=204)
+            self.session.logoff()
+
+    def test_init(self):
+        """Test __init__() on PortManager instance in Adapter."""
+        port_mgr = self.adapters[0].ports
+        self.assertEqual(port_mgr.adapter, self.adapters[0])
+
+    def test_list_short_ok(self):
+        """
+        Test successful list() with short set of properties on PortManager
+        instance in Adapter.
+        """
+        adapters = self.adapters
+        for idy, adapter in enumerate(adapters):
+            port_mgr = adapter.ports
+            ports = port_mgr.list(full_properties=False)
+            if len(ports) != 0:
+                result_adapter = self.result['adapters'][idy]
+                if 'storage-port-uris' in self.result['adapters'][idy]:
+                    self.result['adapters'][idy]
+                    storage_uris = result_adapter['storage-port-uris']
+                    uris = storage_uris
+                else:
+                    network_uris = result_adapter['network-port-uris']
+                    uris = network_uris
+                self.assertEqual(adapter.properties['port-count'], len(uris))
+            else:
+                uris = []
+
+            self.assertEqual(len(ports), len(uris))
+            for idx, port in enumerate(ports):
+                self.assertEqual(
+                    port.properties['element-uri'],
+                    uris[idx])
+                self.assertFalse(port.full_properties)
+                self.assertEqual(port.manager, port_mgr)
+
+    def test_list_full_ok(self):
+        """
+        Test successful list() with full set of properties on PortManager
+        instance in Adapter.
+        """
+        adapters = self.adapters
+        adapter = adapters[0]
+        with requests_mock.mock() as m:
+
+            mock_result_port1 = {
+                'parent': '/api/adapters/fake-adapter-id-1',
+                'index': 0,
+                'fabric-id': '',
+                'description': '',
+                'element-uri':
+                    '/api/adapters/fake-adapter-id-1/storage-ports/0',
+                'element-id': '0',
+                'class': 'storage-port',
+                'name': 'Port 0'
+            }
+
+            m.get('/api/adapters/fake-adapter-id-1/storage-ports/0',
+                  json=mock_result_port1)
+
+            port_mgr = adapter.ports
+            ports = port_mgr.list(full_properties=True)
+            if len(ports) != 0:
+                storage_uris = self.result['adapters'][0]['storage-port-uris']
+                self.assertEqual(adapter.properties['port-count'],
+                                 len(storage_uris))
+            else:
+                storage_uris = []
+
+            self.assertEqual(len(ports), len(storage_uris))
+            for idx, port in enumerate(ports):
+                self.assertEqual(
+                    port.properties['element-uri'],
+                    storage_uris[idx])
+                self.assertTrue(port.full_properties)
+                self.assertEqual(port.manager, port_mgr)
+
+    def test_update_properties(self):
+        """
+        This tests the 'Update Port Properties' operation.
+        """
+        port_mgr = self.adapters[0].ports
+        ports = port_mgr.list(full_properties=False)
+        port = ports[0]
+        with requests_mock.mock() as m:
+            result = {}
+            m.post(
+                '/api/adapters/fake-adapter-id-1/storage-ports/0',
+                json=result)
+            status = port.update_properties(properties={})
+            self.assertEqual(status, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -38,3 +38,4 @@ from ._nic import *           # noqa: F401
 from ._hba import *           # noqa: F401
 from ._virtual_function import *       # noqa: F401
 from ._virtual_switch import *         # noqa: F401
+from ._port import *          # noqa: F401

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -64,6 +64,7 @@ from __future__ import absolute_import
 
 from ._manager import BaseManager
 from ._resource import BaseResource
+from ._port import PortManager
 
 __all__ = ['AdapterManager', 'Adapter']
 
@@ -192,6 +193,18 @@ class Adapter(BaseResource):
         #     details.
         assert isinstance(manager, AdapterManager)
         super(Adapter, self).__init__(manager, uri, properties)
+        self._ports = None
+
+    @property
+    def ports(self):
+        """
+        :class:`~zhmcclient.PortManager`: Manager object for the
+        Ports in this Adapter.
+        """
+        # We do here some lazy loading.
+        if not self._ports:
+            self._ports = PortManager(self)
+        return self._ports
 
     def delete(self):
         """

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -1,0 +1,151 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A **Port** represents a commuportation endpoint of an Adapter
+of a physical z Systems or LinuxONE computer that is in DPM mode
+(Dynamic Partition Manager mode).
+Objects of this class are not provided when the CPC is not in DPM mode.
+A Port is always contained in an Adapter.
+"""
+
+from __future__ import absolute_import
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+
+__all__ = ['PortManager', 'Port']
+
+
+class PortManager(BaseManager):
+    """
+    Manager object for Ports. This manager object is scoped to the Ports
+    of a particular Adapter.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+    """
+
+    def __init__(self, adapter):
+        """
+        Parameters:
+
+          adapter (:class:`~zhmcclient.Adapter`):
+             defining the scope for this manager object.
+        """
+        super(PortManager, self).__init__(adapter)
+
+    @property
+    def adapter(self):
+        """
+        :class:`~zhmcclient.Adapter`: Parent object (Adapter)
+        defining the scope for this manager object.
+        """
+        return self._parent
+
+    def list(self, full_properties=False):
+        """
+        List the Portis of this Adapter.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.Port` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        port_list = []
+        storage_family = ('ficon')
+        network_family = ('osa', 'roce', 'hipersockets')
+        if self.adapter.get_property('adapter-family') in storage_family:
+            ports_res = self.adapter.get_property('storage-port-uris')
+        elif self.adapter.get_property('adapter-family') in network_family:
+            ports_res = self.adapter.get_property('network-port-uris')
+        else:
+            return port_list
+        if ports_res:
+            for port_uri in ports_res:
+                port = Port(self, port_uri, {'element-uri': port_uri})
+                if full_properties:
+                    port.pull_full_properties()
+                port_list.append(port)
+        return port_list
+
+
+class Port(BaseResource):
+    """
+    Representation of an :term:`Port`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    For the properties of an Port resource, see section
+    'Data model - Port Element Object' in section 'Adapter object' in the
+    :term:`HMC API` book.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.PortManager`).
+    """
+
+    def __init__(self, manager, uri, properties):
+        """
+        Parameters:
+
+          manager (:class:`~zhmcclient.PortManager`):
+            Manager object for this resource.
+
+          uri (string):
+            Canoportal URI path of the Port object.
+
+          properties (dict):
+            Properties to be set for this resource object.
+            See initialization of :class:`~zhmcclient.BaseResource` for
+            details.
+        """
+        assert isinstance(manager, PortManager)
+        super(Port, self).__init__(manager, uri, properties)
+
+    def update_properties(self, properties):
+        """
+        Updates one or more of the writable properties of Port
+        with the specified resource properties.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model - Port Element Object' in the
+            :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self._uri, body=properties)

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -191,7 +191,8 @@ class BaseResource(object):
                 status=service-required)
         """
         properties_keys = self._properties.keys()
-        search_keys = ['status', 'object-uri', 'element-uri', 'name', 'type']
+        search_keys = ['status', 'object-uri', 'element-uri', 'name',
+                       'type', 'class']
         sorted_keys = sorted([k for k in properties_keys if k in search_keys])
         info = ", ".join("%s=%s" % (k, self._properties[k])
                          for k in sorted_keys)


### PR DESCRIPTION
Details:
- Add PortManager class.
- Add Port class.
- Add PortManager to Adapter class.
- Add Adapter to documentation reference.
- Add Port to example (example8.py).
- Add 'class' if available to __str__ of BaseResource.
- Add Unit Tests for PortManager and Port.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>