### PR TITLE
Updated documentation of resources classes, part 2.

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -23,6 +23,26 @@ This section contains information that is referenced from other sections,
 and that does not really need to be read in sequence.
 
 
+.. _`BaseManager`:
+.. _`BaseResource`:
+.. _`Base classes for resources`:
+
+Base classes for resources
+--------------------------
+
+.. automodule:: zhmcclient._manager
+
+.. autoclass:: zhmcclient.BaseManager
+   :members:
+   :special-members: __str__
+
+.. automodule:: zhmcclient._resource
+
+.. autoclass:: zhmcclient.BaseResource
+   :members:
+   :special-members: __str__
+
+
 .. _'Special type names`:
 
 Special type names
@@ -91,37 +111,46 @@ attaching storage.
 
 .. glossary::
 
-  accelerator adapter
-     Short term for an :term:`adapter` providing accelerator functions (e.g.
-     for data compression).
+  Activation Profile
+     A general term for specific activation profiles:
 
-  adapter
-     A physical adapter card (e.g. OSA-Express network adapter, FCP storage
-     adapter, accelerator adapter, crypto adapter) or a non-physical adapter
-     (e.g. HiperSockets switch) of a :term:`CPC` in DPM mode.
+     * :term:`Reset Activation Profile`
+     * :term:`Image Activation Profile`
+     * :term:`Load Activation Profile`
+
+     Scope: CPC in classic (or ensemble) mode
+
+  Accelerator Adapter
+     Short term for an :term:`Adapter` providing accelerator functions (e.g.
+     the z Systems Enterprise Data Compression (zEDC) adapter for data
+     compression).
+
+  Adapter
+     A physical adapter card (e.g. OSA-Express adapter, Crypto adapter) or a
+     logical adapter (e.g. HiperSockets switch).
 
      For details, see section :ref:`Adapters`.
 
      Scope: CPC in DPM mode
 
-  adapter port
-     The physical connector port of an :term:`adapter`.
+  Adapter Port
+     The physical connector port (jack) of an :term:`Adapter`.
 
      For details, see section :ref:`Adapter ports`.
 
      Scope: CPC in DPM mode
 
-  capacity group
+  Capacity Group
      TBD
 
      Scope: CPC in DPM mode
 
-  capacity record
+  Capacity Record
      TBD
 
      Scope: CPC in any mode
 
-  console
+  Console
      TBD
 
      Scope: HMC
@@ -133,57 +162,57 @@ attaching storage.
 
      Scope: CPC
 
-  crypto adapter
-     Short term for an :term:`adapter` providing cryptographic functions.
+  Crypto Adapter
+     Short term for an :term:`Adapter` providing cryptographic functions.
 
-  FCP adapter
-     Short term for a :term:`storage adapter` supporting FCP.
+  FCP Adapter
+     Short term for a :term:`Storage Adapter` supporting FCP.
 
-  group
+  Group
      TBD
 
      Scope: HMC
 
-  group profile
+  Group Profile
      TBD
 
      Scope: CPC in classic (or ensemble) mode
 
-  hardware message
+  Hardware Message
      TBD
 
      Scope: HMC, and CPC in any mode
 
   HBA
   vHBA
-     Host Bus Adapter, a virtualized FCP :term:`adapter` that is available to
-     a :term:`partition`.
+     A logical entity that provides a :term:`Partition` with access to
+     external storage area networks (SANs) through an :term:`FCP Adapter`.
 
      For details, see section :ref:`HBAs`.
 
      Scope: CPC in DPM mode
 
-  image activation profile
+  Image Activation Profile
      TBD
 
      Scope: CPC in classic (or ensemble) mode
 
-  job
+  Job
      TBD
 
      Scope: HMC
 
-  LDAP server definition
+  LDAP Server Definition
      TBD
 
      Scope: HMC
 
-  load activation profile
+  Load Activation Profile
      TBD
 
      Scope: CPC in classic (or ensemble) mode
 
-  logical partition
+  Logical Partition
   LPAR
      A subset of the hardware resources of a :term:`CPC` in classic mode (or
      ensemble mode), virtualized as a separate computer.
@@ -192,28 +221,29 @@ attaching storage.
 
      Scope: CPC in classic (or ensemble) mode
 
-  metrics context
+  Metrics Context
      TBD
 
      Scope: HMC
 
