### PR TITLE
Added time statistics entry for overall async operations.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -40,6 +40,11 @@ Released: Not yet
   `details` property that provides access to the underlying exception
   describing details.
 
+* For asynchronous operations that are invoked with `wait_for_completion`,
+  added an entry in the time statistics for the overall operation
+  from the start to completion of the asynchronous operation. That entry
+  is for a URI that is the target URI, appended with "+completion".
+
 **Known Issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
So far,  the time statistics only records the actual async POST operation, i.e. the start of what happens in the background, and separately, all the GET operations that poll for job completion. This makes it hard to figure out what the elapsed time is for the entire operation.

This PR improves that by adding an entry in the time statistics for the overall operation consisting of the sequence of async POST plus all the GETs for polling.

Please review and merge.