### PR TITLE
Added an install test to Travis CI and to Tox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ python:
 install:
   - pip list
   - pip install --upgrade pip
+  - pip install .
+  - pip list
   - make develop
   - pip list
   - pip install python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,15 @@ python:
 install:
   - pip list
   - pip install --upgrade pip
-  - pip install .
+  - make install
   - pip list
   - make develop
-  - pip list
   - pip install python-coveralls
+  - pip list
+  - make clean
 
 # commands to run builds & tests
 script:
-  - make clean
   - make check
   - make build
   - make builddoc

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ help:
 	@echo '  test       - Run unit tests (and test coverage) and save results in: $(test_log_file)'
 	@echo '               Env.var TESTCASES can be used to specify a py.test expression for its -k option'
 	@echo '  all        - Do all of the above (except buildwin when not on Windows)'
-	@echo '  install    - Install package in active Python environment'
+	@echo '  install    - Install package in active Python environment and test import'
 	@echo '  upload     - build + upload the distribution files to PyPI'
 	@echo '  clean      - Remove any temporary files'
 	@echo '  clobber    - clean + remove any build products'
@@ -191,7 +191,8 @@ check: pylint.log flake8.log
 
 .PHONY: install
 install:
-	python setup.py install
+	pip install --upgrade .
+	python -c "import zhmcclient; print('Import: ok')"
 	@echo 'Done: Installed $(package_name) into current Python environment.'
 	@echo '$@ done.'
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ skip_install = true
 whitelist_externals =
     sh
 commands =
-    sh -c "export TESTCASES={posargs}; make -B clean test"
+    sh -c "export TESTCASES={posargs}; make -B clean install test"
 deps =
     -r{toxinidir}/dev-requirements.txt
 


### PR DESCRIPTION
Please review.
    
Details:
- In order to detect missing prereqs in non-development mode, added an install test to Travis CI that installs the package before installing the development dependencies.
- As part of that, changed the `make install` processing to install the package using `pip install .` (from `python setup.py install`), and added an import test to `make install`.
- For the Tox test, it was not easily possible to test installation without also having the development prereqs installed, but added the install test anyway.