-  network adapter
-     Short term for an :term:`adapter` for attaching networks (e.g. OSA-Express
+  Network Adapter
+     Short term for an :term:`Adapter` for attaching networks (e.g. OSA-Express
      adapter).
 
-  network port
-     Short term for an :term:`adapter port` of a :term:`network adapter`.
+  Network Port
+     Short term for an :term:`Adapter Port` of a :term:`Network Adapter`.
 
   NIC
   vNIC
-     Network Interface Card, a virtualized :term:`network adapter` that is
-     available to a :term:`partition`.
+     Network Interface Card, a logical entity that provides a
+     :term:`Partition` with access to external communication networks through a
+     :term:`Network Adapter`.
 
      For details, see section :ref:`NICs`.
 
      Scope: CPC in DPM mode
 
-  partition
+  Partition
      A subset of the hardware resources of a :term:`CPC` in DPM mode,
      virtualized as a separate computer.
 
@@ -221,69 +251,65 @@ attaching storage.
 
      Scope: CPC in DPM mode
 
-  password rule
+  Password Rule
      TBD
 
      Scope: HMC
 
-  reset activation profile
+  Reset Activation Profile
      TBD
 
      Scope: CPC in classic (or ensemble) mode
 
-  session
+  Session
      TBD
 
      Scope: HMC
 
-  storage adapter
-     Short term for an :term:`adapter` for attaching storage (e.g. FCP
-     adapter).
+  Storage Adapter
+     Short term for an :term:`Adapter` for attaching storage.
 
-  storage port
-     Short term for an :term:`adapter port` of a :term:`storage adapter`.
+  Storage Port
+     Short term for an :term:`Adapter Port` of a :term:`Storage Adapter`.
 
-  task
+  Task
      TBD
 
      Scope: HMC
 
-  user
+  User
      TBD
 
      Scope: HMC
 
-  user pattern
+  User Pattern
      TBD
 
      Scope: HMC
 
-  user role
+  User Role
      TBD
 
      Scope: HMC
 
-  virtual function
-     A virtualized function of an :term:`accelerator adapter` (e.g. zEDC
-     compression adapter) or :term:`crypto adapter` that is available to a
-     :term:`partition`.
+  Virtual Function
+     A logical entity that provides a :term:`Partition` with access to
+     :term:`Accelerator Adapters <Accelerator Adapter>`.
 
      For details, see section :ref:`Virtual functions`.
 
      Scope: CPC in DPM mode
 
-  virtual machine
+  Virtual Machine
      TBD
 
      Scope: CPC in classic (or ensemble) mode
 
-  virtual switch
-     A virtualized switch that connects a :term:`network port` with the
-     :term:`NIC <NICs>` assigned to the :term:`partition <partitions>`. Virtual
-     switches are generated automatically every time a new network
-     :term:`adapter` is detected and configured.
+  Virtual Switch
+     A virtualized networking switch connecting :term:`NICs <NIC>` with a
+     :term:`Network Port`.
 
-     For details, see section :ref:`NICs`.
+     For details, see section :ref:`Virtual switches`.
 
      Scope: CPC in DPM mode
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -19,26 +19,6 @@ Reference: Resources
 ====================
 
 
-.. _`BaseManager`:
-.. _`BaseResource`:
-.. _`Base classes for resources`:
-
-Base classes for resources
---------------------------
-
-.. automodule:: zhmcclient._manager
-
-.. autoclass:: zhmcclient.BaseManager
-   :members:
-   :special-members: __str__
-
-.. automodule:: zhmcclient._resource
-
-.. autoclass:: zhmcclient.BaseResource
-   :members:
-   :special-members: __str__
-
-
 .. _`CPCs`:
 
 CPCs

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 """
-**Activation Profiles** control the activation of CPCs and LPARs. They are used
-to tailor the operation of a CPC and are stored in the Support Element
-associated with the CPC.
+**Activation Profiles** control the activation of :term:`CPCs <CPC>` and
+:term:`LPARs <LPAR>`. They are used to tailor the operation of a CPC and are
+stored in the Support Element associated with the CPC.
 
 Activation Profile resources are contained in CPC resources.
 
@@ -56,45 +56,47 @@ __all__ = ['ActivationProfileManager', 'ActivationProfile']
 
 class ActivationProfileManager(BaseManager):
     """
-    Manager providing access to the Activation Profiles of a particular type in
-    a particular CPC.
+    Manager providing access to the
+    :term:`Activation Profiles <Activation Profile>` of a particular type in
+    a particular :term:`CPC`.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case, the
+    :class:`~zhmcclient.Cpc` object).
     """
 
     def __init__(self, cpc, profile_type):
-        """
-        Parameters:
-
-          cpc (:class:`~zhmcclient.Cpc`):
-            CPC defining the scope for this manager.
-
-          profile_type (string):
-            Type of Activation Profiles:
-
-            * `reset`: Reset Activation Profiles
-            * `image`: Image Activation Profiles
-            * `load`: Load Activation Profiles
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   cpc (:class:`~zhmcclient.Cpc`):
+        #     CPC defining the scope for this manager.
+        #   profile_type (string):
+        #     Type of Activation Profiles:
+        #     * `reset`: Reset Activation Profiles
+        #     * `image`: Image Activation Profiles
+        #     * `load`: Load Activation Profiles
         super(ActivationProfileManager, self).__init__(cpc)
         self._profile_type = profile_type
 
     @property
     def cpc(self):
         """
-        :class:`~zhmcclient.Cpc`: CPC defining the scope for this manager.
+        :class:`~zhmcclient.Cpc`: :term:`CPC` defining the scope for this
+        manager.
         """
         return self._parent
 
     @property
     def profile_type(self):
         """
-        Return the type of the Activation Profiles managed by this object:
+        :term:`string`: Type of the Activation Profiles managed by this object:
 
-        * `reset`: Reset Activation Profiles
-        * `image`: Image Activation Profiles
-        * `load`: Load Activation Profiles
+        * ``'reset'`` - Reset Activation Profiles
+        * ``'image'`` - Image Activation Profiles
+        * ``'load'`` - Load Activation Profiles
         """
         return self._profile_type
 
