### PR TITLE
Fixes #137: Accessing properties['name'] may raise KeyError.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,13 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed a bug where accessing the 'name' property via the `properties`
+  attribute caused `KeyError` to be raised (issue #137). Note that there
+  is now a recommendation to use `get_property()` or the `name` or `uri`
+  attributes for accessing specific properties. The `properties` attribute
+  should only be used for iterating over the currently present resource
+  properties, but not for expecting particular properties.
+
 **Enhancements:**
 
 * Changed links to HMC API books in Bibliography to no longer require IBM ID

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -89,8 +89,7 @@ if timestats:
 print("Listing CPCs ...")
 cpcs = cl.cpcs.list()
 for cpc in cpcs:
-    print(cpc.properties['name'], cpc.properties['status'],
-          cpc.properties['object-uri'])
+    print(cpc.name, cpc.get_property('status'), cpc.uri)
 
 print("Finding CPC by name=%s ..." % cpcname)
 try:
@@ -98,8 +97,7 @@ try:
 except zhmcclient.NotFound:
     print("Could not find CPC %s on HMC %s" % (cpcname, hmc))
     sys.exit(1)
-print(cpc.properties['name'], cpc.properties['status'],
-      cpc.properties['object-uri'])
+print(cpc.name, cpc.get_property('status'), cpc.uri)
 
 print("Checking if DPM is enabled on CPC %s..." % cpcname)
 if cpc.dpm_enabled:
@@ -109,8 +107,7 @@ else:
     print("CPC %s is in classic mode: Listing LPARs ..." % cpcname)
     partitions = cpc.lpars.list()
 for partition in partitions:
-    print(partition.properties['name'], partition.properties['status'],
-          partition.properties['object-uri'])
+    print(partition.name, partition.get_property('status'), partition.uri)
 
 print("Logging off ...")
 session.logoff()

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -85,47 +85,46 @@ try:
     print("Finding CPC by name=%s and status=%s ..." % (cpcname, cpcstatus))
     cpc = cl.cpcs.find(name=cpcname, status=cpcstatus)
     print("Status of CPC %s: %s" % \
-          (cpc.properties['name'], cpc.properties['status']))
+          (cpc.name, cpc.get_property('status')))
 
     print("Finding LPAR by name=%s ..." % lparname)
     lpar = cpc.lpars.find(name=lparname)
     print("Status of LPAR %s: %s" % \
-          (lpar.properties['name'], lpar.properties['status']))
+          (lpar.name, lpar.get_property('status')))
 
-    print("Deactivating LPAR %s ..." % lpar.properties['name'])
-    status = lpar.deactivate()
-    print("status: %s" % status)
-
-    print("Finding LPAR by name=%s ..." % lparname)
-    lpar = cpc.lpars.find(name=lparname)
-    print("Status of LPAR %s: %s" % \
-          (lpar.properties['name'], lpar.properties['status']))
-
-    print("Activating LPAR %s ..." % lpar.properties['name'])
-    status = lpar.activate()
+    print("Deactivating LPAR %s ..." % lpar.name)
+    lpar.deactivate()
 
     print("Finding LPAR by name=%s ..." % lparname)
     lpar = cpc.lpars.find(name=lparname)
     print("Status of LPAR %s: %s" % \
-          (lpar.properties['name'], lpar.properties['status']))
+          (lpar.name, lpar.get_property('status')))
+
+    print("Activating LPAR %s ..." % lpar.name)
+    lpar.activate()
+
+    print("Finding LPAR by name=%s ..." % lparname)
+    lpar = cpc.lpars.find(name=lparname)
+    print("Status of LPAR %s: %s" % \
+          (lpar.name, lpar.get_property('status')))
 
     print("Loading LPAR %s from device %s ..." % \
-          (lpar.properties['name'], loaddev))
-    status = lpar.load(loaddev)
+          (lpar.name, loaddev))
+    lpar.load(loaddev)
 
     print("Finding LPAR by name=%s ..." % lparname)
     lpar = cpc.lpars.find(name=lparname)
     print("Status of LPAR %s: %s" % \
-          (lpar.properties['name'], lpar.properties['status']))
+          (lpar.name, lpar.get_property('status')))
 
     if deactivate == "yes":
