### PR TITLE
Fixes #112: For zhmc CLI, added RTD documentation and improved help texts.

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,298 @@
+.. Copyright 2016 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _`Command line interface`:
+
+Command line interface
+======================
+
+This package provides a command line interface (CLI) that utilizes the API of
+the zhmcclient package in order to support shell scripting or simply manual
+command use in a terminal session.
+
+.. _`Modes of operation`:
+
+Modes of operation
+------------------
+
+The zhmc CLI supports two modes of operation:
+
+* `Interactive mode`_: Invoking an interactive zhmc shell for typing zhmc
+  sub-commands.
+* `Command mode`_: Using it as a standalone non-interactive command.
+
+.. _`Interactive mode`:
+
+Interactive mode
+----------------
+
+In interactive mode, an interactive shell environment is brought up that allows
+typing zhmc commands, internal commands (for operating the zhmc shell), and
+external commands (that are executed in the standard shell for the user).
+
+This zhmc shell is started when the ``zhmc`` command is invoked without
+specifying any (sub-)commands::
+
+    $ zhmc [GENERAL-OPTIONS]
+    > _
+
+Alternatively, the zhmc shell can also be started by specifying the ``repl``
+(sub-)command::
+
+    $ zhmc [GENERAL-OPTIONS] repl
+    > _
+
+The zhmc shell uses the ``>`` prompt, and the cursor is shown in the examples
+above as an underscore ``_``.
+
+General options may be specified on the ``zhmc`` command, and they serve as
+defaults for the zhmc commands that can be typed in the zhmc shell.
+
+The zhmc commands that can be typed in the zhmc shell are simply the command
+line arguments that would follow the ``zhmc`` command when used in
+`command mode`_::
+
+    $ zhmc -h zhmc.example.com -u hmcuser
+    Enter password: <password>
+    > cpc list
+    . . . <list of CPCs managed by this HMC>
+    > partition list JLSE1
+    . . . <list of partitions in CPC JLSE1>
+    > :q
+
+For example, the zhmc shell command ``cpc list`` in the example above has the
+same effect as the standalone command::
+
+    $ zhmc -h zhmc.example.com -u hmcuser cpc list
+    Enter password: <password>
+    . . . <list of CPCs managed by this HMC>
+
+However, the zhmc shell will prompt for a password only once during its
+invocation, while the standalone command will prompt for a password every time.
+See also `Environment variables and avoiding password prompts`_.
+
+The internal commands ``:?``, ``:h``, or ``:help`` display general help
+information for external and internal commands::
+
+    > :help
+    REPL help:
+
+      External Commands:
+        prefix external commands with "!"
+
+      Internal Commands:
+        prefix internal commands with ":"
+        :?, :h, :help     displays general help information
+        :exit, :q, :quit  exits the repl
+
+In this help text, "REPL" stands for "Read-Execute-Print-Loop" which is a
+term that denotes the approach used in the zhmc shell (or in any shell, for
+that matter).
+
+In addition to using one of the internal shell commands shown in the help text
+above, you can also exit the zhmc shell by typing `Ctrl-D`.
+
+Typing ``--help`` in the zhmc shell displays general help information for the
+zhmc commands, which includes global options and a list of the supported
+commands::
+
+    > --help
+    Usage: zhmc  [OPTIONS] COMMAND [ARGS]...
+
+      Command line interface for the z Systems HMC.
+      . . .
+
+    Options:
+      -h, --host TEXT                 Hostname or IP address of the HMC (Default:
+                                      ZHMC_HOST environment variable).
+      -u, --userid TEXT               Username for the HMC (Default: ZHMC_USERID
+                                      environment variable).
+      -o, --output-format [table|json]
+                                      Output format (Default: table).
+      -t, --timestats                 Show time statistics of HMC operations.
+      --version                       Show the version of this command and exit.
+      --help                          Show this message and exit.
+
+    Commands:
+      cpc        Command group for managing CPCs.
+      info       Show information about the HMC.
+      lpar       Command group for managing LPARs.
+      partition  Command group for managing partitions.
+      repl       Start an interactive shell.
+      session    Command group for managing sessions.
+
+The usage line in this help text show the standalone command use. Within the
+zhmc shell, the ``zhmc`` word is ommitted and the remainder is typed in.
+
+Typing ``COMMAND --help`` in the zhmc shell displays help information for the
+specified zhmc command, for example::
+
+    > cpc --help
+    Usage: zhmc  cpc [OPTIONS] COMMAND [ARGS]...
+
+      Command group for managing CPCs.
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      list  List the CPCs.
+      show  Show details of a CPC.
+
+The zhmc shell supports popup help text while typing, where the valid choices
+are shown based upon what was typed so far, and where an item from the popup
+list can be picked with <TAB> or with the cursor keys. In the following
+examples, an underscore ``_`` is shown as the cursor::
+
+    > --_
+        --host           Hostname or IP address of the HMC (Default: ZHMC_HOST environment variable).
+        --userid         Username for the HMC (Default: ZHMC_USERID environment variable).
+        --output-format  Output format (Default: table).
+        --timestats      Show time statistics of HMC operations.
+        --version        Show the version of this command and exit.
+
+    > c_
+       cpc    Command group for managing CPCs.
+
+The zhmc shell supports history (within one invocation of the shell, not
+persisted across zhmc shell invocations).
+
+.. _`Command mode`:
+
+Command mode
+------------
+
+In command mode, the ``zhmc`` command performs its task and terminates, like any
+other standalone non-interactive command.
+
+This mode is used when the ``zhmc`` command is invoked with a (sub-)command::
+
+    $ zhmc [GENERAL-OPTIONS] COMMAND [ARGS...] [COMMAND-OPTIONS]
+
+Examples::
+
+    $ zhmc -h zhmc.example.com -u hmcuser cpc list
+    Enter password: <password>
+    . . . <list of CPCs managed by this HMC>
+
+    $ zhmc -h zhmc.example.com info
+    Enter password: <password>
+    . . . <information about this HMC>
+
+In command mode, bash tab completion is also supported, but must be enabled
+first as follows (in a bash shell)::
+
+    $ eval "$(_ZHMC_COMPLETE=source zhmc)"
+
+Bash tab completion for zhmc is used like any other bash tab completion::
+
+    $ zhmc --<TAB><TAB>
+    ... <shows the global options to select from>
+
+    $ zhmc <TAB><TAB>
+    ... <shows the commands to select from>
+
+    $ zhmc cpc <TAB><TAB>
+    ... <shows the cpc sub-commands to select from>
+
+.. _`Environment variables and avoiding password prompts`:
+
+Environment variables and avoiding password prompts
+---------------------------------------------------
+
+The zhmc CLI has command line options for specifying the HMC host and the HMC
+userid to be used. For security reasons, it does not have a command line option
+for specifying the password of the HMC userid.
+
+If the HMC operations performed by a particular zhmc command require a
+password, the password is prompted for (in both modes of operation)::
+
+      $ zhmc -h zhmc.example.com -u hmcuser cpc list
+      Enter password: <password>
+      . . . <list of CPCs managed by this HMC>
+
+If the HMC operations performed by a particular zhmc command do not require a
+password, no password is prompted for::
+
+      $ zhmc -h zhmc.example.com info
+      . . . <information about this HMC>
+
+For script integration, it is important to have a way to avoid the interactive
+password prompt. This can be done by storing the session-id string returned by
+the HMC when logging on, in an environment variable.
+
+The ``zhmc`` command supports a ``session create`` (sub-)command that outputs
+the (bash) shell commands to set all needed environment variables::
+
+      $ zhmc -h zhmc.example.com -u hmcuser session create
+      Enter password: <password>
+      export ZHMC_HOST=zhmc.example.com
+      export ZHMC_USERID=hmcuser
+      export ZHMC_SESSION_ID=<session-id>
+
+This ability can be used to set those environment variables and thus to persist
+the session-id in the shell environment, from where it will be used in
+any subsequent zhmc commands::
+
+      $ eval $(zhmc -h zhmc.example.com -u hmcuser session create)
+      Enter password: <password>
+
+      $ env |grep ZHMC
+      ZHMC_HOST=zhmc.example.com
+      ZHMC_USERID=hmcuser
+      ZHMC_SESSION_ID=<session-id>
+
+      $ zhmc cpc list
+      . . . <list of CPCs managed by this HMC>
+
+As you can see from this example, the password is only prompted for when
+creating the session, and the session-id stored in the shell environment is
+utilized in the ``zhmc cpc list`` command, avoiding another password prompt.
+
+Using the session-id from the environment is also a performance improvement,
+because it avoids the HMC Logon operation that otherwise would take place.
+
+We believe that storing passwords in shell scripting environments should be
+avoided for security reasons, and using the session-id from the ZHMC_SESSION_ID
+environment variable should be a reasonable compromise between security
+and convenience.
+
+The ZHMC_HOST and ZHMC_USERID environment variables act as defaults for the
+corresponding command line options.
+
+.. _`CLI commands`:
+
+CLI commands
+------------
+
+For a description of the commands supported by the zhmc CLI, consult its
+help system. For example::
+
+      $ zhmc --help
+      . . . <general help, listing the general options and possible commands>
+
+      $ zhmc cpc --help
+      . . . <help for cpc command, listing its arguments and command-specific options>
+
+Note that the help text for any zhmc (sub-)commands (such as ``cpc``) will
+not show the general options again. This is caused by flaws in the tooling
+environment used for the zhmc CLI.
+The general options (listed by ``zhmc --help``) can still be specified together
+with (sub-)commands even though they are not listed in their help text, but
+they must be specified before the (sub-)command, and any command-specific
+options (listed by ``zhmc COMMAND --help``) must be specified after the
+(sub-)command, like shown here::
+
+      $ zhmc [GENERAL-OPTIONS] COMMAND [ARGS...] [COMMAND-OPTIONS]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,5 +27,6 @@ zhmcclient - A pure Python client library for the z Systems HMC Web Services API
    concepts.rst
    general.rst
    resources.rst
