### PR TITLE
Fixes #62: Changed get_connected_vnics() to return Nic objects

### DIFF
--- a/tests/test_nic.py
+++ b/tests/test_nic.py
@@ -230,5 +230,24 @@ class NicTests(unittest.TestCase):
             status = nic.update_properties(properties={})
             self.assertEqual(status, None)
 
+    def test_nic_object(self):
+        """
+        This tests the `nic_object()` method.
+        """
+        nic_mgr = self.partition.nics
+        nic_id = 'fake-nic-id0711'
+
+        nic = nic_mgr.nic_object(nic_id)
+
+        nic_uri = self.partition.uri + "/nics/" + nic_id
+
+        self.assertTrue(isinstance(nic, Nic))
+        self.assertEqual(nic.uri, nic_uri)
+        self.assertEqual(nic.properties['element-uri'], nic_uri)
+        self.assertEqual(nic.properties['element-id'], nic_id)
+        self.assertEqual(nic.properties['class'], 'nic')
+        self.assertEqual(nic.properties['parent'], self.partition.uri)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -434,5 +434,24 @@ class PartitionTests(unittest.TestCase):
             status = partition.unmount_iso_image()
             self.assertEqual(status, None)
 
+    def test_partition_object(self):
+        """
+        This tests the `partition_object()` method.
+        """
+        partition_mgr = self.cpc.partitions
+        partition_id = 'fake-partition-id42'
+
+        partition = partition_mgr.partition_object(partition_id)
+
+        partition_uri = "/api/partitions/" + partition_id
+
+        self.assertTrue(isinstance(partition, Partition))
+        self.assertEqual(partition.uri, partition_uri)
+        self.assertEqual(partition.properties['object-uri'], partition_uri)
+        self.assertEqual(partition.properties['object-id'], partition_id)
+        self.assertEqual(partition.properties['class'], 'partition')
+        self.assertEqual(partition.properties['parent'], self.cpc.uri)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_virtual_switch.py
+++ b/tests/test_virtual_switch.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import unittest
 import requests_mock
 
-from zhmcclient import Session, Client
+from zhmcclient import Session, Client, Nic
 
 
 class VirtualSwitchTests(unittest.TestCase):
@@ -224,8 +224,17 @@ class VirtualSwitchTests(unittest.TestCase):
                 "/api/virtual-switches/fake-vswitch-id1/"
                 "operations/get-connected-vnics",
                 json=result)
-            status = vswitch.get_connected_vnics()
-            self.assertEqual(status, result['connected-vnic-uris'])
+
+            nics = vswitch.get_connected_vnics()
+
+            self.assertTrue(isinstance(nics, list))
+            for i, nic in enumerate(nics):
+                self.assertTrue(isinstance(nic, Nic))
+                nic_uri = result['connected-vnic-uris'][i]
+                self.assertEqual(nic.uri, nic_uri)
+                self.assertEqual(nic.properties['element-uri'], nic_uri)
+                # TODO: Add test for element-id
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_virtual_switch.py
+++ b/tests/test_virtual_switch.py
@@ -20,6 +20,7 @@ Unit tests for _virtual_switch module.
 from __future__ import absolute_import
 
 import unittest
+import re
 import requests_mock
 
 from zhmcclient import Session, Client, Nic
@@ -233,7 +234,10 @@ class VirtualSwitchTests(unittest.TestCase):
                 nic_uri = result['connected-vnic-uris'][i]
                 self.assertEqual(nic.uri, nic_uri)
                 self.assertEqual(nic.properties['element-uri'], nic_uri)
-                # TODO: Add test for element-id
+                m = re.match(r"^/api/partitions/([^/]+)/nics/([^/]+)/?$",
+                             nic_uri)
+                nic_id = m.group(2)
+                self.assertEqual(nic.properties['element-id'], nic_id)
 
 
 if __name__ == '__main__':

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -124,6 +124,38 @@ class NicManager(BaseManager):
         props.update(result)
         return Nic(self, props['element-uri'], props)
 
+    def nic_object(self, nic_id):
+        """
+        Return a minimalistic :class:`~zhmcclient.Nic` object for a Nic in this
+        Partition.
+
+        This method is an internal helper function and is not normally called
+        by users.
+
+        This object will be connected in the Python object tree representing
+        the resources (i.e. it has this Partition as a parent), and will have
+        the following properties set:
+
+          * `element-uri`
+          * `element-id`
+          * `parent`
+          * `class`
+
+        Parameters:
+
+            nic_id (string): `element-id` of the Nic
+
+        Returns:
+
+            :class:`~zhmcclient.Nic`: A Python object representing the Nic.
+        """
+        part_uri = self.parent.uri
+        nic_uri = part_uri + "/nics/" + nic_id
+        return Nic(self, nic_uri, {'element-uri': nic_uri,
+                                   'element-id': nic_id,
+                                   'parent': part_uri,
+                                   'class': 'nic'})
+
 
 class Nic(BaseResource):
     """

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -136,6 +136,38 @@ class PartitionManager(BaseManager):
         props.update(result)
         return Partition(self, props['object-uri'], props)
 
+    def partition_object(self, part_id):
+        """
+        Return a minimalistic :class:`~zhmcclient.Partition` object for a
+        Partition in this CPC.
+
+        This method is an internal helper function and is not normally called
+        by users.
+
+        This object will be connected in the Python object tree representing
+        the resources (i.e. it has this CPC as a parent), and will have the
+        following properties set:
+
+          * `object-uri`
+          * `object-id`
+          * `parent`
+          * `class`
+
+        Parameters:
+
+            part_id (string): `object-id` of the Partition
+
+        Returns:
+
+            :class:`~zhmcclient.Partition`: A Python object representing the
+            Partition.
+        """
+        part_uri = "/api/partitions/" + part_id
+        return Partition(self, part_uri, {'object-uri': part_uri,
+                                          'object-id': part_id,
+                                          'parent': self.parent.uri,
+                                          'class': 'partition'})
+
 
 class Partition(BaseResource):
     """


### PR DESCRIPTION
Please review.

The code to create the `Partition` and `Nic` objects has now been consolidated into the respective resource modules, so that the `VirtualSwitch.get_connected_vnics()` method that needs them is now cleaner.