### PR TITLE
Added support in CLI for remaining cmds; client improvements.

### DIFF
--- a/tests/unit/test_hba.py
+++ b/tests/unit/test_hba.py
@@ -236,16 +236,16 @@ class HbaTests(unittest.TestCase):
         """
         hba_mgr = self.partition.hbas
         hba_uri = '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1'
-        hba = Hba(hba_mgr, uri=hba_uri, properties={})
+        hba = Hba(hba_mgr, hba_uri)
 
         adapter_mgr = self.cpc.adapters
         adapter_uri = '/api/adapters/fake-adapter-id-1'
-        adapter = Adapter(adapter_mgr, uri=adapter_uri, properties={})
+        adapter = Adapter(adapter_mgr, adapter_uri)
 
         port_mgr = adapter.ports
         port2_uri = '/api/adapters/fake-adapter-id-2/'\
                     'storage-ports/fake-port-id-2'
-        port2 = Port(port_mgr, uri=port2_uri, properties={})
+        port2 = Port(port_mgr, port2_uri)
 
         with requests_mock.mock() as m:
             # TODO: Add the request body to the mock call:

--- a/tests/unit/test_virtual_switch.py
+++ b/tests/unit/test_virtual_switch.py
@@ -62,7 +62,7 @@ class VirtualSwitchTests(unittest.TestCase):
 
     def test_init(self):
         """Test __init__() on VirtualSwitchManager instance in CPC."""
-        vswitch_mgr = self.cpc.vswitches
+        vswitch_mgr = self.cpc.virtual_switches
         self.assertEqual(vswitch_mgr.cpc, self.cpc)
 
     def test_list_short_ok(self):
@@ -70,7 +70,7 @@ class VirtualSwitchTests(unittest.TestCase):
         Test successful list() with short set of properties
         on VirtualSwitchManager instance in CPC.
         """
-        vswitch_mgr = self.cpc.vswitches
+        vswitch_mgr = self.cpc.virtual_switches
         with requests_mock.mock() as m:
             result = {
                 'virtual-switches': [
@@ -107,7 +107,7 @@ class VirtualSwitchTests(unittest.TestCase):
         Test successful list() with full set of properties on
         VirtualSwitchManager instance in CPC.
         """
-        vswitch_mgr = self.cpc.vswitches
+        vswitch_mgr = self.cpc.virtual_switches
         with requests_mock.mock() as m:
             result = {
                 'virtual-switches': [
@@ -163,7 +163,7 @@ class VirtualSwitchTests(unittest.TestCase):
         """
         This tests the 'Update VirtualSwitch Properties' operation.
         """
-        vswitch_mgr = self.cpc.vswitches
+        vswitch_mgr = self.cpc.virtual_switches
         with requests_mock.mock() as m:
             result = {
                 'virtual-switches': [
@@ -193,7 +193,7 @@ class VirtualSwitchTests(unittest.TestCase):
         """
         This tests the `get_connected_nics()` method.
         """
-        vswitch_mgr = self.cpc.vswitches
+        vswitch_mgr = self.cpc.virtual_switches
         with requests_mock.mock() as m:
             result = {
                 'virtual-switches': [

--- a/zhmccli/__init__.py
+++ b/zhmccli/__init__.py
@@ -14,15 +14,14 @@
 
 from __future__ import absolute_import
 
-from ._cmd_info import *      # noqa: F401
-from ._cmd_session import *   # noqa: F401
-from ._cmd_cpc import *       # noqa: F401
-from ._cmd_lpar import *      # noqa: F401
+from ._cmd_info import *       # noqa: F401
+from ._cmd_session import *    # noqa: F401
+from ._cmd_cpc import *        # noqa: F401
+from ._cmd_lpar import *       # noqa: F401
 from ._cmd_partition import *  # noqa: F401
-from ._cmd_adapter import *   # noqa: F401
-from ._cmd_port import *      # noqa: F401
-from ._cmd_hba import *       # noqa: F401
-from ._cmd_nic import *       # noqa: F401
+from ._cmd_adapter import *    # noqa: F401
+from ._cmd_port import *       # noqa: F401
+from ._cmd_hba import *        # noqa: F401
+from ._cmd_nic import *        # noqa: F401
 from ._cmd_vfunction import *  # noqa: F401
-from ._cmd_vswitch import *   # noqa: F401
-
+from ._cmd_vswitch import *    # noqa: F401

--- a/zhmccli/__init__.py
+++ b/zhmccli/__init__.py
@@ -19,3 +19,10 @@ from ._cmd_session import *   # noqa: F401
 from ._cmd_cpc import *       # noqa: F401
 from ._cmd_lpar import *      # noqa: F401
 from ._cmd_partition import *  # noqa: F401
+from ._cmd_adapter import *   # noqa: F401
+from ._cmd_port import *      # noqa: F401
+from ._cmd_hba import *       # noqa: F401
+from ._cmd_nic import *       # noqa: F401
+from ._cmd_vfunction import *  # noqa: F401
+from ._cmd_vswitch import *   # noqa: F401
+

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -19,7 +19,7 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
-    options_to_properties, original_options
+    options_to_properties, original_options, COMMAND_OPTIONS_METAVAR
 from ._cmd_cpc import find_cpc
 
 
@@ -40,7 +40,7 @@ def find_adapter(client, cpc_name, adapter_name):
     return adapter
 
 
-@cli.group('adapter')
+@cli.group('adapter', options_metavar=COMMAND_OPTIONS_METAVAR)
 def adapter_group():
     """
     Command group for managing adapters.
@@ -49,44 +49,43 @@ def adapter_group():
     created. Logical adapters (HiperSockets) can be created and deleted.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
 
 
-@adapter_group.command('list')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@adapter_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
 @click.pass_obj
-def adapter_list(cmd_ctx, cpc_name):
+def adapter_list(cmd_ctx, cpc):
     """
     List the adapters in a CPC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_adapter_list(cmd_ctx, cpc_name))
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_list(cmd_ctx, cpc))
 
 
-@adapter_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@adapter_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('ADAPTER', type=str, metavar='ADAPTER')
 @click.pass_obj
-def adapter_show(cmd_ctx, cpc_name, adapter_name):
+def adapter_show(cmd_ctx, cpc, adapter):
     """
     Show the details of an adapter.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_adapter_show(cmd_ctx, cpc_name,
-                                                 adapter_name))
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_show(cmd_ctx, cpc, adapter))
 
 
-@adapter_group.command('update')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@adapter_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('ADAPTER', type=str, metavar='ADAPTER')
 @click.option('--name', type=str, required=False,
               help='The new name of the adapter.')
 @click.option('--description', type=str, required=False,
@@ -112,7 +111,7 @@ def adapter_show(cmd_ctx, cpc_name, adapter_name):
               help='Permit TKE commands on the crypto adapter '
               '(Crypto only).')
 @click.pass_obj