@@ -140,27 +142,27 @@ class ActivationProfileManager(BaseManager):
 
 class ActivationProfile(BaseResource):
     """
-    Representation of an Activation Profile of a particular type.
+    Representation of an :term:`Activation Profile` of a particular type.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.ActivationProfileManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.ActivationProfileManager`):
-            Manager for this Activation Profile.
-
-          uri (string):
-            Canonical URI path of this Activation Profile.
-
-          properties (dict):
-            Properties to be set for this Activation Profile.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.ActivationProfileManager`):
+        #     Manager for this Activation Profile.
+        #   uri (string):
+        #     Canonical URI path of this Activation Profile.
+        #   properties (dict):
+        #     Properties to be set for this Activation Profile.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, ActivationProfileManager)
         super(ActivationProfile, self).__init__(manager, uri, properties)
 

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -13,30 +13,29 @@
 # limitations under the License.
 
 """
-An **Adapter** resource represents a single adapter in a CPC.
-Most of the adapters are physical adapters which are installed in the I/O
-drawer of a CPC, but there also are not-physical adapters like HiperSockets.
+An **Adapter** is a physical adapter card (e.g. OSA-Express adapter, Crypto
+adapter) or a logical adapter (e.g. HiperSockets switch).
 
-Adapter resources resources are contained in CPC resources.
+Adapter resources are contained in CPC resources.
 
 Adapters only exist in CPCs that are in DPM mode.
 
 There are four types of Adapters:
 
-1. Network:
+1. Network Adapters:
    Network adapters enable communication through different networking
    transport protocols. These network adapters are OSA-Express,
-   HiperSockets and 10 GbE RoCE Express.
+   HiperSockets and RoCE-Express.
    DPM automatically discovers OSA-Express and RoCE-Express adapters
    because they are physical cards that are installed on the CPC.
-   In contrast, HiperSockets are not physical adapters and must be
-   installed and configured by an administrator using the 'Create Hipersocket'
+   In contrast, HiperSockets are logical adapters and must be
+   created and configured by an administrator using the 'Create Hipersocket'
    operation (see create_hipersocket()).
-   Network interface cards (NICs) provide a partition with access to networks.
+   Network Interface Cards (NICs) provide a partition with access to networks.
    Each NIC represents a unique connection between the partition
    and a specific network adapter.
 
-2. Storage:
+2. Storage Adapters:
    Fibre Channel connections provide high-speed connections between CPCs
    and storage devices.
    DPM automatically discovers any storage adapters installed on the CPC.
@@ -45,8 +44,8 @@ There are four types of Adapters:
    Each HBA represents a unique connection between the partition
    and a specific storage adapter.
 
-3. Accelerators:
-   Accelerators are adapters that provide specialized functions to
+3. Accelerator Adapters:
+   Accelerator adapters provide specialized functions to
    improve performance or use of computer resource like the IBM System z
    Enterprise Data Compression (zEDC) feature.
    DPM automatically discovers accelerators that are installed on the CPC.
@@ -55,8 +54,8 @@ There are four types of Adapters:
    Each virtual function represents a unique connection between
    the partition and a physical feature card.
 
-4. Cryptos:
-   Cryptos are adapters that provide cryptographic processing functions.
+4. Crypto Adapters:
+   Crypto adapters provide cryptographic processing functions.
    DPM automatically discovers cryptographic features that are installed
    on the CPC.
 """
@@ -71,25 +70,29 @@ __all__ = ['AdapterManager', 'Adapter']
 
 class AdapterManager(BaseManager):
     """
-    Manager providing access to the Adapters in a particular CPC.
+    Manager providing access to the :term:`Adapters <Adapter>` in a particular
+    :term:`CPC`.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case, the
+    :class:`~zhmcclient.Cpc` object).
     """
 
     def __init__(self, cpc):
-        """
-        Parameters:
-
-          cpc (:class:`~zhmcclient.Cpc`):
-            CPC defining the scope for this manager.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   cpc (:class:`~zhmcclient.Cpc`):
+        #     CPC defining the scope for this manager.
         super(AdapterManager, self).__init__(cpc)
 
     @property
     def cpc(self):
         """
-        :class:`~zhmcclient.Cpc`: CPC defining the scope for this manager.
+        :class:`~zhmcclient.Cpc`: :term:`CPC` defining the scope for this
+        manager.
         """
         return self._parent
 
