### PR TITLE
Added support for server-side resource filtering.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,11 +27,33 @@ Released: not yet
 
 **Incompatible changes:**
 
+* The support for server-side filtering caused an incompatibility for the
+  `find()` and `findall()` methods: For String typed resource properties,
+  the provided filter string is now interpreted as a regular expression
+  that is matched against the actual property value, whereby previously it
+  was matched by exact string comparison.
+
+* The parameter signatures of the `__init__()` methods of `BaseResource` and
+  `BaseManager` have changed incompatibly. These methods have always been
+  considered internal to the package. They are now explicitly stated to be
+  internal and their parameters are no longer documented.
+  If users have made themselves dependent on these parameters (e.g. by writing
+  a mock layer), they will need to adjust to the new parameter signature. See
+  the code for details.
+
 **Deprecations:**
 
 **Bug fixes:**
 
 **Enhancements:**
+
+* Added filter arguments to the `list()` method, and added support for
+  processing as many filter arguments as supported on the server side via
+  filter query parameters in the URI of the HMC List operation. The remaining
+  filter arguments are processed on the client side in the `list()` method.
+
+* Changed the keyword arguments of the `find()` and `findall()` methods to be
+  interpreted as filter arguments that are passed to the `list()` method.
 
 **Known Issues:**
 

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -103,3 +103,67 @@ Exceptions
 .. autoclass:: zhmcclient.NoUniqueMatch
    :members:
    :special-members: __str__
+
+
+.. _`Filtering`:
+
+Filtering
+---------
+
+Some methods (e.g. :meth:`~zhmcclient.BaseManager.list` or
+:meth:`~zhmcclient.BaseManager.find`) support the concept of resource
+filtering. This concept allows narrowing the set of returned resources based
+upon matching their resource properties against filter arguments.
+
+The filter arguments are used to construct filter query parameters in the
+HMC operations, so that they are processed on the server side by the HMC.
+
+The methods that support resource filtering either have keyword arguments
+``**filter_args``, or have a parameter ``filter_args`` that can be `None` for
+no filtering or a dictionary to enable filtering. In both cases,
+``filter_args`` is a dictionary.
+
+The dictionary keys specify the names of the resource properties that need to
+match for the resource to be included in the result. A resource is included
+in the result only if all resource properties specified in the dictionary
+match.
+
+The dictionary value specifies how the corresponding resource property matches:
+
+* For resource properties of type String (as per the resource's data model in
+  the :term:`HMC API`), the dictionary value is interpreted as a regular
+  expression that must match the actual resource property value. The regular
+  expression syntax used is the same as that used by the Java programming
+  language, as specified for the ``java.util.regex.Pattern`` class (see
+  http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html).
+
+* For resource properties of type String Enum, the dictionary value is
+  interpreted as an exact string that must be equal to the actual resource
+  property value.
+
+* TBD: What happens for other types of resource properties?
+
+* If the dictionary value is a list or a tuple, the resource matches if any
+  item in the list or tuple matches.
+
+Examples:
+
+* This example uses the :meth:`~zhmcclient.BaseManager.findall` method to
+  return those OSA adapters in cage '1234' of a given CPC, whose state is
+  'stand-by', 'reserved', or 'unknown'::
+
+      filter_args = {
+          'adapter-family': 'osa',
+          'card-location': '1234-.*',
+          'state': ['stand-by', 'reserved', 'unknown'],
+      }
+      osa_adapters = cpc.adapters.findall(**filter_args)
+
+  The returned resource objects will have only a minimal set of properties.
+
+* This example uses the :meth:`~zhmcclient.BaseManager.list` method to return
+  the same set of OSA adapters as the previous example, but the returned
+  resource objects have the full set of properties::
+
+      osa_adapters = cpc.adapters.list(full_properties=True,
+                                       filter_args=filter_args)

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -27,18 +27,28 @@ from zhmcclient._resource import BaseResource
 
 class MyResource(BaseResource):
     def __init__(self, manager, uri, name=None, properties=None):
-        super(MyResource, self).__init__(manager, uri, name, properties,
-                                         uri_prop='object-uri',
-                                         name_prop='name')
+        super(MyResource, self).__init__(manager, uri, name, properties)
 
 
 class MyManager(BaseManager):
-    def __init__(self):
-        super(MyManager, self).__init__(MyResource)
-        self._items = []
+    def __init__(self, parent=None):
+        super(MyManager, self).__init__(
+            resource_class=MyResource,
+            parent=parent,
+            uri_prop='object-uri',
+            name_prop='name',
+            query_props=[])
+        self._list_items = []
 