-def adapter_update(cmd_ctx, cpc_name, adapter_name, **options):
+def adapter_update(cmd_ctx, cpc, adapter, **options):
     """
     Update the properties of an adapter.
 
@@ -120,15 +119,15 @@ def adapter_update(cmd_ctx, cpc_name, adapter_name, **options):
     logical adapter (e.g. HiperSockets).
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_adapter_update(
-                        cmd_ctx, cpc_name, adapter_name, options))
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_update(cmd_ctx, cpc, adapter,
+                                                   options))
 
 
-@adapter_group.command('create')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@adapter_group.command('create', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
 @click.option('--name', type=str, required=True,
               help='The name of the new adapter.')
 @click.option('--description', type=str, required=False,
@@ -139,39 +138,39 @@ def adapter_update(cmd_ctx, cpc_name, adapter_name, **options):
               required=False,
               help='The MTU size of the new adapter in KiB.')
 @click.pass_obj
-def adapter_create_hipersocket(cmd_ctx, cpc_name, **options):
+def adapter_create_hipersocket(cmd_ctx, cpc, **options):
     """
     Create a HiperSockets adapter in a CPC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
 
     Some more properties of the new HiperSockets adapter can be set via
     adapter update.
     """
     cmd_ctx.execute_cmd(lambda: cmd_adapter_create_hipersocket(
-                        cmd_ctx, cpc_name, options))
+                        cmd_ctx, cpc, options))
 
 
-@adapter_group.command('delete')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@adapter_group.command('delete', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('ADAPTER', type=str, metavar='ADAPTER')
 @click.option('--yes', is_flag=True, callback=abort_if_false,
               expose_value=False,
               help='Skip prompt to confirm deletion of the adapter.',
               prompt='Are you sure you want to delete this adapter ?')
 @click.pass_obj
-def adapter_delete_hipersocket(cmd_ctx, cpc_name, adapter_name):
+def adapter_delete_hipersocket(cmd_ctx, cpc, adapter):
     """
     Delete a HiperSockets adapter.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
     cmd_ctx.execute_cmd(lambda: cmd_adapter_delete_hipersocket(
-                        cmd_ctx, cpc_name, adapter_name))
+                        cmd_ctx, cpc, adapter))
 
 
 def cmd_adapter_list(cmd_ctx, cpc_name):

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -1,0 +1,259 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import click
+
+import zhmcclient
+from .zhmccli import cli
+from ._helper import print_properties, print_resources, abort_if_false, \
+    options_to_properties, original_options
+from ._cmd_cpc import find_cpc
+
+
+def find_adapter(client, cpc_name, adapter_name):
+    """
+    Find an adapter by name and return its resource object.
+    """
+    cpc = find_cpc(client, cpc_name)
+    if not cpc.dpm_enabled:
+        raise click.ClickException("CPC %s is not in DPM mode." % cpc_name)
+    try:
+        adapter = cpc.adapters.find(name=adapter_name)
+    except zhmcclient.NotFound:
+        raise click.ClickException("Could not find adapter %s in CPC %s." %
+                                   (adapter_name, cpc_name))
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    return adapter
+
+
+@cli.group('adapter')
+def adapter_group():
+    """
+    Command group for managing adapters.
+
+    Physical adapters (e.g. OSA, FICON) are auto-discovered and cannot be
+    created. Logical adapters (HiperSockets) can be created and deleted.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+
+
+@adapter_group.command('list')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.pass_obj
+def adapter_list(cmd_ctx, cpc_name):
+    """
+    List the adapters in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_list(cmd_ctx, cpc_name))
+
+
+@adapter_group.command('show')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@click.pass_obj
+def adapter_show(cmd_ctx, cpc_name, adapter_name):
+    """
+    Show the details of an adapter.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_show(cmd_ctx, cpc_name,
+                                                 adapter_name))
+
+
+@adapter_group.command('update')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@click.option('--name', type=str, required=False,
+              help='The new name of the adapter.')
+@click.option('--description', type=str, required=False,
+              help='The new description of the adapter.')
+@click.option('--port-description', type=str, required=False,
+              help='The new description of the single port of the adapter.')
+@click.option('--mtu-size', type=click.Choice(['8', '16', '32', '56']),
+              required=False,
+              help='The new MTU size of the adapter in KiB '
+              '(HiperSockets only).')
+@click.option('--allowed-capacity', type=int, required=False,
+              help='The maximum number of HBAs per partition '
+              '(FCP only).')
+@click.option('--chpid', type=str, required=False,
+              help='Channel path ID (CHPID, 2 hex chars) used by the '
+              'adapter\'s port '
+              '(OSA, FICON, HiperSockets only).')
+@click.option('--crypto-number', type=int, required=False,
+              help='Identifier of the crypto adapter in the range 0-15 '
+              'Must be unique within the CPC '
+              '(Crypto only).')
+@click.option('--crypto-tke', is_flag=True, required=False,
+              help='Permit TKE commands on the crypto adapter '
+              '(Crypto only).')
+@click.pass_obj
+def adapter_update(cmd_ctx, cpc_name, adapter_name, **options):
+    """
+    Update the properties of an adapter.
+
+    The adapter may be a physical adapter (e.g. a discovered OSA card) or a
+    logical adapter (e.g. HiperSockets).
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_update(
+                        cmd_ctx, cpc_name, adapter_name, options))
+
+
+@adapter_group.command('create')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.option('--name', type=str, required=True,
+              help='The name of the new adapter.')
+@click.option('--description', type=str, required=False,
+              help='The description of the new adapter.')
+@click.option('--port-description', type=str, required=False,
+              help='The description of the (single) port of the new adapter.')
+@click.option('--mtu-size', type=click.Choice(['8', '16', '32', '56']),
+              required=False,
+              help='The MTU size of the new adapter in KiB.')
+@click.pass_obj
+def adapter_create_hipersocket(cmd_ctx, cpc_name, **options):
+    """
+    Create a HiperSockets adapter in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+
+    Some more properties of the new HiperSockets adapter can be set via
+    adapter update.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_create_hipersocket(
+                        cmd_ctx, cpc_name, options))
+
+
+@adapter_group.command('delete')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@click.option('--yes', is_flag=True, callback=abort_if_false,
+              expose_value=False,
+              help='Skip prompt to confirm deletion of the adapter.',
+              prompt='Are you sure you want to delete this adapter ?')
+@click.pass_obj
+def adapter_delete_hipersocket(cmd_ctx, cpc_name, adapter_name):
+    """
+    Delete a HiperSockets adapter.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_delete_hipersocket(
+                        cmd_ctx, cpc_name, adapter_name))
+
+
+def cmd_adapter_list(cmd_ctx, cpc_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+    if not cpc.dpm_enabled:
+        raise click.ClickException("CPC %s is not in DPM mode." % cpc_name)
+    try:
+        adapters = cpc.adapters.list()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    print_resources(adapters, cmd_ctx.output_format)
+
+
+def cmd_adapter_show(cmd_ctx, cpc_name, adapter_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    adapter = find_adapter(client, cpc_name, adapter_name)
+    try:
+        adapter.pull_full_properties()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    skip_list = ()
+    print_properties(adapter.properties, cmd_ctx.output_format, skip_list)
+
+
+def cmd_adapter_update(cmd_ctx, cpc_name, adapter_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    adapter = find_adapter(client, cpc_name, adapter_name)
+
+    name_map = {
+        'mtu-size': 'maximum-transmission-unit-size',
+        'chpid': 'channel-path-id',
+        'crypto-tke': 'tke-commands-enabled',
+    }
+    options = original_options(options)
+    properties = options_to_properties(options, name_map)
+
+    if not properties:
+        click.echo("No properties specified for updating adapter %s." %
+                   adapter_name)
+        return
+
+    try:
+        adapter.update_properties(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    if 'name' in properties and properties['name'] != adapter_name:
+        click.echo("Adapter %s has been renamed to %s and was updated." %
+                   (adapter_name, properties['name']))
+    else:
+        click.echo("Adapter %s has been updated." % adapter_name)
+
+
+def cmd_adapter_create_hipersocket(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+    if not cpc.dpm_enabled:
+        raise click.ClickException("CPC %s is not in DPM mode." % cpc_name)
+
+    name_map = {
+        'mtu-size': 'maximum-transmission-unit-size',
+    }
+    options = original_options(options)
+    properties = options_to_properties(options, name_map)
+
+    try:
+        new_adapter = cpc.adapters.create_hipersocket(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    click.echo("New HiperSockets adapter %s has been created." %
+               new_adapter.properties['name'])
+
+
+def cmd_adapter_delete_hipersocket(cmd_ctx, cpc_name, adapter_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    adapter = find_adapter(client, cpc_name, adapter_name)
+    try:
+        adapter.delete()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    click.echo('HiperSockets adapter %s has been deleted.' % adapter_name)

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -200,6 +200,7 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
         show_list.extend([
             'adapter-family',
             'type',
+            'detected-card-type',
         ])
     if options['uri']:
         show_list.extend([

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -56,8 +56,13 @@ def adapter_group():
 
 @adapter_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
+@click.option('--type', is_flag=True, required=False,
+              help='Show additional properties for the adapter family and '
+              'type.')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def adapter_list(cmd_ctx, cpc):
+def adapter_list(cmd_ctx, cpc, **options):
     """
     List the adapters in a CPC.
 
@@ -65,7 +70,7 @@ def adapter_list(cmd_ctx, cpc):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_adapter_list(cmd_ctx, cpc))
+    cmd_ctx.execute_cmd(lambda: cmd_adapter_list(cmd_ctx, cpc, options))
 
 
 @adapter_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -176,7 +181,7 @@ def adapter_delete_hipersocket(cmd_ctx, cpc, adapter):
                         cmd_ctx, cpc, adapter))
 
 
-def cmd_adapter_list(cmd_ctx, cpc_name):
+def cmd_adapter_list(cmd_ctx, cpc_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     cpc = find_cpc(client, cpc_name)
@@ -186,7 +191,21 @@ def cmd_adapter_list(cmd_ctx, cpc_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
-    print_resources(adapters, cmd_ctx.output_format)
+    show_list = [
+        'name',
+        'adapter-id',
+        'status',
+    ]
+    if options['type']:
+        show_list.extend([
+            'adapter-family',
+            'type',
+        ])
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+    print_resources(adapters, cmd_ctx.output_format, show_list)
 
 
 def cmd_adapter_show(cmd_ctx, cpc_name, adapter_name):

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -21,6 +21,20 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources
 
 
+def find_cpc(client, cpc_name):
+    """
+    Find a CPC by name and return its resource object.
+    """
+    try:
+        cpc = client.cpcs.find(name=cpc_name)
+    except zhmcclient.NotFound:
+        raise click.ClickException("Could not find CPC %s on HMC %s." %
+                                   (cpc_name, client.session.host))
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    return cpc
+
+
 @cli.group('cpc')
 def cpc_group():
     """
@@ -36,7 +50,7 @@ def cpc_group():
 @click.pass_obj
 def cpc_list(cmd_ctx):
     """
-    List the CPCs.
+    List the CPCs managed by the HMC.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified before the
@@ -51,6 +65,7 @@ def cpc_list(cmd_ctx):
 def cpc_show(cmd_ctx, cpc_name):
     """
     Show details of a CPC.
+
     In table format, some properties are skipped.
 
     In addition to the command-specific options shown in this help text, the
@@ -60,10 +75,57 @@ def cpc_show(cmd_ctx, cpc_name):
     cmd_ctx.execute_cmd(lambda: cmd_cpc_show(cmd_ctx, cpc_name))
 
 
+@cpc_group.command('update')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.option('--description', type=str, required=False,
+              help='The new description of the CPC '
+              '(DPM mode only). '
+              'Default: No change.')
+@click.option('--acceptable-status', type=str, required=False,
+              help='The new set of acceptable operational status values. '
+              'Default: No change.')
+# TODO: Support multiple values for acceptable-status
+@click.option('--next-activation-profile', type=str, required=False,
+              help='The name of the new next reset activation profile '
+              '(not in DPM mode). '
+              'Default: No change.')
+@click.option('--processor-time-slice', type=int, required=False,
+              help='The new time slice (in ms) for logical processors. '
+              'A value of 0 causes the time slice to be dynamically '
+              'determined by the system. A positive value causes a constant '
+              'time slice to be used. '
+              '(not in DPM mode). '
+              'Default: No change.')
+@click.option('--wait-ends-slice/--no-wait-ends-slice', required=False,
+              help='The new setting for making logical processors lose their '
+              'time slice when they enter a wait state. '
+              '(not in DPM mode). '
+              'Default: No change.')
+@click.pass_obj
+def cpc_update(cmd_ctx, cpc_name, **options):
+    """
+    Update the properties of a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_partition_update(cmd_ctx, cpc_name,
+                                                     options))
+
+
+def _find_cpc(client, cpc_name):
+    try:
+        cpc = client.cpcs.find(name=cpc_name)
+    except zhmcclient.NotFound:
+        raise click.ClickException("Could not find CPC %s on HMC %s." %
+                                   (cpc_name, client.session.host))
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    return cpc
+
+
 def cmd_cpc_list(cmd_ctx):
-    """
-    List CPCs.
-    """
     client = zhmcclient.Client(cmd_ctx.session)
     try:
         cpcs = client.cpcs.list()
@@ -73,23 +135,64 @@ def cmd_cpc_list(cmd_ctx):
 
 
 def cmd_cpc_show(cmd_ctx, cpc_name):
-    """
-    Show details of a CPC.
-    In table format, some properties are skipped.
-    """
+
     client = zhmcclient.Client(cmd_ctx.session)
+    cpc = _find_cpc(client, cpc_name)
+
     try:
-        cpc = client.cpcs.find(name=cpc_name)
         cpc.pull_full_properties()
-    except zhmcclient.NotFound:
-        raise click.ClickException("Could not find CPC %s on HMC %s" %
-                                   (cpc_name, cmd_ctx.session.host))
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
-    skip_list = ('ec-mcl-description',
-                 'cpc-power-saving-state',
-                 '@@implementation-errors',
-                 'network2-ipv6-info',
-                 'network1-ipv6-info',
-                 'auto-start-list')
+
+    skip_list = (
+        'ec-mcl-description',
+        'cpc-power-saving-state',
+        'network2-ipv6-info',
+        'network1-ipv6-info',
+        'auto-start-list')
     print_properties(cpc.properties, cmd_ctx.output_format, skip_list)
+
+
+def cmd_cpc_update(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = _find_cpc(client, cpc_name)
+
+    name_map = {
+        'next-activation-profile': 'next-activation-profile-name',
+        'processor-time-slice': None,
+        'wait-ends-slice': None,
+        'no-wait-ends-slice': None,
+    }
+    options = original_options(options)
+    properties = options_to_properties(options, name_map)
+
+    time_slice = options['processor-time-slice']
+    if time_slice is None:
+        # 'processor-running-time*' properties not changed
+        pass
+    elif time_slice < 0:
+        raise click.ClickException("Value for processor-time-slice option "
+                                   "must be >= 0")
+    elif time_slice == 0:
+        properties['processor-running-time-type'] = 'system-determined'
+    else:  # time_slice > 0
+        properties['processor-running-time-type'] = 'user-determined'
+        properties['processor-running-time'] = time_slice
+
+    if options['wait-ends-slice']:
+        properties['does-wait-state-end-time-slice'] = True
+    elif options['no-wait-ends-slice']:
+        properties['does-wait-state-end-time-slice'] = False
+
+    if not properties:
+        click.echo("No properties specified for updating CPC %s." % cpc_name)
+        return
+
+    try:
+        cpc.update_properties(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    # Name changes are not supported for CPCs.
+    click.echo("CPC %s has been updated." % cpc_name)

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -48,8 +48,14 @@ def cpc_group():
 
 
 @cpc_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.option('--type', is_flag=True, required=False,
+              help='Show additional properties for CPC mode / type.')
+@click.option('--mach', is_flag=True, required=False,
+              help='Show additional properties with machine information.')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def cpc_list(cmd_ctx):
+def cpc_list(cmd_ctx, **options):
     """
     List the CPCs managed by the HMC.
 
@@ -57,7 +63,7 @@ def cpc_list(cmd_ctx):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_cpc_list(cmd_ctx))
+    cmd_ctx.execute_cmd(lambda: cmd_cpc_list(cmd_ctx, options))
 
 
 @cpc_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -122,7 +128,7 @@ def cpc_update(cmd_ctx, cpc, **options):
     cmd_ctx.execute_cmd(lambda: cmd_cpc_update(cmd_ctx, cpc, options))
 
 
-def cmd_cpc_list(cmd_ctx):
+def cmd_cpc_list(cmd_ctx, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
 
@@ -131,7 +137,27 @@ def cmd_cpc_list(cmd_ctx):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
-    print_resources(cpcs, cmd_ctx.output_format)
+    show_list = [
+        'name',
+        'status',
+    ]
+    if options['type']:
+        show_list.extend([
+            'iml-mode',
+            'dpm-enabled',
+            'is-ensemble-member',
+        ])
+    if options['mach']:
+        show_list.extend([
+            'machine-type',
+            'machine-model',
+            'machine-serial-number',
+        ])
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+    print_resources(cpcs, cmd_ctx.output_format, show_list)
 
 
 def cmd_cpc_show(cmd_ctx, cpc_name):

--- a/zhmccli/_cmd_hba.py
+++ b/zhmccli/_cmd_hba.py
@@ -114,18 +114,18 @@ def hba_create(cmd_ctx, cpc, partition, **options):
 @click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.argument('HBA', type=str, metavar='HBA')
 @click.option('--name', type=str, required=False,
-              help='The new name of the HBA. '
-              'Default: No change.')
+              help='The new name of the HBA.')
 @click.option('--description', type=str, required=False,
-              help='The new description of the HBA. '
-              'Default: No change.')
+              help='The new description of the HBA.')
 @click.option('--device-number', type=str, required=False,
-              help='The new device number to be used for the HBA. '
-              'Default: No change.')
+              help='The new device number to be used for the HBA.')
 @click.pass_obj
 def hba_update(cmd_ctx, cpc, partition, hba, **options):
     """
     Update the properties of an HBA.
+
+    Only the properties will be changed for which a corresponding option is
+    specified, so the default for all options is not to change properties.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -156,24 +156,29 @@ def hba_delete(cmd_ctx, cpc, partition, hba):
 
 
 def cmd_hba_list(cmd_ctx, cpc_name, partition_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(client, cpc_name, partition_name)
+
     try:
         hbas = partition.hbas.list()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
     print_resources(hbas, cmd_ctx.output_format)
 
 
 def cmd_hba_show(cmd_ctx, cpc_name, partition_name, hba_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     hba = find_hba(client, cpc_name, partition_name, hba_name)
+
     try:
         hba.pull_full_properties()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
-    skip_list = ()
-    print_properties(hba.properties, cmd_ctx.output_format, skip_list)
+
+    print_properties(hba.properties, cmd_ctx.output_format)
 
 
 def cmd_hba_create(cmd_ctx, cpc_name, partition_name, options):
@@ -238,10 +243,13 @@ def cmd_hba_update(cmd_ctx, cpc_name, partition_name, hba_name, options):
 
 
 def cmd_hba_delete(cmd_ctx, cpc_name, partition_name, hba_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     hba = find_hba(client, cpc_name, partition_name, hba_name)
+
     try:
         hba.delete()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
     click.echo('HBA %s has been deleted.' % hba_name)

--- a/zhmccli/_cmd_hba.py
+++ b/zhmccli/_cmd_hba.py
@@ -133,7 +133,7 @@ def hba_update(cmd_ctx, cpc, partition, hba, **options):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_hba_update(cmd_ctx, cpc,partition, hba,
+    cmd_ctx.execute_cmd(lambda: cmd_hba_update(cmd_ctx, cpc, partition, hba,
                                                options))
 
 
@@ -169,7 +169,6 @@ def cmd_hba_list(cmd_ctx, cpc_name, partition_name, options):
 
     show_list = [
         'name',
-        'status',
     ]
     if options['uri']:
         show_list.extend([
@@ -206,7 +205,7 @@ def cmd_hba_create(cmd_ctx, cpc_name, partition_name, options):
 
     adapter_name = options['adapter']
     try:
-        adapter = cpc.adapters.find(name=adapter_name)
+        adapter = partition.cpc.adapters.find(name=adapter_name)
     except zhmcclient.NotFound:
         raise click.ClickException("Could not find adapter %s in CPC %s." %
                                    (adapter_name, cpc_name))
@@ -220,7 +219,7 @@ def cmd_hba_create(cmd_ctx, cpc_name, partition_name, options):
     properties['adapter-port'] = port.uri
 
     try:
-        new_hba = cpc.hbas.create(properties)
+        new_hba = partition.hbas.create(properties)
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 

--- a/zhmccli/_cmd_hba.py
+++ b/zhmccli/_cmd_hba.py
@@ -53,8 +53,10 @@ def hba_group():
 @hba_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def hba_list(cmd_ctx, cpc, partition):
+def hba_list(cmd_ctx, cpc, partition, **options):
     """
     List the HBAs in a partition.
 
@@ -62,7 +64,7 @@ def hba_list(cmd_ctx, cpc, partition):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_hba_list(cmd_ctx, cpc, partition))
+    cmd_ctx.execute_cmd(lambda: cmd_hba_list(cmd_ctx, cpc, partition, options))
 
 
 @hba_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -155,7 +157,7 @@ def hba_delete(cmd_ctx, cpc, partition, hba):
     cmd_ctx.execute_cmd(lambda: cmd_hba_delete(cmd_ctx, cpc, partition, hba))
 
 
-def cmd_hba_list(cmd_ctx, cpc_name, partition_name):
+def cmd_hba_list(cmd_ctx, cpc_name, partition_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(client, cpc_name, partition_name)
@@ -165,7 +167,15 @@ def cmd_hba_list(cmd_ctx, cpc_name, partition_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
-    print_resources(hbas, cmd_ctx.output_format)
+    show_list = [
+        'name',
+        'status',
+    ]
+    if options['uri']:
+        show_list.extend([
+            'element-uri',
+        ])
+    print_resources(hbas, cmd_ctx.output_format, show_list)
 
 
 def cmd_hba_show(cmd_ctx, cpc_name, partition_name, hba_name):

--- a/zhmccli/_cmd_hba.py
+++ b/zhmccli/_cmd_hba.py
@@ -19,7 +19,7 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
-    options_to_properties, original_options
+    options_to_properties, original_options, COMMAND_OPTIONS_METAVAR
 from ._cmd_partition import find_partition
 
 
@@ -39,53 +39,51 @@ def find_hba(client, cpc_name, partition_name, hba_name):
     return hba
 
 
-@cli.group('hba')
+@cli.group('hba', options_metavar=COMMAND_OPTIONS_METAVAR)
 def hba_group():
     """
     Command group for managing HBAs.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
 
 
-@hba_group.command('list')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@hba_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.pass_obj
-def hba_list(cmd_ctx, cpc_name, partition_name):
+def hba_list(cmd_ctx, cpc, partition):
     """
     List the HBAs in a partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_hba_list(cmd_ctx, cpc_name,
-                                             partition_name))
+    cmd_ctx.execute_cmd(lambda: cmd_hba_list(cmd_ctx, cpc, partition))
 
 
-@hba_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('HBA-NAME', type=str, metavar='HBA-NAME')
+@hba_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('HBA', type=str, metavar='HBA')
 @click.pass_obj
-def hba_show(cmd_ctx, cpc_name, partition_name, hba_name):
+def hba_show(cmd_ctx, cpc, partition, hba):
     """
     Show the details of an HBA.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_hba_show(cmd_ctx, cpc_name, partition_name,
-                                             hba_name))
+    cmd_ctx.execute_cmd(lambda: cmd_hba_show(cmd_ctx, cpc, partition, hba))
 
 
-@hba_group.command('create')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@hba_group.command('create', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.option('--name', type=str, required=True,
               help='The name of the new HBA.')
 @click.option('--description', type=str, required=False,
@@ -99,22 +97,22 @@ def hba_show(cmd_ctx, cpc_name, partition_name, hba_name):
               help='The device number to be used for the new HBA. '
               'Default: auto-generated')
 @click.pass_obj
-def hba_create(cmd_ctx, cpc_name, partition_name, **options):
+def hba_create(cmd_ctx, cpc, partition, **options):
     """
     Create an HBA in a partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_hba_create(cmd_ctx, cpc_name,
-                                               partition_name, options))
+    cmd_ctx.execute_cmd(lambda: cmd_hba_create(cmd_ctx, cpc, partition,
+                                               options))
 
 
-@hba_group.command('update')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('HBA-NAME', type=str, metavar='HBA-NAME')
+@hba_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('HBA', type=str, metavar='HBA')
 @click.option('--name', type=str, required=False,
               help='The new name of the HBA. '
               'Default: No change.')
@@ -125,38 +123,36 @@ def hba_create(cmd_ctx, cpc_name, partition_name, **options):
               help='The new device number to be used for the HBA. '
               'Default: No change.')
 @click.pass_obj
-def hba_update(cmd_ctx, cpc_name, partition_name, hba_name, **options):
+def hba_update(cmd_ctx, cpc, partition, hba, **options):
     """
     Update the properties of an HBA.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_hba_update(cmd_ctx, cpc_name,
-                                               partition_name, hba_name,
+    cmd_ctx.execute_cmd(lambda: cmd_hba_update(cmd_ctx, cpc,partition, hba,
                                                options))
 
 
-@hba_group.command('delete')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('HBA-NAME', type=str, metavar='HBA-NAME')
+@hba_group.command('delete', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('HBA', type=str, metavar='HBA')
 @click.option('--yes', is_flag=True, callback=abort_if_false,
               expose_value=False,
               help='Skip prompt to confirm deletion of the HBA.',
               prompt='Are you sure you want to delete this HBA ?')
 @click.pass_obj
-def hba_delete(cmd_ctx, cpc_name, partition_name, hba_name):
+def hba_delete(cmd_ctx, cpc, partition, hba):
     """
     Delete an HBA.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_hba_delete(cmd_ctx, cpc_name,
-                                               partition_name, hba_name))
+    cmd_ctx.execute_cmd(lambda: cmd_hba_delete(cmd_ctx, cpc, partition, hba))
 
 
 def cmd_hba_list(cmd_ctx, cpc_name, partition_name):

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -18,7 +18,8 @@ import click
 
 import zhmcclient
 from .zhmccli import cli
-from ._helper import print_properties, print_resources, abort_if_false
+from ._helper import print_properties, print_resources, abort_if_false, \
+    COMMAND_OPTIONS_METAVAR
 from ._cmd_cpc import find_cpc
 
 
@@ -39,51 +40,51 @@ def find_lpar(client, cpc_name, lpar_name):
     return lpar
 
 
-@cli.group('lpar')
+@cli.group('lpar', options_metavar=COMMAND_OPTIONS_METAVAR)
 def lpar_group():
     """
     Command group for managing LPARs.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
 
 
-@lpar_group.command('list')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@lpar_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
 @click.pass_obj
-def lpar_list(cmd_ctx, cpc_name):
+def lpar_list(cmd_ctx, cpc):
     """
     List the LPARs in a CPC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_list(cmd_ctx, cpc_name))
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_list(cmd_ctx, cpc))
 
 
-@lpar_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('LPAR-NAME', type=str, metavar='LPAR-NAME')
+@lpar_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('LPAR', type=str, metavar='LPAR')
 @click.pass_obj
-def lpar_show(cmd_ctx, cpc_name, lpar_name):
+def lpar_show(cmd_ctx, cpc, lpar):
     """
     Show details of an LPAR in a CPC.
 
     In table format, some properties are skipped.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_show(cmd_ctx, cpc_name, lpar_name))
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_show(cmd_ctx, cpc, lpar))
 
 
-@lpar_group.command('update')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('LPAR-NAME', type=str, metavar='LPAR-NAME')
+@lpar_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('LPAR', type=str, metavar='LPAR')
 @click.option('--acceptable-status', type=str, required=False,
               help='The new set of acceptable operational status values. '
               'Default: No change.')
@@ -122,68 +123,73 @@ def lpar_show(cmd_ctx, cpc_name, lpar_name):
 # TODO: Change SSC master password option to ask for password
 # TODO: Add support for updating SSC network-related properties
 @click.pass_obj
-def lpar_update(cmd_ctx, cpc_name, lpar_name, **options):
+def lpar_update(cmd_ctx, cpc, lpar, **options):
     """
     Update the properties of an LPAR.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+
+    Limitations:
+      * The --acceptable-status option does not support multiple values.
+      * The processor capping/sharing/weight related properties cannot be
+        updated.
+      * The network-related properties for zaware and ssc cannot beupdated.
+      * The --zaware-master-password and --ssc-master-password options do not
+        ask for the password.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_update(cmd_ctx, cpc_name, lpar_name,
-                                                options))
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_update(cmd_ctx, cpc, lpar, options))
 
 
-@lpar_group.command('activate')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('LPAR-NAME', type=str, metavar='LPAR-NAME')
+@lpar_group.command('activate', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('LPAR', type=str, metavar='LPAR')
 @click.pass_obj
-def lpar_activate(cmd_ctx, cpc_name, lpar_name):
+def lpar_activate(cmd_ctx, cpc, lpar):
     """
     Activate an LPAR.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_activate(cmd_ctx, cpc_name,
-                                                  lpar_name))
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_activate(cmd_ctx, cpc, lpar))
 
 
-@lpar_group.command('deactivate')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('LPAR-NAME', type=str, metavar='LPAR-NAME')
+@lpar_group.command('deactivate', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('LPAR', type=str, metavar='LPAR')
 @click.option('--yes', is_flag=True, callback=abort_if_false,
               expose_value=False,
               help='Skip prompt to confirm deactivation of the LPAR.',
               prompt='Are you sure you want to deactivate the LPAR ?')
 @click.pass_obj
-def lpar_deactivate(cmd_ctx, cpc_name, lpar_name):
+def lpar_deactivate(cmd_ctx, cpc, lpar):
     """
     Deactivate an LPAR.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_deactivate(cmd_ctx, cpc_name,
-                                                    lpar_name))
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_deactivate(cmd_ctx, cpc, lpar))
 
 
-@lpar_group.command('load')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('LPAR-NAME', type=str, metavar='LPAR-NAME')
+@lpar_group.command('load', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('LPAR', type=str, metavar='LPAR')
 @click.argument('LOAD-ADDRESS', type=str, metavar='LOAD-ADDRESS')
 @click.pass_obj
-def lpar_load(cmd_ctx, cpc_name, lpar_name, load_address):
+def lpar_load(cmd_ctx, cpc, lpar, load_address):
     """
     Load (Boot, IML) an LPAR.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_load(cmd_ctx, cpc_name, lpar_name,
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_load(cmd_ctx, cpc, lpar,
                                               load_address))
 
 

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -53,8 +53,13 @@ def lpar_group():
 
 @lpar_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
+@click.option('--type', is_flag=True, required=False,
+              help='Show additional properties indicating the LPAR and OS '
+              'type.')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def lpar_list(cmd_ctx, cpc):
+def lpar_list(cmd_ctx, cpc, **options):
     """
     List the LPARs in a CPC.
 
@@ -62,7 +67,7 @@ def lpar_list(cmd_ctx, cpc):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_list(cmd_ctx, cpc))
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_list(cmd_ctx, cpc, options))
 
 
 @lpar_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -190,7 +195,7 @@ def lpar_load(cmd_ctx, cpc, lpar, load_address):
                                               load_address))
 
 