@@ -130,7 +133,7 @@ class AdapterManager(BaseManager):
 
     def create_hipersocket(self, properties):
         """
-        Create and configure a HiperSockets Adapter.
+        Create and configure a HiperSockets Adapter in this CPC.
 
         Parameters:
 
@@ -140,7 +143,8 @@ class AdapterManager(BaseManager):
 
         Returns:
 
-          Adapter: The resource object for the new HiperSockets adapter.
+          Adapter:
+            The resource object for the new HiperSockets Adapter.
             The object will have its 'object-uri' property set as returned by
             the HMC, and will also have the input properties set.
 
@@ -162,36 +166,38 @@ class AdapterManager(BaseManager):
 
 class Adapter(BaseResource):
     """
-    Representation of an Adapter.
+    Representation of an :term:`Adapter`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
 
     For the properties of an Adapter, see section 'Data model' in section
     'Adapter object' in the :term:`HMC API` book.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.AdapterManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.AdapterManager`):
-            Manager for this Adapter.
-
-          uri (string):
-            Canonical URI path of this Adapter.
-
-          properties (dict):
-            Properties to be set for this Adapter.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.AdapterManager`):
+        #     Manager for this Adapter.
+        #   uri (string):
+        #     Canonical URI path of this Adapter.
+        #   properties (dict):
+        #     Properties to be set for this Adapter.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, AdapterManager)
         super(Adapter, self).__init__(manager, uri, properties)
 
     def delete(self):
         """
         Delete this Adapter.
+
+        The Adapter must be a HiperSockets Adapter.
 
         Raises:
 

--- a/zhmcclient/_client.py
+++ b/zhmcclient/_client.py
@@ -96,7 +96,7 @@ class Client(object):
 
           :term:`json object`:
             A JSON object with members ``api-major-version``,
-           ``api-minor-version``, ``hmc-version`` and ``hmc-name``.
+            ``api-minor-version``, ``hmc-version`` and ``hmc-name``.
             For details about these properties, see section
             'Response body contents' in section 'Query API Version' in the
             :term:`HMC API` book.

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -14,7 +14,9 @@
 
 """
 A **Central Processor Complex (CPC)** is a physical z Systems or LinuxONE
-computer. A particular HMC can manage multiple CPCs.
+computer.
+
+A particular HMC can manage multiple CPCs.
 
 The HMC can manage a range of old and new CPC generations. Some older CPC
 generations are not capable of supporting the HMC Web Services API; these older
@@ -55,20 +57,22 @@ __all__ = ['CpcManager', 'Cpc']
 
 class CpcManager(BaseManager):
     """
-    Manager providing access to the CPCs exposed by the HMC this client is
-    connected to.
+    Manager providing access to the :term:`CPCs <CPC>` exposed by the HMC this
+    client is connected to.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case,
+    the :class:`~zhmcclient.Client` object connecting to the HMC).
     """
 
     def __init__(self, client):
-        """
-        Parameters:
-
-          client (:class:`~zhmcclient.Client`):
-            Client object for the HMC to be used.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   client (:class:`~zhmcclient.Client`):
+        #      Client object for the HMC to be used.
         super(CpcManager, self).__init__()
         self._session = client.session
 
@@ -109,27 +113,27 @@ class CpcManager(BaseManager):
 
 class Cpc(BaseResource):
     """
-    Representation of a CPC.
+    Representation of a :term:`CPC`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.CpcManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.CpcManager`):
-            Manager for this CPC.
-
-          uri (string):
-            Canonical URI path of this CPC.
-
-          properties (dict):
-            Properties to be set for this CPC.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.CpcManager`):
+        #     Manager for this CPC.
+        #   uri (string):
+        #     Canonical URI path of this CPC.
+        #   properties (dict):
+        #     Properties to be set for this CPC.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, CpcManager)
         super(Cpc, self).__init__(manager, uri, properties)
         # We do here some lazy loading.
@@ -145,7 +149,8 @@ class Cpc(BaseResource):
     @_log_call
     def lpars(self):
         """
-        :class:`~zhmcclient.LparManager`: Access to the LPARs in this CPC.
+        :class:`~zhmcclient.LparManager`: Access to the :term:`LPARs <LPAR>` in
+        this CPC.
         """
         # We do here some lazy loading.
         if not self._lpars:
@@ -156,8 +161,8 @@ class Cpc(BaseResource):
     @_log_call
     def partitions(self):
         """
-        :class:`~zhmcclient.PartitionManager`: Access to the Partitions in this
-        CPC.
+        :class:`~zhmcclient.PartitionManager`: Access to the
+        :term:`Partitions <Partition>` in this CPC.
         """
         # We do here some lazy loading.
         if not self._partitions:
