### PR TITLE
Improved tutorial notebooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ check_py_files := \
     $(wildcard $(package_name)/*.py) \
     $(wildcard tests/unit/*.py) \
     $(wildcard tests/function/*.py) \
+    $(wildcard docs/notebooks/*.py) \
 
 # Test log
 test_log_file := test_$(python_version_fn).log

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,8 @@ Released: Not yet
   'List Partitions' and  'List Logical Partitions' operations, in order to
   avoid the 'List CPC Properties' operation.
 
+* Improved tutorials.
+
 **Known Issues:**
 
 * See `list of open issues`_.

--- a/docs/notebooks/01_notebook_basics.ipynb
+++ b/docs/notebooks/01_notebook_basics.ipynb
@@ -15,7 +15,9 @@
     "\n",
     "This page (and its file, `01_notebook_basics.ipynb`) is termed a *notebook*. Each notebook when opened in Jupyter, is a Python main module that can do anything a normal Python module can do. Specifically, different code sections can be executed one by one and execute all in the same Python main module.\n",
     "\n",
-    "A code section can be executed by selecting it and pressing Ctrl-Enter (For Linux, the key depends on the operating system you are using).\n",
+    "If you view this notebook using the Online Notebook Viewer (e.g. because you clicked on the link in section [Tutorials](https://python-zhmcclient.readthedocs.io/en/latest/tutorial.html#tutorials)), you cannot execute the code sections in the notebook or modify the notebook. Section [Executing code in the tutorials](https://python-zhmcclient.readthedocs.io/en/latest/tutorial.html#executing-code-in-the-tutorials) describes how to do that.\n",
+    "\n",
+    "A code section can be executed by selecting it and pressing Ctrl-Enter (That is for Linux; the key combination depends on the operating system you are using).\n",
     "\n",
     "Please execute this code section:"
    ]
@@ -35,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now execute this code section:"
+    "And this code section:"
    ]
   },
   {
@@ -57,9 +59,7 @@
     "\n",
     "You can repeat the execution of a code section that was executed earlier and you can edit code sections (by double clicking on it).\n",
     "\n",
-    "For example, you can edit the first code section above to use a different value, and execute both sections again.\n",
-    "\n",
-    "Try it now..."
+    "For example, you can edit the first code section above to use a different value, and execute both sections again."
    ]
   },
   {
@@ -108,6 +108,45 @@
    "metadata": {},
    "source": [
     "Different notebooks run in different Python processes and thus have no connection between their modules."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The current working directory in a notebook is the notebooks directory (that was specified when invoking `jupyter notebook`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "print(os.getcwd())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Python module search path within a notebook adds some Jupyter directories at the end but otherwise is the normal search path that would be available when invoking `python`, i.e. it reflects the currently active Python environment. Specifically, it includes the current directory (the empty string), i.e. the notebooks directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pprint import pprint\n",
+    "pprint(sys.path)"
    ]
   }
  ],

--- a/docs/notebooks/02_connections.ipynb
+++ b/docs/notebooks/02_connections.ipynb
@@ -49,12 +49,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "import zhmcclient\n",
-    "\n",
     "zhmc = '9.152.150.65'\n",
     "\n",
     "session = zhmcclient.Session(zhmc)\n",
@@ -65,16 +63,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following code prints the API version supported by that HMC:\n",
-    "\n",
-    "Note that this code would not have needed the credentials."
+    "The following code prints the API version supported by that HMC. If you have no connection to the HMC, a `ConnectionError` will be raised after a while."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -86,7 +82,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following code prints the CPCs managed by that HMC:"
+    "The previous code section most likely will also show a `InsecureRequestWarning` because certificates are not used in the communication with the HMC.\n",
+    "\n",
+    "The following code section turns off that warning and repeats the version gathering:"
    ]
   },
   {
@@ -97,7 +95,61 @@
    },
    "outputs": [],
    "source": [
-    "print(\"Listing CPCs ...\")\n",
+    "import requests\n",
+    "requests.packages.urllib3.disable_warnings()\n",
+    "\n",
+    "vi = client.version_info()\n",
+    "print(\"HMC API version: {}.{}\".format(vi[0], vi[1]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code section attempts to list the CPCs managed by that HMC:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Listing CPCs managed by HMC %s ...\" % zhmc)\n",
+    "cpcs = client.cpcs.list()\n",
+    "for cpc in cpcs:\n",
+    "    print(cpc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Executing the previous code section reveals that listing the CPCs requires to be logged on, but we did not specify credentials. As a result, an `AuthError` was raised.\n",
+    "\n",
+    "The following code section specifies credentials and performs the list opereration again:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "\n",
+    "userid = raw_input('Enter userid for HMC %s: ' % zhmc)\n",
+    "password = getpass.getpass('Enter password for %s: ' % userid)\n",
+    "\n",
+    "session = zhmcclient.Session(zhmc, userid, password)\n",
+    "client = zhmcclient.Client(session)\n",
+    "\n",
+    "print(\"Listing CPCs managed by HMC %s ...\" % zhmc)\n",
     "cpcs = client.cpcs.list()\n",
     "for cpc in cpcs:\n",
     "    print(cpc)"

--- a/docs/notebooks/03_datamodel.ipynb
+++ b/docs/notebooks/03_datamodel.ipynb
@@ -4,14 +4,243 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Tutorial 3: Python data model for the HMC API"
+    "# Tutorial 3: Python objects representing HMC resources"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "TODO: Write this chapter. Cover primitive data types, and explain at what level the user interacts with input and result payloads."
+    "This tutorial explains how the zhmcclient package maps the HMC operations and the resources exposed by the HMC to Python objects, and how to navigate between these objects. this tutorial mostly uses the CPC and its partitions as example resources, but the same principles apply to nearly all types of resources exposed by the HMC."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to keep the code in these tutorials simple, the creation of the `Session` and `Client` objects has been moved into a function `make_client()` in a utility module `tututils`.\n",
+    "\n",
+    "The following code section creates a logged-on client for the specified HMC. When invoked for the first time in a notebook, `make_client()` asks for userid and password and saves that in the module. On subsequent invocations (within the same notebook), it uses the saved userid and password."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import tututils\n",
+    "zhmc = '9.152.150.65'  # edit this to your HMC's IP address or host name \n",
+    "client = tututils.make_client(zhmc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " In the zhmcclient package, all resources exposed by the HMC are encapsulated as Python objects. The following code section lists the CPCs managed by the HMC and examines the first [`Cpc`](https://python-zhmcclient.readthedocs.io/en/latest/resources.html#zhmcclient.Cpc) object in the list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from pprint import pprint\n",
+    "cpcs = client.cpcs.list()\n",
+    "cpc = cpcs[0]\n",
+    "print(type(cpc))\n",
+    "print(\"Public symbols:\")\n",
+    "pprint([s for s in sorted(dir(cpc)) if not s.startswith('_')])\n",
+    "print(\"Properties:\")\n",
+    "pprint(cpc.properties)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The public symbols are properties or methods and are described in the zhmcclient documentation (see [`Cpc`](https://python-zhmcclient.readthedocs.io/en/latest/resources.html#zhmcclient.Cpc)).\n",
+    "\n",
+    "This `Cpc` object has only three properties: `name`, `object-uri`, and `status`. The zhmcclient package provides these properties as a dictionary in the [`properties`](https://python-zhmcclient.readthedocs.io/en/latest/appendix.html#zhmcclient.BaseResource.properties) instance variable of the `Cpc` object. The names of these properties are unchanged from what the [HMC API](https://python-zhmcclient.readthedocs.io/en/latest/appendix.html#term-hmc-api) book defines. The zhmcclient documentation refers to the HMC API book for a list and description of the resource properties.\n",
+    "\n",
+    "The [`list()`](https://python-zhmcclient.readthedocs.io/en/latest/resources.html#zhmcclient.CpcManager.list) method only returned these three properties, but a CPC resource has many more properties. In the HMC API, list operations generally return only a small set of the most important properties, mostly for identification and status of the resource.\n",
+    "\n",
+    "The following code retrieves the full set of properties for that CPC and prints them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "cpc.pull_full_properties()\n",
+    "print(\"Properties:\")\n",
+    "pprint(cpc.properties)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because of this behavior, a Python object representing a resource may not always have all properties of the resource present. The [`get_property()`](https://python-zhmcclient.readthedocs.io/en/latest/appendix.html#zhmcclient.BaseResource.get_property) method allows accessing a specific named property, and retrieves it from the HMC if not currently present in the Python object.\n",
+    "\n",
+    "The following code section again lists the CPCs, creating a `Cpc` object with only three properties. The `get_property()` method is then used to access a property that is not among the initial three properties. This causes all properties to be retrieved from the HMC and stored in the `Cpc` object. The requested one is returned from the method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "cpcs = client.cpcs.list()\n",
+    "cpc = cpcs[0]\n",
+    "print(\"Cpc object returned by list() has {} properties\".format(len(cpc.properties)))\n",
+    "\n",
+    "print(\"Accessing a property that is not yet present ...\")\n",
+    "machine_type = cpc.get_property('machine-type')\n",
+    "print(\"CPC machine type: {}\".format(machine_type))\n",
+    "print(\"After retrieving machine-type, the Cpc object has {} properties\".format(len(cpc.properties)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Cpc` object knows that it now has the full set of properties, so it uses them without further communication with the HMC:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"CPC machine model: {}\".format(cpc.get_property('machine-model')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Accessing invalid properties (i.e. properties not described in the HMC API book for the resource) causes a `KeyError` exception to be raised:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    print(\"CPC foo: {}\".format(cpc.get_property('foo')))\n",
+    "except Exception as exc:\n",
+    "    print(\"{}: {}\".format(exc.__class__.__name__, exc))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [`prop()`](https://python-zhmcclient.readthedocs.io/en/latest/appendix.html#zhmcclient.BaseResource.prop) method returns a property value and allows specifying a default value in case the property is invalid:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"CPC foo: {}\".format(cpc.prop('foo', 'invalid')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The resources in the HMC are organized as a tree. The zhmcclient package reflects that in the organization of the Python objects representing these resources. The top-level object is [`Client`](https://python-zhmcclient.readthedocs.io/en/latest/general.html#zhmcclient.Client) which represents the HMC. It allows navigating to the CPCs managed by the HMC via its [`cpcs`](https://python-zhmcclient.readthedocs.io/en/latest/general.html#zhmcclient.Client.cpcs) property.\n",
+    "\n",
+    "Each Python object representing a resource allows navigating down to its child resources, and each child resource allows navigating up to its parent resource. For example, a [`Cpc`](https://python-zhmcclient.readthedocs.io/en/latest/resources.html#zhmcclient.Cpc) object represents a CPC, and its [`lpars`](https://python-zhmcclient.readthedocs.io/en/latest/resources.html#zhmcclient.Cpc.lpars) instance variable allows navigating to the LPARs of the CPC, represented by [`Lpar`](https://python-zhmcclient.readthedocs.io/en/latest/resources.html#zhmcclient.Lpar) objects. An `Lpar` object allows navigating up to its parent `Cpc` object via the generic [`manager.parent`](https://python-zhmcclient.readthedocs.io/en/latest/appendix.html#zhmcclient.BaseManager.parent) instance variable, and also via the specific [`manager.cpc`](https://python-zhmcclient.readthedocs.io/en/latest/resources.html#zhmcclient.LparManager.cpc) instance variable that is named according to the type of parent.\n",
+    "\n",
+    "The following code navigates from a `Cpc` object to its partitions (`Lpar` or `Partition` dependent on the CPC mode) and navigates back up from the first partition to its parent resource, which is the same `Cpc` Python object we started from:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# We use the cpc object from above\n",
+    "print(\"CPC: name={}, Python object id={}\".format(cpc.prop('name'), id(cpc)))\n",
+    "\n",
+    "if cpc.dpm_enabled:\n",
+    "    parts = cpc.partitions.list()\n",
+    "else:\n",
+    "    parts = cpc.lpars.list()\n",
+    "part = parts[0]\n",
+    "kind = part.__class__.__name__\n",
+    "\n",
+    "print(\"Found {} partitions ({} child resources)\".format(len(parts), kind))\n",
+    "print(\"First {}: name={}, Python object id={}\".format(kind, part.prop('name'), id(part)))\n",
+    "\n",
+    "p_cpc = part.manager.cpc\n",
+    "print(\"Parent CPC: name={}, Python object id={}\".format(p_cpc.prop('name'), id(p_cpc)))\n",
+    "print(\"Same Cpc Python objects: {}\".format(cpc is p_cpc))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [`find()`](https://python-zhmcclient.readthedocs.io/en/latest/appendix.html#zhmcclient.BaseManager.find) method retrieves a resource by specifying the value of one (or more) of its properties.\n",
+    "\n",
+    "The following code finds the CPC we already know, based upon its name:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "cpc_name = cpc.prop('name')  # could also have been specified as input\n",
+    "\n",
+    "print(\"Finding CPC by name={} ...\".format(cpc_name))\n",
+    "cpc2 = client.cpcs.find(name=cpc_name)\n",
+    "\n",
+    "print(\"Found CPC: name={}, Python object id={}\".format(cpc2.prop('name'), id(cpc2)))\n",
+    "print(\"Same Cpc Python objects: {}\".format(cpc is cpc2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the found `Cpc` Python object is not the same as the original `Cpc` Python object. These two Python objects represent the same CPC resource, but their state may be different (e.g. different properties present, properties obtained at different points in time, etc.).\n",
+    "\n",
+    "You generally cannot rely that the zhmcclient API always returns the same Python object for a specific HMC resource. The zhmcclient package tries to minimize the use of different objects (as we saw in the case of navigating back to the parent resource), but sometimes it cannot be avoided to return multiple Python objects for the same resource. The zhmcclient is a very thin client that abstracts the HMC API into a Python API without adding things like a shared resource cache."
    ]
   }
  ],

--- a/docs/notebooks/tututils.py
+++ b/docs/notebooks/tututils.py
@@ -1,0 +1,54 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utility module for the Jupyter notebooks used as tutorials.
+"""
+
+import getpass
+import requests
+import six
+
+import zhmcclient
+
+requests.packages.urllib3.disable_warnings()
+
+USERID = None
+PASSWORD = None
+
+
+def make_client(zhmc, userid=None, password=None):
+    """
+    Create a `Session` object for the specified HMC and log that on. Create a
+    `Client` object using that `Session` object, and return it.
+
+    If no userid and password are specified, and if no previous call to this
+    method was made, userid and password are interactively inquired.
+    Userid and password are saved in module-global variables for future calls
+    to this method.
+    """
+
+    global USERID, PASSWORD
+
+    USERID = userid or USERID or \
+        six.input('Enter userid for HMC {}: '.format(zhmc))
+    PASSWORD = password or PASSWORD or \
+        getpass.getpass('Enter password for {}: '.format(USERID))
+
+    session = zhmcclient.Session(zhmc, USERID, PASSWORD)
+    session.logon()
+    client = zhmcclient.Client(session)
+    print('Established logged-on session with HMC {} using userid {}'.
+          format(zhmc, USERID))
+    return client


### PR DESCRIPTION
Please review.
    
Details:
- Improved notebook `01_notebook_basics` by explaining view-only vs. execute/modify, and by adding code sections about Python search path and current directory within the notebook environment.
- Improved notebook `02_connections` by showing how to turn off the InsecureRequestWarning messages, and by adding an operation that requires to be logged on.
- Wrote content for notebook `03_datamodel`.
- Added a utility module `tututils` in the notebooks directory, that currently has a function `make_client()` that logs on to the HMC and returns a Client object, in order to keep the code sections in the tutorials simpler.