-def cmd_lpar_list(cmd_ctx, cpc_name):
+def cmd_lpar_list(cmd_ctx, cpc_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     cpc = find_cpc(client, cpc_name)
@@ -200,7 +205,21 @@ def cmd_lpar_list(cmd_ctx, cpc_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
-    print_resources(lpars, cmd_ctx.output_format)
+    show_list = [
+        'name',
+        'status',
+    ]
+    if options['type']:
+        show_list.extend([
+            'activation-mode',
+            'os-type',
+            'workload-manager-enabled',
+        ])
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+    print_resources(lpars, cmd_ctx.output_format, show_list)
 
 
 def cmd_lpar_show(cmd_ctx, cpc_name, lpar_name):

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -53,6 +53,8 @@ def nic_group():
 @nic_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.option('--type', is_flag=True, required=False,
+              help='Show additional properties for the NIC type.')
 @click.option('--uri', is_flag=True, required=False,
               help='Show additional properties for the resource URI.')
 @click.pass_obj
@@ -194,14 +196,16 @@ def cmd_nic_list(cmd_ctx, cpc_name, partition_name, options):
 
     show_list = [
         'name',
-        'status',
     ]
+    if options['type']:
+        show_list.extend([
+            'type',
+        ])
     if options['uri']:
         show_list.extend([
             'element-uri',
         ])
-    # TODO: Finalize
-    print_resources(nics, cmd_ctx.output_format)
+    print_resources(nics, cmd_ctx.output_format, show_list)
 
 
 def cmd_nic_show(cmd_ctx, cpc_name, partition_name, nic_name):
@@ -271,7 +275,7 @@ def cmd_nic_create(cmd_ctx, cpc_name, partition_name, options):
                                    "specified.")
 
     try:
-        new_nic = cpc.nics.create(properties)
+        new_nic = partition.nics.create(properties)
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -53,8 +53,10 @@ def nic_group():
 @nic_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def nic_list(cmd_ctx, cpc, partition):
+def nic_list(cmd_ctx, cpc, partition, **options):
     """
     List the NICs in a partition.
 
@@ -62,7 +64,7 @@ def nic_list(cmd_ctx, cpc, partition):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_nic_list(cmd_ctx, cpc, partition))
+    cmd_ctx.execute_cmd(lambda: cmd_nic_list(cmd_ctx, cpc, partition, options))
 
 
 @nic_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -180,7 +182,7 @@ def nic_delete(cmd_ctx, cpc, partition, nic):
     cmd_ctx.execute_cmd(lambda: cmd_nic_delete(cmd_ctx, cpc, partition, nic))
 
 
-def cmd_nic_list(cmd_ctx, cpc_name, partition_name):
+def cmd_nic_list(cmd_ctx, cpc_name, partition_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(client, cpc_name, partition_name)
@@ -190,6 +192,15 @@ def cmd_nic_list(cmd_ctx, cpc_name, partition_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    show_list = [
+        'name',
+        'status',
+    ]
+    if options['uri']:
+        show_list.extend([
+            'element-uri',
+        ])
+    # TODO: Finalize
     print_resources(nics, cmd_ctx.output_format)
 
 

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -1,0 +1,348 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import click
+
+import zhmcclient
+from .zhmccli import cli
+from ._helper import print_properties, print_resources, abort_if_false, \
+    options_to_properties, original_options
+from ._cmd_partition import find_partition
+
+
+def find_nic(client, cpc_name, partition_name, nic_name):
+    """
+    Find a NIC by name and return its resource object.
+    """
+    partition = find_partition(client, cpc_name, partition_name)
+    try:
+        nic = partition.nics.find(name=nic_name)
+    except zhmcclient.NotFound:
+        raise click.ClickException("Could not find NIC %s in partition %s in "
+                                   "CPC %s." %
+                                   (nic_name, partition_name, cpc_name))
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    return nic
+
+
+@cli.group('nic')
+def nic_group():
+    """
+    Command group for managing NICs.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+
+
+@nic_group.command('list')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.pass_obj
+def nic_list(cmd_ctx, cpc_name, partition_name):
+    """
+    List the NICs in a partition.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_nic_list(cmd_ctx, cpc_name,
+                                             partition_name))
+
+
+@nic_group.command('show')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.argument('NIC-NAME', type=str, metavar='NIC-NAME')
+@click.pass_obj
+def nic_show(cmd_ctx, cpc_name, partition_name, nic_name):
+    """
+    Show the details of a NIC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_nic_show(cmd_ctx, cpc_name, partition_name,
+                                             nic_name))
+
+
+@nic_group.command('create')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.option('--name', type=str, required=True,
+              help='The name of the new NIC.')
+@click.option('--description', type=str, required=False,
+              help='The description of the new NIC. '
+              'Default: empty')
+@click.option('--adapter', type=str, required=False,
+              help='The name of the network adapter with the port backing the '
+              'new NIC. '
+              'Required for ROCE adapters')
+@click.option('--port', type=str, required=False,
+              help='The name of the network port backing the new NIC. '
+              'Required for ROCE adapters')
+@click.option('--virtual-switch', type=str, required=False,
+              help='The name of the virtual switch of the network port '
+              'backing the new NIC. '
+              'Required for OSA and HiperSocket adapters')
+@click.option('--device-number', type=str, required=False,
+              help='The device number to be used for the new NIC. '
+              'Default: auto-generated')
+@click.pass_obj
+def nic_create(cmd_ctx, cpc_name, partition_name, **options):
+    """
+    Create a NIC in a partition.
+
+    The NIC is backed by a port (jack) on an adapter. For OSA and HiperSocket
+    adapters, this backing is defined by associating the NIC with the virtual
+    switch of the adapter port. For ROCE adapters, this backing is defined
+    by associating the NIC with the network adapter port directly.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_nic_create(cmd_ctx, cpc_name,
+                                               partition_name, options))
+
+
+@nic_group.command('update')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.argument('NIC-NAME', type=str, metavar='NIC-NAME')
+@click.option('--name', type=str, required=False,
+              help='The new name of the NIC. '
+              'Default: No change.')
+@click.option('--description', type=str, required=False,
+              help='The new description of the NIC. '
+              'Default: No change.')
+@click.option('--adapter', type=str, required=False,
+              help='The name of the new network adapter with the port backing '
+              'the NIC. '
+              'Only for ROCE adapters'
+              'Default: No change.')
+@click.option('--port', type=str, required=False,
+              help='The name of the new network port backing the NIC. '
+              'Only for ROCE adapters'
+              'Default: No change.')
+@click.option('--virtual-switch', type=str, required=False,
+              help='The name of the virtual switch of the new network port '
+              'backing the NIC. '
+              'Only for OSA and HiperSocket adapters. '
+              'Default: No change.')
+@click.option('--device-number', type=str, required=False,
+              help='The new device number to be used for the NIC. '
+              'Default: No change.')
+@click.pass_obj
+def nic_update(cmd_ctx, cpc_name, partition_name, nic_name, **options):
+    """
+    Update the properties of a NIC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_nic_update(cmd_ctx, cpc_name,
+                                               partition_name, nic_name,
+                                               options))
+
+
+@nic_group.command('delete')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.argument('NIC-NAME', type=str, metavar='NIC-NAME')
+@click.option('--yes', is_flag=True, callback=abort_if_false,
+              expose_value=False,
+              help='Skip prompt to confirm deletion of the NIC.',
+              prompt='Are you sure you want to delete this NIC ?')
+@click.pass_obj
+def nic_delete(cmd_ctx, cpc_name, partition_name, nic_name):
+    """
+    Delete a NIC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_nic_delete(cmd_ctx, cpc_name,
+                                               partition_name, nic_name))
+
+
+def cmd_nic_list(cmd_ctx, cpc_name, partition_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    partition = _find_partition(client, cpc_name, partition_name)
+    try:
+        nics = partition.nics.list()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    print_resources(nics, cmd_ctx.output_format)
+
+
+def cmd_nic_show(cmd_ctx, cpc_name, partition_name, nic_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    nic = _find_nic(client, cpc_name, partition_name, nic_name)
+    try:
+        nic.pull_full_properties()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    skip_list = ()
+    print_properties(nic.properties, cmd_ctx.output_format, skip_list)
+
+
+def cmd_nic_create(cmd_ctx, cpc_name, partition_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    partition = find_partition(client, cpc_name, partition_name)
+
+    name_map = {
+        # The following options are handled in this function:
+        'adapter': None,
+        'port': None,
+        'virtual-switch': None,
+    }
+    options = original_options(options)
+    properties = options_to_properties(options, name_map)
+
+    required_roce_option_names = (
+        'adapter',
+        'port')
+    if any([options[name] for name in required_roce_option_names]):
+        missing_option_names = [name for name in required_roce_option_names
+                                if options[name] is None]
+        if missing_option_names:
+            raise click.ClickException("ROCE adapter specified, but "
+                                       "misses the following options: %s" %
+                                       ', '.join(missing_option_names))
+
+        adapter_name = options['adapter']
+        try:
+            adapter = partition.cpc.adapters.find(name=adapter_name)
+        except zhmcclient.NotFound:
+            raise click.ClickException("Could not find adapter %s in CPC %s." %
+                                       (adapter_name, cpc_name))
+        port_name = options['port']
+        try:
+            port = adapter.ports.find(name=port_name)
+        except zhmcclient.NotFound:
+            raise click.ClickException("Could not find port %s on adapter %s "
+                                       "in CPC %s." %
+                                       (port_name, adapter_name, cpc_name))
+        properties['network-adapter-port-uri'] = port.uri
+
+    elif options['virtual-switch'] is not None:
+        vswitch_name = options['virtual-switch']
+        try:
+            vswitch = partition.cpc.virtual_switches.find(name=vswitch_name)
+        except zhmcclient.NotFound:
+            raise click.ClickException("Could not find virtual switch %s "
+                                       "in CPC %s." %
+                                       (vswitch_name, cpc_name))
+        properties['virtual-switch-uri'] = vswitch.uri
+    else:
+        raise click.ClickException("No backing adapter port or virtual switch "
+                                   "specified.")
+
+    try:
+        new_nic = cpc.nics.create(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    click.echo("New NIC %s has been created." %
+               new_nic.properties['name'])
+
+
+def cmd_nic_update(cmd_ctx, cpc_name, partition_name, nic_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    nic = find_nic(client, cpc_name, partition_name, nic_name)
+
+    name_map = {
+        # The following options are handled in this function:
+        'adapter': None,
+        'port': None,
+        'virtual-switch': None,
+    }
+    options = original_options(options)
+    properties = options_to_properties(options, name_map)
+
+    required_roce_option_names = (
+        'adapter',
+        'port')
+    if any([options[name] for name in required_roce_option_names]):
+        missing_option_names = [name for name in required_roce_option_names
+                                if options[name] is None]
+        if missing_option_names:
+            raise click.ClickException("ROCE adapter specified, but "
+                                       "misses the following options: %s" %
+                                       ', '.join(missing_option_names))
+
+        adapter_name = options['adapter']
+        try:
+            adapter = nic.partition.cpc.adapters.find(name=adapter_name)
+        except zhmcclient.NotFound:
+            raise click.ClickException("Could not find adapter %s in CPC %s." %
+                                       (adapter_name, cpc_name))
+        port_name = options['port']
+        try:
+            port = adapter.ports.find(name=port_name)
+        except zhmcclient.NotFound:
+            raise click.ClickException("Could not find port %s on adapter %s "
+                                       "in CPC %s." %
+                                       (port_name, adapter_name, cpc_name))
+        properties['network-adapter-port-uri'] = port.uri
+
+    elif options['virtual-switch'] is not None:
+        vswitch_name = options['virtual-switch']
+        try:
+            vswitch = nic.partition.cpc.virtual_switches.find(
+                name=vswitch_name)
+        except zhmcclient.NotFound:
+            raise click.ClickException("Could not find virtual switch %s "
+                                       "in CPC %s." %
+                                       (vswitch_name, cpc_name))
+        properties['virtual-switch-uri'] = vswitch.uri
+    else:
+        # The backing adapter port or virtual switch is not being updated.
+        pass
+
+    if not properties:
+        click.echo("No properties specified for updating NIC %s." % nic_name)
+        return
+
+    try:
+        nic.update_properties(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    if 'name' in properties and properties['name'] != nic_name:
+        click.echo("NIC %s has been renamed to %s and was updated." %
+                   (nic_name, properties['name']))
+    else:
+        click.echo("NIC %s has been updated." % nic_name)
+
+
+def cmd_nic_delete(cmd_ctx, cpc_name, partition_name, nic_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    nic = _find_nic(client, cpc_name, partition_name, nic_name)
+    try:
+        nic.delete()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    click.echo('NIC %s has been deleted.' % nic_name)

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -19,7 +19,7 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
-    options_to_properties, original_options
+    options_to_properties, original_options, COMMAND_OPTIONS_METAVAR
 from ._cmd_partition import find_partition
 
 
@@ -39,53 +39,51 @@ def find_nic(client, cpc_name, partition_name, nic_name):
     return nic
 
 
-@cli.group('nic')
+@cli.group('nic', options_metavar=COMMAND_OPTIONS_METAVAR)
 def nic_group():
     """
     Command group for managing NICs.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
 
 
