### PR TITLE
Added more HBA/storage related methods.

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -169,6 +169,9 @@ attaching storage.
   FCP Adapter
      Short term for a :term:`Storage Adapter` supporting FCP.
 
+  FCP Port
+     Short term for a :term:`Port` of an :term:`FCP Adapter`.
+
   Group
      TBD
 

--- a/tests/test_cpc.py
+++ b/tests/test_cpc.py
@@ -286,5 +286,91 @@ class CpcTests(unittest.TestCase):
             status = cpc.export_profiles(1, wait_for_completion=False)
             self.assertEqual(status, result)
 
+    def test_wwpns_of_partitions(self):
+        """
+        This tests the 'wwpns_of_partitions()' method.
+        """
+        cpc_mgr = self.client.cpcs
+        with requests_mock.mock() as m:
+
+            result = {
+                'cpcs': [
+                    {
+                        'object-uri': '/api/cpcs/fake-cpc-id-1',
+                        'name': 'P0ZHMP02',
+                        'status': 'service-required',
+                    },
+                    {
+                        'object-uri': '/api/cpcs/fake-cpc-id-2',
+                        'name': 'P0000P30',
+                        'status': 'service-required',
+                    }
+                ]
+            }
+            m.get('/api/cpcs', json=result)
+
+            result = {
+                'partitions': [
+                    {
+                        'object-uri': '/api/cpcs/fake-cpc-id-1/'
+                                      'partitions/part-id-1',
+                        'name': 'part-name-1',
+                        'status': 'active',
+                    },
+                    {
+                        'object-uri': '/api/cpcs/fake-cpc-id-1/'
+                                      'partitions/part-id-2',
+                        'name': 'part-name-2',
+                        'status': 'active',
+                    },
+                    {
+                        'object-uri': '/api/cpcs/fake-cpc-id-1/'
+                                      'partitions/part-id-3',
+                        'name': 'part-name-3',
+                        'status': 'active',
+                    },
+                ]
+            }
+            m.get('/api/cpcs/fake-cpc-id-1/partitions', json=result)
+
+            # TODO: Add the request body to the mock call:
+            # request = {
+            #     'partitions': [
+            #         '/api/cpcs/fake-cpc-id-1/partitions/part-id-1',
+            #         '/api/cpcs/fake-cpc-id-1/partitions/part-id-2',
+            #     ]
+            # }
+            result = {
+                'wwpn-list': [
+                    'part-name-1,adapter-id-1,devno-1,wwpn-1',
+                    'part-name-2,adapter-id-1,devno-2,wwpn-2',
+                ]
+            }
+            m.post('/api/cpcs/fake-cpc-id-1/operations/export-port-names-list',
+                   json=result)
+
+            exp_wwpn_list = [
+                {
+                    'partition-name': 'part-name-1',
+                    'adapter-id': 'adapter-id-1',
+                    'device-number': 'devno-1',
+                    'wwpn': 'wwpn-1'
+                },
+                {
+                    'partition-name': 'part-name-2',
+                    'adapter-id': 'adapter-id-1',
+                    'device-number': 'devno-2',
+                    'wwpn': 'wwpn-2'
+                },
+            ]
+
+            cpcs = cpc_mgr.list()
+            cpc = cpcs[0]
+            partitions = cpc.partitions.list()
+
+            wwpn_list = cpc.get_wwpns(partitions[0:2])
+
+            self.assertEqual(wwpn_list, exp_wwpn_list)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_hba.py
+++ b/tests/test_hba.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import unittest
 import requests_mock
 
-from zhmcclient import Session, Client, Hba
+from zhmcclient import Session, Client, Hba, Adapter, Port
 
 
 class HbaTests(unittest.TestCase):
@@ -229,6 +229,33 @@ class HbaTests(unittest.TestCase):
                 json=result)
             status = hba.update_properties(properties={})
             self.assertEqual(status, None)
