### PR TITLE
Added HTTP method and URI to HTTPError information.

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -249,13 +249,14 @@ class TestHTTPError(unittest.TestCase, SimpleTestMixin):
         self.assertEqual(exc.error_details, resp_body['error-details'])
 
         # Check str()
-        exp_str = str(resp_body['http-status']) + ',' + \
-            str(resp_body['reason']) + ': ' + resp_body['message']
+        exp_str = "{http-status},{reason}: {message} [{request-method} "\
+                  "{request-uri}]".format(**resp_body)
         self.assertEqual(str(exc), exp_str)
 
         # Check repr()
-        exp_repr = 'HTTPError(' + str(resp_body['http-status']) + ', ' + \
-            str(resp_body['reason']) + ', ' + resp_body['message'] + ', ...)'
+        exp_repr = "HTTPError(http_status={http-status}, reason={reason}, "\
+                   "message={message}, request_method={request-method}, "\
+                   "request_uri={request-uri}, ...)".format(**resp_body)
         self.assertEqual(repr(exc), exp_repr)
 
 

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -287,11 +287,15 @@ class HTTPError(Error):
         return self._body.get('error-details', None)
 
     def __str__(self):
-        return "{},{}: {}".format(self.http_status, self.reason, self.message)
+        return "{},{}: {} [{} {}]".\
+               format(self.http_status, self.reason, self.message,
+                      self.request_method, self.request_uri)
 
     def __repr__(self):
-        return "HTTPError({}, {}, {}, ...)".\
-               format(self.http_status, self.reason, self.message)
+        return "HTTPError(http_status={}, reason={}, message={}, "\
+               "request_method={}, request_uri={}, ...)".\
+               format(self.http_status, self.reason, self.message,
+                      self.request_method, self.request_uri)
 
 
 class NoUniqueMatch(Error):


### PR DESCRIPTION
This is in support of an HTTP error Elisabeth sees, and allows to find the operation in the HMC API book that documents the HTTP status code and reason code.

Please review.