+   cli.rst
    development.rst
    appendix.rst

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -23,13 +23,25 @@ from ._helper import print_properties, print_resources
 
 @cli.group('cpc')
 def cpc_group():
-    """Command group for managing CPCs."""
+    """
+    Command group for managing CPCs.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
 
 
 @cpc_group.command('list')
 @click.pass_obj
 def cpc_list(cmd_ctx):
-    """List the CPCs."""
+    """
+    List the CPCs.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_cpc_list(cmd_ctx))
 
 
@@ -37,7 +49,14 @@ def cpc_list(cmd_ctx):
 @click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
 @click.pass_obj
 def cpc_show(cmd_ctx, cpc_name):
-    """Show details of a CPC."""
+    """
+    Show details of a CPC.
+    In table format, some properties are skipped.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_cpc_show(cmd_ctx, cpc_name))
 
 
@@ -55,7 +74,8 @@ def cmd_cpc_list(cmd_ctx):
 
 def cmd_cpc_show(cmd_ctx, cpc_name):
     """
-    Show details of a CPC. In table format, some properties are skipped.
+    Show details of a CPC.
+    In table format, some properties are skipped.
     """
     client = zhmcclient.Client(cmd_ctx.session)
     try:

--- a/zhmccli/_cmd_info.py
+++ b/zhmccli/_cmd_info.py
@@ -26,6 +26,10 @@ from ._helper import print_properties
 def info(cmd_ctx):
     """
     Show information about the HMC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
     """
     cmd_ctx.execute_cmd(lambda: cmd_info(cmd_ctx))
 

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -23,14 +23,26 @@ from ._helper import print_properties, print_resources, abort_if_false
 
 @cli.group('lpar')
 def lpar_group():
-    """Command group for managing LPARs."""
+    """
+    Command group for managing LPARs.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
 
 
 @lpar_group.command('list')
 @click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
 @click.pass_obj
 def lpar_list(cmd_ctx, cpc_name):