-@nic_group.command('list')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@nic_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.pass_obj
-def nic_list(cmd_ctx, cpc_name, partition_name):
+def nic_list(cmd_ctx, cpc, partition):
     """
     List the NICs in a partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_nic_list(cmd_ctx, cpc_name,
-                                             partition_name))
+    cmd_ctx.execute_cmd(lambda: cmd_nic_list(cmd_ctx, cpc, partition))
 
 
-@nic_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('NIC-NAME', type=str, metavar='NIC-NAME')
+@nic_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('NIC', type=str, metavar='NIC')
 @click.pass_obj
-def nic_show(cmd_ctx, cpc_name, partition_name, nic_name):
+def nic_show(cmd_ctx, cpc, partition, nic):
     """
     Show the details of a NIC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_nic_show(cmd_ctx, cpc_name, partition_name,
-                                             nic_name))
+    cmd_ctx.execute_cmd(lambda: cmd_nic_show(cmd_ctx, cpc, partition, nic))
 
 
-@nic_group.command('create')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@nic_group.command('create', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.option('--name', type=str, required=True,
               help='The name of the new NIC.')
 @click.option('--description', type=str, required=False,
@@ -106,7 +104,7 @@ def nic_show(cmd_ctx, cpc_name, partition_name, nic_name):
               help='The device number to be used for the new NIC. '
               'Default: auto-generated')
 @click.pass_obj
-def nic_create(cmd_ctx, cpc_name, partition_name, **options):
+def nic_create(cmd_ctx, cpc, partition, **options):
     """
     Create a NIC in a partition.
 
@@ -116,17 +114,17 @@ def nic_create(cmd_ctx, cpc_name, partition_name, **options):
     by associating the NIC with the network adapter port directly.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_nic_create(cmd_ctx, cpc_name,
-                                               partition_name, options))
+    cmd_ctx.execute_cmd(lambda: cmd_nic_create(cmd_ctx, cpc, partition,
+                                               options))
 
 
-@nic_group.command('update')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('NIC-NAME', type=str, metavar='NIC-NAME')
+@nic_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('NIC', type=str, metavar='NIC')
 @click.option('--name', type=str, required=False,
               help='The new name of the NIC. '
               'Default: No change.')
@@ -151,43 +149,41 @@ def nic_create(cmd_ctx, cpc_name, partition_name, **options):
               help='The new device number to be used for the NIC. '
               'Default: No change.')
 @click.pass_obj
-def nic_update(cmd_ctx, cpc_name, partition_name, nic_name, **options):
+def nic_update(cmd_ctx, cpc, partition, nic, **options):
     """
     Update the properties of a NIC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_nic_update(cmd_ctx, cpc_name,
-                                               partition_name, nic_name,
+    cmd_ctx.execute_cmd(lambda: cmd_nic_update(cmd_ctx, cpc, partition, nic,
                                                options))
 
 
-@nic_group.command('delete')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('NIC-NAME', type=str, metavar='NIC-NAME')
+@nic_group.command('delete', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('NIC', type=str, metavar='NIC')
 @click.option('--yes', is_flag=True, callback=abort_if_false,
               expose_value=False,
               help='Skip prompt to confirm deletion of the NIC.',
               prompt='Are you sure you want to delete this NIC ?')
 @click.pass_obj
-def nic_delete(cmd_ctx, cpc_name, partition_name, nic_name):
+def nic_delete(cmd_ctx, cpc, partition, nic):
     """
     Delete a NIC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_nic_delete(cmd_ctx, cpc_name,
-                                               partition_name, nic_name))
+    cmd_ctx.execute_cmd(lambda: cmd_nic_delete(cmd_ctx, cpc, partition, nic))
 
 
 def cmd_nic_list(cmd_ctx, cpc_name, partition_name):
     client = zhmcclient.Client(cmd_ctx.session)
-    partition = _find_partition(client, cpc_name, partition_name)
+    partition = find_partition(client, cpc_name, partition_name)
     try:
         nics = partition.nics.list()
     except zhmcclient.Error as exc:
@@ -197,7 +193,7 @@ def cmd_nic_list(cmd_ctx, cpc_name, partition_name):
 
 def cmd_nic_show(cmd_ctx, cpc_name, partition_name, nic_name):
     client = zhmcclient.Client(cmd_ctx.session)
-    nic = _find_nic(client, cpc_name, partition_name, nic_name)
+    nic = find_nic(client, cpc_name, partition_name, nic_name)
     try:
         nic.pull_full_properties()
     except zhmcclient.Error as exc:
@@ -340,7 +336,7 @@ def cmd_nic_update(cmd_ctx, cpc_name, partition_name, nic_name, options):
 
 def cmd_nic_delete(cmd_ctx, cpc_name, partition_name, nic_name):
     client = zhmcclient.Client(cmd_ctx.session)
-    nic = _find_nic(client, cpc_name, partition_name, nic_name)
+    nic = find_nic(client, cpc_name, partition_name, nic_name)
     try:
         nic.delete()
     except zhmcclient.Error as exc:

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -126,11 +126,9 @@ def nic_create(cmd_ctx, cpc, partition, **options):
 @click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.argument('NIC', type=str, metavar='NIC')
 @click.option('--name', type=str, required=False,
-              help='The new name of the NIC. '
-              'Default: No change.')
+              help='The new name of the NIC.')
 @click.option('--description', type=str, required=False,
-              help='The new description of the NIC. '
-              'Default: No change.')
+              help='The new description of the NIC.')
 @click.option('--adapter', type=str, required=False,
               help='The name of the new network adapter with the port backing '
               'the NIC. '
@@ -143,15 +141,16 @@ def nic_create(cmd_ctx, cpc, partition, **options):
 @click.option('--virtual-switch', type=str, required=False,
               help='The name of the virtual switch of the new network port '
               'backing the NIC. '
-              'Only for OSA and HiperSocket adapters. '
-              'Default: No change.')
+              'Only for OSA and HiperSocket adapters.')
 @click.option('--device-number', type=str, required=False,
-              help='The new device number to be used for the NIC. '
-              'Default: No change.')
+              help='The new device number to be used for the NIC.')
 @click.pass_obj
 def nic_update(cmd_ctx, cpc, partition, nic, **options):
     """
     Update the properties of a NIC.
+
+    Only the properties will be changed for which a corresponding option is
+    specified, so the default for all options is not to change properties.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -182,24 +181,29 @@ def nic_delete(cmd_ctx, cpc, partition, nic):
 
 
 def cmd_nic_list(cmd_ctx, cpc_name, partition_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(client, cpc_name, partition_name)
+
     try:
         nics = partition.nics.list()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
     print_resources(nics, cmd_ctx.output_format)
 
 
 def cmd_nic_show(cmd_ctx, cpc_name, partition_name, nic_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     nic = find_nic(client, cpc_name, partition_name, nic_name)
+
     try:
         nic.pull_full_properties()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
-    skip_list = ()
-    print_properties(nic.properties, cmd_ctx.output_format, skip_list)
+
+    print_properties(nic.properties, cmd_ctx.output_format)
 
 
 def cmd_nic_create(cmd_ctx, cpc_name, partition_name, options):
@@ -335,10 +339,13 @@ def cmd_nic_update(cmd_ctx, cpc_name, partition_name, nic_name, options):
 
 
 def cmd_nic_delete(cmd_ctx, cpc_name, partition_name, nic_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     nic = find_nic(client, cpc_name, partition_name, nic_name)
+
     try:
         nic.delete()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
     click.echo('NIC %s has been deleted.' % nic_name)

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -53,8 +53,13 @@ def partition_group():
 
 @partition_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
+@click.option('--type', is_flag=True, required=False,
+              help='Show additional properties indicating the partition and '
+              'OS type.')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def partition_list(cmd_ctx, cpc):
+def partition_list(cmd_ctx, cpc, **options):
     """
     List the partitions in a CPC.
 
@@ -62,7 +67,7 @@ def partition_list(cmd_ctx, cpc):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_partition_list(cmd_ctx, cpc))
+    cmd_ctx.execute_cmd(lambda: cmd_partition_list(cmd_ctx, cpc, options))
 
 
 @partition_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -238,7 +243,7 @@ def partition_delete(cmd_ctx, cpc, partition):
     cmd_ctx.execute_cmd(lambda: cmd_partition_delete(cmd_ctx, cpc, partition))
 
 
-def cmd_partition_list(cmd_ctx, cpc_name):
+def cmd_partition_list(cmd_ctx, cpc_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     cpc = find_cpc(client, cpc_name)
@@ -248,7 +253,20 @@ def cmd_partition_list(cmd_ctx, cpc_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
-    print_resources(partitions, cmd_ctx.output_format)
+    show_list = [
+        'name',
+        'status',
+    ]
+    if options['type']:
+        show_list.extend([
+            'partition-type',
+            'os-type',
+        ])
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+    print_resources(partitions, cmd_ctx.output_format, show_list)
 
 
 def cmd_partition_show(cmd_ctx, cpc_name, partition_name):

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -19,7 +19,7 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
-    options_to_properties, original_options
+    options_to_properties, original_options, COMMAND_OPTIONS_METAVAR
 from ._cmd_cpc import find_cpc
 
 
@@ -40,81 +40,78 @@ def find_partition(client, cpc_name, partition_name):
     return partition
 
 
-@cli.group('partition')
+@cli.group('partition', options_metavar=COMMAND_OPTIONS_METAVAR)
 def partition_group():
     """
     Command group for managing partitions.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
 
 
-@partition_group.command('list')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@partition_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
 @click.pass_obj
-def partition_list(cmd_ctx, cpc_name):
+def partition_list(cmd_ctx, cpc):
     """
     List the partitions in a CPC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_partition_list(cmd_ctx, cpc_name))
+    cmd_ctx.execute_cmd(lambda: cmd_partition_list(cmd_ctx, cpc))
 
 
-@partition_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@partition_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.pass_obj
-def partition_show(cmd_ctx, cpc_name, partition_name):
+def partition_show(cmd_ctx, cpc, partition):
     """
     Show the details of a partition in a CPC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_partition_show(cmd_ctx, cpc_name,
-                                                   partition_name))
+    cmd_ctx.execute_cmd(lambda: cmd_partition_show(cmd_ctx, cpc, partition))
 
 
-@partition_group.command('start')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@partition_group.command('start', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.pass_obj
-def partition_start(cmd_ctx, cpc_name, partition_name):
+def partition_start(cmd_ctx, cpc, partition):
     """
     Start a partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_partition_start(cmd_ctx, cpc_name,
-                                                    partition_name))
+    cmd_ctx.execute_cmd(lambda: cmd_partition_start(cmd_ctx, cpc, partition))
 
 
-@partition_group.command('stop')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@partition_group.command('stop', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.pass_obj
-def partition_stop(cmd_ctx, cpc_name, partition_name):
+def partition_stop(cmd_ctx, cpc, partition):
     """
     Stop a partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_partition_stop(cmd_ctx, cpc_name,
-                                                   partition_name))
+    cmd_ctx.execute_cmd(lambda: cmd_partition_stop(cmd_ctx, cpc, partition))
 
 
-@partition_group.command('create')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@partition_group.command('create', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
 @click.option('--name', type=str, required=True,
               help='The name of the new partition.')
 @click.option('--description', type=str, required=False,
@@ -151,21 +148,20 @@ def partition_stop(cmd_ctx, cpc_name, partition_name):
               help='Boot from removable media on the HMC: The path to the '
               'image file on the HMC.')
 @click.pass_obj
-def partition_create(cmd_ctx, cpc_name, **options):
+def partition_create(cmd_ctx, cpc, **options):
     """
     Create a partition in a CPC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_partition_create(cmd_ctx, cpc_name,
-                                                     options))
+    cmd_ctx.execute_cmd(lambda: cmd_partition_create(cmd_ctx, cpc, options))
 
 
-@partition_group.command('update')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@partition_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.option('--name', type=str, required=False,
               help='The new name of the partition. '
               'Default: No change.')
@@ -225,37 +221,35 @@ def partition_create(cmd_ctx, cpc_name, **options):
               help='Boot from an ISO image mounted to this partition. '
               'Default: No change.')
 @click.pass_obj
-def partition_update(cmd_ctx, cpc_name, partition_name, **options):
+def partition_update(cmd_ctx, cpc, partition, **options):
     """
     Update the properties of a partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_partition_update(cmd_ctx, cpc_name,
-                                                     partition_name,
+    cmd_ctx.execute_cmd(lambda: cmd_partition_update(cmd_ctx, cpc, partition,
                                                      options))
 
 
-@partition_group.command('delete')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@partition_group.command('delete', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.option('--yes', is_flag=True, callback=abort_if_false,
               expose_value=False,
               help='Skip prompt to confirm deletion of the partition.',
               prompt='Are you sure you want to delete this partition ?')
 @click.pass_obj
-def partition_delete(cmd_ctx, cpc_name, partition_name):
+def partition_delete(cmd_ctx, cpc, partition):
     """
     Delete a partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_partition_delete(cmd_ctx, cpc_name,
-                                                     partition_name))
+    cmd_ctx.execute_cmd(lambda: cmd_partition_delete(cmd_ctx, cpc, partition))
 
 
 def cmd_partition_list(cmd_ctx, cpc_name):

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -18,7 +18,7 @@ import click
 
 import zhmcclient
 from .zhmccli import cli
-from ._helper import print_properties, print_resources, abort_if_false, \
+from ._helper import print_properties, print_resources, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR
 from ._cmd_adapter import find_adapter
 
@@ -120,14 +120,13 @@ def cmd_port_list(cmd_ctx, cpc_name, adapter_name, options):
 
     show_list = [
         'name',
-        'status',
+        'index',
     ]
     if options['uri']:
         show_list.extend([
             'element-uri',
         ])
-    # TODO: Finalize
-    print_resources(ports, cmd_ctx.output_format)
+    print_resources(ports, cmd_ctx.output_format, show_list)
 
 
 def cmd_port_show(cmd_ctx, cpc_name, adapter_name, port_name):

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -19,11 +19,8 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
-    options_to_properties, original_options
+    options_to_properties, original_options, COMMAND_OPTIONS_METAVAR
 from ._cmd_adapter import find_adapter
-
-
-# TODO: Add "update" using new approach from partition.
 
 
 def find_port(client, cpc_name, adapter_name, port_name):
@@ -42,57 +39,56 @@ def find_port(client, cpc_name, adapter_name, port_name):
     return port
 
 
-@cli.group('port')
+@cli.group('port', options_metavar=COMMAND_OPTIONS_METAVAR)
 def port_group():
     """
     Command group for managing adapter ports.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
 
 
-@port_group.command('list')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@port_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('ADAPTER', type=str, metavar='ADAPTER')
 @click.pass_obj
-def port_list(cmd_ctx, cpc_name, adapter_name):
+def port_list(cmd_ctx, cpc, adapter):
     """
     List the ports of an adapter.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_port_list(cmd_ctx, cpc_name, adapter_name))
+    cmd_ctx.execute_cmd(lambda: cmd_port_list(cmd_ctx, cpc, adapter))
 
 
-@port_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
-@click.argument('PORT-NAME', type=str, metavar='PORT-NAME')
+@port_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('ADAPTER', type=str, metavar='ADAPTER')
+@click.argument('PORT', type=str, metavar='PORT')
 @click.pass_obj
-def port_show(cmd_ctx, cpc_name, adapter_name, port_name):
+def port_show(cmd_ctx, cpc, adapter, port):
     """
     Show the details of an adapter port.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_port_show(cmd_ctx, cpc_name, adapter_name,
-                                              port_name))
+    cmd_ctx.execute_cmd(lambda: cmd_port_show(cmd_ctx, cpc, adapter, port))
 
 
-@port_group.command('update')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
-@click.argument('PORT-NAME', type=str, metavar='PORT-NAME')
+@port_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('ADAPTER', type=str, metavar='ADAPTER')
+@click.argument('PORT', type=str, metavar='PORT')
 @click.option('--description', type=str, required=False,
               help='The new description of the port.')
 @click.pass_obj
-def port_update(cmd_ctx, cpc_name, adapter_name, port_name, **options):
+def port_update(cmd_ctx, cpc, adapter, port, **options):
     """
     Update the properties of an adapter port.
 
@@ -100,16 +96,16 @@ def port_update(cmd_ctx, cpc_name, adapter_name, port_name, **options):
     logical adapter (e.g. HiperSockets).
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_port_update(
-                        cmd_ctx, cpc_name, adapter_name, port_name, options))
+    cmd_ctx.execute_cmd(lambda: cmd_port_update(cmd_ctx, cpc, adapter, port,
+                                                options))
 
 
 def cmd_port_list(cmd_ctx, cpc_name, adapter_name):
     client = zhmcclient.Client(cmd_ctx.session)
-    adapter = _find_adapter(client, cpc_name, adapter_name)
+    adapter = find_adapter(client, cpc_name, adapter_name)
     try:
         ports = adapter.ports.list()
     except zhmcclient.Error as exc:
@@ -119,7 +115,7 @@ def cmd_port_list(cmd_ctx, cpc_name, adapter_name):
 
 def cmd_port_show(cmd_ctx, cpc_name, adapter_name, port_name):
     client = zhmcclient.Client(cmd_ctx.session)
-    port = _find_port(client, cpc_name, adapter_name, port_name)
+    port = find_port(client, cpc_name, adapter_name, port_name)
     try:
         port.pull_full_properties()
     except zhmcclient.Error as exc:

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -92,6 +92,9 @@ def port_update(cmd_ctx, cpc, adapter, port, **options):
     """
     Update the properties of an adapter port.
 
+    Only the properties will be changed for which a corresponding option is
+    specified, so the default for all options is not to change properties.
+
     The port may be on a physical adapter (e.g. a discovered OSA card) or a
     logical adapter (e.g. HiperSockets).
 
@@ -104,24 +107,29 @@ def port_update(cmd_ctx, cpc, adapter, port, **options):
 
 
 def cmd_port_list(cmd_ctx, cpc_name, adapter_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     adapter = find_adapter(client, cpc_name, adapter_name)
+
     try:
         ports = adapter.ports.list()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
     print_resources(ports, cmd_ctx.output_format)
 
 
 def cmd_port_show(cmd_ctx, cpc_name, adapter_name, port_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     port = find_port(client, cpc_name, adapter_name, port_name)
+
     try:
         port.pull_full_properties()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
-    skip_list = ()
-    print_properties(port.properties, cmd_ctx.output_format, skip_list)
+
+    print_properties(port.properties, cmd_ctx.output_format)
 
 
 def cmd_port_update(cmd_ctx, cpc_name, adapter_name, port_name, options):
@@ -143,4 +151,3 @@ def cmd_port_update(cmd_ctx, cpc_name, adapter_name, port_name, options):
 
     # Adapter ports cannot be renamed.
     click.echo("Port %s has been updated." % port_name)
-

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -1,0 +1,150 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import click
+
+import zhmcclient
+from .zhmccli import cli
+from ._helper import print_properties, print_resources, abort_if_false, \
+    options_to_properties, original_options
+from ._cmd_adapter import find_adapter
+
+
+# TODO: Add "update" using new approach from partition.
+
+
+def find_port(client, cpc_name, adapter_name, port_name):
+    """
+    Find a port by name and return its resource object.
+    """
+    adapter = find_adapter(client, cpc_name, adapter_name)
+    try:
+        port = adapter.ports.find(name=port_name)
+    except zhmcclient.NotFound:
+        raise click.ClickException("Could not find port %s in adapter %s in "
+                                   "CPC %s." %
+                                   (port_name, adapter_name, cpc_name))
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    return port
+
+
+@cli.group('port')
+def port_group():
+    """
+    Command group for managing adapter ports.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+
+
+@port_group.command('list')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@click.pass_obj
+def port_list(cmd_ctx, cpc_name, adapter_name):
+    """
+    List the ports of an adapter.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_port_list(cmd_ctx, cpc_name, adapter_name))
+
+
+@port_group.command('show')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@click.argument('PORT-NAME', type=str, metavar='PORT-NAME')
+@click.pass_obj
+def port_show(cmd_ctx, cpc_name, adapter_name, port_name):
+    """
+    Show the details of an adapter port.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_port_show(cmd_ctx, cpc_name, adapter_name,
+                                              port_name))
+
+
+@port_group.command('update')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('ADAPTER-NAME', type=str, metavar='ADAPTER-NAME')
+@click.argument('PORT-NAME', type=str, metavar='PORT-NAME')
+@click.option('--description', type=str, required=False,
+              help='The new description of the port.')
+@click.pass_obj
+def port_update(cmd_ctx, cpc_name, adapter_name, port_name, **options):
+    """
+    Update the properties of an adapter port.
+
+    The port may be on a physical adapter (e.g. a discovered OSA card) or a
+    logical adapter (e.g. HiperSockets).
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_port_update(
+                        cmd_ctx, cpc_name, adapter_name, port_name, options))
+
+
+def cmd_port_list(cmd_ctx, cpc_name, adapter_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    adapter = _find_adapter(client, cpc_name, adapter_name)
+    try:
+        ports = adapter.ports.list()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    print_resources(ports, cmd_ctx.output_format)
+
+
+def cmd_port_show(cmd_ctx, cpc_name, adapter_name, port_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    port = _find_port(client, cpc_name, adapter_name, port_name)
+    try:
+        port.pull_full_properties()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    skip_list = ()
+    print_properties(port.properties, cmd_ctx.output_format, skip_list)
+
+
+def cmd_port_update(cmd_ctx, cpc_name, adapter_name, port_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    port = find_port(client, cpc_name, adapter_name, port_name)
+
+    options = original_options(options)
+    properties = options_to_properties(options)
+
+    if not properties:
+        click.echo("No properties specified for updating port %s." % port_name)
+        return
+
+    try:
+        port.update_properties(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    # Adapter ports cannot be renamed.
+    click.echo("Port %s has been updated." % port_name)
+

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -53,8 +53,10 @@ def port_group():
 @port_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('ADAPTER', type=str, metavar='ADAPTER')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def port_list(cmd_ctx, cpc, adapter):
+def port_list(cmd_ctx, cpc, adapter, **options):
     """
     List the ports of an adapter.
 
@@ -62,7 +64,7 @@ def port_list(cmd_ctx, cpc, adapter):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_port_list(cmd_ctx, cpc, adapter))
+    cmd_ctx.execute_cmd(lambda: cmd_port_list(cmd_ctx, cpc, adapter, options))
 
 
 @port_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -106,16 +108,25 @@ def port_update(cmd_ctx, cpc, adapter, port, **options):
                                                 options))
 
 
-def cmd_port_list(cmd_ctx, cpc_name, adapter_name):
+def cmd_port_list(cmd_ctx, cpc_name, adapter_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     adapter = find_adapter(client, cpc_name, adapter_name)
 
     try:
-        ports = adapter.ports.list()
+        ports = adapter.ports.list(full_properties=True)
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    show_list = [
+        'name',
+        'status',
+    ]
+    if options['uri']:
+        show_list.extend([
+            'element-uri',
+        ])
+    # TODO: Finalize
     print_resources(ports, cmd_ctx.output_format)
 
 

--- a/zhmccli/_cmd_vfunction.py
+++ b/zhmccli/_cmd_vfunction.py
@@ -1,0 +1,274 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import click
+
+import zhmcclient
+from .zhmccli import cli
+from ._helper import print_properties, print_resources, abort_if_false, \
+    options_to_properties, original_options
+from ._cmd_partition import find_partition
+
+
+def find_vfunction(client, cpc_name, partition_name, vfunction_name):
+    """
+    Find a virtual function by name and return its resource object.
+    """
+    partition = find_partition(client, cpc_name, partition_name)
+    try:
+        vfunction = partition.virtual_functions.find(name=vfunction_name)
+    except zhmcclient.NotFound:
+        raise click.ClickException("Could not find virtual function %s in "
+                                   "partition %s in CPC %s." %
+                                   (vfunction_name, partition_name, cpc_name))
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    return vfunction
+
+
+@cli.group('vfunction')
+def vfunction_group():
+    """
+    Command group for managing virtual functions.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+
+
+@vfunction_group.command('list')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.pass_obj
+def vfunction_list(cmd_ctx, cpc_name, partition_name):
+    """
+    List the virtual functions in a partition.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_list(cmd_ctx, cpc_name,
+                                                   partition_name))
+
+
+@vfunction_group.command('show')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.argument('VFUNCTION-NAME', type=str, metavar='VFUNCTION-NAME')
+@click.pass_obj
+def vfunction_show(cmd_ctx, cpc_name, partition_name, vfunction_name):
+    """
+    Show the details of a virtual function.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_show(cmd_ctx, cpc_name,
+                                                   partition_name,
+                                                   vfunction_name))
+
+
+@vfunction_group.command('create')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.option('--name', type=str, required=True,
+              help='The name of the new virtual function. Must be unique '
+              'within the virtual functions of the partition')
+@click.option('--description', type=str, required=False,
+              help='The description of the new virtual function. '
+              'Default: empty')
+@click.option('--adapter', type=str, required=True,
+              help='The name of the adapter backing the virtual function.')
+@click.option('--device-number', type=str, required=False,
+              help='The device number to be used for the new virtual '
+              'function. Default: auto-generated')
+@click.pass_obj
+def vfunction_create(cmd_ctx, cpc_name, partition_name, **options):
+    """
+    Create a virtual function in a partition.
+
+    This assigns a virtual function of an adapter to a partition, creating
+    a named virtual function resource within that partition.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_create(cmd_ctx, cpc_name,
+                                                     partition_name,
+                                                     options))
+
+
+@vfunction_group.command('update')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.argument('VFUNCTION-NAME', type=str, metavar='VFUNCTION-NAME')
+@click.option('--name', type=str, required=False,
+              help='The new name of the virtual function. Must be unique '
+              'within the virtual functions of the partition. '
+              'Default: No change.')
+@click.option('--description', type=str, required=False,
+              help='The new description of the virtual function. '
+              'Default: No change.')
+@click.option('--adapter', type=str, required=False,
+              help='The name of the new adapter (in the same CPC) that will '
+              'back the virtual function. '
+              'Default: No change.')
+@click.option('--device-number', type=str, required=False,
+              help='The new device number to be used for the virtual '
+              'function. '
+              'Default: No change.')
+@click.pass_obj
+def vfunction_update(cmd_ctx, cpc_name, partition_name, vfunction_name,
+                     **options):
+    """
+    Update the properties of a virtual function.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_update(cmd_ctx, cpc_name,
+                                                     partition_name,
+                                                     vfunction_name,
+                                                     options))
+
+
+@vfunction_group.command('delete')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@click.argument('VFUNCTION-NAME', type=str, metavar='VFUNCTION-NAME')
+@click.option('--yes', is_flag=True, callback=abort_if_false,
+              expose_value=False,
+              help='Skip prompt to confirm deletion of the virtual function.',
+              prompt='Are you sure you want to delete this virtual function ?')
+@click.pass_obj
+def vfunction_delete(cmd_ctx, cpc_name, partition_name, vfunction_name):
+    """
+    Delete a virtual function.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_delete(cmd_ctx, cpc_name,
+                                                     partition_name,
+                                                     vfunction_name))
+
+
+def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    partition = find_partition(client, cpc_name, partition_name)
+    try:
+        vfunctions = partition.virtual_functions.list()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    print_resources(vfunctions, cmd_ctx.output_format)
+
+
+def cmd_vfunction_show(cmd_ctx, cpc_name, partition_name, vfunction_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    vfunction = find_vfunction(client, cpc_name, partition_name,
+                                vfunction_name)
+    try:
+        vfunction.pull_full_properties()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    skip_list = ()
+    print_properties(vfunction.properties, cmd_ctx.output_format, skip_list)
+
+
+def cmd_vfunction_create(cmd_ctx, cpc_name, partition_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    partition = find_partition(client, cpc_name, partition_name)
+
+    name_map = {
+        # The following options are handled in this function:
+        'adapter': None,
+    }
+    options = original_options(options)
+    properties = options_to_properties(options, name_map)
+
+    adapter_name = options['adapter']
+    try:
+        adapter = partition.cpc.adapters.find(name=adapter_name)
+    except zhmcclient.NotFound:
+        raise click.ClickException("Could not find adapter %s in CPC %s." %
+                                   (adapter_name, cpc_name))
+    properties['adapter-uri'] = adapter.uri
+
+    try:
+        new_vfunction = partition.virtual_functions.create(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    click.echo("New virtual function %s has been created." %
+               new_vfunction.properties['name'])
+
+
+def cmd_vfunction_update(cmd_ctx, cpc_name, partition_name, vfunction_name,
+                         options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    vfunction = find_vfunction(client, cpc_name, partition_name,
+                               vfunction_name)
+
+    name_map = {
+        # The following options are handled in this function:
+        'adapter': None,
+    }
+    options = original_options(options)
+    properties = options_to_properties(options, name_map)
+
+    if options['adapter'] is not None:
+        adapter_name = options['adapter']
+        try:
+            adapter = vfunction.partition.cpc.adapters.find(name=adapter_name)
+        except zhmcclient.NotFound:
+            raise click.ClickException("Could not find adapter %s in CPC %s." %
+                                       (adapter_name, cpc_name))
+        properties['adapter-uri'] = adapter.uri
+
+    if not properties:
+        click.echo("No properties specified for updating virtual function "
+                   "%s." % vfunction_name)
+        return
+
+    try:
+        vfunction.update_properties(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    if 'name' in properties and properties['name'] != vfunction_name:
+        click.echo("Virtual function %s has been renamed to %s and was "
+                   "updated." % (vfunction_name, properties['name']))
+    else:
+        click.echo("Virtual function %s has been updated." % vfunction_name)
+
+
+def cmd_vfunction_delete(cmd_ctx, cpc_name, partition_name, vfunction_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    vfunction = find_vfunction(client, cpc_name, partition_name,
+                                vfunction_name)
+    try:
+        vfunction.delete()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    click.echo('Virtual function %s has been deleted.' % vfunction_name)

--- a/zhmccli/_cmd_vfunction.py
+++ b/zhmccli/_cmd_vfunction.py
@@ -19,7 +19,7 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
-    options_to_properties, original_options
+    options_to_properties, original_options, COMMAND_OPTIONS_METAVAR
 from ._cmd_partition import find_partition
 
 
@@ -39,54 +39,52 @@ def find_vfunction(client, cpc_name, partition_name, vfunction_name):
     return vfunction
 
 
-@cli.group('vfunction')
+@cli.group('vfunction', options_metavar=COMMAND_OPTIONS_METAVAR)
 def vfunction_group():
     """
     Command group for managing virtual functions.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
 
 
-@vfunction_group.command('list')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@vfunction_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.pass_obj
-def vfunction_list(cmd_ctx, cpc_name, partition_name):
+def vfunction_list(cmd_ctx, cpc, partition):
     """
     List the virtual functions in a partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vfunction_list(cmd_ctx, cpc_name,
-                                                   partition_name))
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_list(cmd_ctx, cpc, partition))
 
 
-@vfunction_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('VFUNCTION-NAME', type=str, metavar='VFUNCTION-NAME')
+@vfunction_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('VFUNCTION', type=str, metavar='VFUNCTION')
 @click.pass_obj
-def vfunction_show(cmd_ctx, cpc_name, partition_name, vfunction_name):
+def vfunction_show(cmd_ctx, cpc, partition, vfunction):
     """
     Show the details of a virtual function.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vfunction_show(cmd_ctx, cpc_name,
-                                                   partition_name,
-                                                   vfunction_name))
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_show(cmd_ctx, cpc, partition,
+                                                   vfunction))
 
 
-@vfunction_group.command('create')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
+@vfunction_group.command('create', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.option('--name', type=str, required=True,
               help='The name of the new virtual function. Must be unique '
               'within the virtual functions of the partition')
@@ -99,7 +97,7 @@ def vfunction_show(cmd_ctx, cpc_name, partition_name, vfunction_name):
               help='The device number to be used for the new virtual '
               'function. Default: auto-generated')
 @click.pass_obj
-def vfunction_create(cmd_ctx, cpc_name, partition_name, **options):
+def vfunction_create(cmd_ctx, cpc, partition, **options):
     """
     Create a virtual function in a partition.
 
@@ -107,18 +105,17 @@ def vfunction_create(cmd_ctx, cpc_name, partition_name, **options):
     a named virtual function resource within that partition.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vfunction_create(cmd_ctx, cpc_name,
-                                                     partition_name,
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_create(cmd_ctx, cpc, partition,
                                                      options))
 
 
-@vfunction_group.command('update')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('VFUNCTION-NAME', type=str, metavar='VFUNCTION-NAME')
+@vfunction_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('VFUNCTION', type=str, metavar='VFUNCTION')
 @click.option('--name', type=str, required=False,
               help='The new name of the virtual function. Must be unique '
               'within the virtual functions of the partition. '
@@ -135,41 +132,38 @@ def vfunction_create(cmd_ctx, cpc_name, partition_name, **options):
               'function. '
               'Default: No change.')
 @click.pass_obj
-def vfunction_update(cmd_ctx, cpc_name, partition_name, vfunction_name,
+def vfunction_update(cmd_ctx, cpc, partition, vfunction,
                      **options):
     """
     Update the properties of a virtual function.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vfunction_update(cmd_ctx, cpc_name,
-                                                     partition_name,
-                                                     vfunction_name,
-                                                     options))
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_update(cmd_ctx, cpc, partition,
+                                                     vfunction, options))
 
 
-@vfunction_group.command('delete')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('PARTITION-NAME', type=str, metavar='PARTITION-NAME')
-@click.argument('VFUNCTION-NAME', type=str, metavar='VFUNCTION-NAME')
+@vfunction_group.command('delete', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.argument('VFUNCTION', type=str, metavar='VFUNCTION')
 @click.option('--yes', is_flag=True, callback=abort_if_false,
               expose_value=False,
               help='Skip prompt to confirm deletion of the virtual function.',
               prompt='Are you sure you want to delete this virtual function ?')
 @click.pass_obj
-def vfunction_delete(cmd_ctx, cpc_name, partition_name, vfunction_name):
+def vfunction_delete(cmd_ctx, cpc, partition, vfunction):
     """
     Delete a virtual function.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vfunction_delete(cmd_ctx, cpc_name,
-                                                     partition_name,
-                                                     vfunction_name))
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_delete(cmd_ctx, cpc, partition,
+                                                     vfunction))
 
 
 def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name):

--- a/zhmccli/_cmd_vfunction.py
+++ b/zhmccli/_cmd_vfunction.py
@@ -179,21 +179,19 @@ def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name, options):
 
     show_list = [
         'name',
-        'status',
     ]
     if options['uri']:
         show_list.extend([
-            'object-uri',
+            'element-uri',
         ])
-    # TODO: Finalize
-    print_resources(vfunctions, cmd_ctx.output_format)
+    print_resources(vfunctions, cmd_ctx.output_format, show_list)
 
 
 def cmd_vfunction_show(cmd_ctx, cpc_name, partition_name, vfunction_name):
 
     client = zhmcclient.Client(cmd_ctx.session)
     vfunction = find_vfunction(client, cpc_name, partition_name,
-                                vfunction_name)
+                               vfunction_name)
 
     try:
         vfunction.pull_full_properties()

--- a/zhmccli/_cmd_vfunction.py
+++ b/zhmccli/_cmd_vfunction.py
@@ -118,24 +118,22 @@ def vfunction_create(cmd_ctx, cpc, partition, **options):
 @click.argument('VFUNCTION', type=str, metavar='VFUNCTION')
 @click.option('--name', type=str, required=False,
               help='The new name of the virtual function. Must be unique '
-              'within the virtual functions of the partition. '
-              'Default: No change.')
+              'within the virtual functions of the partition.')
 @click.option('--description', type=str, required=False,
-              help='The new description of the virtual function. '
-              'Default: No change.')
+              help='The new description of the virtual function.')
 @click.option('--adapter', type=str, required=False,
               help='The name of the new adapter (in the same CPC) that will '
-              'back the virtual function. '
-              'Default: No change.')
+              'back the virtual function.')
 @click.option('--device-number', type=str, required=False,
               help='The new device number to be used for the virtual '
-              'function. '
-              'Default: No change.')
+              'function.')
 @click.pass_obj
-def vfunction_update(cmd_ctx, cpc, partition, vfunction,
-                     **options):
+def vfunction_update(cmd_ctx, cpc, partition, vfunction, **options):
     """
     Update the properties of a virtual function.
+
+    Only the properties will be changed for which a corresponding option is
+    specified, so the default for all options is not to change properties.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -167,25 +165,30 @@ def vfunction_delete(cmd_ctx, cpc, partition, vfunction):
 
 
 def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(client, cpc_name, partition_name)
+
     try:
         vfunctions = partition.virtual_functions.list()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
     print_resources(vfunctions, cmd_ctx.output_format)
 
 
 def cmd_vfunction_show(cmd_ctx, cpc_name, partition_name, vfunction_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     vfunction = find_vfunction(client, cpc_name, partition_name,
                                 vfunction_name)
+
     try:
         vfunction.pull_full_properties()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
-    skip_list = ()
-    print_properties(vfunction.properties, cmd_ctx.output_format, skip_list)
+
+    print_properties(vfunction.properties, cmd_ctx.output_format)
 
 
 def cmd_vfunction_create(cmd_ctx, cpc_name, partition_name, options):
@@ -258,11 +261,14 @@ def cmd_vfunction_update(cmd_ctx, cpc_name, partition_name, vfunction_name,
 
 
 def cmd_vfunction_delete(cmd_ctx, cpc_name, partition_name, vfunction_name):
+
     client = zhmcclient.Client(cmd_ctx.session)
     vfunction = find_vfunction(client, cpc_name, partition_name,
-                                vfunction_name)
+                               vfunction_name)
+
     try:
         vfunction.delete()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
     click.echo('Virtual function %s has been deleted.' % vfunction_name)

--- a/zhmccli/_cmd_vfunction.py
+++ b/zhmccli/_cmd_vfunction.py
@@ -53,8 +53,10 @@ def vfunction_group():
 @vfunction_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('PARTITION', type=str, metavar='PARTITION')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def vfunction_list(cmd_ctx, cpc, partition):
+def vfunction_list(cmd_ctx, cpc, partition, **options):
     """
     List the virtual functions in a partition.
 
@@ -62,7 +64,8 @@ def vfunction_list(cmd_ctx, cpc, partition):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vfunction_list(cmd_ctx, cpc, partition))
+    cmd_ctx.execute_cmd(lambda: cmd_vfunction_list(cmd_ctx, cpc, partition,
+                                                   options))
 
 
 @vfunction_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -164,7 +167,7 @@ def vfunction_delete(cmd_ctx, cpc, partition, vfunction):
                                                      vfunction))
 
 
-def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name):
+def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(client, cpc_name, partition_name)
@@ -174,6 +177,15 @@ def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    show_list = [
+        'name',
+        'status',
+    ]
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+    # TODO: Finalize
     print_resources(vfunctions, cmd_ctx.output_format)
 
 

--- a/zhmccli/_cmd_vswitch.py
+++ b/zhmccli/_cmd_vswitch.py
@@ -53,8 +53,10 @@ def vswitch_group():
 
 @vswitch_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
+@click.option('--uri', is_flag=True, required=False,
+              help='Show additional properties for the resource URI.')
 @click.pass_obj
-def vswitch_list(cmd_ctx, cpc):
+def vswitch_list(cmd_ctx, cpc, **options):
     """
     List the virtual switches in a CPC.
 
@@ -62,7 +64,7 @@ def vswitch_list(cmd_ctx, cpc):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vswitch_list(cmd_ctx, cpc))
+    cmd_ctx.execute_cmd(lambda: cmd_vswitch_list(cmd_ctx, cpc, options))
 
 
 @vswitch_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -103,7 +105,7 @@ def vswitch_update(cmd_ctx, cpc, vswitch, **options):
                                                    options))
 
 
-def cmd_vswitch_list(cmd_ctx, cpc_name):
+def cmd_vswitch_list(cmd_ctx, cpc_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     cpc = find_cpc(client, cpc_name)
@@ -113,6 +115,15 @@ def cmd_vswitch_list(cmd_ctx, cpc_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    show_list = [
+        'name',
+        'status',
+    ]
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+    # TODO: Finalize
     print_resources(vswitches, cmd_ctx.output_format)
 
 

--- a/zhmccli/_cmd_vswitch.py
+++ b/zhmccli/_cmd_vswitch.py
@@ -1,0 +1,151 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import click
+
+import zhmcclient
+from .zhmccli import cli
+from ._helper import print_properties, print_resources, abort_if_false, \
+    options_to_properties, original_options
+from ._cmd_cpc import find_cpc
+
+
+def find_vswitch(client, cpc_name, vswitch_name):
+    """
+    Find a virtual switch by name and return its resource object.
+    """
+    cpc = find_cpc(client, cpc_name)
+    if not cpc.dpm_enabled:
+        raise click.ClickException("CPC %s is not in DPM mode." % cpc_name)
+    try:
+        vswitch = cpc.virtual_switches.find(name=vswitch_name)
+    except zhmcclient.NotFound:
+        raise click.ClickException("Could not find virtual switch %s in "
+                                   "CPC %s." % (vswitch_name, cpc_name))
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    return vswitch
+
+
+@cli.group('vswitch')
+def vswitch_group():
+    """
+    Command group for managing virtual switches.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+
+
+@vswitch_group.command('list')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.pass_obj
+def vswitch_list(cmd_ctx, cpc_name):
+    """
+    List the virtual switches in a CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_vswitch_list(cmd_ctx, cpc_name))
+
+
+@vswitch_group.command('show')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('VSWITCH-NAME', type=str, metavar='VSWITCH-NAME')
+@click.pass_obj
+def vswitch_show(cmd_ctx, cpc_name, vswitch_name):
+    """
+    Show the details of a virtual switch.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_vswitch_show(cmd_ctx, cpc_name,
+                                                 vswitch_name))
+
+
+@vswitch_group.command('update')
+@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@click.argument('VSWITCH-NAME', type=str, metavar='VSWITCH-NAME')
+@click.option('--name', type=str, required=False,
+              help='The new name of the virtual switch. '
+              'Default: No change.')
+@click.option('--description', type=str, required=False,
+              help='The new description of the virtual switch. '
+              'Default: No change.')
+@click.pass_obj
+def vswitch_update(cmd_ctx, cpc_name, vswitch_name, **options):
+    """
+    Update the properties of a virtual switch.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_vswitch_update(
+                        cmd_ctx, cpc_name, vswitch_name, options))
+
+
+def cmd_vswitch_list(cmd_ctx, cpc_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+    if not cpc.dpm_enabled:
+        raise click.ClickException("CPC %s is not in DPM mode." % cpc_name)
+    try:
+        vswitches = cpc.virtual_switches.list()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    print_resources(vswitches, cmd_ctx.output_format)
+
+
+def cmd_vswitch_show(cmd_ctx, cpc_name, vswitch_name):
+    client = zhmcclient.Client(cmd_ctx.session)
+    vswitch = find_vswitch(client, cpc_name, vswitch_name)
+    try:
+        vswitch.pull_full_properties()
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+    skip_list = ()
+    print_properties(vswitch.properties, cmd_ctx.output_format, skip_list)
+
+
+def cmd_vswitch_update(cmd_ctx, cpc_name, vswitch_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    vswitch = find_vswitch(client, cpc_name, vswitch_name)
+
+    options = original_options(options)
+    properties = options_to_properties(options, name_map)
+
+    if not properties:
+        click.echo("No properties specified for updating virtual switch %s." %
+                   vswitch_name)
+        return
+
+    try:
+        vswitch.update_properties(properties)
+    except zhmcclient.Error as exc:
+        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    if 'name' in properties and properties['name'] != vswitch_name:
+        click.echo("Virtual switch %s has been renamed to %s and was "
+                   "updated." % (vswitch_name, properties['name']))
+    else:
+        click.echo("Virtual switch %s has been updated." % vswitch_name)

--- a/zhmccli/_cmd_vswitch.py
+++ b/zhmccli/_cmd_vswitch.py
@@ -19,7 +19,7 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
-    options_to_properties, original_options
+    options_to_properties, original_options, COMMAND_OPTIONS_METAVAR
 from ._cmd_cpc import find_cpc
 
 
@@ -40,50 +40,49 @@ def find_vswitch(client, cpc_name, vswitch_name):
     return vswitch
 
 
-@cli.group('vswitch')
+@cli.group('vswitch', options_metavar=COMMAND_OPTIONS_METAVAR)
 def vswitch_group():
     """
     Command group for managing virtual switches.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
 
 
-@vswitch_group.command('list')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
+@vswitch_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
 @click.pass_obj
-def vswitch_list(cmd_ctx, cpc_name):
+def vswitch_list(cmd_ctx, cpc):
     """
     List the virtual switches in a CPC.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vswitch_list(cmd_ctx, cpc_name))
+    cmd_ctx.execute_cmd(lambda: cmd_vswitch_list(cmd_ctx, cpc))
 
 
-@vswitch_group.command('show')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('VSWITCH-NAME', type=str, metavar='VSWITCH-NAME')
+@vswitch_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('VSWITCH', type=str, metavar='VSWITCH')
 @click.pass_obj
-def vswitch_show(cmd_ctx, cpc_name, vswitch_name):
+def vswitch_show(cmd_ctx, cpc, vswitch):
     """
     Show the details of a virtual switch.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vswitch_show(cmd_ctx, cpc_name,
-                                                 vswitch_name))
+    cmd_ctx.execute_cmd(lambda: cmd_vswitch_show(cmd_ctx, cpc, vswitch))
 
 
-@vswitch_group.command('update')
-@click.argument('CPC-NAME', type=str, metavar='CPC-NAME')
-@click.argument('VSWITCH-NAME', type=str, metavar='VSWITCH-NAME')
+@vswitch_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('VSWITCH', type=str, metavar='VSWITCH')
 @click.option('--name', type=str, required=False,
               help='The new name of the virtual switch. '
               'Default: No change.')
@@ -91,16 +90,16 @@ def vswitch_show(cmd_ctx, cpc_name, vswitch_name):
               help='The new description of the virtual switch. '
               'Default: No change.')
 @click.pass_obj
-def vswitch_update(cmd_ctx, cpc_name, vswitch_name, **options):
+def vswitch_update(cmd_ctx, cpc, vswitch, **options):
     """
     Update the properties of a virtual switch.
 
     In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified before the
-    command.
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_vswitch_update(
-                        cmd_ctx, cpc_name, vswitch_name, options))
+    cmd_ctx.execute_cmd(lambda: cmd_vswitch_update(cmd_ctx, cpc, vswitch,
+                                                   options))
 
 
 def cmd_vswitch_list(cmd_ctx, cpc_name):

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -292,9 +292,10 @@ def print_resources_as_table(resources, show_list=None):
         row = properties.values()
         table.append(row)
     if not table:
-        click.echo("No entries.")
+        click.echo("No resources.")
     else:
-        click.echo(tabulate(table, headers, tablefmt="psql"))
+        sorted_table = sorted(table, key=lambda row: row[0])
+        click.echo(tabulate(sorted_table, headers, tablefmt="psql"))
 
 
 def print_properties_as_json(properties):

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -21,6 +21,10 @@ from tabulate import tabulate
 
 import zhmcclient
 
+# Display of options in usage line
+GENERAL_OPTIONS_METAVAR = '[GENERAL-OPTIONS]'
+COMMAND_OPTIONS_METAVAR = '[COMMAND-OPTIONS]'
+
 
 def abort_if_false(ctx, param, value):
     # pylint: disable=unused-argument

--- a/zhmccli/zhmccli.py
+++ b/zhmccli/zhmccli.py
@@ -18,7 +18,7 @@ import requests.packages.urllib3
 import click
 from click_repl import register_repl, repl
 
-from ._helper import CmdContext
+from ._helper import CmdContext, GENERAL_OPTIONS_METAVAR
 
 
 requests.packages.urllib3.disable_warnings()
@@ -28,7 +28,8 @@ DEFAULT_OUTPUT_FORMAT = 'table'
 DEFAULT_TIMESTATS = False
 
 
-@click.group(invoke_without_command=True)
+@click.group(invoke_without_command=True,
+             options_metavar=GENERAL_OPTIONS_METAVAR)
 @click.option('-h', '--host', type=str, envvar='ZHMC_HOST',
               help="Hostname or IP address of the HMC "
                    "(Default: ZHMC_HOST environment variable).")

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -151,22 +151,22 @@ class ActivationProfile(BaseResource):
     (in this case, :class:`~zhmcclient.ActivationProfileManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.ActivationProfileManager`):
-        #     Manager for this Activation Profile.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this Activation Profile.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this Activation Profile.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, ActivationProfileManager):
             raise AssertionError("ActivationProfile init: Expected manager "
                                  "type %s, got %s" %
                                  (ActivationProfileManager, type(manager)))
-        super(ActivationProfile, self).__init__(manager, uri, properties)
+        super(ActivationProfile, self).__init__(manager, uri, properties,
+                                                uri_prop='element-uri',
+                                                name_prop='name')
 
     def update_properties(self, properties):
         """

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -125,7 +125,7 @@ class ActivationProfileManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         activation_profiles_name = self._profile_type + '-activation-profiles'
-        profiles_res = self.session.get(self.cpc.uri + '/' + \
+        profiles_res = self.session.get(self.cpc.uri + '/' +
                                         activation_profiles_name)
         profile_list = []
         if profiles_res:

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -163,7 +163,10 @@ class ActivationProfile(BaseResource):
         #     Properties to be set for this Activation Profile.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, ActivationProfileManager)
+        if not isinstance(manager, ActivationProfileManager):
+            raise AssertionError("ActivationProfile init: Expected manager "
+                                 "type %s, got %s" %
+                                 (ActivationProfileManager, type(manager)))
         super(ActivationProfile, self).__init__(manager, uri, properties)
 
     def update_properties(self, properties):

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -124,13 +124,12 @@ class ActivationProfileManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.cpc.get_property('object-uri')
-        activation_profile = self._profile_type + '-activation-profiles'
-        profiles_res = self.session.get(cpc_uri + '/' + activation_profile)
+        activation_profiles_name = self._profile_type + '-activation-profiles'
+        profiles_res = self.session.get(self.cpc.uri + '/' + \
+                                        activation_profiles_name)
         profile_list = []
         if profiles_res:
-            profile_items = profiles_res[self._profile_type +
-                                         '-activation-profiles']
+            profile_items = profiles_res[activation_profiles_name]
             for profile_props in profile_items:
                 profile = ActivationProfile(self, profile_props['element-uri'],
                                             profile_props)
@@ -190,5 +189,4 @@ class ActivationProfile(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        profile_uri = self.get_property('element-uri')
-        self.manager.session.post(profile_uri, body=properties)
+        self.manager.session.post(self.uri, body=properties)

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -78,7 +78,7 @@ class ActivationProfileManager(BaseManager):
         #     * `reset`: Reset Activation Profiles
         #     * `image`: Image Activation Profiles
         #     * `load`: Load Activation Profiles
-        super(ActivationProfileManager, self).__init__(cpc)
+        super(ActivationProfileManager, self).__init__(ActivationProfile, cpc)
         self._profile_type = profile_type
 
     @property

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -191,7 +191,10 @@ class Adapter(BaseResource):
         #     Properties to be set for this Adapter.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, AdapterManager)
+        if not isinstance(manager, AdapterManager):
+            raise AssertionError("Adapter init: Expected manager type %s, "
+                                 "got %s" %
+                                 (AdapterManager, type(manager)))
         super(Adapter, self).__init__(manager, uri, properties)
         self._ports = None
 

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -87,7 +87,7 @@ class AdapterManager(BaseManager):
         # Parameters:
         #   cpc (:class:`~zhmcclient.Cpc`):
         #     CPC defining the scope for this manager.
-        super(AdapterManager, self).__init__(cpc)
+        super(AdapterManager, self).__init__(Adapter, cpc)
 
     @property
     def cpc(self):

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -119,8 +119,7 @@ class AdapterManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.cpc.get_property('object-uri')
-        adapters_res = self.session.get(cpc_uri + '/adapters')
+        adapters_res = self.session.get(self.cpc.uri + '/adapters')
         adapter_list = []
         if adapters_res:
             adapter_items = adapters_res['adapters']
@@ -156,8 +155,7 @@ class AdapterManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.cpc.get_property('object-uri')
-        result = self.session.post(cpc_uri + '/adapters', body=properties)
+        result = self.session.post(self.cpc.uri + '/adapters', body=properties)
         # There should not be overlaps, but just in case there are, the
         # returned props should overwrite the input props:
         props = properties.copy()
@@ -222,8 +220,7 @@ class Adapter(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        adapter_uri = self.get_property('object-uri')
-        self.manager.session.delete(adapter_uri)
+        self.manager.session.delete(self.uri)
 
     def update_properties(self, properties):
         """
@@ -244,5 +241,4 @@ class Adapter(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        adapter_uri = self.get_property('object-uri')
-        self.manager.session.post(adapter_uri, body=properties)
+        self.manager.session.post(self.uri, body=properties)

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -178,22 +178,23 @@ class Adapter(BaseResource):
     (in this case, :class:`~zhmcclient.AdapterManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.AdapterManager`):
-        #     Manager for this Adapter.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this Adapter.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this Adapter.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, AdapterManager):
             raise AssertionError("Adapter init: Expected manager type %s, "
                                  "got %s" %
                                  (AdapterManager, type(manager)))
-        super(Adapter, self).__init__(manager, uri, properties)
+        super(Adapter, self).__init__(manager, uri, properties,
+                                      uri_prop='object-uri',
+                                      name_prop='name')
+        # The manager objects for child resources (with lazy initialization):
         self._ports = None
 
     @property

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -313,9 +313,8 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.get_property('object-uri')
         result = self.manager.session.post(
-            cpc_uri + '/operations/start',
+            self.uri + '/operations/start',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -354,9 +353,8 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.get_property('object-uri')
         result = self.manager.session.post(
-            cpc_uri + '/operations/stop',
+            self.uri + '/operations/stop',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -405,10 +403,9 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.get_property('object-uri')
         body = {'profile-area': profile_area}
         result = self.manager.session.post(
-            cpc_uri + '/operations/import-profiles', body,
+            self.uri + '/operations/import-profiles', body,
             wait_for_completion=wait_for_completion)
         return result
 
@@ -456,10 +453,9 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.get_property('object-uri')
         body = {'profile-area': profile_area}
         result = self.manager.session.post(
-            cpc_uri + '/operations/export-profiles', body,
+            self.uri + '/operations/export-profiles', body,
             wait_for_completion=wait_for_completion)
         return result
 

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -75,6 +75,7 @@ class CpcManager(BaseManager):
         #   client (:class:`~zhmcclient.Client`):
         #      Client object for the HMC to be used.
         super(CpcManager, self).__init__()
+        self._resource_class = Cpc
         self._session = client.session
 
     @_log_call

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -124,22 +124,22 @@ class Cpc(BaseResource):
     (in this case, :class:`~zhmcclient.CpcManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.CpcManager`):
-        #     Manager for this CPC.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this CPC.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this CPC.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, CpcManager):
             raise AssertionError("Cpc init: Expected manager type %s, got %s" %
                                  (CpcManager, type(manager)))
-        super(Cpc, self).__init__(manager, uri, properties)
-        # We do here some lazy loading.
+        super(Cpc, self).__init__(manager, uri, properties,
+                                  uri_prop='object-uri',
+                                  name_prop='name')
+        # The manager objects for child resources (with lazy initialization):
         self._lpars = None
         self._partitions = None
         self._adapters = None

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -143,7 +143,7 @@ class Cpc(BaseResource):
         self._lpars = None
         self._partitions = None
         self._adapters = None
-        self._vswitches = None
+        self._virtual_switches = None
         self._reset_activation_profiles = None
         self._image_activation_profiles = None
         self._load_activation_profiles = None
@@ -186,15 +186,23 @@ class Cpc(BaseResource):
 
     @property
     @_log_call
-    def vswitches(self):
+    def virtual_switches(self):
         """
         :class:`~zhmcclient.VirtualSwitchManager`: Access to the
         :term:`Virtual Switches <Virtual Switch>` in this CPC.
         """
         # We do here some lazy loading.
-        if not self._vswitches:
-            self._vswitches = VirtualSwitchManager(self)
-        return self._vswitches
+        if not self._virtual_switches:
+            self._virtual_switches = VirtualSwitchManager(self)
+        return self._virtual_switches
+
+    @property
+    def vswitches(self):
+        """
+        Deprecated: Use :attr:`~zhmcclient.Cpc.virtual_switches` instead.
+        """
+        # TODO: Issue a deprecation warning
+        return self.virtual_switches
 
     @property
     @_log_call

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -74,8 +74,7 @@ class CpcManager(BaseManager):
         # Parameters:
         #   client (:class:`~zhmcclient.Client`):
         #      Client object for the HMC to be used.
-        super(CpcManager, self).__init__()
-        self._resource_class = Cpc
+        super(CpcManager, self).__init__(Cpc)
         self._session = client.session
 
     @_log_call

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -136,7 +136,9 @@ class Cpc(BaseResource):
         #     Properties to be set for this CPC.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, CpcManager)
+        if not isinstance(manager, CpcManager):
+            raise AssertionError("Cpc init: Expected manager type %s, got %s" %
+                                 (CpcManager, type(manager)))
         super(Cpc, self).__init__(manager, uri, properties)
         # We do here some lazy loading.
         self._lpars = None

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -81,11 +81,11 @@ class HbaManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        hbas_res = self.partition.get_property('hba-uris')
+        hba_uris = self.partition.get_property('hba-uris')
         hba_list = []
-        if hbas_res:
-            for hba_uri in hbas_res:
-                hba = Hba(self, hba_uri, {'element-uri': hba_uri})
+        if hba_uris:
+            for uri in hba_uris:
+                hba = Hba(self, uri)
                 if full_properties:
                     hba.pull_full_properties()
                 hba_list.append(hba)
@@ -143,21 +143,22 @@ class Hba(BaseResource):
     (in this case, :class:`~zhmcclient.HbaManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
         # Parameters:
         #   manager (:class:`~zhmcclient.HbaManager`):
-        #     Manager for this HBA.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this HBA.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this HBA.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, HbaManager):
             raise AssertionError("Hba init: Expected manager type %s, got %s" %
                                  (HbaManager, type(manager)))
-        super(Hba, self).__init__(manager, uri, properties)
+        super(Hba, self).__init__(manager, uri, properties,
+                                  uri_prop='element-uri',
+                                  name_prop='name')
 
     def delete(self):
         """

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -154,7 +154,9 @@ class Hba(BaseResource):
         #     Properties to be set for this HBA.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, HbaManager)
+        if not isinstance(manager, HbaManager):
+            raise AssertionError("Hba init: Expected manager type %s, got %s" %
+                                 (HbaManager, type(manager)))
         super(Hba, self).__init__(manager, uri, properties)
 
     def delete(self):

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -49,7 +49,7 @@ class HbaManager(BaseManager):
         # Parameters:
         #   partition (:class:`~zhmcclient.Partition`):
         #     Partition defining the scope for this manager.
-        super(HbaManager, self).__init__(partition)
+        super(HbaManager, self).__init__(Hba, partition)
 
     @property
     def partition(self):

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -118,8 +118,8 @@ class HbaManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.partition.get_property('object-uri')
-        result = self.session.post(partition_uri + '/hbas', body=properties)
+        result = self.session.post(self.partition.uri + '/hbas',
+                                   body=properties)
         # There should not be overlaps, but just in case there are, the
         # returned props should overwrite the input props:
         props = properties.copy()

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -109,22 +109,22 @@ class Lpar(BaseResource):
     (in this case, :class:`~zhmcclient.LparManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.LparManager`):
-        #     Manager object for this LPAR.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this LPAR.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this LPAR.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, LparManager):
             raise AssertionError("Lpar init: Expected manager type %s, "
                                  "got %s" %
                                  (LparManager, type(manager)))
-        super(Lpar, self).__init__(manager, uri, properties)
+        super(Lpar, self).__init__(manager, uri, properties,
+                                   uri_prop='object-uri',
+                                   name_prop='name')
 
     @_log_call
     def activate(self, wait_for_completion=True):

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -52,7 +52,7 @@ class LparManager(BaseManager):
         # Parameters:
         #   cpc (:class:`~zhmcclient.Cpc`):
         #     CPC defining the scope for this manager.
-        super(LparManager, self).__init__(cpc)
+        super(LparManager, self).__init__(Lpar, cpc)
 
     @property
     def cpc(self):

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -85,8 +85,7 @@ class LparManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.cpc.get_property('object-uri')
-        lpars_res = self.session.get(cpc_uri + '/logical-partitions')
+        lpars_res = self.session.get(self.cpc.uri + '/logical-partitions')
         lpar_list = []
         if lpars_res:
             lpar_items = lpars_res['logical-partitions']
@@ -165,10 +164,9 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        lpar_uri = self.get_property('object-uri')
         body = {}
         result = self.manager.session.post(
-            lpar_uri + '/operations/activate', body,
+            self.uri + '/operations/activate', body,
             wait_for_completion=wait_for_completion)
         return result
 
@@ -210,10 +208,9 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        lpar_uri = self.get_property('object-uri')
         body = {'force': True}
         result = self.manager.session.post(
-            lpar_uri + '/operations/deactivate', body,
+            self.uri + '/operations/deactivate', body,
             wait_for_completion=wait_for_completion)
         return result
 
@@ -257,9 +254,8 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        lpar_uri = self.get_property('object-uri')
         body = {'load-address': load_address}
         result = self.manager.session.post(
-            lpar_uri + '/operations/load', body,
+            self.uri + '/operations/load', body,
             wait_for_completion=wait_for_completion)
         return result

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -121,7 +121,10 @@ class Lpar(BaseResource):
         #     Properties to be set for this LPAR.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, LparManager)
+        if not isinstance(manager, LparManager):
+            raise AssertionError("Lpar init: Expected manager type %s, "
+                                 "got %s" %
+                                 (LparManager, type(manager)))
         super(Lpar, self).__init__(manager, uri, properties)
 
     @_log_call

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -79,7 +79,10 @@ class BaseManager(object):
         """
         The Python class of the parent resource of this manager.
         """
-        assert self._resource_class is not None
+        if self._resource_class is None:
+            raise AssertionError("%s.resource_class: No resource "
+                                 "class set" %
+                                 self.__class__.__name__)
         return self._resource_class
 
     @property
@@ -88,7 +91,9 @@ class BaseManager(object):
         :class:`~zhmcclient.Session`:
           Session with the HMC.
         """
-        assert self._session is not None
+        if self._session is None:
+            raise AssertionError("%s.session: No session set" %
+                                 self.__class__.__name__)
         return self._session
 
     @property
@@ -231,8 +236,8 @@ class BaseManager(object):
           Exceptions raised by the `list()` method in the derived classes.
         """
         uri = self._get_uri(name)
-        props = self._session.get(uri)
-        obj = self._resource_class(self, uri, props)
+        props = self.session.get(uri)
+        obj = self.resource_class(self, uri, props)
         return obj
 
     def flush(self):

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -41,9 +41,12 @@ class BaseManager(object):
     methods that have a common implementation for the derived manager classes.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, resource_class, parent=None):
         """
         Parameters:
+
+          resource_class (class):
+            Python class for the resources of this manager.
 
           parent (subclass of :class:`~zhmcclient.BaseResource`):
             Parent resource defining the scope for this manager.
@@ -51,12 +54,12 @@ class BaseManager(object):
             `None`, if the manager has no parent, i.e. when it manages
             top-level resources.
         """
+        self._resource_class = resource_class
         self._parent = parent
         self._uris = {}
         # Note: Managers of top-level resources must update the following
         # instance variables in their init:
         self._session = parent.manager.session if parent else None
-        self._resource_class = parent.__class__ if parent else None
 
     def _get_uri(self, name):
         """
@@ -79,10 +82,6 @@ class BaseManager(object):
         """
         The Python class of the parent resource of this manager.
         """
-        if self._resource_class is None:
-            raise AssertionError("%s.resource_class: No resource "
-                                 "class set" %
-                                 self.__class__.__name__)
         return self._resource_class
 
     @property
@@ -92,7 +91,8 @@ class BaseManager(object):
           Session with the HMC.
         """
         if self._session is None:
-            raise AssertionError("%s.session: No session set" %
+            raise AssertionError("%s.session: No session set (in top-level "
+                                 "resource manager class?)" %
                                  self.__class__.__name__)
         return self._session
 

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -75,7 +75,7 @@ class BaseManager(object):
             try:
                 return self._uris[name]
             except KeyError:
-                raise zhmcclient.NotFound
+                raise NotFound
 
     @property
     def resource_class(self):

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -236,8 +236,8 @@ class BaseManager(object):
           Exceptions raised by the `list()` method in the derived classes.
         """
         uri = self._get_uri(name)
-        props = self.session.get(uri)
-        obj = self.resource_class(self, uri, props)
+        #props = self.session.get(uri)
+        obj = self.resource_class(self, uri, {})
         return obj
 
     def flush(self):

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -236,8 +236,7 @@ class BaseManager(object):
           Exceptions raised by the `list()` method in the derived classes.
         """
         uri = self._get_uri(name)
-        #props = self.session.get(uri)
-        obj = self.resource_class(self, uri, {})
+        obj = self.resource_class(self, uri)
         return obj
 
     def flush(self):

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -184,7 +184,9 @@ class Nic(BaseResource):
         #     Properties to be set for this resource.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, NicManager)
+        if not isinstance(manager, NicManager):
+            raise AssertionError("Nic init: Expected manager type %s, got %s" %
+                                 (NicManager, type(manager)))
         super(Nic, self).__init__(manager, uri, properties)
 
     def delete(self):

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -50,7 +50,7 @@ class NicManager(BaseManager):
         # Parameters:
         #   partition (:class:`~zhmcclient.Partition`):
         #     Partition defining the scope for this manager.
-        super(NicManager, self).__init__(partition)
+        super(NicManager, self).__init__(Nic, partition)
 
     @property
     def partition(self):

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -116,8 +116,8 @@ class NicManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.partition.get_property('object-uri')
-        result = self.session.post(partition_uri + '/nics', body=properties)
+        result = self.session.post(self.partition.uri + '/nics',
+                                   body=properties)
         # There should not be overlaps, but just in case there are, the
         # returned props should overwrite the input props:
         props = properties.copy()

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -82,11 +82,11 @@ class NicManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        nics_res = self.partition.get_property('nic-uris')
+        nic_uris = self.partition.get_property('nic-uris')
         nic_list = []
-        if nics_res:
-            for nic_uri in nics_res:
-                nic = Nic(self, nic_uri, {'element-uri': nic_uri})
+        if nic_uris:
+            for uri in nic_uris:
+                nic = Nic(self, uri)
                 if full_properties:
                     nic.pull_full_properties()
                 nic_list.append(nic)
@@ -151,10 +151,12 @@ class NicManager(BaseManager):
         """
         part_uri = self.parent.uri
         nic_uri = part_uri + "/nics/" + nic_id
-        return Nic(self, nic_uri, {'element-uri': nic_uri,
-                                   'element-id': nic_id,
-                                   'parent': part_uri,
-                                   'class': 'nic'})
+        nic_props = {
+            'element-id': nic_id,
+            'parent': part_uri,
+            'class': 'nic',
+        }
+        return Nic(self, nic_uri, nic_props)
 
 
 class Nic(BaseResource):
@@ -173,21 +175,21 @@ class Nic(BaseResource):
     (in this case, :class:`~zhmcclient.NicManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.NicManager`):
-        #     Manager for this resource.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this resource.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this resource.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, NicManager):
             raise AssertionError("Nic init: Expected manager type %s, got %s" %
                                  (NicManager, type(manager)))
-        super(Nic, self).__init__(manager, uri, properties)
+        super(Nic, self).__init__(manager, uri, properties,
+                                  uri_prop='element-uri',
+                                  name_prop='name')
 
     def delete(self):
         """

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -91,8 +91,7 @@ class PartitionManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.cpc.get_property('object-uri')
-        partitions_res = self.session.get(cpc_uri + '/partitions')
+        partitions_res = self.session.get(self.cpc.uri + '/partitions')
         partition_list = []
         if partitions_res:
             partition_items = partitions_res['partitions']
@@ -128,8 +127,8 @@ class PartitionManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.cpc.get_property('object-uri')
-        result = self.session.post(cpc_uri + '/partitions', body=properties)
+        result = self.session.post(self.cpc.uri + '/partitions',
+                                   body=properties)
         # There should not be overlaps, but just in case there are, the
         # returned props should overwrite the input props:
         props = properties.copy()
@@ -277,9 +276,8 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.get_property('object-uri')
         result = self.manager.session.post(
-            partition_uri + '/operations/start',
+            self.uri + '/operations/start',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -320,9 +318,8 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.get_property('object-uri')
         result = self.manager.session.post(
-            partition_uri + '/operations/stop',
+            self.uri + '/operations/stop',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -337,8 +334,7 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.get_property('object-uri')
-        self.manager.session.delete(partition_uri)
+        self.manager.session.delete(self.uri)
 
     def update_properties(self, properties):
         """
@@ -359,8 +355,7 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.get_property('object-uri')
-        self.manager.session.post(partition_uri, body=properties)
+        self.manager.session.post(self.uri, body=properties)
 
     def dump_partition(self, parameters, wait_for_completion=True):
         """
@@ -405,9 +400,8 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.get_property('object-uri')
         result = self.manager.session.post(
-            partition_uri + '/operations/scsi-dump',
+            self.uri + '/operations/scsi-dump',
             wait_for_completion=wait_for_completion, body=parameters)
         return result
 
@@ -448,9 +442,8 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.get_property('object-uri')
         result = self.manager.session.post(
-            partition_uri + '/operations/psw-restart',
+            self.uri + '/operations/psw-restart',
             wait_for_completion=wait_for_completion)
         return result
 
@@ -478,9 +471,8 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.get_property('object-uri')
         self.manager.session.post(
-            partition_uri + '/operations/mount-iso-image',
+            self.uri + '/operations/mount-iso-image',
             wait_for_completion=True, body=properties)
 
     def unmount_iso_image(self):
@@ -495,6 +487,5 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.get_property('object-uri')
         self.manager.session.post(
-            partition_uri + '/operations/unmount-iso-image')
+            self.uri + '/operations/unmount-iso-image')

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -162,10 +162,12 @@ class PartitionManager(BaseManager):
             Partition.
         """
         part_uri = "/api/partitions/" + part_id
-        return Partition(self, part_uri, {'object-uri': part_uri,
-                                          'object-id': part_id,
-                                          'parent': self.parent.uri,
-                                          'class': 'partition'})
+        part_props = {
+            'object-id': part_id,
+            'parent': self.parent.uri,
+            'class': 'partition',
+        }
+        return Partition(self, part_uri, part_props)
 
 
 class Partition(BaseResource):
@@ -180,22 +182,23 @@ class Partition(BaseResource):
     (in this case, :class:`~zhmcclient.PartitionManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.PartitionManager`):
-        #     Manager for this Partition.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this Partition.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this Partition.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, PartitionManager):
             raise AssertionError("Partition init: Expected manager type %s, "
                                  "got %s" %
                                  (PartitionManager, type(manager)))
-        super(Partition, self).__init__(manager, uri, properties)
+        super(Partition, self).__init__(manager, uri, properties,
+                                        uri_prop='object-uri',
+                                        name_prop='name')
+        # The manager objects for child resources (with lazy initialization):
         self._nics = None
         self._hbas = None
         self._virtual_functions = None

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -59,7 +59,7 @@ class PartitionManager(BaseManager):
         # Parameters:
         #   cpc (:class:`~zhmcclient.Cpc`):
         #     CPC defining the scope for this manager.
-        super(PartitionManager, self).__init__(cpc)
+        super(PartitionManager, self).__init__(Partition, cpc)
 
     @property
     def cpc(self):

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -192,7 +192,10 @@ class Partition(BaseResource):
         #     Properties to be set for this Partition.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, PartitionManager)
+        if not isinstance(manager, PartitionManager):
+            raise AssertionError("Partition init: Expected manager type %s, "
+                                 "got %s" %
+                                 (PartitionManager, type(manager)))
         super(Partition, self).__init__(manager, uri, properties)
         self._nics = None
         self._hbas = None

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -46,7 +46,7 @@ class PortManager(BaseManager):
         # Parameters:
         #   adapter (:class:`~zhmcclient.Adapter`):
         #     Adapter defining the scope for this manager.
-        super(PortManager, self).__init__(adapter)
+        super(PortManager, self).__init__(Port, adapter)
 
     @property
     def adapter(self):

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -89,7 +89,7 @@ class PortManager(BaseManager):
             return port_list
         if ports_res:
             for port_uri in ports_res:
-                port = Port(self, port_uri, {'element-uri': port_uri})
+                port = Port(self, port_uri)
                 if full_properties:
                     port.pull_full_properties()
                 port_list.append(port)
@@ -112,22 +112,22 @@ class Port(BaseResource):
     (in this case, :class:`~zhmcclient.PortManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.PortManager`):
-        #     Manager for this Port.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this Port.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this Port.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, PortManager):
             raise AssertionError("Port init: Expected manager type %s, "
                                  "got %s" %
                                  (PortManager, type(manager)))
-        super(Port, self).__init__(manager, uri, properties)
+        super(Port, self).__init__(manager, uri, properties,
+                                   uri_prop='element-uri',
+                                   name_prop='name')
 
     def update_properties(self, properties):
         """

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -123,7 +123,10 @@ class Port(BaseResource):
         #     Properties to be set for this Port.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, PortManager)
+        if not isinstance(manager, PortManager):
+            raise AssertionError("Port init: Expected manager type %s, "
+                                 "got %s" %
+                                 (PortManager, type(manager)))
         super(Port, self).__init__(manager, uri, properties)
 
     def update_properties(self, properties):

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -100,6 +100,19 @@ class BaseResource(object):
         return self._uri
 
     @property
+    def name(self):
+        """
+        string: The name of the resource.
+
+        The name of a resource is the value of its `name` property.
+        The resource name is unique across its sibling resources of the same
+        type and with the same parent resource.
+        """
+        # Just in case this happens: If the statements above are not true for
+        # a particular resource class, it needs to re-implement this property.
+        return self._properties['name']
+
+    @property
     def manager(self):
         """
         Subclass of :class:`~zhmcclient.BaseManager`:

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -326,7 +326,6 @@ class Session(object):
         """
         Log off, unconditionally.
         """
-        assert 'X-API-Session' in self._headers
         session_uri = '/api/sessions/this-session'
         self.delete(session_uri, logon_required=False)
         self._session_id = None

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -49,7 +49,8 @@ class VirtualFunctionManager(BaseManager):
         # Parameters:
         #   partition (:class:`~zhmcclient.Partition`):
         #     Partition defining the scope for this manager.
-        super(VirtualFunctionManager, self).__init__(partition)
+        super(VirtualFunctionManager, self).__init__(VirtualFunction,
+                                                     partition)
 
     @property
     def partition(self):

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -82,11 +82,11 @@ class VirtualFunctionManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        vfs_res = self.partition.get_property('virtual-function-uris')
+        vfs_uris = self.partition.get_property('virtual-function-uris')
         vf_list = []
-        if vfs_res:
-            for vf_uri in vfs_res:
-                vf = VirtualFunction(self, vf_uri, {'element-uri': vf_uri})
+        if vfs_uris:
+            for uri in vfs_uris:
+                vf = VirtualFunction(self, uri)
                 if full_properties:
                     vf.pull_full_properties()
                 vf_list.append(vf)
@@ -141,22 +141,22 @@ class VirtualFunction(BaseResource):
     (in this case, :class:`~zhmcclient.VirtualFunctionManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.VirtualFunctionManager`):
-        #     Manager object for this Virtual Function.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this Virtual Function.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this Virtual Function.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, VirtualFunctionManager):
             raise AssertionError("VirtualFunction init: Expected manager "
                                  "type %s, got %s" %
                                  (VirtualFunctionManager, type(manager)))
-        super(VirtualFunction, self).__init__(manager, uri, properties)
+        super(VirtualFunction, self).__init__(manager, uri, properties,
+                                              uri_prop='element-uri',
+                                              name_prop='name')
 
     def delete(self):
         """

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -116,8 +116,7 @@ class VirtualFunctionManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partition_uri = self.partition.get_property('object-uri')
-        result = self.session.post(partition_uri + '/virtual-functions',
+        result = self.session.post(self.partition.uri + '/virtual-functions',
                                    body=properties)
         # There should not be overlaps, but just in case there are, the
         # returned props should overwrite the input props:

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -152,7 +152,10 @@ class VirtualFunction(BaseResource):
         #     Properties to be set for this Virtual Function.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, VirtualFunctionManager)
+        if not isinstance(manager, VirtualFunctionManager):
+            raise AssertionError("VirtualFunction init: Expected manager "
+                                 "type %s, got %s" %
+                                 (VirtualFunctionManager, type(manager)))
         super(VirtualFunction, self).__init__(manager, uri, properties)
 
     def delete(self):

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -52,7 +52,7 @@ class VirtualSwitchManager(BaseManager):
         # Parameters:
         #   cpc (:class:`~zhmcclient.Cpc`):
         #     CPC defining the scope for this manager.
-        super(VirtualSwitchManager, self).__init__(cpc)
+        super(VirtualSwitchManager, self).__init__(VirtualSwitch, cpc)
 
     @property
     def cpc(self):

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -84,8 +84,7 @@ class VirtualSwitchManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        cpc_uri = self.cpc.get_property('object-uri')
-        vswitch_res = self.session.get(cpc_uri + '/virtual-switches')
+        vswitch_res = self.session.get(self.cpc.uri + '/virtual-switches')
         vswitch_list = []
         if vswitch_res:
             vswitch_items = vswitch_res['virtual-switches']
@@ -155,9 +154,8 @@ class VirtualSwitch(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        vswitch_uri = self.get_property('object-uri')
         result = self.manager.session.get(
-            vswitch_uri + '/operations/get-connected-vnics')
+            self.uri + '/operations/get-connected-vnics')
         nic_uris = result['connected-vnic-uris']
         nic_list = []
         parts = {}  # Key: Partition ID; Value: Partition object
@@ -194,5 +192,4 @@ class VirtualSwitch(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        vswitch_uri = self.get_property('object-uri')
-        self.manager.session.post(vswitch_uri, body=properties)
+        self.manager.session.post(self.uri, body=properties)

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -124,7 +124,10 @@ class VirtualSwitch(BaseResource):
         #     Properties to be set for this Virtual Switch.
         #     See initialization of :class:`~zhmcclient.BaseResource` for
         #     details.
-        assert isinstance(manager, VirtualSwitchManager)
+        if not isinstance(manager, VirtualSwitchManager):
+            raise AssertionError("VirtualSwitch init: Expected manager "
+                                 "type %s, got %s" %
+                                 (VirtualSwitchManager, type(manager)))
         super(VirtualSwitch, self).__init__(manager, uri, properties)
 
     def get_connected_nics(self):

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -112,22 +112,22 @@ class VirtualSwitch(BaseResource):
     (in this case, :class:`~zhmcclient.VirtualSwitchManager`).
     """
 
-    def __init__(self, manager, uri, properties):
+    def __init__(self, manager, uri, properties=None):
         # This function should not go into the docs.
-        # Parameters:
         #   manager (:class:`~zhmcclient.VirtualSwitchManager`):
-        #     Manager object for this Virtual Switch.
+        #     Manager object for this resource object.
         #   uri (string):
-        #     Canonical URI path of this Virtual Switch.
+        #     Canonical URI path of the resource.
         #   properties (dict):
-        #     Properties to be set for this Virtual Switch.
-        #     See initialization of :class:`~zhmcclient.BaseResource` for
-        #     details.
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
         if not isinstance(manager, VirtualSwitchManager):
             raise AssertionError("VirtualSwitch init: Expected manager "
                                  "type %s, got %s" %
                                  (VirtualSwitchManager, type(manager)))
-        super(VirtualSwitch, self).__init__(manager, uri, properties)
+        super(VirtualSwitch, self).__init__(manager, uri, properties,
+                                            uri_prop='object-uri',
+                                            name_prop='name')
 
     def get_connected_nics(self):
         """


### PR DESCRIPTION
This PR is pretty much completely tested and ready for serious use.

zhmcclient library changes:
- Added support in the `BaseResource` class for optimized resource access by name. This includes:
  - an instance variable `_uris` that is a cached mapping of resource names to resource URIs
  - a new `find_by_name()` method that is automatically used by `findall()` and `find()` when called with 'name' as the single filter, but can also be called by the user.
  - a `flush()` method that flushes the cached name-to-URI mapping. This is only needed when renaming resources.
- Added two required parameters to the init method of class BaseResource. This method is not part of the external API, so this is not an incompatible change.

zhmc CLI changes:
- Added support for all missing resource types for DPM mode.
- Added and changed options for creating and updating resources for already supported resource types. Resources referenced in options are now consistently referenced by resource name.
- The resource name is now always part of the output.
- Added options for showing additional properties. The URI is now only shown when its option is used.
- In table output, resources are now sorted  by resource name.
- In table output, the columns now have a specific ordering.