-        print("Deactivating LPAR %s ..." % lpar.properties['name'])
-        status = lpar.deactivate()
+        print("Deactivating LPAR %s ..." % lpar.name)
+        lpar.deactivate()
 
         print("Finding LPAR by name=%s ..." % lparname)
         lpar = cpc.lpars.find(name=lparname)
         print("Status of LPAR %s: %s" % \
-              (lpar.properties['name'], lpar.properties['status']))
+              (lpar.name, lpar.get_property('status')))
 
     print("Logging off ...")
     session.logoff()

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -86,10 +86,9 @@ for full_properties in (False, True):
     print("Local current time :", localtime)
     for cpc in cpcs:
         print("Number of properties of cpc %s: %d (full_properties_flag=%r timestamp=%d)" \
-        % (cpc.properties['name'], len(cpc.properties), cpc.full_properties, \
+        % (cpc.name, len(cpc.properties), cpc.full_properties, \
         cpc.properties_timestamp))
-        print(cpc.properties['name'], cpc.properties['status'],
-        cpc.properties['object-uri'])
+        print(cpc.name, cpc.get_property('status'), cpc.uri)
 
 print("Finding CPC by name=%s ..." % cpcname)
 try:
@@ -107,10 +106,9 @@ for full_properties in (False, True):
     print("Local current time :", localtime)
     for lpar in lpars:
         print("Number of properties of lpar %s: %d (full_properties_flag=%r timestamp=%d)" \
-        % (lpar.properties['name'], len(lpar.properties), lpar.full_properties, \
+        % (lpar.name, len(lpar.properties), lpar.full_properties, \
         lpar.properties_timestamp))
-#        print(lpar.properties['name'], lpar.properties['status'], \
-#              lpar.properties['object-uri'])
+#        print(lpar.name, lpar.get_property('status'), lpar.uri)
 
 print("Logging off ...")
 session.logoff()

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -83,32 +83,37 @@ try:
 
     cpc = cl.cpcs.find(name=cpcname, status=cpcstatus)
     print("Status of CPC %s: %s" % \
-          (cpc.properties['name'], cpc.properties['status']))
+          (cpc.name, cpc.get_property('status')))
 
     lpar = cpc.lpars.find(name=lparname)
     print("Status of LPAR %s: %s" % \
-          (lpar.properties['name'], lpar.properties['status']))
+          (lpar.name, lpar.get_property('status')))
 
-    print("De-Activating LPAR %s ..." % lpar.properties['name'])
-    status = lpar.deactivate(wait_for_completion=False)
+    print("De-Activating LPAR %s (async.) ..." % lpar.name)
+    job_obj = lpar.deactivate(wait_for_completion=False)
+    job_uri = job_obj['job-uri']
+    print("Job URI: %s" % job_uri)
 
-    print("job-uri: %s" % (status['job-uri']))
-    job = session.query_job_status(status['job-uri'])
-    print("job response: %s" % job)
+    print("Retrieving job properties ...")
+    job = session.query_job_status(job_uri)
+    print("Job properties: %s" % job)
 
     while job['status'] != 'complete':
-        print("Job Status: %s" % (job['status']))
         time.sleep(1)
-        job = session.query_job_status(status['job-uri'])
+        print("Retrieving job properties ...")
+        job = session.query_job_status(job_uri)
+        print("Job properties: %s" % job)
 
-    print("job response: %s" % job)
-    print('De-Activate complete !')
+    print('De-Activate complete!')
 
-    print('Deleting completed job status ...')
-    session.delete_completed_job_status(status['job-uri'])
+    print("Status of LPAR %s: %s" % \
+          (lpar.name, lpar.get_property('status')))
+
+    print('Deleting completed job ...')
+    session.delete_completed_job_status(job_uri)
 
 #    print('Deleting completed job status again ...')
-#    session.delete_completed_job_status(status['job-uri'])
+#    session.delete_completed_job_status(job_uri)
 #    Returns exception:
 #    HTTPError: 404,1: No job or status for 'b571dbde-c9cb-11e1-8327-00215e676926_45fdd752-65f4-11e6-a6c3-00215e676926
 