+
+    def test_reassign_port(self):
+        """
+        This tests the 'reassign_port()' method.
+        """
+        hba_mgr = self.partition.hbas
+        hba_uri = '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1'
+        hba = Hba(hba_mgr, uri=hba_uri, properties={})
+
+        adapter_mgr = self.cpc.adapters
+        adapter_uri = '/api/adapters/fake-adapter-id-1'
+        adapter = Adapter(adapter_mgr, uri=adapter_uri, properties={})
+
+        port_mgr = adapter.ports
+        port2_uri = '/api/adapters/fake-adapter-id-2/'\
+                    'storage-ports/fake-port-id-2'
+        port2 = Port(port_mgr, uri=port2_uri, properties={})
+
+        with requests_mock.mock() as m:
+            # TODO: Add the request body to the mock call:
+            # request_reassign = {
+            #     'adapter-port-uri': port2_uri
+            # }
+            m.post(hba_uri + '/operations/reassign-storage-adapter-port',
+                   json={})
+
+            hba.reassign_port(port2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -442,3 +442,44 @@ class Cpc(BaseResource):
             cpc_uri + '/operations/export-profiles', body,
             wait_for_completion=wait_for_completion)
         return result
+
+    def get_wwpns(self, partitions):
+        """
+        Return the WWPNs of the host ports (of the :term:`HBAs <HBA>`) of the
+        specified :term:`Partitions <Partition>` of this CPC.
+
+        This method performs the HMC operation "Export WWPN List".
+
+        Parameters:
+
+          partitions (:term:`iterable` of :class:`~zhmcclient.Partition`):
+            :term:`Partitions <Partition>` to be used.
+
+        Returns:
+
+          A list of items for each WWPN, where each item is a dict with the
+          following keys:
+
+          * 'partition-name' (string): Name of the :term:`Partition`.
+          * 'adapter-id' (string): ID of the :term:`FCP Adapter`.
+          * 'device-number' (string): Virtual device number of the :term:`HBA`.
+          * 'wwpn' (string): WWPN of the HBA.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`: See the HTTP status and reason codes of
+            operation "Export WWPN List" in the :term:`HMC API` book.
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'partitions': [p.uri for p in partitions]}
+        result = self.manager.session.post(self._uri + '/operations/'
+                                           'export-port-names-list', body=body)
+        # Parse the returned comma-separated string for each WWPN into a dict:
+        wwpn_list = []
+        dict_keys = ('partition-name', 'adapter-id', 'device-number', 'wwpn')
+        for wwpn_item in result['wwpn-list']:
+            dict_values = wwpn_item.split(',')
+            wwpn_list.append(dict(zip(dict_keys, dict_values)))
+        return wwpn_list

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -101,6 +101,9 @@ class HbaManager(BaseManager):
             Allowable properties are defined in section 'Request body contents'
             in section 'Create HBA' in the :term:`HMC API` book.
 
+            The underlying :term:`FCP port` for the new HBA is assigned via the
+            "adapter-port-uri" property.
+
         Returns:
 
           Hba:
@@ -187,3 +190,27 @@ class Hba(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         self.manager.session.post(self._uri, body=properties)
+
+    def reassign_port(self, port):
+        """
+        Reassign this HBA to a new underlying :term:`FCP port`.
+
+        This method performs the HMC operation "Reassign Storage Adapter Port".
+
+        Parameters:
+
+          port (:class:`~zhmcclient.Port`): :term:`FCP port` to be used.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`: See the HTTP status and reason codes of
+            operation "Reassign Storage Adapter Port" in the :term:`HMC API`
+            book.
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'adapter-port-uri': port.uri}
+        self.manager.session.post(self._uri +
+                                  '/operations/reassign-storage-adapter-port',
+                                  body=body)


### PR DESCRIPTION
Details:
- Added `get_wwpns()` to `Cpc` class, which performs HMC operation 'Export WWPN List', and extended the unit test cases for it.
- Added `reassign_port()` to `Hba` class, which performs HMC operation 'Reassign Storage Adapter Port', and extended the unit test cases for it.
- Added 'FCP Port' as a term to the resource model (docs only).

Please review.