@@ -168,8 +173,8 @@ class Cpc(BaseResource):
     @_log_call
     def adapters(self):
         """
-        :class:`~zhmcclient.AdapterManager`: Access to the Adapters in this
-        CPC.
+        :class:`~zhmcclient.AdapterManager`: Access to the
+        :term:`Adapters <Adapter>` in this CPC.
         """
         # We do here some lazy loading.
         if not self._adapters:
@@ -180,8 +185,8 @@ class Cpc(BaseResource):
     @_log_call
     def vswitches(self):
         """
-        :class:`~zhmcclient.VirtualSwitchManager`: Access to the Virtual
-        Switches in this CPC.
+        :class:`~zhmcclient.VirtualSwitchManager`: Access to the
+        :term:`Virtual Switches <Virtual Switch>` in this CPC.
         """
         # We do here some lazy loading.
         if not self._vswitches:
@@ -192,8 +197,9 @@ class Cpc(BaseResource):
     @_log_call
     def reset_activation_profiles(self):
         """
-        :class:`~zhmcclient.ActivationManager`: Access to the Reset
-        Activation Profiles in this CPC.
+        :class:`~zhmcclient.ActivationProfileManager`: Access to the
+        :term:`Reset Activation Profiles <Reset Activation Profile>` in this
+        CPC.
         """
         # We do here some lazy loading.
         if not self._reset_activation_profiles:
@@ -205,8 +211,9 @@ class Cpc(BaseResource):
     @_log_call
     def image_activation_profiles(self):
         """
-        :class:`~zhmcclient.ActivationManager`: Access to the Image
-        Activation Profiles in this CPC.
+        :class:`~zhmcclient.ActivationProfileManager`: Access to the
+        :term:`Image Activation Profiles <Image Activation Profile>` in this
+        CPC.
         """
         # We do here some lazy loading.
         if not self._image_activation_profiles:
@@ -218,8 +225,9 @@ class Cpc(BaseResource):
     @_log_call
     def load_activation_profiles(self):
         """
-        :class:`~zhmcclient.ActivationManager`: Access to the Load
-        Activation Profiles in this CPC.
+        :class:`~zhmcclient.ActivationProfileManager`: Access to the
+        :term:`Load Activation Profiles <load Activation Profile>` in this
+        CPC.
         """
         # We do here some lazy loading.
         if not self._load_activation_profiles:

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 """
-A **Host Bus Adapter (HBA)** provides a Partition with access to external
-storage area networks (SANs) through a storage adapter.
+A **Host Bus Adapter (HBA)** is a logical entity that provides a
+:term:`Partition` with access to external storage area networks (SANs) through
+an :term:`FCP Adapter`. More specifically, an HBA connects a Partition with an
+:term:`Adapter Port` on an FCP Adapter.
 
 HBA resources are contained in Partition resources.
 
-HBAs only exist in CPCs that are in DPM mode.
+HBAs only exist in :term:`CPCs <CPC>` that are in DPM mode.
 """
 
 from __future__ import absolute_import
@@ -31,26 +33,29 @@ __all__ = ['HbaManager', 'Hba']
 
 class HbaManager(BaseManager):
     """
-    Manager providing access to the HBAs in a particular Partition.
+    Manager providing access to the :term:`HBAs <HBA>` in a particular
+    :term:`Partition`.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case, the
+    :class:`~zhmcclient.Partition` object).
     """
 
     def __init__(self, partition):
-        """
-        Parameters:
-
-          partition (:class:`~zhmcclient.Partition`):
-            Partition defining the scope for this manager.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   partition (:class:`~zhmcclient.Partition`):
+        #     Partition defining the scope for this manager.
         super(HbaManager, self).__init__(partition)
 
     @property
     def partition(self):
         """
-        :class:`~zhmcclient.Partition`: Partition defining the scope for this
-        manager.
+        :class:`~zhmcclient.Partition`: :term:`Partition` defining the scope
+        for this manager.
         """
         return self._parent
 
@@ -98,7 +103,8 @@ class HbaManager(BaseManager):
 
         Returns:
 
-          Hba: The resource object for the new HBA.
+          Hba:
+            The resource object for the new HBA.
             The object will have its 'element-uri' property set as returned by
             the HMC, and will also have the input properties set.
 
@@ -120,7 +126,7 @@ class HbaManager(BaseManager):
 
 class Hba(BaseResource):
     """
-    Representation of an HBA.
+    Representation of an :term:`HBA`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
@@ -128,23 +134,23 @@ class Hba(BaseResource):
     For the properties of an HBA resource, see section
     'Data model - HBA Element Object' in section 'Partition object' in the
     :term:`HMC API` book.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.HbaManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.HbaManager`):
-            Manager for this HBA.
-
-          uri (string):
-            Canonical URI path of this HBA.
-
-          properties (dict):
-            Properties to be set for this HBA.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.HbaManager`):
+        #     Manager for this HBA.
+        #   uri (string):
+        #     Canonical URI path of this HBA.
+        #   properties (dict):
+        #     Properties to be set for this HBA.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, HbaManager)
         super(Hba, self).__init__(manager, uri, properties)
 

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -36,25 +36,29 @@ __all__ = ['LparManager', 'Lpar']
 
 class LparManager(BaseManager):
     """
-    Manager providing access to the LPARs in a particular CPC.
+    Manager providing access to the :term:`LPARs <LPAR>` in a particular
+    :term:`CPC`.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case, the
+    :class:`~zhmcclient.Cpc` object).
     """
 
     def __init__(self, cpc):
