### PR TITLE
Upgraded click-spinner to v0.1.5 and simplified its use

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,18 +20,16 @@ Change log
 ----------
 
 
-Version 0.7.0
+Version 0.8.0
 ^^^^^^^^^^^^^
 
-Released: 2016-12-08
+Released: not yet
 
 **Incompatible changes:**
 
 **Deprecations:**
 
 **Bug fixes:**
-
-* IOError during click-spinner 0.1.4 install (issue #120)
 
 **Enhancements:**
 
@@ -40,6 +38,20 @@ Released: 2016-12-08
 * See `list of open issues`_.
 
 .. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
+
+
+Version 0.7.0
+^^^^^^^^^^^^^
+
+Released: 2016-12-08
+
+**Bug fixes:**
+
+* IOError during click-spinner 0.1.4 install (issue #120)
+
+**Enhancements:**
+
+* Documentation for zhmc CLI
 
 
 Version 0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ decorator # new BSD
 tabulate # MIT
 progressbar2 # BSD
 click # BSD
-click-spinner==0.1.3 # MIT
+click-spinner>=0.1.5 # MIT
 click-repl # MIT

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-import sys
 import json
 import click
 import click_spinner
@@ -50,7 +49,7 @@ class CmdContext(object):
         self._session_id = session_id
         self._get_password = get_password
         self._session = None
-        self._spinner = None
+        self._spinner = click_spinner.Spinner()
 
     @property
     def host(self):
@@ -104,30 +103,13 @@ class CmdContext(object):
     @property
     def spinner(self):
         """
-        :class:`~click_spinner.Spinner` object if a spinner is running, or
-        `None`.
+        :class:`~click_spinner.Spinner` object.
+
+        Since click_spinner 0.1.5, the Spinner object takes care of suppressing
+        the spinner when not on a tty, and is able to suspend/resume the
+        spinner via its stop() and start() methods.
         """
         return self._spinner
-
-    def spinner_start(self):
-        """
-        Start the spinner (unless redirected).
-
-        Unlike :meth:`click_spinner.Spinner.start`, this function can be called
-        to restart the spinner after having stopped it (via
-        :meth:`spinner_stop`).
-        """
-        if sys.stdout.isatty():
-            self._spinner = click_spinner.Spinner()
-            self._spinner.start()
-
-    def spinner_stop(self):
-        """
-        Stop the spinner.
-        """
-        if self._spinner is not None:
-            self._spinner.stop()
-            self._spinner = None
 
     def execute_cmd(self, cmd):
         if self._session is None:
@@ -142,11 +124,11 @@ class CmdContext(object):
                     self._host, self._userid, get_password=self._get_password)
         if self.timestats:
             self._session.time_stats_keeper.enable()
-        self.spinner_start()
+        self.spinner.start()
         try:
             cmd()
         finally:
-            self.spinner_stop()
+            self.spinner.stop()
             if self._session.time_stats_keeper.enabled:
                 click.echo(self._session.time_stats_keeper)
 

--- a/zhmccli/zhmccli.py
+++ b/zhmccli/zhmccli.py
@@ -84,15 +84,12 @@ def cli(ctx, host, userid, output_format, timestats):
 
     def password_prompt():
         if userid is not None and host is not None:
-            spinner_running = (ctx.obj.spinner is not None)
-            if spinner_running:
-                ctx.obj.spinner_stop()
+            ctx.obj.spinner.stop()
             password = click.prompt(
                 "Enter password (for user {userid} at HMC {host})"
                 .format(userid=userid, host=host), hide_input=True,
                 confirmation_prompt=False, type=str, err=True)
-            if spinner_running:
-                ctx.obj.spinner_start()
+            ctx.obj.spinner.start()
             return password
         else:
             raise click.ClickException("{cmd} command requires logon, but "


### PR DESCRIPTION
This PR removes the pinning of click-spinner to 0.1.3 and instead requires >=0.1.5, and at the same time it exploits the new abilities in 0.1.5 (ability to pause via stop/start, and automatic suppression when not on a tty).