### PR TITLE
Fixed incorrect package version for pypi upload.

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -291,9 +291,11 @@ the `Makefile` is), and perform the following steps in that directory:
 
         make upload
 
-    **Attention!!** This only works once. You cannot re-release the same
-    version to PyPI.
+    This will show the package version and will ask for confirmation.
 
+    **Attention!!** This only works once for each version. You cannot
+    re-release the same version to PyPI.
+    
 11. Verify that the released version is shown on PyPI:
 
     https://pypi.python.org/pypi/zhmcclient/


### PR DESCRIPTION
Please review and merge.

Details:
- Probably, the bug that an incorrect version was uploaded to Pypi was caused by having that version installed as a package in the virtual Python environment.
- Fixed that bug in the Makefile, by:
  - Adding an 'uninstall' target that uninstalls the Python package from the current Python environment.
  - Invoking that 'uninstall' target as part of the 'clobber' and 'upload' targets.
  - As an additional safety net, added a check to the 'upload' target that rejects the attempt to upload development versions.
  - As a second additional safety net, added a confirmation prompt in the 'upload' target that asks the user for confirmation.
- Updated the Pypi upload steps in the RTD documentation to state that a user confirmation is needed for 'make upload'.