-        """
-        Parameters:
-
-          cpc (:class:`~zhmcclient.Cpc`):
-            CPC defining the scope for this manager.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   cpc (:class:`~zhmcclient.Cpc`):
+        #     CPC defining the scope for this manager.
         super(LparManager, self).__init__(cpc)
 
     @property
     def cpc(self):
         """
-        :class:`~zhmcclient.Cpc`: CPC defining the scope for this manager.
+        :class:`~zhmcclient.Cpc`: :term:`CPC` defining the scope for this
+        manager.
         """
         return self._parent
 
@@ -96,27 +100,27 @@ class LparManager(BaseManager):
 
 class Lpar(BaseResource):
     """
-    Representation of an LPAR.
+    Representation of an :term:`LPAR`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.LparManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.LparManager`):
-            Manager object for this LPAR.
-
-          uri (string):
-            Canonical URI path of this LPAR.
-
-          properties (dict):
-            Properties to be set for this LPAR.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.LparManager`):
+        #     Manager object for this LPAR.
+        #   uri (string):
+        #     Canonical URI path of this LPAR.
+        #   properties (dict):
+        #     Properties to be set for this LPAR.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, LparManager)
         super(Lpar, self).__init__(manager, uri, properties)
 

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 """
-A **Network Interface Card (NIC)** provides a Partition with access to external
-communication networks through a network adapter.
+A **Network Interface Card (NIC)** is a logical entity that provides a
+:term:`Partition` with access to external communication networks through a
+:term:`Network Adapter`. More specifically, a NIC connects a Partition with a
+:term:`Network Port`, or with a :term:`Virtual Switch` which then connects to
+the Network Port.
 
 NIC resources are contained in Partition resources.
 
-NICs only exist in CPCs that are in DPM mode.
+NICs only exist in :term:`CPCs <CPC>` that are in DPM mode.
 """
 
 from __future__ import absolute_import
@@ -31,26 +34,29 @@ __all__ = ['NicManager', 'Nic']
 
 class NicManager(BaseManager):
     """
-    Manager providing access to the NICs in a particular Partition.
+    Manager providing access to the :term:`NICs <NIC>` in a particular
+    :term:`Partition`.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case, the
+    :class:`~zhmcclient.Partition` object).
     """
 
     def __init__(self, partition):
-        """
-        Parameters:
-
-          partition (:class:`~zhmcclient.Partition`):
-            Partition defining the scope for this manager.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   partition (:class:`~zhmcclient.Partition`):
+        #     Partition defining the scope for this manager.
         super(NicManager, self).__init__(partition)
 
     @property
     def partition(self):
         """
-        :class:`~zhmcclient.Partition`: Partition defining the scope for this
-        manager.
+        :class:`~zhmcclient.Partition`: :term:`Partition` defining the scope
+        for this manager.
         """
         return self._parent
 
@@ -98,7 +104,8 @@ class NicManager(BaseManager):
 
         Returns:
 
-          Nic: The resource object for the new NIC.
+          Nic:
+            The resource object for the new NIC.
             The object will have its 'element-uri' property set as returned by
             the HMC, and will also have the input properties set.
 
@@ -120,7 +127,7 @@ class NicManager(BaseManager):
 
 class Nic(BaseResource):
     """
-    Representation of a NIC resource.
+    Representation of a :term:`NIC`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
@@ -128,29 +135,29 @@ class Nic(BaseResource):
     For the properties of a NIC resource, see section
     'Data model - NIC Element Object' in section 'Partition object' in the
     :term:`HMC API` book.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.NicManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.NicManager`):
-            Manager for this resource.
-
-          uri (string):
-            Canonical URI path of this resource.
-
-          properties (dict):
-            Properties to be set for this resource.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.NicManager`):
+        #     Manager for this resource.
+        #   uri (string):
+        #     Canonical URI path of this resource.
+        #   properties (dict):
+        #     Properties to be set for this resource.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, NicManager)
         super(Nic, self).__init__(manager, uri, properties)
 
     def delete(self):
         """
-        Delete this NIC resource.
+        Delete this NIC.
 
         Raises:
 

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -43,25 +43,29 @@ __all__ = ['PartitionManager', 'Partition']
 
 class PartitionManager(BaseManager):
     """
