### PR TITLE
Fixing regression in findall(name=..)

### DIFF
--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _manager module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import unittest
+
+from zhmcclient._manager import BaseManager
+from zhmcclient._resource import BaseResource
+
+
+class MyResource(BaseResource):
+    def __init__(self, manager, uri, name=None, properties=None):
+        super(MyResource, self).__init__(manager, uri, name, properties,
+                                         uri_prop='object-uri',
+                                         name_prop='name')
+
+
+class MyManager(BaseManager):
+    def __init__(self):
+        super(MyManager, self).__init__(MyResource)
+        self._items = []
+
+    def list(self):
+        return self._items
+
+
+class ManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = MyManager()
+
+        self.resource = MyResource(self.manager, "foo-uri",
+                                   properties={"name": "foo-name",
+                                               "other": "foo-other"})
+        self.manager._items = [self.resource]
+
+    def test_findall_attribute(self):
+        items = self.manager.findall(other="foo-other")
+        self.assertIn(self.resource, items)
+
+    def test_findall_attribute_no_result(self):
+        items = self.manager.findall(other="not-exists")
+        self.assertEqual([], items)
+
+    def test_findall_name(self):
+        items = self.manager.findall(name="foo-name")
+        self.assertEqual(1, len(items))
+        item = items[0]
+        self.assertEqual("foo-name", item.properties['name'])
+        self.assertEqual("foo-uri", item.properties['object-uri'])
+
+    def test_findall_name_no_result(self):
+        items = self.manager.findall(name="not-exists")
+        self.assertEqual([], items)

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -198,8 +198,11 @@ class BaseManager(object):
         """
         found = list()
         if list(kwargs.keys()) == ['name']:
-            obj = self.find_by_name(kwargs['name'])
-            found.append(obj)
+            try:
+                obj = self.find_by_name(kwargs['name'])
+                found.append(obj)
+            except NotFound:
+                pass
         else:
             searches = kwargs.items()
             listing = self.list()


### PR DESCRIPTION
Before [1], manager.findall(name=..) returned an empty list
if nothing was found. This patch restores that initial behavior.

[1] https://github.com/zhmcclient/python-zhmcclient/commit/
ff6be0dfb81e47cf74b16336eb264d274b2eee22

closes #141

Signed-off-by: Andreas Scheuring <andreas.scheuring@de.ibm.com>