-    """List the LPARs in a CPC."""
+    """
+    List the LPARs in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_lpar_list(cmd_ctx, cpc_name))
 
 
@@ -39,7 +51,14 @@ def lpar_list(cmd_ctx, cpc_name):
 @click.argument('LPAR-NAME', type=str, metavar='LPAR-NAME')
 @click.pass_obj
 def lpar_show(cmd_ctx, cpc_name, lpar_name):
-    """Show details of an LPAR in a CPC."""
+    """
+    Show details of an LPAR in a CPC.
+    In table format, some properties are skipped.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_lpar_show(cmd_ctx, cpc_name, lpar_name))
 
 
@@ -48,7 +67,13 @@ def lpar_show(cmd_ctx, cpc_name, lpar_name):
 @click.argument('LPAR-NAME', type=str, metavar='LPAR-NAME')
 @click.pass_obj
 def lpar_activate(cmd_ctx, cpc_name, lpar_name):
-    """Activate an LPAR in a CPC."""
+    """
+    Activate an LPAR in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_lpar_activate(cmd_ctx, cpc_name,
                                                   lpar_name))
 
@@ -62,7 +87,13 @@ def lpar_activate(cmd_ctx, cpc_name, lpar_name):
               prompt='Are you sure you want to deactivate the LPAR ?')
 @click.pass_obj
 def lpar_deactivate(cmd_ctx, cpc_name, lpar_name):
-    """Deactivate an LPAR in a CPC."""
+    """
+    Deactivate an LPAR in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_lpar_deactivate(cmd_ctx, cpc_name,
                                                     lpar_name))
 
