### PR TITLE
Fixed #120: Pin click-spinner to 0.1.3

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,16 +20,18 @@ Change log
 ----------
 
 
-Version 0.7.0.devXX
-^^^^^^^^^^^^^^^^^^^
+Version 0.7.0
+^^^^^^^^^^^^^
 
-Released: not yet
+Released: 2016-12-08
 
 **Incompatible changes:**
 
 **Deprecations:**
 
 **Bug fixes:**
+
+* IOError during click-spinner 0.1.4 install (issue #120)
 
 **Enhancements:**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ decorator # new BSD
 tabulate # MIT
 progressbar2 # BSD
 click # BSD
-click-spinner # MIT
+click-spinner==0.1.3 # MIT
 click-repl # MIT


### PR DESCRIPTION
Details:
- During 'pip install zhmcclient' and
  building the package we run into IOError when
  trying to install click-spinner 0.1.4.
  There we pin click-spinner to version 0.1.3.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>