### PR TITLE
Improved the AuthError and ConnectionError exceptions and their use.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,10 @@ Released: Not yet
 
 **Enhancements:**
 
+* Started raising a `ParseError` exception when the JSON payload in a HTTP
+  response cannot be parsed, and improved the definition of the ParseError
+  exception by adding line and column information.
+
 **Known Issues:**
 
 * See `list of open issues`_.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,26 @@ Released: Not yet
 
 **Incompatible changes:**
 
+**Deprecations:**
+
+**Bug fixes:**
+
+**Enhancements:**
+
+**Known Issues:**
+
+* See `list of open issues`_.
+
+.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
+
+
+Version 0.5.0
+^^^^^^^^^^^^^
+
+Released: 2016-10-04
+
+**Incompatible changes:**
+
 * In ``VirtualSwitch.get_connected_vnics()``, renamed the method to
   :meth:`~zhmcclient.VirtualSwitch.get_connected_nics` and changed its return value
   to return :class:`~zhmcclient.Nic` objects instead of their URIs.
@@ -55,12 +75,6 @@ Released: Not yet
   avoid the 'List CPC Properties' operation.
 
 * Improved tutorials.
-
-**Known Issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
 
 
 Version 0.4.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,10 @@ Released: Not yet
   response cannot be parsed, and improved the definition of the ParseError
   exception by adding line and column information.
 
+* Improved the `AuthError` and `ConnectionError` exceptions by adding a
+  `details` property that provides access to the underlying exception
+  describing details.
+
 **Known Issues:**
 
 * See `list of open issues`_.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -244,18 +244,23 @@ the `Makefile` is), and perform the following steps in that directory:
         git checkout master
         git pull
 
-4.  Verify that the change log (`docs/changes.rst`) reflects all changes since
-    the previous version. Make sure the changes listed there are relevant and
-    understandable for users.
+4.  Edit the change log (`docs/changes.rst`) and perform the following changes:
 
-    * If changes were needed, commit them to the `master` branch and push them
-      upstream::
+    * Insert a heading and release date for the version that is now released,
+      below the "in development" heading and release date.
 
-          git add docs/changes.rst
-          git commit -sm "Updated change log."
-          git push
+    * Make sure that the change log entries for the new release reflect all
+      changes since the previous version. Make sure the changes listed there are
+      relevant and understandable for users.
 
-5.  Perform a complete test::
+5.  Commit your changes to the change log to the `master` branch and push them
+    upstream (without using a topic branch)::
+
+        git add docs/changes.rst
+        git commit -sm "Updated change log for $MNU release."
+        git push
+
+6.  Perform a complete test::
 
         tox
 
@@ -271,39 +276,39 @@ the `Makefile` is), and perform the following steps in that directory:
 
       Wait for the Travis CI to show success for this change.
 
-6.  Tag the head of the master branch with the release label::
+7.  Tag the head of the master branch with the release label::
 
         git tag $MNU
 
-7.  Push the tag upstream::
+8.  Push the tag upstream::
 
         git push --tags
 
-8.  On GitHub, edit the new tag, and create a release description on it. This
+9.  On GitHub, edit the new tag, and create a release description on it. This
     will cause it to appear in the Release tab.
 
-9.  Upload the package to PyPI::
+10. Upload the package to PyPI::
 
         make upload
 
     **Attention!!** This only works once. You cannot re-release the same
     version to PyPI.
 
-10. Verify that the released version is shown on PyPI:
+11. Verify that the released version is shown on PyPI:
 
     https://pypi.python.org/pypi/zhmcclient/
 
-11. Verify that RTD shows the released version as its stable version:
+12. Verify that RTD shows the released version as its stable version:
 
     https://python-zhmcclient.readthedocs.io/en/stable/intro.html#versioning
 
     Note: The pushing of the tag to GitHub should be sufficient for RTD to
     rebuild the stable documentation, but it may take a while to build it.
 
-12. On GitHub, close milestone `M.N.U`.
+13. On GitHub, close milestone `M.N.U`.
 