@@ -73,7 +104,13 @@ def lpar_deactivate(cmd_ctx, cpc_name, lpar_name):
 @click.argument('LOAD-ADDRESS', type=str, metavar='LOAD-ADDRESS')
 @click.pass_obj
 def lpar_load(cmd_ctx, cpc_name, lpar_name, load_address):
-    """Load an LPAR in a CPC."""
+    """
+    Load an LPAR in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_lpar_load(cmd_ctx, cpc_name, lpar_name,
                                               load_address))
 
@@ -121,6 +158,7 @@ def cmd_lpar_list(cmd_ctx, cpc_name):
 def cmd_lpar_show(cmd_ctx, cpc_name, lpar_name):
     """
     Show the details of an LPAR in a CPC.
+    In table format, some properties are skipped.
     """
     client = zhmcclient.Client(cmd_ctx.session)
     lpar = _find_lpar(client, cpc_name, lpar_name)

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -24,15 +24,76 @@ from ._helper import print_properties, print_resources, abort_if_false, \
 
 @cli.group('partition')
 def partition_group():
-    """Command group for managing partitions."""
+    """
+    Command group for managing partitions.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
 
 
 @partition_group.command('list')
 @click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
 @click.pass_obj
 def partition_list(cmd_ctx, cpc_name):