-    Manager providing access to the Partitions in a particular CPC.
+    Manager providing access to the :term:`Partitions <Partition>` in a
+    particular :term:`CPC`.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case, the
+    :class:`~zhmcclient.Cpc` object).
     """
 
     def __init__(self, cpc):
-        """
-        Parameters:
-
-          cpc (:class:`~zhmcclient.Cpc`):
-            CPC defining the scope for this manager.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   cpc (:class:`~zhmcclient.Cpc`):
+        #     CPC defining the scope for this manager.
         super(PartitionManager, self).__init__(cpc)
 
     @property
     def cpc(self):
         """
-        :class:`~zhmcclient.Cpc`: CPC defining the scope for this manager.
+        :class:`~zhmcclient.Cpc`: :term:`CPC` defining the scope for this
+        manager.
         """
         return self._parent
 
@@ -102,7 +106,7 @@ class PartitionManager(BaseManager):
 
     def create(self, properties):
         """
-        Create a Partition in this CPC.
+        Create and configure a Partition in this CPC.
 
         Parameters:
 
@@ -112,7 +116,8 @@ class PartitionManager(BaseManager):
 
         Returns:
 
-          Partition: The resource object for the new partition.
+          Partition:
+            The resource object for the new Partition.
             The object will have its 'object-uri' property set as returned by
             the HMC, and will also have the input properties set.
 
@@ -134,27 +139,27 @@ class PartitionManager(BaseManager):
 
 class Partition(BaseResource):
     """
-    Representation of a Partition.
+    Representation of a :term:`Partition`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.PartitionManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.PartitionManager`):
-            Manager for this Partition.
-
-          uri (string):
-            Canonical URI path of this Partition.
-
-          properties (dict):
-            Properties to be set for this Partition.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.PartitionManager`):
+        #     Manager for this Partition.
+        #   uri (string):
+        #     Canonical URI path of this Partition.
+        #   properties (dict):
+        #     Properties to be set for this Partition.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, PartitionManager)
         super(Partition, self).__init__(manager, uri, properties)
         self._nics = None
@@ -165,8 +170,8 @@ class Partition(BaseResource):
     @_log_call
     def nics(self):
         """
-        :class:`~zhmcclient.NicManager`: Access to the NICs in this
-        Partition.
+        :class:`~zhmcclient.NicManager`: Access to the :term:`NICs <NIC>` in
+        this Partition.
         """
         # We do here some lazy loading.
         if not self._nics:
@@ -177,8 +182,8 @@ class Partition(BaseResource):
     @_log_call
     def hbas(self):
         """
-        :class:`~zhmcclient.NicManager`: Access to the HBAs in this
-        Partition.
+        :class:`~zhmcclient.NicManager`: Access to the :term:`HBAs <HBA>` in
+        this Partition.
         """
         # We do here some lazy loading.
         if not self._hbas:
@@ -190,7 +195,7 @@ class Partition(BaseResource):
     def virtual_functions(self):
         """
         :class:`~zhmcclient.VirtualFunctionManager`: Access to the
-        Virtual Functions in this Partition.
+        :term:`Virtual Functions <Virtual Function>` in this Partition.
         """
         # We do here some lazy loading.
         if not self._virtual_functions:

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 """
-A **Virtual Function** provides a Partition with access to accelerator Adapters
-like the System z Enterprise Data Compression (zEDC) adapter.
+A **Virtual Function** is a logical entity that provides a :term:`Partition`
+with access to :term:`Accelerator Adapters <Accelerator Adapter>`.
 
 Virtual Function resources are contained in Partition resources.
 
-Virtual Functions only exist in CPCs that are in DPM mode.
+Virtual Functions only exist in :term:`CPCs <CPC>` that are in DPM mode.
 """
 
 from __future__ import absolute_import
@@ -31,27 +31,30 @@ __all__ = ['VirtualFunctionManager', 'VirtualFunction']
 
 class VirtualFunctionManager(BaseManager):
     """
-    Manager providing access to the Virtual Functions in a particular
-    Partition.
+    Manager providing access to the
+    :term:`Virtual Functions <Virtual Function>` in a particular
+    :term:`Partition`.
 
-    Derived from :class:`~zhmcclient.BaseManager`;
-    see there for common methods and attributes.
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case, the
+    :class:`~zhmcclient.Partition` object).
     """
 
     def __init__(self, partition):
-        """
-        Parameters:
-
-          partition (:class:`~zhmcclient.Partition`):
-            Partition defining the scope for this manager.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   partition (:class:`~zhmcclient.Partition`):
+        #     Partition defining the scope for this manager.
         super(VirtualFunctionManager, self).__init__(partition)
 
     @property
     def partition(self):
         """
