### PR TITLE
Fixed HTTPError in dpm_enabled.

### DIFF
--- a/tests/unit/test_cpc.py
+++ b/tests/unit/test_cpc.py
@@ -124,8 +124,8 @@ class CpcTests(unittest.TestCase):
             }
             m.get('/api/cpcs/fake-cpc-id-1/partitions', json=mock_result_cpc1p)
             mock_result_cpc1l = {
-                'http-status': '404',
-                'reason': '1',
+                'http-status': 404,
+                'reason': 1,
                 'message': 'Invalid resource',
             }
             m.get('/api/cpcs/fake-cpc-id-1/logical-partitions',
@@ -140,8 +140,8 @@ class CpcTests(unittest.TestCase):
             }
             m.get('/api/cpcs/fake-cpc-id-2', json=mock_result_cpc2)
             mock_result_cpc2p = {
-                'http-status': '404',
-                'reason': '1',
+                'http-status': 404,
+                'reason': 1,
                 'message': 'Invalid resource',
             }
             m.get('/api/cpcs/fake-cpc-id-2/partitions',
@@ -167,8 +167,8 @@ class CpcTests(unittest.TestCase):
             }
             m.get('/api/cpcs/fake-cpc-id-3', json=mock_result_cpc3)
             mock_result_cpc3p = {
-                'http-status': '404',
-                'reason': '1',
+                'http-status': 404,
+                'reason': 1,
                 'message': 'Invalid resource',
             }
             m.get('/api/cpcs/fake-cpc-id-3/partitions',

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -262,7 +262,7 @@ class Cpc(BaseResource):
             self.partitions.list()
             return True
         except HTTPError as exc:
-            if exc.http_status == '404' and exc.reason == '1':
+            if exc.http_status == 404 and exc.reason == 1:
                 # Description of this error: The request URI does not designate
                 # an existing resource of the expected type, or designates a
                 # resource for which the API user does not have object-access


### PR DESCRIPTION
Please review.

This issue went by undetected because the mocked HMC responses in the unit tests made the same mistake as the code that was tested. This shows the importance of a real test.

Details:
- In the optimized implementation of dpm_enabled, the http_status and reason properties of HTTPError were incorrectly tested against strings. Fixed that by testing against integers.
- The mocked HMC responses defined in the unit tests had the same problem and returned strings for http_status and reason, which is why the problem went in, undetected. Fixed that also by changing the mocked responses to use integers.