-    """List the partitions in a CPC."""
+    """
+    List the partitions in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_partition_list(cmd_ctx, cpc_name))
+
+
+@partition_group.command('show')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.pass_obj
+def partition_show(cmd_ctx, cpc_name, partition_name):
+    """
+    Show the details of a partition in a CPC.
+    In table format, some properties are skipped.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_partition_show(cmd_ctx, cpc_name,
+                                                   partition_name))
+
+
+@partition_group.command('start')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.pass_obj
+def partition_start(cmd_ctx, cpc_name, partition_name):
+    """
+    Start a partition in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_partition_start(cmd_ctx, cpc_name,
+                                                    partition_name))
+
+
+@partition_group.command('stop')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.pass_obj
+def partition_stop(cmd_ctx, cpc_name, partition_name):
+    """
+    Stop a partition in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_partition_stop(cmd_ctx, cpc_name,
+                                                   partition_name))
 
 
 @partition_group.command('create')
@@ -54,41 +115,17 @@ def partition_list(cmd_ctx, cpc_name):
               help='The type of device from which the partition is booted.')
 @click.pass_context
 def partition_create(ctx, cpc_name, **options):
-    """Create a partition in a CPC."""
+    """
+    Create a partition in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     properties = options_to_properties(options)
     cmd_ctx = ctx.obj
     cmd_ctx.execute_cmd(lambda: cmd_partition_create(cmd_ctx, cpc_name,
                                                      properties))
-
-
-@partition_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.pass_obj
-def partition_show(cmd_ctx, cpc_name, partition_name):
-    """Show the details of a partition in a CPC."""
-    cmd_ctx.execute_cmd(lambda: cmd_partition_show(cmd_ctx, cpc_name,
-                                                   partition_name))
-
-
-@partition_group.command('start')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.pass_obj
-def partition_start(cmd_ctx, cpc_name, partition_name):
-    """Start a partition in a CPC."""
-    cmd_ctx.execute_cmd(lambda: cmd_partition_start(cmd_ctx, cpc_name,
-                                                    partition_name))
-
-
-@partition_group.command('stop')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.pass_obj
-def partition_stop(cmd_ctx, cpc_name, partition_name):
-    """Stop a partition in a CPC."""
-    cmd_ctx.execute_cmd(lambda: cmd_partition_stop(cmd_ctx, cpc_name,
-                                                   partition_name))
 
 
 @partition_group.command('delete')
@@ -100,7 +137,13 @@ def partition_stop(cmd_ctx, cpc_name, partition_name):
               prompt='Are you sure you want to delete this partition ?')
 @click.pass_obj
 def partition_delete(cmd_ctx, cpc_name, partition_name):
-    """Delete a partition in a CPC."""
+    """
+    Delete a partition in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_partition_delete(cmd_ctx, cpc_name,
                                                      partition_name))
 
@@ -148,6 +191,7 @@ def cmd_partition_list(cmd_ctx, cpc_name):
 def cmd_partition_show(cmd_ctx, cpc_name, partition_name):
     """
     Show the details of a partition in a CPC.
+    In table format, some properties are skipped.
     """
     client = zhmcclient.Client(cmd_ctx.session)
     partition = _find_partition(client, cpc_name, partition_name)

--- a/zhmccli/_cmd_session.py
+++ b/zhmccli/_cmd_session.py
@@ -22,24 +22,43 @@ from .zhmccli import cli
 
 @cli.group('session')
 def session_group():
-    """Command group for managing sessions."""
+    """
+    Command group for managing sessions.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
 
 
 @session_group.command('create')
 @click.pass_obj
 def session_create(cmd_ctx):
-    """Create a HMC session."""
+    """
+    Create an HMC session.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_session_create(cmd_ctx))
 
 
 @session_group.command('delete')
 @click.pass_obj
 def session_delete(cmd_ctx):
