### PR TITLE
[WIP] Mocking support for zhmcclient.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ check_py_files := \
     $(wildcard $(package_name)/*.py) \
     $(wildcard $(cli_package_name)/*.py) \
     $(wildcard tests/unit/*.py) \
+    $(wildcard tests/unit/zhmcclient_mock/*.py) \
     $(wildcard tests/function/*.py) \
     $(wildcard docs/notebooks/*.py) \
 
@@ -289,7 +290,7 @@ flake8.log: Makefile $(flake8_rc_file) $(check_py_files)
 	mv -f $@.tmp $@
 	@echo 'Done: Created Flake8 log file: $@'
 
-$(test_log_file): Makefile $(package_name)/*.py tests/unit/*.py tests/function/*.py .coveragerc
+$(test_log_file): Makefile $(package_name)/*.py tests/unit/*.py tests/unit/zhmcclient_mock/*.py tests/function/*.py .coveragerc
 	rm -fv $@
 	bash -c 'set -o pipefail; PYTHONWARNINGS=default py.test --cov $(package_name) --cov-config .coveragerc --cov-report=html $(pytest_opts) -s 2>&1 |tee $@.tmp'
 	mv -f $@.tmp $@

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,5 +28,6 @@ zhmcclient - A pure Python client library for the z Systems HMC Web Services API
    general.rst
    resources.rst
    cli.rst
+   mocksupport.rst
    development.rst
    appendix.rst

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -1,0 +1,106 @@
+.. Copyright 2016 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _`Mock support`:
+
+Mock support
+============
+
+The zhmcclient PyPI package provides unit testing support for its users via its
+`zhmcclient_mock` Python package. This package allows users of
+the zhmcclient package to easily define a mocked environment that provides
+a faked HMC that is pre-populated with resource state as needed by the test
+case, and that supports all relevant operations.
+
+The mocked environment is set up by the user by using an instance of the
+:class:`zhmcclient_mock.Session` class instead of the
+:class:`zhmcclient.Session` class when setting up the zhmcclient package
+in a unit test::
+
+    import unittest
+    import zhmcclient
+    import zhmcclient_mock
+
+    class MyTests(unittest.TestCase):
+
+        def setUp(self):
+
+            self.session = zhmcclient_mock.Session('fake-host', '2.13.1')
+            self.session.hmc.add_resources({
+                'cpcs': [
+                    {
+                        'properties': {
+                            'name': 'cpc_1',
+                            'description': 'CPC #1',
+                        },
+                    },
+                ]
+            })
+            self.client = zhmcclient.Client(self.session)
+
+        def test_list(self):
+            cpcs = self.client.cpcs.list()
+            self.assertEqual(len(cpcs), 1)
+            self.assertEqual(cpcs[0].name, 'cpc_1')
+
+In this example, the faked HMC of the faked session is preloaded with a
+single CPC resource. For simplicity of the example, the CPC resource did not
+have any child resources, but it is possible to define en entire resource tree
+via :meth:`zhmcclient_mock.Hmc.add_resources`.
+
+.. _`Faked session`:
+
+Faked session
+-------------
+
+.. automodule:: zhmcclient_mock._session
+
+.. autoclass:: zhmcclient_mock.Session
+   :members:
+
+
+.. _`Faked HMC`:
+
+Faked HMC
+---------
+
+.. automodule:: zhmcclient_mock._hmc
+
+.. autoclass:: zhmcclient_mock.Hmc
+   :members:
+
+.. autoclass:: zhmcclient_mock.CpcManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.Cpc
+   :members:
+
+.. autoclass:: zhmcclient_mock.AdapterManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.Adapter
+   :members:
+
+.. autoclass:: zhmcclient_mock.PortManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.Port
+   :members:
+
+.. autoclass:: zhmcclient_mock.LocalResourceManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.LocalResource
+   :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ progressbar2 # BSD
 click # BSD
 click-spinner>=0.1.5 # MIT
 click-repl # MIT
+
+# for zhmcclient_mock:
+web.py # Public domain

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifier =
 packages =
     zhmcclient
     zhmccli
+    zhmcclient_mock
 scripts =
     tools/cpcinfo
     tools/cpcdata

--- a/tests/unit/zhmcclient_mock/test_example.py
+++ b/tests/unit/zhmcclient_mock/test_example.py
@@ -29,7 +29,8 @@ class MyTests(unittest.TestCase):
 
     def setUp(self):
 
-        self.session = zhmcclient_mock.Session('fake-host', '2.13.1')
+        self.session = zhmcclient_mock.Session('fake-host', 'fake-hmc',
+                                               '2.13.1', '1.8')
         self.session.hmc.add_resources({
             'cpcs': [
                 {
@@ -55,7 +56,7 @@ class MyTests(unittest.TestCase):
     def test_initial(self):
 
         self.assertEqual(self.session.host, 'fake-host')
-        #self.assertEqual(self.client.version_info(), (2, 13))
+        self.assertEqual(self.client.version_info(), (1, 8))
 
     def test_list(self):
 
@@ -64,15 +65,38 @@ class MyTests(unittest.TestCase):
 
         self.assertEqual(len(cpcs), 2)
 
-        self.assertEqual(cpcs[0].uri, '/api/cpcs/%s' % cpcs[0]['object-id'])
-        self.assertEqual(cpcs[0].name, 'cpc_1')
-        self.assertEqual(cpcs[0].get_property('name'), 'cpc_1')
-        self.assertEqual(cpcs[0].get_property('description'), 'CPC #1')
+        cpc_1 = cpcs[0]
+        cpc_1_oid = cpc_1.uri.split('/')[-1]
+        self.assertEqual(cpc_1.uri, '/api/cpcs/%s' % cpc_1_oid)
+        self.assertEqual(cpc_1.name, 'cpc_1')
+        self.assertEqual(cpc_1.get_property('object-id'), cpc_1_oid)
+        self.assertEqual(cpc_1.get_property('object-uri'), cpc_1.uri)
+        self.assertEqual(cpc_1.get_property('name'), cpc_1.name)
 
-        self.assertEqual(cpcs[1].uri, '/api/cpcs/%s' % cpcs[1]['object-id'])
-        self.assertEqual(cpcs[1].name, 'cpc_2')
-        self.assertEqual(cpcs[1].get_property('name'), 'cpc_2')
-        self.assertEqual(cpcs[1].get_property('description'), 'CPC #2')
+        cpc_2 = cpcs[1]
+        cpc_2_oid = cpc_2.uri.split('/')[-1]
+        self.assertEqual(cpc_2.uri, '/api/cpcs/%s' % cpc_2_oid)
+        self.assertEqual(cpc_2.name, 'cpc_2')
+        self.assertEqual(cpc_2.get_property('object-id'), cpc_2_oid)
+        self.assertEqual(cpc_2.get_property('object-uri'), cpc_2.uri)
+        self.assertEqual(cpc_2.get_property('name'), cpc_2.name)
+
+    def test_get_properties(self):
+        cpcs = self.client.cpcs.list()
+        cpc_1 = cpcs[0]
+
+        # the function to be tested:
+        cpc_1.pull_full_properties()
+
+        cpc_1_uri = cpc_1.uri
+        cpc_1_oid = cpc_1.uri.split('/')[-1]
+
+        self.assertEqual(len(cpc_1.properties), 4)
+        self.assertEqual(cpc_1.get_property('object-id'), cpc_1_oid)
+        self.assertEqual(cpc_1.get_property('object-uri'), cpc_1_uri)
+        self.assertEqual(cpc_1.get_property('name'), 'cpc_1')
+        self.assertEqual(cpc_1.get_property('description'), 'CPC #1')
+
 
 if __name__ == '__main__':
     requests.packages.urllib3.disable_warnings()

--- a/tests/unit/zhmcclient_mock/test_example.py
+++ b/tests/unit/zhmcclient_mock/test_example.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example unit test for a user of the zhmcclient package.
+"""
+
+from __future__ import absolute_import, print_function
+
+import requests.packages.urllib3
+import unittest
+import zhmcclient
+import zhmcclient_mock
+
+
+class MyTests(unittest.TestCase):
+
+    def setUp(self):
+
+        self.session = zhmcclient_mock.Session('fake-host', '2.13.1')
+        self.session.hmc.add_resources({
+            'cpcs': [
+                {
+                    'properties': {
+                        # object-id is auto-generated
+                        # object-uri is auto-generated
+                        'name': 'cpc_1',
+                        'description': 'CPC #1',
+                    },
+                },
+                {
+                    'properties': {
+                        # object-id is auto-generated
+                        # object-uri is auto-generated
+                        'name': 'cpc_2',
+                        'description': 'CPC #2',
+                    },
+                },
+            ]
+        })
+        self.client = zhmcclient.Client(self.session)
+
+    def test_initial(self):
+
+        self.assertEqual(self.session.host, 'fake-host')
+        #self.assertEqual(self.client.version_info(), (2, 13))
+
+    def test_list(self):
+
+        # the function to be tested:
+        cpcs = self.client.cpcs.list()
+
+        self.assertEqual(len(cpcs), 2)
+
+        self.assertEqual(cpcs[0].uri, '/api/cpcs/%s' % cpcs[0]['object-id'])
+        self.assertEqual(cpcs[0].name, 'cpc_1')
+        self.assertEqual(cpcs[0].get_property('name'), 'cpc_1')
+        self.assertEqual(cpcs[0].get_property('description'), 'CPC #1')
+
+        self.assertEqual(cpcs[1].uri, '/api/cpcs/%s' % cpcs[1]['object-id'])
+        self.assertEqual(cpcs[1].name, 'cpc_2')
+        self.assertEqual(cpcs[1].get_property('name'), 'cpc_2')
+        self.assertEqual(cpcs[1].get_property('description'), 'CPC #2')
+
+if __name__ == '__main__':
+    requests.packages.urllib3.disable_warnings()
+    unittest.main()

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _hmc module of the zhmcclient_mock package.
+"""
+
+from __future__ import absolute_import, print_function
+
+import unittest
+
+from zhmcclient_mock._hmc import Hmc, CpcManager, Cpc, Adapter, Port
+
+
+class HmcTests(unittest.TestCase):
+    """All tests for the zhmcclient_mock._hmc.Hmc class."""
+
+    def test_hmc(self):
+
+        # the function to be tested:
+        hmc = Hmc('fake-host', '2.13.1')
+
+        self.assertEqual(hmc.host, 'fake-host')
+        self.assertEqual(hmc.api_version, '2.13.1')
+        self.assertIsInstance(hmc.cpcs, CpcManager)
+
+        # the function to be tested:
+        cpcs = hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 0)
+
+    def test_hmc_1_cpc(self):
+        hmc = Hmc('fake-host', '2.13.1')
+
+        cpc1_in_props = {'name': 'cpc1'}
+
+        # the function to be tested:
+        cpc1 = hmc.cpcs.add({'name': 'cpc1'})
+
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+
+        # the function to be tested:
+        cpcs = hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 1)
+        self.assertEqual(cpcs[0], cpc1)
+
+        self.assertIsInstance(cpc1, Cpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, hmc.cpcs)
+
+    def test_hmc_2_cpcs(self):
+        hmc = Hmc('fake-host', '2.13.1')
+
+        cpc1_in_props = {'name': 'cpc1'}
+
+        # the function to be tested:
+        cpc1 = hmc.cpcs.add(cpc1_in_props)
+
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+
+        cpc2_in_props = {'name': 'cpc2'}
+
+        # the function to be tested:
+        cpc2 = hmc.cpcs.add(cpc2_in_props)
+
+        cpc2_out_props = cpc2_in_props.copy()
+        cpc2_out_props.update({
+            'object-id': cpc2.oid,
+            'object-uri': cpc2.uri,
+        })
+
+        # the function to be tested:
+        cpcs = hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 2)
+        # We expect the order of addition to be maintained:
+        self.assertEqual(cpcs[0], cpc1)
+        self.assertEqual(cpcs[1], cpc2)
+
+        self.assertIsInstance(cpc1, Cpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, hmc.cpcs)
+
+        self.assertIsInstance(cpc2, Cpc)
+        self.assertEqual(cpc2.properties, cpc2_out_props)
+        self.assertEqual(cpc2.manager, hmc.cpcs)
+
+    # TODO: Add test cases for:
+    #    osa1 = cpc1.adapters.add({'adapter-family': 'osa'})
+    #    osa1_1 = osa1.ports.add({'name': 'fake-osa1-port1'})
+    #    manager.remove() for all types
+    #    manager attributes for all types
+
+    def test_res_dict(self):
+        hmc = Hmc('fake-host', '2.13.1')
+
+        cpc1_in_props = {'name': 'cpc1'}
+        adapter1_in_props = {'name': 'osa1'}
+        port1_in_props = {'name': 'osa1_1'}
+
+        rd = {
+            'cpcs': [
+                {
+                    'properties': cpc1_in_props,
+                    'adapters': [
+                        {
+                            'properties': adapter1_in_props,
+                            'ports': [
+                                {'properties': port1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+
+        # the function to be tested:
+        hmc.add_resources(rd)
+
+        cpcs = hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 1)
+
+        cpc1 = cpcs[0]
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+        self.assertIsInstance(cpc1, Cpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, hmc.cpcs)
+
+        cpc1_adapters = cpc1.adapters.list()
+
+        self.assertEqual(len(cpc1_adapters), 1)
+
+        adapter1 = cpc1_adapters[0]
+        adapter1_out_props = adapter1_in_props.copy()
+        adapter1_out_props.update({
+            'object-id': adapter1.oid,
+            'object-uri': adapter1.uri,
+        })
+        self.assertIsInstance(adapter1, Adapter)
+        self.assertEqual(adapter1.properties, adapter1_out_props)
+        self.assertEqual(adapter1.manager, cpc1.adapters)
+
+        adapter1_ports = adapter1.ports.list()
+
+        self.assertEqual(len(adapter1_ports), 1)
+
+        port1 = adapter1_ports[0]
+        port1_out_props = port1_in_props.copy()
+        port1_out_props.update({
+            'element-id': port1.oid,
+            'element-uri': port1.uri,
+        })
+        self.assertIsInstance(port1, Port)
+        self.assertEqual(port1.properties, port1_out_props)
+        self.assertEqual(port1.manager, adapter1.ports)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -27,27 +27,25 @@ from zhmcclient_mock._hmc import Hmc, CpcManager, Cpc, Adapter, Port
 class HmcTests(unittest.TestCase):
     """All tests for the zhmcclient_mock._hmc.Hmc class."""
 
+    def setUp(self):
+        self.hmc = Hmc('fake-hmc', '2.13.1', '1.8')
+
     def test_hmc(self):
+        self.assertEqual(self.hmc.hmc_name, 'fake-hmc')
+        self.assertEqual(self.hmc.hmc_version, '2.13.1')
+        self.assertEqual(self.hmc.api_version, '1.8')
+        self.assertIsInstance(self.hmc.cpcs, CpcManager)
 
         # the function to be tested:
-        hmc = Hmc('fake-host', '2.13.1')
-
-        self.assertEqual(hmc.host, 'fake-host')
-        self.assertEqual(hmc.api_version, '2.13.1')
-        self.assertIsInstance(hmc.cpcs, CpcManager)
-
-        # the function to be tested:
-        cpcs = hmc.cpcs.list()
+        cpcs = self.hmc.cpcs.list()
 
         self.assertEqual(len(cpcs), 0)
 
     def test_hmc_1_cpc(self):
-        hmc = Hmc('fake-host', '2.13.1')
-
         cpc1_in_props = {'name': 'cpc1'}
 
         # the function to be tested:
-        cpc1 = hmc.cpcs.add({'name': 'cpc1'})
+        cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
 
         cpc1_out_props = cpc1_in_props.copy()
         cpc1_out_props.update({
@@ -56,22 +54,20 @@ class HmcTests(unittest.TestCase):
         })
 
         # the function to be tested:
-        cpcs = hmc.cpcs.list()
+        cpcs = self.hmc.cpcs.list()
 
         self.assertEqual(len(cpcs), 1)
         self.assertEqual(cpcs[0], cpc1)
 
         self.assertIsInstance(cpc1, Cpc)
         self.assertEqual(cpc1.properties, cpc1_out_props)
-        self.assertEqual(cpc1.manager, hmc.cpcs)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
 
     def test_hmc_2_cpcs(self):
-        hmc = Hmc('fake-host', '2.13.1')
-
         cpc1_in_props = {'name': 'cpc1'}
 
         # the function to be tested:
-        cpc1 = hmc.cpcs.add(cpc1_in_props)
+        cpc1 = self.hmc.cpcs.add(cpc1_in_props)
 
         cpc1_out_props = cpc1_in_props.copy()
         cpc1_out_props.update({
@@ -82,7 +78,7 @@ class HmcTests(unittest.TestCase):
         cpc2_in_props = {'name': 'cpc2'}
 
         # the function to be tested:
-        cpc2 = hmc.cpcs.add(cpc2_in_props)
+        cpc2 = self.hmc.cpcs.add(cpc2_in_props)
 
         cpc2_out_props = cpc2_in_props.copy()
         cpc2_out_props.update({
@@ -91,7 +87,7 @@ class HmcTests(unittest.TestCase):
         })
 
         # the function to be tested:
-        cpcs = hmc.cpcs.list()
+        cpcs = self.hmc.cpcs.list()
 
         self.assertEqual(len(cpcs), 2)
         # We expect the order of addition to be maintained:
@@ -100,11 +96,11 @@ class HmcTests(unittest.TestCase):
 
         self.assertIsInstance(cpc1, Cpc)
         self.assertEqual(cpc1.properties, cpc1_out_props)
-        self.assertEqual(cpc1.manager, hmc.cpcs)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
 
         self.assertIsInstance(cpc2, Cpc)
         self.assertEqual(cpc2.properties, cpc2_out_props)
-        self.assertEqual(cpc2.manager, hmc.cpcs)
+        self.assertEqual(cpc2.manager, self.hmc.cpcs)
 
     # TODO: Add test cases for:
     #    osa1 = cpc1.adapters.add({'adapter-family': 'osa'})
@@ -113,8 +109,6 @@ class HmcTests(unittest.TestCase):
     #    manager attributes for all types
 
     def test_res_dict(self):
-        hmc = Hmc('fake-host', '2.13.1')
-
         cpc1_in_props = {'name': 'cpc1'}
         adapter1_in_props = {'name': 'osa1'}
         port1_in_props = {'name': 'osa1_1'}
@@ -136,9 +130,9 @@ class HmcTests(unittest.TestCase):
         }
 
         # the function to be tested:
-        hmc.add_resources(rd)
+        self.hmc.add_resources(rd)
 
-        cpcs = hmc.cpcs.list()
+        cpcs = self.hmc.cpcs.list()
 
         self.assertEqual(len(cpcs), 1)
 
@@ -150,7 +144,7 @@ class HmcTests(unittest.TestCase):
         })
         self.assertIsInstance(cpc1, Cpc)
         self.assertEqual(cpc1.properties, cpc1_out_props)
-        self.assertEqual(cpc1.manager, hmc.cpcs)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
 
         cpc1_adapters = cpc1.adapters.list()
 

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -143,7 +143,7 @@ class AdapterManager(BaseManager):
 
         Returns:
 
-          Adapter:
+          :class:`~zhmcclient.Adapter`:
             The resource object for the new HiperSockets Adapter.
             The object will have its 'object-uri' property set as returned by
             the HMC, and will also have the input properties set.

--- a/zhmcclient_mock/__init__.py
+++ b/zhmcclient_mock/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+zhmcclient_mock - Unit test support for users of the zhmcclient package.
+"""
+
+from __future__ import absolute_import
+
+from ._session import *       # noqa: F401
+from ._hmc import *           # noqa: F401

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -1,0 +1,444 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A faked (local, simulated, in-memory) HMC with all resources that are relevant
+for the zhmcclient package.
+"""
+
+from __future__ import absolute_import
+
+import os
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+import six
+
+# TODO: Move the resources into their own files.
+
+__all__ = ['LocalResource', 'LocalResourceManager', 'Hmc', 'CpcManager',
+           'Cpc', 'AdapterManager', 'Adapter', 'PortManager', 'Port']
+
+
+class LocalResource(object):
+    """
+    A base class for local resources that are implemented in-memory and that
+    act like resources in the HMC.
+    """
+
+    def __init__(self, manager, properties):
+        self.manager = manager
+        self.properties = properties
+
+        if self.manager.oid_prop not in self.properties:
+            new_oid = self.manager.new_oid()
+            self.properties[self.manager.oid_prop] = new_oid
+        self.oid = self.properties[self.manager.oid_prop]
+
+        if self.manager.uri_prop not in self.properties:
+            new_uri = os.path.join(self.manager.base_uri, self.oid)
+            self.properties[self.manager.uri_prop] = new_uri
+        self.uri = self.properties[self.manager.uri_prop]
+
+
+class LocalResourceManager(object):
+    """
+    A base class for manager classes for
+    :class:`zhmcclient_mock.LocalResource`, with similar responsibility as the
+    zhmcclient manager classes.
+    """
+
+    next_oid = 1  # next object ID, for auto-generating them
+
+    def __init__(self, parent, resource_class, base_uri, oid_prop, uri_prop):
+        self.parent = parent
+        self.resource_class = resource_class
+        self.base_uri = base_uri
+        self.oid_prop = oid_prop
+        self.uri_prop = uri_prop
+        self.resources = OrderedDict()  # Resource objects, by object ID
+
+    def new_oid(self):
+        new_oid = self.next_oid
+        self.next_oid += 1
+        return str(new_oid)
+
+    def add(self, properties):
+        """
+        Add a resource to this manager.
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property (e.g. 'object-uri') or the
+            object ID property (e.g. 'object-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          LocalResource: The resource object.
+        """
+        resource = self.resource_class(self, properties)
+        self.resources[resource.oid] = resource
+        return resource
+
+    def remove(self, oid):
+        """
+        Remove a resource from this manager.
+
+        Parameters:
+
+          oid (string):
+            The object ID of the resource (e.g. value of the 'object-uri'
+            property).
+        """
+        del self.resources[oid]
+
+    def list(self):
+        """
+        List the resources of this manager.
+
+        Returns:
+          list of LocalResource: The resource objects of this manager.
+        """
+        return list(six.itervalues(self.resources))
+
+    def lookup_by_oid(self, oid):
+        """
+        Look up a resource by its object ID.
+
+        Parameters:
+
+          oid (string):
+            The object ID of the resource (e.g. value of the 'object-uri'
+            property).
+
+        Returns:
+          LocalResource: The resource object.
+        """
+        del self.resources[oid]
+
+
+class Hmc(LocalResource):
+    """
+    A local (faked) HMC.
+
+    An object of this class represents a local, faked, in-memory HMC
+    that can have all resources that are relevant for the zhmcclient.
+
+    The Python API to this class and its child resource classes is not
+    compatible with the zhmcclient API. Instead, these classes serve
+    as an in-memory backend for a mocking layer for the zhmcclient package,
+    that replaces access to a real HMC and directs that to the local, in-memory
+    "HMC".
+
+    Objects of this class should not be created by the user. Instead,
+    access the :attr:`~zhmcclient_mock.Session.hmc` attribute of the
+    fake session object (see :class:`~zhmcclient_mock.Session`).
+    """
+
+    def __init__(self, host, api_version):
+        self.host = host
+        self.api_version = api_version
+        self.special_operations = {}  # user-provided operations
+        self.cpcs = CpcManager(client=self)
+
+    def add_resources(self, resources):
+        """
+        Add resources to the faked HMC, from the provided resource definitions.
+
+        Duplicate resource names in the same scope are not permitted.
+
+        Although this method is typically used to initially load the faked
+        HMC with resource state just once, it can be invoked multiple times.
+
+        Parameters:
+
+          resources (dict):
+            Definitions of resources to be added, see example below.
+
+        Example for 'resources' parameter::
+
+            resources = {
+                'cpcs': [  # name of manager attribute for this resource
+                    {
+                        'properties': {
+                            # object-id is not provided -> auto-generated
+                            # object-uri is not provided -> auto-generated
+                            'name': 'cpc_1',
+                            . . .  # more properties
+                        },
+                        'adapters': [  # name of manager attribute for this
+                                       # resource
+                            {
+                                'properties': {
+                                    'object-id': '123',
+                                    'object-uri': '/api/cpcs/../adapters/123',
+                                    'name': 'ad_1',
+                                    . . .  # more properties
+                                },
+                                'ports': [
+                                    {
+                                        'properties': {
+                                            # element-id is auto-generated
+                                            # element-uri is auto-generated
+                                            'name': 'port_1',
+                                            . . .  # more properties
+                                        }
+                                    },
+                                    . . .  # more Ports
+                                ],
+                            },
+                            . . .  # more Adapters
+                        ],
+                        . . .  # more CPC child resources of other types
+                    },
+                    . . .  # more CPCs
+                ]
+            }
+        """
+        for child_attr in resources:
+            child_list = resources[child_attr]
+            self._process_child_list(self, child_attr, child_list)
+
+    def _process_child_list(self, parent_resource, child_attr, child_list):
+        child_manager = getattr(parent_resource, child_attr, None)
+        if child_manager is None:
+            raise ValueError("Invalid child resource type specified in "
+                             "resource dictionary: {}".format(child_attr))
+        for child_dict in child_list:
+            # child_dict is a dict of 'properties' and grand child resources
+            properties = child_dict.get('properties', None)
+            if properties is None:
+                raise ValueError("A resource for resource type {} has no"
+                                 "properties specified.".format(child_attr))
+            child_resource = child_manager.add(properties)
+            for grandchild_attr in child_dict:
+                if grandchild_attr == 'properties':
+                    continue
+                grandchild_list = child_dict[grandchild_attr]
+                self._process_child_list(child_resource, grandchild_attr,
+                                         grandchild_list)
+
+    def add_operations(self, operations):
+        """
+        Add operations with a specific, non-standard, behavior to the faked
+        HMC, from operation definitions in an operation dictionary.
+
+        Operations are matched by all of:
+        * HTTP method (get, post, delete)
+        * Canonical target URI (e.g. '/api/cpcs/1234')
+        * Request body (as JSON object)
+
+        Duplicate operation matches are not permitted.
+
+        Although this method is typically used to initially load the faked
+        HMC with operation behavior, it can be invoked multiple times.
+
+        Parameters:
+
+          operations (list):
+            List of operation behavior definitions to be added, see example
+            below.
+
+        Example for 'operations' parameter::
+
+            operations = [
+                {
+                    'method': 'get',           # used for matching the request
+                    'uri': '/api/version',     # used for matching the request
+                    'request_body': None,      # used for matching the request
+                    'response_status': 200,    # desired HTTP status code
+                    'response_body': {         # desired response body
+                        'api-minor-version': '1'
+                    }
+                },
+                {
+                    'method': 'get',           # used for matching the request
+                    'uri': '/api/cpcs',        # used for matching the request
+                    'request_body': None,      # used for matching the request
+                    'response_status': 400,    # desired HTTP status code
+                    'response_error': {        # desired error info
+                        'reason': 25,          # desired HMC reason code
+                        'message': 'bla',      # desired HMC message text
+                }
+            ]
+        """
+        for _op, i in enumerate(operations):
+            op = _op.copy()
+            self._assert_op_key(i, op, 'method')
+            op['method'] = op['method'].lower()
+            self._assert_op_key(i, op, 'uri')
+            if 'request_body' not in op:
+                op['request_body'] = None
+            self._assert_op_key(i, op, 'response_status')
+            if 'response_body' not in op and 'response_error' not in op:
+                raise ValueError("One of 'response_body' or 'response_error' "
+                                 "is missing in operations item #{}".
+                                 format(i))
+            if 'response_body' in new_op and 'response_error' in op:
+                raise ValueError("'response_body' and 'response_error' are "
+                                 "both specified in operations item #{}".
+                                 format(i))
+            op_key = '{} {}'.format(op['method'], op['uri'])
+            if op_key in self.special_operations:
+                raise ValueError("Operaiton '{}' specified in operations "
+                                 "item #{} was already defined.".
+                                 format(i))
+            self.special_operations[op_key] = op
+
+    @staticmethod
+    def _assert_op_key(i, op, key):
+        if key not in op:
+            raise ValueError("Missing '{}' key in operations item #{}".
+                             format(key, i))
+
+    def get(self, uri, logon_required):
+        # TODO: Implement
+        pass
+
+    def post(self, uri, body, logon_required, wait_for_completion):
+        # TODO: Implement
+        pass
+
+    def delete(self, uri, logon_required):
+        # TODO: Implement
+        pass
+
+
+class CpcManager(LocalResourceManager):
+    """
+    A manager for CPC resources within a local HMC (see
+    :class:`zhmcclient_mock.Hmc`).
+    """
+
+    def __init__(self, client):
+        super(CpcManager, self).__init__(
+            parent=client,
+            resource_class=Cpc,
+            base_uri='/api/cpcs/',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class Cpc(LocalResource):
+    """
+    A CPC resource within a local HMC (see :class:`zhmcclient_mock.Hmc`).
+    """
+
+    def __init__(self, manager, properties):
+        super(Cpc, self).__init__(
+            manager=manager,
+            properties=properties)
+        self.adapters = AdapterManager(cpc=self)
+
+
+class AdapterManager(LocalResourceManager):
+    """
+    A manager for Adapter resources within a local HMC (see
+    :class:`zhmcclient_mock.Hmc`).
+    """
+
+    def __init__(self, cpc):
+        super(AdapterManager, self).__init__(
+            parent=cpc,
+            resource_class=Adapter,
+            base_uri=cpc.uri + '/adapters',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class Adapter(LocalResource):
+    """
+    An Adapter resource within a local HMC (see :class:`zhmcclient_mock.Hmc`).
+    """
+
+    def __init__(self, manager, properties):
+        super(Adapter, self).__init__(
+            manager=manager,
+            properties=properties)
+        self.ports = PortManager(adapter=self)
+
+
+class PortManager(LocalResourceManager):
+    """
+    A manager for Adapter Port resources within a local HMC (see
+    :class:`zhmcclient_mock.Hmc`).
+    """
+
+    def __init__(self, adapter):
+        super(PortManager, self).__init__(
+            parent=adapter,
+            resource_class=Port,
+            base_uri=adapter.uri + '/ports',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a Port resource to this manager.
+
+        This method also updates the 'network-port-uris' or 'storage-port-uris'
+        property in the parent Adapter resource (whichever exists, gets
+        updated).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          Port: The resource object.
+        """
+        adapter = self.parent
+        if 'network-port-uris' in adapter.properties:
+            adapter.properties['network-port-uris'].append(resource.uri)
+        elif 'storage-port-uris' in adapter.properties:
+            adapter.properties['storage-port-uris'].append(resource.uri)
+        return super(PortManager, self).add(properties)
+
+    def remove(self, oid):
+        """
+        Remove a Port resource from this manager.
+
+        This method also updates the 'network-port-uris' or 'storage-port-uris'
+        property in the parent Adapter resource (whichever exists, gets
+        updated).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the Port resource.
+        """
+        resource = self.lookup_by_oid(oid)
+        adapter = resource.parent
+        if 'network-port-uris' in adapter.properties:
+            del adapter.properties['network-port-uris'][resource.uri]
+        elif 'storage-port-uris' in adapter.properties:
+            del adapter.properties['storage-port-uris'][resource.uri]
+        super(PortManager, self).remove(oid)  # last, because it deletes res
+
+
+class Port(LocalResource):
+    """
+    An Adapter Port resource within a local HMC (see
+    :class:`zhmcclient_mock.Hmc`).
+    """
+
+    def __init__(self, manager, properties):
+        super(Port, self).__init__(
+            manager=manager,
+            properties=properties)

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -53,24 +53,26 @@ class Session(ZhmcclientSession):
     :meth:`~zhmcclient_mock.Session.add_operations`).
     """
 
-    def __init__(self, host, api_version):
+    def __init__(self, host, hmc_name, hmc_version, api_version):
         """
         Parameters:
 
           host (:term:`string`):
-            HMC host. For valid formats, see the
-            :attr:`~zhmcclient.Session.host` property.
+            HMC host.
 
-            May be `None`.
+          hmc_name (:term:`string`):
+            HMC name. Used for result of Query Version Info operation.
 
-            This parameter is used only for descriptiove purposes. No
-            communication will happen to that host.
+          hmc_version (:term:`string`):
+            HMC version string (e.g. '2.13.1'). Used for result of
+            Query Version Info operation.
 
           api_version (:term:`string`):
-            Version string for the HMC API version (e.g. '2.13.1').
+            HMC API version string (e.g. '1.8'). Used for result of
+            Query Version Info operation.
         """
         super(Session, self).__init__(host)
-        self._hmc = Hmc(host, api_version)
+        self._hmc = Hmc(hmc_name, hmc_version, api_version)
 
     @property
     def hmc(self):
@@ -116,7 +118,7 @@ class Session(ZhmcclientSession):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        self._hmc.get(uri, logon_required)
+        return self._hmc.get(uri, logon_required)
 
     def post(self, uri, body=None, logon_required=True,
              wait_for_completion=True):
@@ -211,7 +213,7 @@ class Session(ZhmcclientSession):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        self._hmc.post(uri, body, logon_required, wait_for_completion)
+        return self._hmc.post(uri, body, logon_required, wait_for_completion)
 
     def delete(self, uri, logon_required=True):
         """

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -1,0 +1,245 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A fake Session class for the zhmcclient package.
+"""
+
+from __future__ import absolute_import
+
+from zhmcclient import Session as ZhmcclientSession
+
+from ._hmc import Hmc
+
+__all__ = ['Session']
+
+
+class Session(ZhmcclientSession):
+    """
+    A fake Session class for the zhmcclient package, that can be used as a
+    replacement for the :class:`zhmcclient.Session` class.
+    This class is derived from :class:`zhmcclient.Session`.
+
+    This class can be used by projects using the zhmcclient package for their
+    unit testing. It can also be used by unit tests of the zhmcclient package
+    itself.
+
+    This class provides faked HMC with all of its resources that are relevant
+    for the zhmcclient.
+
+    The faked HMC provided by this class maintains its resource state in memory
+    as Python objects, and no communication happens to any real HMC. The
+    faked HMC implements all HMC operations that are relevant for the
+    zhmcclient package in a successful manner.
+
+    It is possible to populate the faked HMC with an initial resource state
+    (see :meth:`~zhmcclient_mock.Session.add_resources`).
+
+    For testing error scenarios, or to simulate changes on the HMC resources
+    that are performed through other channels than the zhmcclient, it is
+    possible to override the default implementations of the operations against
+    the faked HMC with operations that show specific user-defined behavior (see
+    :meth:`~zhmcclient_mock.Session.add_operations`).
+    """
+
+    def __init__(self, host, api_version):
+        """
+        Parameters:
+
+          host (:term:`string`):
+            HMC host. For valid formats, see the
+            :attr:`~zhmcclient.Session.host` property.
+
+            May be `None`.
+
+            This parameter is used only for descriptiove purposes. No
+            communication will happen to that host.
+
+          api_version (:term:`string`):
+            Version string for the HMC API version (e.g. '2.13.1').
+        """
+        super(Session, self).__init__(host)
+        self._hmc = Hmc(host, api_version)
+
+    @property
+    def hmc(self):
+        """
+        :class:`~zhmcclient_mock.Hmc`: The faked HMC provided by this session.
+
+        This faked HMC supports being populated with initial resource state,
+        for example using its :meth:`zhmcclient_mock.Hmc.add_resources` method,
+        or the more fine grained methods such as
+        :meth:`zhmcclient_mock.Hmc.add` and :meth:`zhmcclient_mock.Hmc.remove`
+        (or the corresponding methods on its child resource classes).
+        """
+        return self._hmc
+
+    def get(self, uri, logon_required=True):
+        """
+        Perform the HTTP GET method against the resource identified by a URI,
+        on the faked HMC.
+
+        Parameters:
+
+          uri (:term:`string`):
+            Relative URI path of the resource, e.g. "/api/session".
+            This URI is relative to the base URL of the session (see
+            the :attr:`~zhmcclient.Session.base_url` property).
+            Must not be `None`.
+
+          logon_required (bool):
+            Boolean indicating whether the operation requires that the session
+            is logged on to the HMC.
+
+            Because this is a faked HMC, this does not perform a real logon,
+            but it is still used to update the state in the faked HMC.
+
+        Returns:
+
+          :term:`json object` with the operation result.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self._hmc.get(uri, logon_required)
+
+    def post(self, uri, body=None, logon_required=True,
+             wait_for_completion=True):
+        """
+        Perform the HTTP POST method against the resource identified by a URI,
+        using a provided request body, on the faked HMC.
+
+        HMC operations using HTTP POST are either synchronous or asynchronous.
+        Asynchronous operations return the URI of an asynchronously executing
+        job that can be queried for status and result.
+
+        Examples for synchronous operations:
+
+        * With no response body: "Logon", "Update CPC Properties"
+        * With a response body: "Create Partition"
+
+        Examples for asynchronous operations:
+
+        * With no ``job-results`` field in the completed job status response:
+          "Start Partition"
+        * With a ``job-results`` field in the completed job status response
+          (under certain conditions): "Activate a Blade", or "Set CPC Power
+          Save"
+
+        The `wait_for_completion` parameter of this method can be used to deal
+        with asynchronous HMC operations in a synchronous way.
+
+        Parameters:
+
+          uri (:term:`string`):
+            Relative URI path of the resource, e.g. "/api/session".
+            This URI is relative to the base URL of the session (see the
+            :attr:`~zhmcclient.Session.base_url` property).
+            Must not be `None`.
+
+          body (:term:`json object`):
+            JSON object to be used as the HTTP request body (payload).
+            `None` means the same as an empty dictionary, namely that no HTTP
+            body is included in the request.
+
+          logon_required (bool):
+            Boolean indicating whether the operation requires that the session
+            is logged on to the HMC. For example, the "Logon" operation does
+            not require that.
+
+            Because this is a faked HMC, this does not perform a real logon,
+            but it is still used to update the state in the faked HMC.
+
+          wait_for_completion (bool):
+            Boolean controlling whether this method should wait for completion
+            of the requested HMC operation, as follows:
+
+            * If `True`, this method will wait for completion of the requested
+              operation, regardless of whether the operation is synchronous or
+              asynchronous.
+
+              This will cause an additional entry in the time statistics to be
+              created for the asynchronous operation and waiting for its
+              completion. This entry will have a URI that is the targeted URI,
+              appended with "+completion".
+
+            * If `False`, this method will immediately return the result of the
+              HTTP POST method, regardless of whether the operation is
+              synchronous or asynchronous.
+
+        Returns:
+
+          :term:`json object`:
+
+            If `wait_for_completion` is `True`, returns a JSON object
+            representing the response body of the synchronous operation, or the
+            response body of the completed job that performed the asynchronous
+            operation. If a synchronous operation has no response body, `None`
+            is returned.
+
+            If `wait_for_completion` is `False`, returns a JSON object
+            representing the response body of the synchronous or asynchronous
+            operation. In case of an asynchronous operation, the JSON object
+            will have a member named ``job-uri``, whose value can be used with
+            the :meth:`~zhmcclient.Session.query_job_status` method to
+            determine the status of the job and the result of the original
+            operation, once the job has completed.
+
+            See the section in the :term:`HMC API` book about the specific HMC
+            operation and about the 'Query Job Status' operation, for a
+            description of the members of the returned JSON objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self._hmc.post(uri, body, logon_required, wait_for_completion)
+
+    def delete(self, uri, logon_required=True):
+        """
+        Perform the HTTP DELETE method against the resource identified by a
+        URI, on the faked HMC.
+
+        Parameters:
+
+          uri (:term:`string`):
+            Relative URI path of the resource, e.g.
+            "/api/session/{session-id}".
+            This URI is relative to the base URL of the session (see
+            the :attr:`~zhmcclient.Session.base_url` property).
+            Must not be `None`.
+
+          logon_required (bool):
+            Boolean indicating whether the operation requires that the session
+            is logged on to the HMC. For example, for the logoff operation, it
+            does not make sense to first log on.
+
+            Because this is a faked HMC, this does not perform a real logon,
+            but it is still used to update the state in the faked HMC.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self._hmc.delete(uri, logon_required)


### PR DESCRIPTION
Initial stab, not yet done.

Besides the code, have a look at the example testcase (`tests/unit/zhmcclient_mock/test_example.py`) and at the new chapter "Mock support" in the generated documentation (`make builddoc`, to generate it).

The new example unit test fails because the implementation is not complete yet.