--- a/examples/example5.py
+++ b/examples/example5.py
@@ -94,14 +94,14 @@ except zhmcclient.NotFound:
 print("Checking if DPM is enabled on CPC %s..." % cpcname)
 if cpc.dpm_enabled:
     print("CPC %s is in DPM mode." % cpcname)
-    if cpc.properties['status'] not in ('active', 'service-required'):
+    if cpc.get_property('status') not in ('active', 'service-required'):
         print("CPC %s is in an inactive state: %s" %
-              (cpcname, cpc.properties['status']))
+              (cpcname, cpc.get_property('status')))
         sys.exit(1)
     try:
         print("Finding Partition by name=%s ..." % partname)
         partition = cpc.partitions.find(name=partname)
-        if partition.properties['status'] == 'active':
+        if partition.get_property('status') == 'active':
             print("Stopping Partition %s ..." % partname)
             partition.stop()
         print("Deleting Partition %s ..." % partname)
@@ -130,7 +130,7 @@ if cpc.dpm_enabled:
     print("Pull full properties of Partition %s ..." % partname)
     new_partition.pull_full_properties()
     print("Description of Partition %s: %s"
-        % (partname, new_partition.properties["description"]))
+        % (partname, new_partition.get_property('description')))
 
     print("Updating Partition %s properties ..." % partname)
     updated_properties = dict()
@@ -140,7 +140,7 @@ if cpc.dpm_enabled:
     print("Pull full properties of Partition %s ..." % partname)
     new_partition.pull_full_properties()
     print("Updated description of Partition %s: %s"
-        % (partname, new_partition.properties["description"]))
+        % (partname, new_partition.get_property('description')))
 
 else:
     print("CPC %s is not in DPM mode." % cpcname)

--- a/examples/example6.py
+++ b/examples/example6.py
@@ -81,8 +81,7 @@ if timestats:
 print("Listing CPCs ...")
 cpcs = cl.cpcs.list()
 for cpc in cpcs:
-    print(cpc.properties["name"], cpc.properties["status"],
-          cpc.properties["object-uri"])
+    print(cpc.name, cpc.get_property('status'), cpc.uri)
 
 
 print("Finding CPC by name=%s ..." % cpcname)
@@ -101,8 +100,7 @@ try:
             print("Listing %d %s Activation Profiles ..."
                     % (len(profiles), profile_type.capitalize()))
             for profile in profiles:
-                print(profile.properties["name"],
-                      profile.properties["element-uri"])
+                print(profile.name, profile.get_property('element-uri'))
 
             if profile_type == 'image':
                 print("Finding %s Activation Profile by name=%s ..."
@@ -115,21 +113,21 @@ try:
 #                print("Printing full properties:")
 #                profile.pull_full_properties()
 #                print(profile.properties)
-                original_description = profile.get_property("description")
+                original_description = profile.get_property('description')
                 print("description: %s" % original_description)
                 updated_properties = dict()
                 updated_properties["description"] = "Test Test Test"
                 profile.update_properties(updated_properties)
                 print("Pull full properties of Image Activation Profile %s ..." % lparname)
                 profile.pull_full_properties()
-                print("Updated description of Image Activation Profile %s: %s" % (lparname, profile.properties["description"]))
+                print("Updated description of Image Activation Profile %s: %s" % (lparname, profile.get_property('description')))
                 print("Re-setting description ...")
                 original_properties = dict()
                 original_properties["description"] = original_description
 #                original_properties["description"] = "OpenStack zKVM"
                 profile.update_properties(original_properties)
                 profile.pull_full_properties()
-                print("Updated description of Image Activation Profile %s: %s" % (lparname, profile.properties["description"]))
+                print("Updated description of Image Activation Profile %s: %s" % (lparname, profile.get_property('description')))
 
 
 

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -82,41 +82,41 @@ try:
     cpcs = cl.cpcs.list()
     for cpc in cpcs:
         print(cpc)
-        print("\tListing Adapters for %s ..." % cpc.properties['name'])
+        print("\tListing Adapters for %s ..." % cpc.name)
         adapters = cpc.adapters.list()
         for i, adapter in enumerate(adapters):
             print('\t' + str(adapter))
             ports = adapter.ports.list(full_properties=False)
             for p, port in enumerate(ports):
                 if p == 0:
-                    print("\t\tListing Ports for %s ..." % adapter.properties['name'])
+                    print("\t\tListing Ports for %s ..." % adapter.name)
 #                port.pull_full_properties()
                 print('\t\t' + str(port))
-        print("\tListing Virtual Switches for %s ..." % cpc.properties['name'])
+        print("\tListing Virtual Switches for %s ..." % cpc.name)
         vswitches = cpc.vswitches.list()
         for i, vswitch in enumerate(vswitches):
             print('\t' + str(vswitch))
-        print("\tListing Partitions for %s ..." % cpc.properties['name'])
+        print("\tListing Partitions for %s ..." % cpc.name)
         partitions = cpc.partitions.list()
         for i, partition in enumerate(partitions):
             print('\t' + str(partition))
             nics = partition.nics.list(full_properties=False)
             for j, nic in enumerate(nics):
                 if j == 0:
-                    print("\t\tListing NICs for %s ..." % partition.properties['name'])
+                    print("\t\tListing NICs for %s ..." % partition.name)
                 print('\t\t' + str(nic))
 
             hbas = partition.hbas.list(full_properties=False)
             for j, hba in enumerate(hbas):
                 if j == 0:
-                    print("\t\tListing HBAs for %s ..." % partition.properties['name'])
+                    print("\t\tListing HBAs for %s ..." % partition.name)
                 print('\t\t' + str(hba))
 #                hba.pull_full_properties()
 #                print('\t\t' + str(hba.properties))
             vfs = partition.virtual_functions.list(full_properties=False)
             for k, vf in enumerate(vfs):
                 if k == 0:
-                    print("\t\tListing Virtual Functions for %s ..." % partition.properties['name'])
+                    print("\t\tListing Virtual Functions for %s ..." % partition.name)
                 print('\t\t' + str(vf))
 #                vf.pull_full_properties()
 #                print('\t\t' + str(vf.properties))

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -32,8 +32,8 @@ class MyResource(BaseResource):
 
     # This init method is not part of the external API, so this testcase may
     # need to be updated if the API changes.
-    def __init__(self, manager, uri, properties):
-        super(MyResource, self).__init__(manager, uri, properties,
+    def __init__(self, manager, uri, name, properties):
+        super(MyResource, self).__init__(manager, uri, name, properties,
                                          uri_prop='fake-uri-prop',
                                          name_prop='fake-name-prop')
 
@@ -63,6 +63,7 @@ class ResourceTestCase(unittest.TestCase):
     def setUp(self):
         self.mgr = MyManager()
         self.uri = "/api/resource/deadbeef-beef-beef-beef-deadbeefbeef"
+        self.name = "fake-name"
         self.uri_prop = 'fake-uri-prop'
         self.name_prop = 'fake-name-prop'
 
@@ -83,14 +84,32 @@ class ResourceTestCase(unittest.TestCase):
 class InitTests(ResourceTestCase):
     """Test BaseResource initialization."""
 
-    def test_empty(self):
-        """Test with an empty set of input properties."""
+    def test_empty_name(self):
+        """Test with an empty set of input properties, with 'name'."""
+        init_props = {}
+        res_props = {
+            self.uri_prop: self.uri,
+            self.name_prop: self.name,
+        }
+
+        res = MyResource(self.mgr, self.uri, self.name, init_props)
+
+        self.assertTrue(res.manager is self.mgr)
+        self.assertEqual(res.uri, self.uri)
+        self.assertEqual(res.name, self.name)
+        self.assert_properties(res, res_props)
+        self.assertTrue(int(time.time()) - res.properties_timestamp <= 1)
+        self.assertEqual(res.full_properties, False)
+        self.assertTrue(repr(res).startswith(res.__class__.__name__ + '('))
+
+    def test_empty_no_name(self):
+        """Test with an empty set of input properties, without 'name'."""
         init_props = {}
         res_props = {
             self.uri_prop: self.uri,
         }
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         self.assertTrue(res.manager is self.mgr)
         self.assertEqual(res.uri, self.uri)
@@ -111,7 +130,7 @@ class InitTests(ResourceTestCase):
             'prop2': 100042
         }
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         self.assertTrue(res.manager is self.mgr)
         self.assertEqual(res.uri, self.uri)
@@ -131,7 +150,7 @@ class InitTests(ResourceTestCase):
             'Prop1': 100042,
         }
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         self.assertTrue(res.manager is self.mgr)
         self.assertEqual(res.uri, self.uri)