-    """Delete a HMC session."""
+    """
+    Delete the current HMC session.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
     cmd_ctx.execute_cmd(lambda: cmd_session_delete(cmd_ctx))
 
 
 def cmd_session_create(cmd_ctx):
+    """Create an HMC session."""
     session = cmd_ctx.session
     try:
         session.logon(verify=True)
@@ -51,7 +70,7 @@ def cmd_session_create(cmd_ctx):
 
 
 def cmd_session_delete(cmd_ctx):
-    """Delete the current session."""
+    """Delete the current HMC session."""
     session = cmd_ctx.session
     try:
         session.logoff()

--- a/zhmccli/zhmccli.py
+++ b/zhmccli/zhmccli.py
@@ -21,12 +21,6 @@ from click_repl import register_repl, repl
 from ._helper import CmdContext
 
 
-# TODO: Documentation for zhmc cli
-# TODO: Automated tests for zhmc cli
-# TODO: Find a way to clarify in the sub-command help texts that the global
-#       options can be used.
-
-
 requests.packages.urllib3.disable_warnings()
 
 # Default values for some options
@@ -52,77 +46,8 @@ def cli(ctx, host, userid, output_format, timestats):
     """
     Command line interface for the z Systems HMC.
 
-    zhmc is a command line interface for interacting with the Web Services API
-    of the Hardware Management Console (HMC) of z Systems or LinuxONE machines.
-    It allows management of LPARs, partitions and much more.
-
-    \b
-    The zhmc command line interface can be used in these modes:
-    - Interactive - an interactive shell
-    - Command-Session - command mode that prompts for a password only once and
-      stores the session-id in an environment variable
-    - Command-Prompt - command mode that prompts for a password every time
-
-    Example for interactive mode:
-
-       \b
-       $ zhmc -h zhmc.example.com -u hmcuser
-       Enter password: <password>
-       > cpc list
-       > partition list JLSE1
-       > partition create JLSE1 --name TESTPART_JL --description "blablabla"
-       --cp-processors 1 --initial-memory 4096 --maximum-memory 4096
-       --processor-mode shared --boot-device test-operating-system
-       > partition show JLSE1 TESTPART_JL
-       > partition start JLSE1 TESTPART_JL
-       > partition stop JLSE1 TESTPART_JL
-       > partition delete JLSE1 TESTPART_JL --yes
-       > :q
-
-    Example for command-session mode:
-
-       \b
-       $ eval $(zhmc -h zhmc.example.com -u hmcuser session create)
-       Enter password: <password>
-       $ zhmc cpc list
-       $ zhmc lpar list P0000P99
-       $ zhmc lpar deactivate P0000P99 PART8 --yes
-       $ zhmc --timestats lpar activate P0000P99 PART8
-       $ zhmc lpar load P0000P99 PART8 5172
-       $ zhmc lpar show P0000P99 PART8
-       $ zhmc -o json lpar show P0000P30 PART8
-       $ eval $(zhmc session delete --yes)
-
-    Example for command-prompt mode:
-
-       \b
-       $ zhmc -h zhmc.example.com -u hmcuser cpc list
-       Enter password: <password>
-       $ zhmc -h zhmc.example.com info
-       Enter password: <password>
-
-    To get overall help:
-
-       \b
-       $ zhmc --help
-
-    To get help for a specific command (or command group):
-
-       \b
-       $ zhmc <command> --help
-
-    To enable bash completion in the current shell:
-
-       \b
-       $ eval "$(_ZHMC_COMPLETE=source zhmc)"
-
-    To use bash completion:
-
-       \b
-       $ zhmc --<TAB><TAB>
-       ... shows the global options to select from ...
-       $ zhmc <TAB><TAB>
-       ... shows the commands to select from ...
+    The options shown in this help text are general options that can also
+    be specified on any of the (sub-)commands.
     """
 
     # Concept: In interactive mode, the global options specified in the command


### PR DESCRIPTION
Please review and merge.

Details:
- Added a new chapter "Command line interface" to the RTD documentation.
- Shortened the help text of `zhmc --help`.
- Added a note in `zhmc --help` that its options are general options and can be specified on all (sub-)commands.
- Added a note in all other zhmc command help texts that the general options can be specified as well.
- Added a note to some help texts that some properties are ommitted  in table format (for those that defined a skip list).
- Switched order of sub-commands in partition command to be consistent.