-        :class:`~zhmcclient.Partition`: Partition defining the scope for this
-        manager.
+        :class:`~zhmcclient.Partition`: :term:`Partition` defining the scope
+        for this manager.
         """
         return self._parent
 
@@ -99,7 +102,8 @@ class VirtualFunctionManager(BaseManager):
 
         Returns:
 
-          VirtualFunction: The resource object for the new virtual function.
+          VirtualFunction:
+            The resource object for the new Virtual Function.
             The object will have its 'element-uri' property set as returned by
             the HMC, and will also have the input properties set.
 
@@ -122,7 +126,7 @@ class VirtualFunctionManager(BaseManager):
 
 class VirtualFunction(BaseResource):
     """
-    Representation of a Virtual Function.
+    Representation of a :term:`Virtual Function`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
@@ -130,23 +134,23 @@ class VirtualFunction(BaseResource):
     For the properties of a Virtual Function, see section
     'Data model - Virtual Function Element Object' in section
     'Partition object' in the :term:`HMC API` book.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.VirtualFunctionManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.VirtualFunctionManager`):
-            Manager object for this Virtual Function.
-
-          uri (string):
-            Canonical URI path of this Virtual Function.
-
-          properties (dict):
-            Properties to be set for this Virtual Function.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.VirtualFunctionManager`):
+        #     Manager object for this Virtual Function.
+        #   uri (string):
+        #     Canonical URI path of this Virtual Function.
+        #   properties (dict):
+        #     Properties to be set for this Virtual Function.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, VirtualFunctionManager)
         super(VirtualFunction, self).__init__(manager, uri, properties)
 

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -14,13 +14,14 @@
 
 """
 A **Virtual Switch** is a virtualized networking switch connecting
-the NICs in Partitions with a Port on a Network Adapter.
-Virtual Switches are generated automatically every time a new Adapter
-is detected and configured.
+:term:`NICs <NIC>` with a :term:`Network Port`.
+
+Virtual Switches are generated automatically every time a new
+:term:`Network Adapter` is detected and configured.
 
 Virtual Switch resources are contained in CPC resources.
 
-Virtual Switches only exist in CPCs that are in DPM mode.
+Virtual Switches only exist in :term:`CPCs <CPC>` that are in DPM mode.
 """
 
 from __future__ import absolute_import
@@ -33,25 +34,29 @@ __all__ = ['VirtualSwitchManager', 'VirtualSwitch']
 
 class VirtualSwitchManager(BaseManager):
     """
-    Manager providing access to the Virtual Switches in a particular CPC.
+    Manager providing access to the :term:`Virtual Switches <Virtual Switch>`
+    in a particular :term:`CPC`.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible as properties in higher level resources (in this case, the
+    :class:`~zhmcclient.Cpc` object).
     """
 
     def __init__(self, cpc):
-        """
-        Parameters:
-
-          cpc (:class:`~zhmcclient.Cpc`):
-            CPC defining the scope for this manager.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   cpc (:class:`~zhmcclient.Cpc`):
+        #     CPC defining the scope for this manager.
         super(VirtualSwitchManager, self).__init__(cpc)
 
     @property
     def cpc(self):
         """
-        :class:`~zhmcclient.Cpc`: CPC defining the scope for this manager.
+        :class:`~zhmcclient.Cpc`: :term:`CPC` defining the scope for this
+        manager.
         """
         return self._parent
 
@@ -93,30 +98,30 @@ class VirtualSwitchManager(BaseManager):
 
 class VirtualSwitch(BaseResource):
     """
-    Representation of a Virtual Switch.
+    Representation of a :term:`Virtual Switch`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.
 
     For the properties of a Virtual Switch, see section 'Data model'
     in section 'Virtual Switch object' in the :term:`HMC API` book.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.VirtualSwitchManager`).
     """
 
     def __init__(self, manager, uri, properties):
-        """
-        Parameters:
-
-          manager (:class:`~zhmcclient.VirtualSwitchManager`):
-            Manager object for this Virtual Switch.
-
-          uri (string):
-            Canonical URI path of this Virtual Switch.
-
-          properties (dict):
-            Properties to be set for this Virtual Switch.
-            See initialization of :class:`~zhmcclient.BaseResource` for
-            details.
-        """
+        # This function should not go into the docs.
+        # Parameters:
+        #   manager (:class:`~zhmcclient.VirtualSwitchManager`):
+        #     Manager object for this Virtual Switch.
+        #   uri (string):
+        #     Canonical URI path of this Virtual Switch.
+        #   properties (dict):
+        #     Properties to be set for this Virtual Switch.
+        #     See initialization of :class:`~zhmcclient.BaseResource` for
+        #     details.
         assert isinstance(manager, VirtualSwitchManager)
         super(VirtualSwitch, self).__init__(manager, uri, properties)
 


### PR DESCRIPTION
Please review. Only docs changes.

Details:
- Moved description of resource and manager base classes into appendix.
- Made terms in Resource Model glossary consistent and fixed any links between them.
- In all resource and manager descriptions, turned all references to resources into links to their entries in the resource model glossary.
- Removed `__init__()` methods of resource classes and manager classes from the documentation, because these objects are not supposed to be created by the user.