@@ -144,7 +163,7 @@ class InitTests(ResourceTestCase):
         init_props = 42
         try:
 
-            MyResource(self.mgr, self.uri, init_props)
+            MyResource(self.mgr, self.uri, None, init_props)
 
         except TypeError:
             pass
@@ -169,7 +188,7 @@ class PropertySetTests(ResourceTestCase):
             'prop2': 100042,
         }
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         for key, value in set_props.items():
             res.properties[key] = value
@@ -191,7 +210,7 @@ class PropertySetTests(ResourceTestCase):
             'prop2': 100042,
         }
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         for key, value in set_props.items():
             res.properties[key] = value
@@ -214,7 +233,7 @@ class PropertyDelTests(ResourceTestCase):
             'prop2': 100042,
         }
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         for key in del_keys:
             del res.properties[key]
@@ -232,7 +251,7 @@ class PropertyDelTests(ResourceTestCase):
             self.uri_prop: self.uri,
         }
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         for key in del_keys:
             del res.properties[key]
@@ -247,7 +266,7 @@ class PropertyDelTests(ResourceTestCase):
         }
         org_init_props = dict(init_props)
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         invalid_key = 'inv1'
         try:
@@ -268,7 +287,7 @@ class PropertyDelTests(ResourceTestCase):
             'prop2': 100042,
         }
 
-        res = MyResource(self.mgr, self.uri, init_props)
+        res = MyResource(self.mgr, self.uri, None, init_props)
 
         res.properties.clear()
 

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -132,7 +132,7 @@ class ActivationProfileManager(BaseManager):
             profile_items = profiles_res[activation_profiles_name]
             for profile_props in profile_items:
                 profile = ActivationProfile(self, profile_props['element-uri'],
-                                            profile_props)
+                                            None, profile_props)
                 if full_properties:
                     profile.pull_full_properties()
                 profile_list.append(profile)