-13. On GitHub, create a new milestone for development of the next release,
+14. On GitHub, create a new milestone for development of the next release,
     e.g. `M.N+1.0`.
 
-14. On GitHub, re-assign any open issues and pull request that still have
+15. On GitHub, re-assign any open issues and pull request that still have
     milestone `M.N.U` set, to the next milestone, or remove the milestone.

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -156,6 +156,31 @@ class TestParseError(unittest.TestCase, SimpleTestMixin):
     def setUp(self):
         self.exc_class = ParseError
 
+    def test_line_column_1(self):
+        """A simple message string that matches the line/col parsing."""
+
+        exc = ParseError("Bla: line 42 column 7 (char 6)")
+
+        self.assertEqual(exc.line, 42)
+        self.assertEqual(exc.column, 7)
+
+    def test_line_column_2(self):
+        """A minimally matching message string."""
+
+        exc = ParseError(": line 7 column 42 ")
+
+        self.assertEqual(exc.line, 7)
+        self.assertEqual(exc.column, 42)
+
+    def test_line_column_3(self):
+        """A message string that does not match (because of the 'x' in the
+        line)."""
+
+        exc = ParseError(": line 7x column 42 ")
+
+        self.assertEqual(exc.line, None)
+        self.assertEqual(exc.column, None)
+
 
 class TestVersionError(unittest.TestCase, SimpleTestMixin):
     """

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -84,11 +84,14 @@ class SimpleTestMixin(object):
     """
     Mixin to test a number of simple exception classes.
 
-    Simple exception classes take a message string as the single input
-    argument.
+    Simple exception classes take a message string as the first input
+    argument. Additional arguments may be defined and are not tested by this
+    mixin class.
     """
 
-    exc_class = Exception  # Exception class to be tested
+    # Derived classes set this (as an instance variable) to the exception class
+    # to be tested:
+    exc_class = None
 
     def test_empty(self):
         """Test simple exception with no argument."""
@@ -115,8 +118,14 @@ class SimpleTestMixin(object):
         self.assertEqual(len(exc.args), 1)
         self.assertEqual(exc.args[0], 'zaphod')
 
-    def test_two(self):
-        """Test simple exception with two arguments."""
+
+class SingleArgTestMixin(object):
+    """
+    Mixin to test simple exception classes with a single argument.
+    """
+
+    def test_fail_two(self):
+        """Test that single argument exception fails with two arguments."""
 
         try:
             self.exc_class('zaphod', 42)
@@ -130,7 +139,37 @@ class SimpleTestMixin(object):
             self.fail("No exception was raised.")
 
 
-class TestConnectionError(unittest.TestCase, SimpleTestMixin):
+class DetailsTestMixin(object):
+    """
+    Mixin to test exception classes with a `details` property.
+    """
+
+    def test_details_none(self):
+        """Test details property with None."""
+
+        exc = AuthError("Bla bla", None)
+
+        self.assertIsNone(exc.details)
+
+    def test_details_default(self):
+        """Test details property with default."""
+
+        exc = AuthError("Bla bla")
+
+        self.assertIsNone(exc.details)
+
+    def test_details_valueerror(self):
+        """Test details property with a ValueError."""
+
+        details_exc = ValueError("value error")
+
+        exc = AuthError("Bla bla", details_exc)
+
+        self.assertEqual(exc.details, details_exc)
+
+
+class TestConnectionError(unittest.TestCase, SimpleTestMixin,
+                          DetailsTestMixin):
     """
     Test the simple exception class ``ConnectionError``.
     """
@@ -139,7 +178,7 @@ class TestConnectionError(unittest.TestCase, SimpleTestMixin):
         self.exc_class = ConnectionError
 
 
-class TestAuthError(unittest.TestCase, SimpleTestMixin):
+class TestAuthError(unittest.TestCase, SimpleTestMixin, DetailsTestMixin):
     """
     Test the simple exception class ``AuthError``.
     """
@@ -148,7 +187,7 @@ class TestAuthError(unittest.TestCase, SimpleTestMixin):
         self.exc_class = AuthError
 
 
-class TestParseError(unittest.TestCase, SimpleTestMixin):
+class TestParseError(unittest.TestCase, SimpleTestMixin, SingleArgTestMixin):
     """
     Test the simple exception class ``ParseError``.
     """
@@ -182,7 +221,7 @@ class TestParseError(unittest.TestCase, SimpleTestMixin):
         self.assertEqual(exc.column, None)
 
 
-class TestVersionError(unittest.TestCase, SimpleTestMixin):
+class TestVersionError(unittest.TestCase, SimpleTestMixin, SingleArgTestMixin):
     """
     Test the simple exception class ``VersionError``.
     """
@@ -191,10 +230,13 @@ class TestVersionError(unittest.TestCase, SimpleTestMixin):
         self.exc_class = VersionError
 
 
-class TestHTTPError(unittest.TestCase, SimpleTestMixin):
+class TestHTTPError(unittest.TestCase, SimpleTestMixin, SingleArgTestMixin):
     """
     Test exception class ``HTTPError``.
     """
+
+    def setUp(self):
+        self.exc_class = HTTPError
 
     def test_empty(self):
         """Test HTTPError with no arguments (expecting failure)."""

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -57,14 +57,32 @@ class ConnectionError(Error):
     Derived from :exc:`~zhmcclient.Error`.
     """
 
