### PR TITLE
Add example for CLI zhmc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ hmc*.yaml
 session.yml
 # Files created by releasenotes build
 releasenotes/build
+zhmcrc.sh

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,8 @@ Released: not yet
 * Changed links to HMC API books in Bibliography to no longer require IBM ID
   (issue #131).
 
+* Added example shell script showing how to use the command line interface.
+
 **Known Issues:**
 
 * See `list of open issues`_.

--- a/examples/cli/crud_partition.sh
+++ b/examples/cli/crud_partition.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+echo "Example script demonstrating zhmc CLI partition commands."
+
+eval $(zhmc -h $HMC_HOST -u $HMC_USER session create)
+zhmc cpc list
+out=$(zhmc -o json cpc show $CPC_NAME)
+dpm=$(echo "$out" | python -c "import json,sys; obj=json.load(sys.stdin); print(obj['dpm-enabled'])")
+if [ $dpm != "True" ]
+then
+   echo "CPC $CPC_NAME is not in DPM mode."
+   eval $(zhmc session delete)
+   exit 2
+else
+   echo "CPC $CPC_NAME is in DPM mode."
+fi
+zhmc partition list $CPC_NAME
+zhmc partition create $CPC_NAME \
+   --name $PART_NAME \
+   --description "This is a partition created by zhmc." \
+   --cp-processors 1 \
+   --initial-memory 4096 \
+   --maximum-memory 4096 \
+   --processor-mode shared \
+#   --boot-device test-operating-system
+zhmc partition show $CPC_NAME $PART_NAME
+zhmc partition start $CPC_NAME $PART_NAME
+zhmc partition stop $CPC_NAME $PART_NAME
+zhmc partition delete $CPC_NAME $PART_NAME --yes
+eval $(zhmc session delete)

--- a/examples/cli/example_zhmcrc.sh
+++ b/examples/cli/example_zhmcrc.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# In order to use the shell script examples in this folder,
+# you have to rename example_zhmcrc.sh to zhmcrc.sh and setup
+# your runtime configuration information like HMC_HOST, HMC_USER, etc.
+# When you source the file, environment variables are set
+# for your current shell.
+export HMC_HOST="Put here the HMC host"
+export HMC_USER="Put here HMC user"
+export CPC_NAME="Put here the name of the CPC"
+export PART_NAME="TESTPARTITION"
+


### PR DESCRIPTION
Add example for CLI zhmc
    
Details:
- Example implements create, delete, updates
  and list of a partition using the CLI.
- Example implements check of DPM mode.
- Example file provided for runtime configuration
  information stored in zhmcrc.sh file.
- zhmcrc.sh added to gitignore file to
  avoid accidentally release runtime information
  to repository.