@@ -151,12 +151,14 @@ class ActivationProfile(BaseResource):
     (in this case, :class:`~zhmcclient.ActivationProfileManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.ActivationProfileManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
@@ -164,7 +166,7 @@ class ActivationProfile(BaseResource):
             raise AssertionError("ActivationProfile init: Expected manager "
                                  "type %s, got %s" %
                                  (ActivationProfileManager, type(manager)))
-        super(ActivationProfile, self).__init__(manager, uri, properties,
+        super(ActivationProfile, self).__init__(manager, uri, name, properties,
                                                 uri_prop='element-uri',
                                                 name_prop='name')
 

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -125,7 +125,7 @@ class AdapterManager(BaseManager):
             adapter_items = adapters_res['adapters']
             for adapter_props in adapter_items:
                 adapter = Adapter(self, adapter_props['object-uri'],
-                                  adapter_props)
+                                  None, adapter_props)
                 if full_properties:
                     adapter.pull_full_properties()
                 adapter_list.append(adapter)
@@ -160,7 +160,7 @@ class AdapterManager(BaseManager):
         # returned props should overwrite the input props:
         props = properties.copy()
         props.update(result)
-        return Adapter(self, props['object-uri'], props)
+        return Adapter(self, props['object-uri'], None, props)
 
 
 class Adapter(BaseResource):
@@ -178,12 +178,14 @@ class Adapter(BaseResource):
     (in this case, :class:`~zhmcclient.AdapterManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.AdapterManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
@@ -191,7 +193,7 @@ class Adapter(BaseResource):
             raise AssertionError("Adapter init: Expected manager type %s, "
                                  "got %s" %
                                  (AdapterManager, type(manager)))
-        super(Adapter, self).__init__(manager, uri, properties,
+        super(Adapter, self).__init__(manager, uri, name, properties,
                                       uri_prop='object-uri',
                                       name_prop='name')
         # The manager objects for child resources (with lazy initialization):

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -105,7 +105,7 @@ class CpcManager(BaseManager):
         if cpcs_res:
             cpc_items = cpcs_res['cpcs']
             for cpc_props in cpc_items:
-                cpc = Cpc(self, cpc_props['object-uri'], cpc_props)
+                cpc = Cpc(self, cpc_props['object-uri'], None, cpc_props)
                 if full_properties:
                     cpc.pull_full_properties()
                 cpc_list.append(cpc)
@@ -124,19 +124,21 @@ class Cpc(BaseResource):
     (in this case, :class:`~zhmcclient.CpcManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.CpcManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
         if not isinstance(manager, CpcManager):
             raise AssertionError("Cpc init: Expected manager type %s, got %s" %
                                  (CpcManager, type(manager)))
-        super(Cpc, self).__init__(manager, uri, properties,
+        super(Cpc, self).__init__(manager, uri, name, properties,
                                   uri_prop='object-uri',
                                   name_prop='name')
         # The manager objects for child resources (with lazy initialization):

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -124,7 +124,7 @@ class HbaManager(BaseManager):
         # returned props should overwrite the input props:
         props = properties.copy()
         props.update(result)
-        return Hba(self, props['element-uri'], props)
+        return Hba(self, props['element-uri'], None, props)
 
 
 class Hba(BaseResource):
@@ -143,20 +143,22 @@ class Hba(BaseResource):
     (in this case, :class:`~zhmcclient.HbaManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         # Parameters:
         #   manager (:class:`~zhmcclient.HbaManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
         if not isinstance(manager, HbaManager):
             raise AssertionError("Hba init: Expected manager type %s, got %s" %
                                  (HbaManager, type(manager)))
-        super(Hba, self).__init__(manager, uri, properties,
+        super(Hba, self).__init__(manager, uri, name, properties,
                                   uri_prop='element-uri',
                                   name_prop='name')
 

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -90,7 +90,7 @@ class LparManager(BaseManager):
         if lpars_res:
             lpar_items = lpars_res['logical-partitions']
             for lpar_props in lpar_items:
-                lpar = Lpar(self, lpar_props['object-uri'], lpar_props)
+                lpar = Lpar(self, lpar_props['object-uri'], None, lpar_props)
                 if full_properties:
                     lpar.pull_full_properties()
                 lpar_list.append(lpar)
@@ -109,12 +109,14 @@ class Lpar(BaseResource):
     (in this case, :class:`~zhmcclient.LparManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.LparManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
@@ -122,7 +124,7 @@ class Lpar(BaseResource):
             raise AssertionError("Lpar init: Expected manager type %s, "
                                  "got %s" %
                                  (LparManager, type(manager)))
-        super(Lpar, self).__init__(manager, uri, properties,
+        super(Lpar, self).__init__(manager, uri, name, properties,
                                    uri_prop='object-uri',
                                    name_prop='name')
 

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -236,7 +236,7 @@ class BaseManager(object):
           Exceptions raised by the `list()` method in the derived classes.
         """
         uri = self._get_uri(name)
-        obj = self.resource_class(self, uri)
+        obj = self.resource_class(self, uri, name)
         return obj
 
     def flush(self):

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -122,7 +122,7 @@ class NicManager(BaseManager):
         # returned props should overwrite the input props:
         props = properties.copy()
         props.update(result)
-        return Nic(self, props['element-uri'], props)
+        return Nic(self, props['element-uri'], None, props)
 
     def nic_object(self, nic_id):
         """
@@ -156,7 +156,7 @@ class NicManager(BaseManager):
             'parent': part_uri,
             'class': 'nic',
         }
-        return Nic(self, nic_uri, nic_props)
+        return Nic(self, nic_uri, None, nic_props)
 
 
 class Nic(BaseResource):
@@ -175,19 +175,21 @@ class Nic(BaseResource):
     (in this case, :class:`~zhmcclient.NicManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.NicManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
         if not isinstance(manager, NicManager):
             raise AssertionError("Nic init: Expected manager type %s, got %s" %
                                  (NicManager, type(manager)))
-        super(Nic, self).__init__(manager, uri, properties,
+        super(Nic, self).__init__(manager, uri, name, properties,
                                   uri_prop='element-uri',
                                   name_prop='name')
 

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -97,7 +97,7 @@ class PartitionManager(BaseManager):
             partition_items = partitions_res['partitions']
             for partition_props in partition_items:
                 partition = Partition(self, partition_props['object-uri'],
-                                      partition_props)
+                                      None, partition_props)
                 if full_properties:
                     partition.pull_full_properties()
                 partition_list.append(partition)
@@ -133,7 +133,7 @@ class PartitionManager(BaseManager):
         # returned props should overwrite the input props:
         props = properties.copy()
         props.update(result)
-        return Partition(self, props['object-uri'], props)
+        return Partition(self, props['object-uri'], None, props)
 
     def partition_object(self, part_id):
         """
@@ -167,7 +167,7 @@ class PartitionManager(BaseManager):
             'parent': self.parent.uri,
             'class': 'partition',
         }
-        return Partition(self, part_uri, part_props)
+        return Partition(self, part_uri, None, part_props)
 
 
 class Partition(BaseResource):
@@ -182,12 +182,14 @@ class Partition(BaseResource):
     (in this case, :class:`~zhmcclient.PartitionManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.PartitionManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
@@ -195,7 +197,7 @@ class Partition(BaseResource):
             raise AssertionError("Partition init: Expected manager type %s, "
                                  "got %s" %
                                  (PartitionManager, type(manager)))
-        super(Partition, self).__init__(manager, uri, properties,
+        super(Partition, self).__init__(manager, uri, name, properties,
                                         uri_prop='object-uri',
                                         name_prop='name')
         # The manager objects for child resources (with lazy initialization):

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -112,12 +112,14 @@ class Port(BaseResource):
     (in this case, :class:`~zhmcclient.PortManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.PortManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
@@ -125,7 +127,7 @@ class Port(BaseResource):
             raise AssertionError("Port init: Expected manager type %s, "
                                  "got %s" %
                                  (PortManager, type(manager)))
-        super(Port, self).__init__(manager, uri, properties,
+        super(Port, self).__init__(manager, uri, name, properties,
                                    uri_prop='element-uri',
                                    name_prop='name')
 

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -37,7 +37,7 @@ class BaseResource(object):
     methods that have a common implementation for the derived resource classes.
     """
 
-    def __init__(self, manager, uri, properties, uri_prop, name_prop):
+    def __init__(self, manager, uri, name, properties, uri_prop, name_prop):
         """
         Parameters:
 
@@ -51,6 +51,13 @@ class BaseResource(object):
             Will be used to set the corresponding property in this resource
             object (see `uri_prop` parameter).
             Must not be `None`.
+
+          name (string):
+            The name of the resource.
+            Will be used to set the corresponding property in this resource
+            object (see `name_prop` parameter).
+            May be `None`; in that case, the resource properties will be
+            retrieved from the resource, once the name property accessed.
 
           properties (dict):
             Properties for this resource object. May be `None` or empty.
@@ -84,11 +91,19 @@ class BaseResource(object):
         self._manager = manager
         self._uri = uri
         self._properties = dict(properties) if properties else {}
-        self._properties[uri_prop] = uri
+        if name:
+            if name_prop in self._properties:
+                assert self._properties[name_prop] == name
+            else:
+                self._properties[name_prop] = name
+        if uri_prop in self._properties:
+            assert self._properties[uri_prop] == uri
+        else:
+            self._properties[uri_prop] = uri
         self._uri_prop = uri_prop
         self._name_prop = name_prop
+        self._name = name  # Will be retrieved once needed, if None
 
-        self._name = None  # Will be retrieved once needed
         self._properties_timestamp = int(time.time())
         self._full_properties = False
 
@@ -107,11 +122,15 @@ class BaseResource(object):
           The dictionary contains either the full set of resource properties,
           or a subset thereof, or can be empty in some cases.
 
-          Because this dictionary may be empty in some cases, the name and the
-          URI of the resource should be obtained via the
-          :attr:`~zhmcclient.BaseResource.name` and
-          :attr:`~zhmcclient.BaseResource.uri` attributes of this object,
-          respectively.
+          Because the presence of properties in this dictionary depends on the
+          situation, the purpose of this dictionary is only for iterating
+          through the resource properties that are currently present.
+
+          Specific resource properties should be accessed via:
+          * The resource name, via :attr:`~zhmcclient.BaseResource.name`.
+          * The resource URI, via :attr:`~zhmcclient.BaseResource.uri`.
+          * Any resource property, via
+            :meth:`~zhmcclient.BaseResource.get_property`.
         """
         return self._properties
 

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -122,7 +122,7 @@ class VirtualFunctionManager(BaseManager):
         # returned props should overwrite the input props:
         props = properties.copy()
         props.update(result)
-        return VirtualFunction(self, props['element-uri'], props)
+        return VirtualFunction(self, props['element-uri'], None, props)
 
 
 class VirtualFunction(BaseResource):
@@ -141,12 +141,14 @@ class VirtualFunction(BaseResource):
     (in this case, :class:`~zhmcclient.VirtualFunctionManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.VirtualFunctionManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
@@ -154,7 +156,7 @@ class VirtualFunction(BaseResource):
             raise AssertionError("VirtualFunction init: Expected manager "
                                  "type %s, got %s" %
                                  (VirtualFunctionManager, type(manager)))
-        super(VirtualFunction, self).__init__(manager, uri, properties,
+        super(VirtualFunction, self).__init__(manager, uri, name, properties,
                                               uri_prop='element-uri',
                                               name_prop='name')
 

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -90,7 +90,7 @@ class VirtualSwitchManager(BaseManager):
             vswitch_items = vswitch_res['virtual-switches']
             for vswitch_props in vswitch_items:
                 vswitch = VirtualSwitch(self, vswitch_props['object-uri'],
-                                        vswitch_props)
+                                        None, vswitch_props)
                 if full_properties:
                     vswitch.pull_full_properties()
                 vswitch_list.append(vswitch)
@@ -112,12 +112,14 @@ class VirtualSwitch(BaseResource):
     (in this case, :class:`~zhmcclient.VirtualSwitchManager`).
     """
 
-    def __init__(self, manager, uri, properties=None):
+    def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.VirtualSwitchManager`):
         #     Manager object for this resource object.
         #   uri (string):
         #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
         #   properties (dict):
         #     Properties to be set for this resource object. May be `None` or
         #     empty.
@@ -125,7 +127,7 @@ class VirtualSwitch(BaseResource):
             raise AssertionError("VirtualSwitch init: Expected manager "
                                  "type %s, got %s" %
                                  (VirtualSwitchManager, type(manager)))
-        super(VirtualSwitch, self).__init__(manager, uri, properties,
+        super(VirtualSwitch, self).__init__(manager, uri, name, properties,
                                             uri_prop='object-uri',
                                             name_prop='name')
 


### PR DESCRIPTION
Please review and merge.

Details from the commit message:
* This bug was introduced recently with the URI-to-name caching, which now causes the 'properties' attribute to be empty where it was not empty before.
* Fixed by maintaining the 'name' property in the 'properties' attribute whenever possible (i.e. available). This does not solve all situations, therefore updated the documentation of the 'properties' attribute to make users aware, and to recommend use of 'get_property()' or 'name' or 'uri', for accessing specific resource properties.
* Also, added assertions in `BaseResource.__init__()` that ensure that the uri and the name are consistent, if provided both ways (via direct argument and via the 'properties' dict).
* Updated the examples accordingly. They all runs again, now.
* In example2, removed the storing of the job in a 'status' variable because it is mis-named and was not used anyway.
* In example 4, changed the variables for storing the async job and its URI more logical, and made the prints more logical.