-    def __init__(self, msg):
+    def __init__(self, msg, details=None):
         """
         Parameters:
 
           msg (:term:`string`):
             A human readable message describing the problem.
+
+          details (Exception):
+            The original exception describing details about the error.
         """
         super(ConnectionError, self).__init__(msg)
+        self._details = details
+
+    @property
+    def details(self):
+        """
+        The original exception describing details about the error, if there
+        was such an original exception.  This may be one of the following
+        exceptions:
+
+        * :exc:`~requests.exceptions.RequestException`
+        * Other exceptions (TODO: Describe details)
+
+        `None`, otherwise.
+        """
+        return self._details
 
 
 class AuthError(Error):
@@ -76,14 +94,32 @@ class AuthError(Error):
     Derived from :exc:`~zhmcclient.Error`.
     """
 
-    def __init__(self, msg):
+    def __init__(self, msg, details=None):
         """
         Parameters:
 
           msg (:term:`string`):
             A human readable message describing the problem.
+
+          details (Exception):
+            The original exception describing details about the error.
         """
         super(AuthError, self).__init__(msg)
+        self._details = details
+
+    @property
+    def details(self):
+        """
+        The original exception describing details about the error, if there
+        was such an original exception.  This may be one of the following
+        exceptions:
+
+        * :exc:`~zhmcclient.HTTPError`
+        * Other exceptions (TODO: Describe details)
+
+        `None`, otherwise.
+        """
+        return self._details
 
 
 class ParseError(Error):


### PR DESCRIPTION
This PR addresses the AuthError and ConnectionError portion of issue #94.
The other parts will be addressed separately.

This PR is based on PRs #95 and #96, so the first two commits have already been reviewed as part of their review.

Please review and merge.

Details:
- In `AuthError`, added a `details` property that is the underlying exception, and that is set to an `HTTPError` object in case the error is triggered by a failed HTTP response.
- In `ConnectionError`, added a `details` property that is the underlying exception, and that is set to a `RequestException` object in case the error is triggered by a failed requests method.
- Extended the unit testcases for `AuthError` and `ConnectionError` to test the new `details` property.
- Fixed a bug in the unit test cases for HTTPError, that caused the simple tests defined in `SimpleTestMixin` to be executed for the default exception class `Exception`, instead of `HttpError`. Changed the default exception class in `SimpleTestMixin` to `None`, in order to avoid such mistakes in the future.
- In the low level HTTP methods of the `Session` class, optimized the conversion of the response body into a Python dictionary (=JSON object) to avoid multiple conversions. In addition, separated that conversion onto a separate line for better debugging.