-    def list(self):
-        return self._items
+    def list(self, full_properties=False, filter_args=None):
+        # We need to have a quick way to mock this method. This mocked
+        # implementation basically uses the _list_items instance variable,
+        # and then applies the client-side filtering on top of it.
+        result_list = []
+        for obj in self._list_items:
+            if not filter_args or self._matches_filters(obj, filter_args):
+                result_list.append(obj)
+        return result_list
 
 
 class ManagerTests(unittest.TestCase):
@@ -48,7 +58,7 @@ class ManagerTests(unittest.TestCase):
         self.resource = MyResource(self.manager, "foo-uri",
                                    properties={"name": "foo-name",
                                                "other": "foo-other"})
-        self.manager._items = [self.resource]
+        self.manager._list_items = [self.resource]
 
     def test_findall_attribute(self):
         items = self.manager.findall(other="foo-other")

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -59,7 +59,22 @@ class PartitionManager(BaseManager):
         # Parameters:
         #   cpc (:class:`~zhmcclient.Cpc`):
         #     CPC defining the scope for this manager.
-        super(PartitionManager, self).__init__(Partition, cpc)
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+            'status',
+        ]
+
+        super(PartitionManager, self).__init__(
+            resource_class=Partition,
+            parent=cpc,
+            uri_prop='object-uri',
+            name_prop='name',
+            query_props=query_props)
 
     @property
     def cpc(self):
@@ -69,7 +84,7 @@ class PartitionManager(BaseManager):
         """
         return self._parent
 
-    def list(self, full_properties=False):
+    def list(self, full_properties=False, filter_args=None):
         """
         List the Partitions in this CPC.
 
@@ -79,6 +94,14 @@ class PartitionManager(BaseManager):
             Controls whether the full set of resource properties should be
             retrieved, vs. only the short set as returned by the list
             operation.
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
 
         Returns:
 
@@ -91,17 +114,29 @@ class PartitionManager(BaseManager):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        partitions_res = self.session.get(self.cpc.uri + '/partitions')
-        partition_list = []
-        if partitions_res:
-            partition_items = partitions_res['partitions']
-            for partition_props in partition_items:
-                partition = Partition(self, partition_props['object-uri'],
-                                      None, partition_props)
-                if full_properties:
-                    partition.pull_full_properties()
-                partition_list.append(partition)
-        return partition_list
+        query_parms, client_filters = self._divide_filter_args(filter_args)
+
+        resources_name = 'partitions'
+        uri = '{}/{}{}'.format(self.cpc.uri, resources_name, query_parms)
+
+        resource_obj_list = []
+        result = self.session.get(uri)
+        if result:
+            props_list = result[resources_name]
+            for props in props_list:
+
+                resource_obj = self.resource_class(
+                    manager=self,
+                    uri=props[self._uri_prop],
+                    name=props.get(self._name_prop, None),
+                    properties=props)
+
+                if self._matches_filters(resource_obj, client_filters):
+                    resource_obj_list.append(resource_obj)
+                    if full_properties:
+                        resource_obj.pull_full_properties()
+
+        return resource_obj_list
 
     def create(self, properties):
         """
@@ -197,9 +232,7 @@ class Partition(BaseResource):
             raise AssertionError("Partition init: Expected manager type %s, "
                                  "got %s" %
                                  (PartitionManager, type(manager)))
-        super(Partition, self).__init__(manager, uri, name, properties,
-                                        uri_prop='object-uri',
-                                        name_prop='name')
+        super(Partition, self).__init__(manager, uri, name, properties)
         # The manager objects for child resources (with lazy initialization):
         self._nics = None
         self._hbas = None


### PR DESCRIPTION
This PR adds support for filtering properties on the server side via filter query parameters. This is done transparently, for those properties that are supported. The rest of the properties is still filtered on the client side.

Please review and merge.

There are two incompatibilities:
* The support for server-side filtering caused an incompatibility for the `find()` and `findall()` methods: For String typed resource properties, the provided filter string is now interpreted as a regular expression that is matched against the actual property value, whereby previously it was matched by exact string comparison.
* The parameter signatures of the `__init__()` methods of `BaseResource` and `BaseManager` have changed incompatibly. These methods have always been  considered internal to the package. They are now explicitly stated to be internal and their parameters are no longer documented. If users have made themselves dependent on these parameters (e.g. by writing a mock layer), they will need to adjust to the new parameter signature. See the code for details.