### PR TITLE
Fixes #152: Fixed assertion error in TimeStats testing on Windows.

### DIFF
--- a/tests/unit/test_timestats.py
+++ b/tests/unit/test_timestats.py
@@ -34,11 +34,11 @@ PRINT_HEADER_DISABLED = \
     "Disabled."
 
 
-def time_equal(t1, t2, delta):
+def time_abs_delta(t1, t2):
     """
-    Return True if two float values are nearly equal (as defined by delta).
+    Return the positive difference between two float values.
     """
-    return abs(t1 - t2) < delta
+    return abs(t1 - t2)
 
 
 class TimeStatsTests(unittest.TestCase):
@@ -120,8 +120,9 @@ class TimeStatsTests(unittest.TestCase):
         keeper = TimeStatsKeeper()
         keeper.enable()
 
-        duration = 0.2
-        delta = duration / 100
+        duration = 0.4
+        # TimeStatsKeeper on Windows has only a precision of 1/60 sec:
+        delta = 0.04
 
         stats = keeper.get_stats('foo')
         stats.begin()
@@ -130,9 +131,9 @@ class TimeStatsTests(unittest.TestCase):
 
         for _, stats in keeper.snapshot():
             self.assertEqual(stats.count, 1)
-            self.assertTrue(time_equal(stats.avg_time, duration, delta))
-            self.assertTrue(time_equal(stats.min_time, duration, delta))
-            self.assertTrue(time_equal(stats.max_time, duration, delta))
+            self.assertLess(time_abs_delta(stats.avg_time, duration), delta)
+            self.assertLess(time_abs_delta(stats.min_time, duration), delta)
+            self.assertLess(time_abs_delta(stats.max_time, duration), delta)
 
         stats.reset()
         self.assertEqual(stats.count, 0)
@@ -166,8 +167,9 @@ class TimeStatsTests(unittest.TestCase):
         keeper = TimeStatsKeeper()
         keeper.enable()
 
-        duration = 0.2
-        delta = duration / 100
+        duration = 0.4
+        # TimeStatsKeeper on Windows has only a precision of 1/60 sec:
+        delta = 0.04
 
         stats = keeper.get_stats('foo')
         stats.begin()
@@ -179,15 +181,15 @@ class TimeStatsTests(unittest.TestCase):
 
         # keep producing statistics data
         stats.begin()
-        time.sleep(duration * 2)
+        time.sleep(duration)
         stats.end()
 
         # verify that only the first set of data is in the snapshot
         for _, stats in snapshot:
             self.assertEqual(stats.count, 1)
-            self.assertTrue(time_equal(stats.avg_time, duration, delta))
-            self.assertTrue(time_equal(stats.min_time, duration, delta))
-            self.assertTrue(time_equal(stats.max_time, duration, delta))
+            self.assertLess(time_abs_delta(stats.avg_time, duration), delta)
+            self.assertLess(time_abs_delta(stats.min_time, duration), delta)
+            self.assertLess(time_abs_delta(stats.max_time, duration), delta)
 
     def test_str_empty(self):
         """Test str() for an empty enabled keeper."""


### PR DESCRIPTION
Please review and merge.

Details:
* In test_timestats, improved the approach for checking time deltas such
  that the assertion error now shows the actual and expected delta, instead
  of just the mismatch between true and false.
* In test_timestats, increased the allowable time delta and the measured times
  in order to accomodate the fact that `time.time()` which is used by the `TimeStats`
  class, has only a 1/60 sec precision on Windows. This is a circumvention - the real
  solution would be to use some other service that returns high precision  timings
  on all supported operating systems.