### PR TITLE
Several logistical cpcinfo fixes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,6 @@ six # MIT
 pbr>=1.8 # Apache-2.0
 requests>=2.10.0 # Apache-2.0
 decorator # new BSD
+tabulate # MIT
+progressbar2 # BSD
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ classifier =
 [files]
 packages =
     zhmcclient
+scripts =
+    tools/cpcinfo
 
 [wheel]
 universal = 1

--- a/tools/cpcinfo
+++ b/tools/cpcinfo
@@ -28,6 +28,7 @@ import requests.packages.urllib3
 from tabulate import tabulate
 import progressbar
 from pprint import pprint
+from platform import python_version
 
 import zhmcclient
 
@@ -40,6 +41,7 @@ def parse_args():
     """
 
     prog = "cpcinfo"  # Name of this program, used for help etc.
+    version = zhmcclient.__version__
     usage = '%(prog)s [options] hmc [cpcname ...]'
     desc = 'Display information about CPCs.'
     epilog = """
@@ -79,6 +81,11 @@ Example:
     general_arggroup.add_argument(
         '-t', '--timestats', dest='timestats', action='store_true',
         help='Display time statistics for the HMC operations that were used.')
+    version_str = '%s/zhmcclient %s, Python %s' %\
+        (prog, version, python_version())
+    general_arggroup.add_argument(
+        '--version', action='version', version=version_str,
+        help='Show the versions of this program etc. and exit')
     general_arggroup.add_argument(
         '-h', '--help', action='help',
         help='Show this help message and exit')


### PR DESCRIPTION
Please review.

Details:
- Added tabulate and progressbar2 as prereqs in requirements.txt.
- Added tools/cpcinfo as a script in setup.cfg to get it installed into the PATH.
- Added a --version option to cpcinfo that displays its own/zhmcclient version and the Python version.