### PR TITLE
Added initial support for Appveyor CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,16 @@
 #     Windows with CygWin
 #     Linux (any)
 #     OS-X
-#   All of these commands:
+#   These commands on all OS platforms:
 #     make (GNU make)
 #     bash
-#     rm, find, xargs, grep, sed, tar
+#     rm, mv, find, xargs, tee
 #     python (This Makefile uses the active Python environment, virtual Python
 #        environments are supported)
 #     pip (in the active Python environment)
-#
+#     twine (in the active Python environment)
+#   These commands on Linux and OS-X:
+#     uname
 # Additional prerequisites for running this Makefile are installed by running:
 #   make develop
 # ------------------------------------------------------------------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,84 @@
+# Control file for Appveyor CI (https://www.appveyor.com/)
+# Must be located in the root directory of the Git repository.
+
+environment:
+  matrix:
+    - PYTHON27: C:\Python27
+      PYTHON27_VERSION: 2.7.12
+      PYTHON27_ARCH: 32
+
+install:
+
+  # Examine the environment
+  - echo %PATH%
+  - echo %INCLUDE%
+  - echo %LIB%
+  - dir C:\
+  - dir
+
+  # Show OS-level packages available for installation via "choco"
+  # Note: "choco" is a Windows installer, similar to "yum" on RHEL.
+  - choco source list
+
+  # Add Python
+  - reg ADD HKCU\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+  - reg ADD HKLM\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+  - set PATH=%PYTHON27%;%PYTHON27%\Scripts;%PATH%
+
+  ## Install pip via get-pip.py - disabled because pip is already installed
+  #- ps: (new-object System.Net.WebClient).Downloadfile('https://bootstrap.pypa.io/get-pip.py', 'C:\Users\appveyor\get-pip.py')
+  #- ps: Start-Process -FilePath "C:\Python27\python.exe" -ArgumentList "C:\Users\appveyor\get-pip.py" -Wait -Passthru
+
+  # Add CygWin
+  - set PATH=C:\cygwin\bin;%PATH%
+
+  ## Example for installing an OS-level package via "choco":
+  #
+  #- choco install -y <package-name>
+  #- set PATH=<package-path>;%PATH%
+
+  ## Example for manually installing OS-level prereqs:
+  #
+  ## Preparation
+  #- echo set _PWD=%%%%~dp0>tmp_prereq_dir.bat
+  #- call tmp_prereq_dir.bat
+  #- rm tmp_prereq_dir.bat
+  #- set _PREREQ_DIR=prereqs
+  #- set _PREREQ_ABSDIR=%_PWD%%_PREREQ_DIR%
+  #- echo Installing OS-level prereqs into: %_PREREQ_ABSDIR%
+  #- mkdir %_PREREQ_DIR%
+  #
+  ## Install libxml2
+  #- set _PKGFILE=libxml2-2.7.8.win32.zip
+  #- set _PKGDIR=libxml2-2.7.8.win32
+  #- wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
+  #- unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
+  #- set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
+  #- set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
+  #- set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+
+  # Install tox
+  - pip install tox==2.0.0
+
+  # Verify that the commands used in tox.ini are available
+  - tox --version
+  - make --version
+  - sh --version
+
+  # Verify that the commands used in Makefile are available
+  - bash --version
+  - rm --version
+  - mv --version
+  - find --version
+  - xargs --version
+  - tee --version
+  - pip --version
+  - python --version
+
+# This is not a C# project, build stuff at the test step instead:
+build: false
+
+before_test:
+
+test_script:
+  - tox -e pywin27

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 # -----------------------------------------------------------------------------
 # Tox config file for the zhmcclient project
 #
-# Supported platforms:
+# Supported OS platforms:
 #   Linux
-#
+#   Windows
+#   OS-X (not tested)
 
 [tox]
 minversion = 1.9
@@ -36,3 +37,6 @@ basepython = python3.4
 [testenv:py35]
 basepython = python3.5
 
+[testenv:pywin27]
+basepython = {env:PYTHON27:}\python.exe
+passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE PATH INCLUDE LIB


### PR DESCRIPTION
This PR should already work in the Appveyor CI.

Please merge and establish Appveyor web service, then it can be tested.
Possibly needs an account on https://www.appveyor.com/, not sure.

Details in this PR:
- Added an appveyor.yml control file.
- Added pywin27 environment to tox.ini.
- Corrected commands listed in header of Makefile.