### PR TITLE
PyLint fixes and a real fix in dump_partition().

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,9 @@ Released: Not yet
 
 **Bug fixes:**
 
+* Fixed that in `Partition.dump_partition()`, `wait_for_completion` was always
+  passed on as `True`, ignoring the corresponding input argument.
+
 **Enhancements:**
 
 * Added a script named ``tools/cpcinfo`` that displays information about CPCs.

--- a/docs/notebooks/tututils.py
+++ b/docs/notebooks/tututils.py
@@ -39,7 +39,7 @@ def make_client(zhmc, userid=None, password=None):
     to this method.
     """
 
-    global USERID, PASSWORD
+    global USERID, PASSWORD  # pylint: disable=global-statement
 
     USERID = userid or USERID or \
         six.input('Enter userid for HMC {}: '.format(zhmc))

--- a/tests/unit/test_activation_profile.py
+++ b/tests/unit/test_activation_profile.py
@@ -122,12 +122,12 @@ class ActivationProfileTests(unittest.TestCase):
                     {
                         'name': 'LPAR1',
                         'element-uri': '/api/cpcs/fake-element-uri-id-1/'
-                        'image-activation-profiles/LPAR1'
+                                       'image-activation-profiles/LPAR1'
                     },
                     {
                         'name': 'LPAR2',
                         'element-uri': '/api/cpcs/fake-element-uri-id-2/'
-                        'image-activation-profiles/LPAR2'
+                                       'image-activation-profiles/LPAR2'
                     }
                 ]
             }
@@ -181,12 +181,12 @@ class ActivationProfileTests(unittest.TestCase):
                     {
                         'name': 'LPAR1',
                         'element-uri': '/api/cpcs/fake-element-uri-id-1/'
-                        'image-activation-profiles/LPAR1'
+                                       'image-activation-profiles/LPAR1'
                     },
                     {
                         'name': 'LPAR2',
                         'element-uri': '/api/cpcs/fake-element-uri-id-2/'
-                        'image-activation-profiles/LPAR2'
+                                       'image-activation-profiles/LPAR2'
                     }
                 ]
             }

--- a/tests/unit/test_port.py
+++ b/tests/unit/test_port.py
@@ -131,8 +131,7 @@ class PortTests(unittest.TestCase):
             ports = port_mgr.list(full_properties=False)
             if len(ports) != 0:
                 result_adapter = self.result['adapters'][idy]
-                if 'storage-port-uris' in self.result['adapters'][idy]:
-                    self.result['adapters'][idy]
+                if 'storage-port-uris' in result_adapter:
                     storage_uris = result_adapter['storage-port-uris']
                     uris = storage_uris
                 else:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -102,7 +102,7 @@ class SessionTests(unittest.TestCase):
         self.assertFalse(logged_on)
 
     @staticmethod
-    def test_delete_completed_job_status():
+    def test_delete_compl_job_status():
         """
         This tests the 'Delete Completed Job Status' operation.
         """

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -405,7 +405,7 @@ class Partition(BaseResource):
         partition_uri = self.get_property('object-uri')
         result = self.manager.session.post(
             partition_uri + '/operations/scsi-dump',
-            wait_for_completion=True, body=parameters)
+            wait_for_completion=wait_for_completion, body=parameters)
         return result
 
     def psw_restart(self, wait_for_completion=True):


### PR DESCRIPTION
Details:
- In `Partition.dump_partition()`, wait_for_completion was always set to True, and the corresponding input argument was ignored.
- Fixed several pyLint issues.