### PR TITLE
Mocking support for zhmcclient, stage 1: Faked HMC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ doc_dependent_files := \
     $(wildcard $(doc_conf_dir)/*.rst) \
     $(wildcard $(doc_conf_dir)/notebooks/*.ipynb) \
     $(wildcard $(package_name)/*.py) \
+    $(wildcard zhmcclient_mock/*.py) \
 
 # Flake8 config file
 flake8_rc_file := setup.cfg
@@ -87,8 +88,10 @@ pylint_rc_file := .pylintrc
 check_py_files := \
     setup.py \
     $(wildcard $(package_name)/*.py) \
+    $(wildcard zhmcclient_mock/*.py) \
     $(wildcard $(cli_package_name)/*.py) \
     $(wildcard tests/unit/*.py) \
+    $(wildcard tests/unit/zhmcclient_mock/*.py) \
     $(wildcard tests/function/*.py) \
     $(wildcard docs/notebooks/*.py) \
 
@@ -289,7 +292,7 @@ flake8.log: Makefile $(flake8_rc_file) $(check_py_files)
 	mv -f $@.tmp $@
 	@echo 'Done: Created Flake8 log file: $@'
 
-$(test_log_file): Makefile $(package_name)/*.py tests/unit/*.py tests/function/*.py .coveragerc
+$(test_log_file): Makefile $(package_name)/*.py zhmcclient_mock/*.py tests/unit/*.py tests/unit/zhmcclient_mock/*.py tests/function/*.py .coveragerc
 	rm -fv $@
 	bash -c 'set -o pipefail; PYTHONWARNINGS=default py.test --cov $(package_name) --cov-config .coveragerc --cov-report=html $(pytest_opts) -s 2>&1 |tee $@.tmp'
 	mv -f $@.tmp $@

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,5 +28,6 @@ zhmcclient - A pure Python client library for the z Systems HMC Web Services API
    general.rst
    resources.rst
    cli.rst
+   mocksupport.rst
    development.rst
    appendix.rst

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -1,0 +1,165 @@
+.. Copyright 2016 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _`Mock support`:
+
+Mock support
+============
+
+The zhmcclient PyPI package provides unit testing support for its users via its
+`zhmcclient_mock` Python package. This package allows users of
+the zhmcclient package to easily define a mocked environment that provides
+a faked HMC that is pre-populated with resource state as needed by the test
+case, and that supports all relevant operations.
+
+The mocked environment is set up by the user by using an instance of the
+:class:`zhmcclient_mock.FakedSession` class instead of the
+:class:`zhmcclient.Session` class when setting up the zhmcclient package
+in a unit test::
+
+    import unittest
+    import zhmcclient
+    import zhmcclient_mock
+
+    class MyTests(unittest.TestCase):
+
+        def setUp(self):
+
+            self.session = zhmcclient_mock.FakedSession(
+                'fake-host', 'fake-hmc', '2.13.1', '1.8')
+            self.session.hmc.add_resources({
+                'cpcs': [
+                    {
+                        'properties': {
+                            'name': 'cpc_1',
+                            'description': 'CPC #1',
+                        },
+                        'adapters': [
+                            {
+                                'properties': {
+                                    'name': 'osa_1',
+                                    'description': 'OSA #1',
+                                },
+                                'ports': [
+                                    {
+                                        'properties': {
+                                            'name': 'osa_1_1',
+                                            'description': 'OSA #1 Port #1',
+                                        },
+                                    },
+                                ]
+                            },
+                        ]
+                    },
+                ]
+            })
+            self.client = zhmcclient.Client(self.session)
+
+        def test_list(self):
+            cpcs = self.client.cpcs.list()
+            self.assertEqual(len(cpcs), 1)
+            self.assertEqual(cpcs[0].name, 'cpc_1')
+
+In this example, the faked HMC of the faked session is preloaded with a
+CPC that has one adapter with one port. For details on the format of
+the input dictionary, see :meth:`zhmcclient_mock.FakedHmc.add_resources`.
+
+It is also possible to add resources one by one, from top to bottom,
+by using add() methods on the resource manager classes, for example see
+:meth:`zhmcclient_mock.FakedBaseManager.add`.
+
+.. _`Faked session`:
+
+Faked session
+-------------
+
+TODO: Add the faked Session class.
+
+
+.. _`Faked HMC`:
+
+Faked HMC
+---------
+
+.. automodule:: zhmcclient_mock._hmc
+
+.. autoclass:: zhmcclient_mock.FakedHmc
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedActivationProfileManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedActivationProfile
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedAdapterManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedAdapter
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedCpcManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedCpc
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedHbaManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedHba
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedLparManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedLpar
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedNicManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedNic
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPartitionManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPartition
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPortManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPort
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedVirtualFunctionManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedVirtualFunction
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedVirtualSwitchManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedVirtualSwitch
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedBaseManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedBaseResource
+   :members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifier =
 packages =
     zhmcclient
     zhmccli
+    zhmcclient_mock
 scripts =
     tools/cpcinfo
     tools/cpcdata

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -1,0 +1,1267 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _hmc module of the zhmcclient_mock package.
+"""
+
+from __future__ import absolute_import, print_function
+
+import unittest
+
+from zhmcclient_mock._hmc import FakedHmc, \
+    FakedActivationProfileManager, FakedActivationProfile, \
+    FakedAdapterManager, FakedAdapter, \
+    FakedCpcManager, FakedCpc, \
+    FakedHbaManager, FakedHba, \
+    FakedLparManager, FakedLpar, \
+    FakedNicManager, FakedNic, \
+    FakedPartitionManager, FakedPartition, \
+    FakedPortManager, FakedPort, \
+    FakedVirtualFunctionManager, FakedVirtualFunction, \
+    FakedVirtualSwitchManager, FakedVirtualSwitch
+
+
+class FakedHmcTests(unittest.TestCase):
+    """All tests for the zhmcclient_mock.FakedHmc class."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+
+    def test_hmc(self):
+        self.assertEqual(self.hmc.hmc_name, 'fake-hmc')
+        self.assertEqual(self.hmc.hmc_version, '2.13.1')
+        self.assertEqual(self.hmc.api_version, '1.8')
+        self.assertIsInstance(self.hmc.cpcs, FakedCpcManager)
+
+        # the function to be tested:
+        cpcs = self.hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 0)
+
+    def test_hmc_1_cpc(self):
+        cpc1_in_props = {'name': 'cpc1'}
+
+        # the function to be tested:
+        cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
+
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+
+        # the function to be tested:
+        cpcs = self.hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 1)
+        self.assertEqual(cpcs[0], cpc1)
+
+        self.assertIsInstance(cpc1, FakedCpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+
+    def test_hmc_2_cpcs(self):
+        cpc1_in_props = {'name': 'cpc1'}
+
+        # the function to be tested:
+        cpc1 = self.hmc.cpcs.add(cpc1_in_props)
+
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+
+        cpc2_in_props = {'name': 'cpc2'}
+
+        # the function to be tested:
+        cpc2 = self.hmc.cpcs.add(cpc2_in_props)
+
+        cpc2_out_props = cpc2_in_props.copy()
+        cpc2_out_props.update({
+            'object-id': cpc2.oid,
+            'object-uri': cpc2.uri,
+        })
+
+        # the function to be tested:
+        cpcs = self.hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 2)
+        # We expect the order of addition to be maintained:
+        self.assertEqual(cpcs[0], cpc1)
+        self.assertEqual(cpcs[1], cpc2)
+
+        self.assertIsInstance(cpc1, FakedCpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+
+        self.assertIsInstance(cpc2, FakedCpc)
+        self.assertEqual(cpc2.properties, cpc2_out_props)
+        self.assertEqual(cpc2.manager, self.hmc.cpcs)
+
+    def test_res_dict(self):
+        cpc1_in_props = {'name': 'cpc1'}
+        adapter1_in_props = {'name': 'osa1'}
+        port1_in_props = {'name': 'osa1_1'}
+
+        rd = {
+            'cpcs': [
+                {
+                    'properties': cpc1_in_props,
+                    'adapters': [
+                        {
+                            'properties': adapter1_in_props,
+                            'ports': [
+                                {'properties': port1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+
+        # the function to be tested:
+        self.hmc.add_resources(rd)
+
+        cpcs = self.hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 1)
+
+        cpc1 = cpcs[0]
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+        self.assertIsInstance(cpc1, FakedCpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+
+        cpc1_adapters = cpc1.adapters.list()
+
+        self.assertEqual(len(cpc1_adapters), 1)
+
+        adapter1 = cpc1_adapters[0]
+        adapter1_out_props = adapter1_in_props.copy()
+        adapter1_out_props.update({
+            'object-id': adapter1.oid,
+            'object-uri': adapter1.uri,
+        })
+        self.assertIsInstance(adapter1, FakedAdapter)
+        self.assertEqual(adapter1.properties, adapter1_out_props)
+        self.assertEqual(adapter1.manager, cpc1.adapters)
+
+        adapter1_ports = adapter1.ports.list()
+
+        self.assertEqual(len(adapter1_ports), 1)
+
+        port1 = adapter1_ports[0]
+        port1_out_props = port1_in_props.copy()
+        port1_out_props.update({
+            'element-id': port1.oid,
+            'element-uri': port1.uri,
+        })
+        self.assertIsInstance(port1, FakedPort)
+        self.assertEqual(port1.properties, port1_out_props)
+        self.assertEqual(port1.manager, adapter1.ports)
+
+
+class FakedActivationProfileTests(unittest.TestCase):
+    """All tests for the FakedActivationProfileManager and
+    FakedActivationProfile classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.resetprofile1_in_props = {'name': 'resetprofile1'}
+        self.imageprofile1_in_props = {'name': 'imageprofile1'}
+        self.loadprofile1_in_props = {'name': 'loadprofile1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'reset_activation_profiles': [
+                        {'properties': self.resetprofile1_in_props},
+                    ],
+                    'image_activation_profiles': [
+                        {'properties': self.imageprofile1_in_props},
+                    ],
+                    'load_activation_profiles': [
+                        {'properties': self.loadprofile1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedActivationProfileManager:
+        self.hmc.add_resources(rd)
+
+    def test_profiles_attr(self):
+        """Test CPC '*_activation_profiles' attributes."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # Test reset activation profiles
+
+        self.assertIsInstance(cpc1.reset_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertEqual(cpc1.reset_activation_profiles.profile_type, 'reset')
+        self.assertRegexpMatches(cpc1.reset_activation_profiles.base_uri,
+                                 r'/api/cpcs/.*/reset-activation-profiles')
+
+        # Test image activation profiles
+
+        self.assertIsInstance(cpc1.image_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertEqual(cpc1.image_activation_profiles.profile_type, 'image')
+        self.assertRegexpMatches(cpc1.image_activation_profiles.base_uri,
+                                 r'/api/cpcs/.*/image-activation-profiles')
+
+        # Test load activation profiles
+
+        self.assertIsInstance(cpc1.load_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertEqual(cpc1.load_activation_profiles.profile_type, 'load')
+        self.assertRegexpMatches(cpc1.load_activation_profiles.base_uri,
+                                 r'/api/cpcs/.*/load-activation-profiles')
+
+    def test_profiles_list(self):
+        """Test list() of FakedActivationProfileManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # Test reset activation profiles
+
+        resetprofiles = cpc1.reset_activation_profiles.list()
+
+        self.assertEqual(len(resetprofiles), 1)
+        resetprofile1 = resetprofiles[0]
+        resetprofile1_out_props = self.resetprofile1_in_props.copy()
+        resetprofile1_out_props.update({
+            'object-id': resetprofile1.oid,
+            'object-uri': resetprofile1.uri,
+        })
+        self.assertIsInstance(resetprofile1, FakedActivationProfile)
+        self.assertEqual(resetprofile1.properties, resetprofile1_out_props)
+        self.assertEqual(resetprofile1.manager, cpc1.reset_activation_profiles)
+
+        # Test image activation profiles
+
+        imageprofiles = cpc1.image_activation_profiles.list()
+
+        self.assertEqual(len(imageprofiles), 1)
+        imageprofile1 = imageprofiles[0]
+        imageprofile1_out_props = self.imageprofile1_in_props.copy()
+        imageprofile1_out_props.update({
+            'object-id': imageprofile1.oid,
+            'object-uri': imageprofile1.uri,
+        })
+        self.assertIsInstance(imageprofile1, FakedActivationProfile)
+        self.assertEqual(imageprofile1.properties, imageprofile1_out_props)
+        self.assertEqual(imageprofile1.manager, cpc1.image_activation_profiles)
+
+        # Test load activation profiles
+
+        loadprofiles = cpc1.load_activation_profiles.list()
+
+        self.assertEqual(len(loadprofiles), 1)
+        loadprofile1 = loadprofiles[0]
+        loadprofile1_out_props = self.loadprofile1_in_props.copy()
+        loadprofile1_out_props.update({
+            'object-id': loadprofile1.oid,
+            'object-uri': loadprofile1.uri,
+        })
+        self.assertIsInstance(loadprofile1, FakedActivationProfile)
+        self.assertEqual(loadprofile1.properties, loadprofile1_out_props)
+        self.assertEqual(loadprofile1.manager, cpc1.load_activation_profiles)
+
+    def test_profiles_add(self):
+        """Test add() of FakedActivationProfileManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        resetprofiles = cpc1.reset_activation_profiles.list()
+        self.assertEqual(len(resetprofiles), 1)
+
+        resetprofile2_in_props = {'name': 'resetprofile2'}
+
+        # the function to be tested:
+        new_resetprofile = cpc1.reset_activation_profiles.add(
+            resetprofile2_in_props)
+
+        resetprofiles = cpc1.reset_activation_profiles.list()
+        self.assertEqual(len(resetprofiles), 2)
+
+        resetprofile2 = [p for p in resetprofiles
+                         if p.properties['name'] ==
+                         resetprofile2_in_props['name']][0]
+
+        self.assertEqual(new_resetprofile.properties, resetprofile2.properties)
+        self.assertEqual(new_resetprofile.manager, resetprofile2.manager)
+
+        resetprofile2_out_props = resetprofile2_in_props.copy()
+        resetprofile2_out_props.update({
+            'object-id': resetprofile2.oid,
+            'object-uri': resetprofile2.uri,
+        })
+        self.assertIsInstance(resetprofile2, FakedActivationProfile)
+        self.assertEqual(resetprofile2.properties, resetprofile2_out_props)
+        self.assertEqual(resetprofile2.manager, cpc1.reset_activation_profiles)
+
+        # Because we know that the image and load profile managers are of the
+        # same class, we don't need to test them.
+
+    def test_profiles_remove(self):
+        """Test remove() of FakedActivationProfileManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        resetprofiles = cpc1.reset_activation_profiles.list()
+        resetprofile1 = resetprofiles[0]
+        self.assertEqual(len(resetprofiles), 1)
+
+        # the function to be tested:
+        cpc1.reset_activation_profiles.remove(resetprofile1.oid)
+
+        resetprofiles = cpc1.reset_activation_profiles.list()
+        self.assertEqual(len(resetprofiles), 0)
+
+        # Because we know that the image and load profile managers are of the
+        # same class, we don't need to test them.
+
+
+class FakedAdapterTests(unittest.TestCase):
+    """All tests for the FakedAdapterManager and FakedAdapter classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.adapter1_in_props = {'name': 'adapter1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'adapters': [
+                        {'properties': self.adapter1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedAdapterManager:
+        self.hmc.add_resources(rd)
+
+    def test_adapters_attr(self):
+        """Test CPC 'adapters' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        self.assertIsInstance(cpc1.adapters, FakedAdapterManager)
+        self.assertRegexpMatches(cpc1.adapters.base_uri, r'/api/adapters')
+
+    def test_adapters_list(self):
+        """Test list() of FakedAdapterManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # the function to be tested:
+        adapters = cpc1.adapters.list()
+
+        self.assertEqual(len(adapters), 1)
+        adapter1 = adapters[0]
+        adapter1_out_props = self.adapter1_in_props.copy()
+        adapter1_out_props.update({
+            'object-id': adapter1.oid,
+            'object-uri': adapter1.uri,
+        })
+        self.assertIsInstance(adapter1, FakedAdapter)
+        self.assertEqual(adapter1.properties, adapter1_out_props)
+        self.assertEqual(adapter1.manager, cpc1.adapters)
+
+        # Quick check of child resources:
+        self.assertIsInstance(adapter1.ports, FakedPortManager)
+
+    def test_adapters_add(self):
+        """Test add() of FakedAdapterManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        self.assertEqual(len(adapters), 1)
+
+        adapter2_in_props = {'name': 'adapter2'}
+
+        # the function to be tested:
+        new_adapter = cpc1.adapters.add(
+            adapter2_in_props)
+
+        adapters = cpc1.adapters.list()
+        self.assertEqual(len(adapters), 2)
+
+        adapter2 = [a for a in adapters
+                    if a.properties['name'] == adapter2_in_props['name']][0]
+
+        self.assertEqual(new_adapter.properties, adapter2.properties)
+        self.assertEqual(new_adapter.manager, adapter2.manager)
+
+        adapter2_out_props = adapter2_in_props.copy()
+        adapter2_out_props.update({
+            'object-id': adapter2.oid,
+            'object-uri': adapter2.uri,
+        })
+        self.assertIsInstance(adapter2, FakedAdapter)
+        self.assertEqual(adapter2.properties, adapter2_out_props)
+        self.assertEqual(adapter2.manager, cpc1.adapters)
+
+    def test_adapters_remove(self):
+        """Test remove() of FakedAdapterManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+        self.assertEqual(len(adapters), 1)
+
+        # the function to be tested:
+        cpc1.adapters.remove(adapter1.oid)
+
+        adapters = cpc1.adapters.list()
+        self.assertEqual(len(adapters), 0)
+
+
+class FakedCpcTests(unittest.TestCase):
+    """All tests for the FakedCpcManager and FakedCpc classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                },
+            ]
+        }
+        # This already uses add() of FakedCpcManager:
+        self.hmc.add_resources(rd)
+
+    def test_cpcs_attr(self):
+        """Test HMC 'cpcs' attribute."""
+        self.assertIsInstance(self.hmc.cpcs, FakedCpcManager)
+        self.assertRegexpMatches(self.hmc.cpcs.base_uri, r'/api/cpcs')
+
+    def test_cpcs_list(self):
+        """Test list() of FakedCpcManager."""
+
+        # the function to be tested:
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        cpc1_out_props = self.cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+        self.assertIsInstance(cpc1, FakedCpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+
+        # Quick check of child resources:
+        self.assertIsInstance(cpc1.lpars, FakedLparManager)
+        self.assertIsInstance(cpc1.partitions, FakedPartitionManager)
+        self.assertIsInstance(cpc1.adapters, FakedAdapterManager)
+        self.assertIsInstance(cpc1.virtual_switches, FakedVirtualSwitchManager)
+        self.assertIsInstance(cpc1.reset_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertIsInstance(cpc1.image_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertIsInstance(cpc1.load_activation_profiles,
+                              FakedActivationProfileManager)
+
+    def test_cpcs_add(self):
+        """Test add() of FakedCpcManager."""
+        cpcs = self.hmc.cpcs.list()
+        self.assertEqual(len(cpcs), 1)
+
+        cpc2_in_props = {'name': 'cpc2'}
+
+        # the function to be tested:
+        new_cpc = self.hmc.cpcs.add(cpc2_in_props)
+
+        cpcs = self.hmc.cpcs.list()
+        self.assertEqual(len(cpcs), 2)
+
+        cpc2 = [cpc for cpc in cpcs
+                if cpc.properties['name'] == cpc2_in_props['name']][0]
+
+        self.assertEqual(new_cpc.properties, cpc2.properties)
+        self.assertEqual(new_cpc.manager, cpc2.manager)
+
+        cpc2_out_props = cpc2_in_props.copy()
+        cpc2_out_props.update({
+            'object-id': cpc2.oid,
+            'object-uri': cpc2.uri,
+        })
+        self.assertIsInstance(cpc2, FakedCpc)
+        self.assertEqual(cpc2.properties, cpc2_out_props)
+        self.assertEqual(cpc2.manager, self.hmc.cpcs)
+
+    def test_cpcs_remove(self):
+        """Test remove() of FakedCpcManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        self.assertEqual(len(cpcs), 1)
+
+        # the function to be tested:
+        self.hmc.cpcs.remove(cpc1.oid)
+
+        cpcs = self.hmc.cpcs.list()
+        self.assertEqual(len(cpcs), 0)
+
+
+class FakedHbaTests(unittest.TestCase):
+    """All tests for the FakedHbaManager and FakedHba classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.partition1_in_props = {'name': 'partition1'}
+        self.hba1_in_props = {'name': 'hba1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'partitions': [
+                        {
+                            'properties': self.partition1_in_props,
+                            'hbas': [
+                                {'properties': self.hba1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedHbaManager:
+        self.hmc.add_resources(rd)
+
+    def test_hbas_attr(self):
+        """Test Partition 'hbas' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        self.assertIsInstance(partition1.hbas, FakedHbaManager)
+        self.assertRegexpMatches(partition1.hbas.base_uri,
+                                 r'/api/partitions/.*/hbas')
+
+    def test_hbas_list(self):
+        """Test list() of FakedHbaManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        # the function to be tested:
+        hbas = partition1.hbas.list()
+
+        self.assertEqual(len(hbas), 1)
+        hba1 = hbas[0]
+        hba1_out_props = self.hba1_in_props.copy()
+        hba1_out_props.update({
+            'element-id': hba1.oid,
+            'element-uri': hba1.uri,
+        })
+        self.assertIsInstance(hba1, FakedHba)
+        self.assertEqual(hba1.properties, hba1_out_props)
+        self.assertEqual(hba1.manager, partition1.hbas)
+
+    def test_hbas_add(self):
+        """Test add() of FakedHbaManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        hbas = partition1.hbas.list()
+        self.assertEqual(len(hbas), 1)
+
+        hba2_in_props = {'name': 'hba2'}
+
+        # the function to be tested:
+        new_hba = partition1.hbas.add(
+            hba2_in_props)
+
+        hbas = partition1.hbas.list()
+        self.assertEqual(len(hbas), 2)
+
+        hba2 = [hba for hba in hbas
+                if hba.properties['name'] == hba2_in_props['name']][0]
+
+        self.assertEqual(new_hba.properties, hba2.properties)
+        self.assertEqual(new_hba.manager, hba2.manager)
+
+        hba2_out_props = hba2_in_props.copy()
+        hba2_out_props.update({
+            'element-id': hba2.oid,
+            'element-uri': hba2.uri,
+        })
+        self.assertIsInstance(hba2, FakedHba)
+        self.assertEqual(hba2.properties, hba2_out_props)
+        self.assertEqual(hba2.manager, partition1.hbas)
+
+    def test_hbas_remove(self):
+        """Test remove() of FakedHbaManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        hbas = partition1.hbas.list()
+        hba1 = hbas[0]
+        self.assertEqual(len(hbas), 1)
+
+        # the function to be tested:
+        partition1.hbas.remove(hba1.oid)
+
+        hbas = partition1.hbas.list()
+        self.assertEqual(len(hbas), 0)
+
+    # TODO: Add testcases for updating 'hba-uris' parent property
+
+
+class FakedLparTests(unittest.TestCase):
+    """All tests for the FakedLparManager and FakedLpar classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.lpar1_in_props = {'name': 'lpar1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'lpars': [
+                        {'properties': self.lpar1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedLparManager:
+        self.hmc.add_resources(rd)
+
+    def test_lpars_attr(self):
+        """Test CPC 'lpars' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        self.assertIsInstance(cpc1.lpars, FakedLparManager)
+        self.assertRegexpMatches(cpc1.lpars.base_uri,
+                                 r'/api/logical-partitions')
+
+    def test_lpars_list(self):
+        """Test list() of FakedLparManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # the function to be tested:
+        lpars = cpc1.lpars.list()
+
+        self.assertEqual(len(lpars), 1)
+        lpar1 = lpars[0]
+        lpar1_out_props = self.lpar1_in_props.copy()
+        lpar1_out_props.update({
+            'object-id': lpar1.oid,
+            'object-uri': lpar1.uri,
+        })
+        self.assertIsInstance(lpar1, FakedLpar)
+        self.assertEqual(lpar1.properties, lpar1_out_props)
+        self.assertEqual(lpar1.manager, cpc1.lpars)
+
+    def test_lpars_add(self):
+        """Test add() of FakedLparManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        lpars = cpc1.lpars.list()
+        self.assertEqual(len(lpars), 1)
+
+        lpar2_in_props = {'name': 'lpar2'}
+
+        # the function to be tested:
+        new_lpar = cpc1.lpars.add(
+            lpar2_in_props)
+
+        lpars = cpc1.lpars.list()
+        self.assertEqual(len(lpars), 2)
+
+        lpar2 = [p for p in lpars
+                 if p.properties['name'] == lpar2_in_props['name']][0]
+
+        self.assertEqual(new_lpar.properties, lpar2.properties)
+        self.assertEqual(new_lpar.manager, lpar2.manager)
+
+        lpar2_out_props = lpar2_in_props.copy()
+        lpar2_out_props.update({
+            'object-id': lpar2.oid,
+            'object-uri': lpar2.uri,
+        })
+        self.assertIsInstance(lpar2, FakedLpar)
+        self.assertEqual(lpar2.properties, lpar2_out_props)
+        self.assertEqual(lpar2.manager, cpc1.lpars)
+
+    def test_lpars_remove(self):
+        """Test remove() of FakedLparManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        lpars = cpc1.lpars.list()
+        lpar1 = lpars[0]
+        self.assertEqual(len(lpars), 1)
+
+        # the function to be tested:
+        cpc1.lpars.remove(lpar1.oid)
+
+        lpars = cpc1.lpars.list()
+        self.assertEqual(len(lpars), 0)
+
+
+class FakedNicTests(unittest.TestCase):
+    """All tests for the FakedNicManager and FakedNic classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.partition1_in_props = {'name': 'partition1'}
+        self.nic1_in_props = {'name': 'nic1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'partitions': [
+                        {
+                            'properties': self.partition1_in_props,
+                            'nics': [
+                                {'properties': self.nic1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedNicManager:
+        self.hmc.add_resources(rd)
+
+    def test_nics_attr(self):
+        """Test Partition 'nics' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        self.assertIsInstance(partition1.nics, FakedNicManager)
+        self.assertRegexpMatches(partition1.nics.base_uri,
+                                 r'/api/partitions/.*/nics')
+
+    def test_nics_list(self):
+        """Test list() of FakedNicManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        # the function to be tested:
+        nics = partition1.nics.list()
+
+        self.assertEqual(len(nics), 1)
+        nic1 = nics[0]
+        nic1_out_props = self.nic1_in_props.copy()
+        nic1_out_props.update({
+            'element-id': nic1.oid,
+            'element-uri': nic1.uri,
+        })
+        self.assertIsInstance(nic1, FakedNic)
+        self.assertEqual(nic1.properties, nic1_out_props)
+        self.assertEqual(nic1.manager, partition1.nics)
+
+    def test_nics_add(self):
+        """Test add() of FakedNicManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        nics = partition1.nics.list()
+        self.assertEqual(len(nics), 1)
+
+        nic2_in_props = {'name': 'nic2'}
+
+        # the function to be tested:
+        new_nic = partition1.nics.add(
+            nic2_in_props)
+
+        nics = partition1.nics.list()
+        self.assertEqual(len(nics), 2)
+
+        nic2 = [nic for nic in nics
+                if nic.properties['name'] == nic2_in_props['name']][0]
+
+        self.assertEqual(new_nic.properties, nic2.properties)
+        self.assertEqual(new_nic.manager, nic2.manager)
+
+        nic2_out_props = nic2_in_props.copy()
+        nic2_out_props.update({
+            'element-id': nic2.oid,
+            'element-uri': nic2.uri,
+        })
+        self.assertIsInstance(nic2, FakedNic)
+        self.assertEqual(nic2.properties, nic2_out_props)
+        self.assertEqual(nic2.manager, partition1.nics)
+
+    def test_nics_remove(self):
+        """Test remove() of FakedNicManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        nics = partition1.nics.list()
+        nic1 = nics[0]
+        self.assertEqual(len(nics), 1)
+
+        # the function to be tested:
+        partition1.nics.remove(nic1.oid)
+
+        nics = partition1.nics.list()
+        self.assertEqual(len(nics), 0)
+
+    # TODO: Add testcases for updating 'nic-uris' parent property
+
+
+class FakedPartitionTests(unittest.TestCase):
+    """All tests for the FakedPartitionManager and FakedPartition classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.partition1_in_props = {'name': 'partition1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'partitions': [
+                        {'properties': self.partition1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedPartitionManager:
+        self.hmc.add_resources(rd)
+
+    def test_partitions_attr(self):
+        """Test CPC 'partitions' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        self.assertIsInstance(cpc1.partitions, FakedPartitionManager)
+        self.assertRegexpMatches(cpc1.partitions.base_uri, r'/api/partitions')
+
+    def test_partitions_list(self):
+        """Test list() of FakedPartitionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # the function to be tested:
+        partitions = cpc1.partitions.list()
+
+        self.assertEqual(len(partitions), 1)
+        partition1 = partitions[0]
+        partition1_out_props = self.partition1_in_props.copy()
+        partition1_out_props.update({
+            'object-id': partition1.oid,
+            'object-uri': partition1.uri,
+        })
+        self.assertIsInstance(partition1, FakedPartition)
+        self.assertEqual(partition1.properties, partition1_out_props)
+        self.assertEqual(partition1.manager, cpc1.partitions)
+
+    def test_partitions_add(self):
+        """Test add() of FakedPartitionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        self.assertEqual(len(partitions), 1)
+
+        partition2_in_props = {'name': 'partition2'}
+
+        # the function to be tested:
+        new_partition = cpc1.partitions.add(
+            partition2_in_props)
+
+        partitions = cpc1.partitions.list()
+        self.assertEqual(len(partitions), 2)
+
+        partition2 = [p for p in partitions
+                      if p.properties['name'] ==
+                      partition2_in_props['name']][0]
+
+        self.assertEqual(new_partition.properties, partition2.properties)
+        self.assertEqual(new_partition.manager, partition2.manager)
+
+        partition2_out_props = partition2_in_props.copy()
+        partition2_out_props.update({
+            'object-id': partition2.oid,
+            'object-uri': partition2.uri,
+        })
+        self.assertIsInstance(partition2, FakedPartition)
+        self.assertEqual(partition2.properties, partition2_out_props)
+        self.assertEqual(partition2.manager, cpc1.partitions)
+
+    def test_partitions_remove(self):
+        """Test remove() of FakedPartitionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        self.assertEqual(len(partitions), 1)
+
+        # the function to be tested:
+        cpc1.partitions.remove(partition1.oid)
+
+        partitions = cpc1.partitions.list()
+        self.assertEqual(len(partitions), 0)
+
+
+class FakedPortTests(unittest.TestCase):
+    """All tests for the FakedPortManager and FakedPort classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.adapter1_in_props = {'name': 'adapter1'}
+        self.port1_in_props = {'name': 'port1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'adapters': [
+                        {
+                            'properties': self.adapter1_in_props,
+                            'ports': [
+                                {'properties': self.port1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedPortManager:
+        self.hmc.add_resources(rd)
+
+    def test_ports_attr(self):
+        """Test Adapter 'ports' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+
+        self.assertIsInstance(adapter1.ports, FakedPortManager)
+        self.assertRegexpMatches(adapter1.ports.base_uri,
+                                 r'/api/adapters/.*/ports')
+
+    def test_ports_list(self):
+        """Test list() of FakedPortManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+
+        # the function to be tested:
+        ports = adapter1.ports.list()
+
+        self.assertEqual(len(ports), 1)
+        port1 = ports[0]
+        port1_out_props = self.port1_in_props.copy()
+        port1_out_props.update({
+            'element-id': port1.oid,
+            'element-uri': port1.uri,
+        })
+        self.assertIsInstance(port1, FakedPort)
+        self.assertEqual(port1.properties, port1_out_props)
+        self.assertEqual(port1.manager, adapter1.ports)
+
+    def test_ports_add(self):
+        """Test add() of FakedPortManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+        ports = adapter1.ports.list()
+        self.assertEqual(len(ports), 1)
+
+        port2_in_props = {'name': 'port2'}
+
+        # the function to be tested:
+        new_port = adapter1.ports.add(
+            port2_in_props)
+
+        ports = adapter1.ports.list()
+        self.assertEqual(len(ports), 2)
+
+        port2 = [p for p in ports
+                 if p.properties['name'] == port2_in_props['name']][0]
+
+        self.assertEqual(new_port.properties, port2.properties)
+        self.assertEqual(new_port.manager, port2.manager)
+
+        port2_out_props = port2_in_props.copy()
+        port2_out_props.update({
+            'element-id': port2.oid,
+            'element-uri': port2.uri,
+        })
+        self.assertIsInstance(port2, FakedPort)
+        self.assertEqual(port2.properties, port2_out_props)
+        self.assertEqual(port2.manager, adapter1.ports)
+
+    def test_ports_remove(self):
+        """Test remove() of FakedPortManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+        ports = adapter1.ports.list()
+        port1 = ports[0]
+        self.assertEqual(len(ports), 1)
+
+        # the function to be tested:
+        adapter1.ports.remove(port1.oid)
+
+        ports = adapter1.ports.list()
+        self.assertEqual(len(ports), 0)
+
+    # TODO: Add testcases for updating 'network-port-uris' and
+    #       'storage-port-uris' parent properties
+
+
+class FakedVirtualFunctionTests(unittest.TestCase):
+    """All tests for the FakedVirtualFunctionManager and FakedVirtualFunction
+    classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.partition1_in_props = {'name': 'partition1'}
+        self.virtual_function1_in_props = {'name': 'virtual_function1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'partitions': [
+                        {
+                            'properties': self.partition1_in_props,
+                            'virtual_functions': [
+                                {'properties':
+                                 self.virtual_function1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedVirtualFunctionManager:
+        self.hmc.add_resources(rd)
+
+    def test_virtual_functions_attr(self):
+        """Test CPC 'virtual_functions' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        self.assertIsInstance(partition1.virtual_functions,
+                              FakedVirtualFunctionManager)
+        self.assertRegexpMatches(partition1.virtual_functions.base_uri,
+                                 r'/api/partitions/.*/virtual-functions')
+
+    def test_virtual_functions_list(self):
+        """Test list() of FakedVirtualFunctionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        # the function to be tested:
+        virtual_functions = partition1.virtual_functions.list()
+
+        self.assertEqual(len(virtual_functions), 1)
+        virtual_function1 = virtual_functions[0]
+        virtual_function1_out_props = self.virtual_function1_in_props.copy()
+        virtual_function1_out_props.update({
+            'element-id': virtual_function1.oid,
+            'element-uri': virtual_function1.uri,
+        })
+        self.assertIsInstance(virtual_function1, FakedVirtualFunction)
+        self.assertEqual(virtual_function1.properties,
+                         virtual_function1_out_props)
+        self.assertEqual(virtual_function1.manager,
+                         partition1.virtual_functions)
+
+    def test_virtual_functions_add(self):
+        """Test add() of FakedVirtualFunctionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        virtual_functions = partition1.virtual_functions.list()
+        self.assertEqual(len(virtual_functions), 1)
+
+        virtual_function2_in_props = {'name': 'virtual_function2'}
+
+        # the function to be tested:
+        new_virtual_function = partition1.virtual_functions.add(
+            virtual_function2_in_props)
+
+        virtual_functions = partition1.virtual_functions.list()
+        self.assertEqual(len(virtual_functions), 2)
+
+        virtual_function2 = [vf for vf in virtual_functions
+                             if vf.properties['name'] ==
+                             virtual_function2_in_props['name']][0]
+
+        self.assertEqual(new_virtual_function.properties,
+                         virtual_function2.properties)
+        self.assertEqual(new_virtual_function.manager,
+                         virtual_function2.manager)
+
+        virtual_function2_out_props = virtual_function2_in_props.copy()
+        virtual_function2_out_props.update({
+            'element-id': virtual_function2.oid,
+            'element-uri': virtual_function2.uri,
+        })
+        self.assertIsInstance(virtual_function2, FakedVirtualFunction)
+        self.assertEqual(virtual_function2.properties,
+                         virtual_function2_out_props)
+        self.assertEqual(virtual_function2.manager,
+                         partition1.virtual_functions)
+
+    def test_virtual_functions_remove(self):
+        """Test remove() of FakedVirtualFunctionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        virtual_functions = partition1.virtual_functions.list()
+        virtual_function1 = virtual_functions[0]
+        self.assertEqual(len(virtual_functions), 1)
+
+        # the function to be tested:
+        partition1.virtual_functions.remove(virtual_function1.oid)
+
+        virtual_functions = partition1.virtual_functions.list()
+        self.assertEqual(len(virtual_functions), 0)
+
+    # TODO: Add testcases for updating 'virtual-function-uris' parent property
+
+
+class FakedVirtualSwitchTests(unittest.TestCase):
+    """All tests for the FakedVirtualSwitchManager and FakedVirtualSwitch
+    classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.virtual_switch1_in_props = {'name': 'virtual_switch1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'virtual_switches': [
+                        {'properties': self.virtual_switch1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedVirtualSwitchManager:
+        self.hmc.add_resources(rd)
+
+    def test_virtual_switches_attr(self):
+        """Test CPC 'virtual_switches' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        self.assertIsInstance(cpc1.virtual_switches, FakedVirtualSwitchManager)
+        self.assertRegexpMatches(cpc1.virtual_switches.base_uri,
+                                 r'/api/virtual-switches')
+
+    def test_virtual_switches_list(self):
+        """Test list() of FakedVirtualSwitchManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # the function to be tested:
+        virtual_switches = cpc1.virtual_switches.list()
+
+        self.assertEqual(len(virtual_switches), 1)
+        virtual_switch1 = virtual_switches[0]
+        virtual_switch1_out_props = self.virtual_switch1_in_props.copy()
+        virtual_switch1_out_props.update({
+            'object-id': virtual_switch1.oid,
+            'object-uri': virtual_switch1.uri,
+        })
+        self.assertIsInstance(virtual_switch1, FakedVirtualSwitch)
+        self.assertEqual(virtual_switch1.properties, virtual_switch1_out_props)
+        self.assertEqual(virtual_switch1.manager, cpc1.virtual_switches)
+
+    def test_virtual_switches_add(self):
+        """Test add() of FakedVirtualSwitchManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        virtual_switches = cpc1.virtual_switches.list()
+        self.assertEqual(len(virtual_switches), 1)
+
+        virtual_switch2_in_props = {'name': 'virtual_switch2'}
+
+        # the function to be tested:
+        new_virtual_switch = cpc1.virtual_switches.add(
+            virtual_switch2_in_props)
+
+        virtual_switches = cpc1.virtual_switches.list()
+        self.assertEqual(len(virtual_switches), 2)
+
+        virtual_switch2 = [p for p in virtual_switches
+                           if p.properties['name'] ==
+                           virtual_switch2_in_props['name']][0]
+
+        self.assertEqual(new_virtual_switch.properties,
+                         virtual_switch2.properties)
+        self.assertEqual(new_virtual_switch.manager,
+                         virtual_switch2.manager)
+
+        virtual_switch2_out_props = virtual_switch2_in_props.copy()
+        virtual_switch2_out_props.update({
+            'object-id': virtual_switch2.oid,
+            'object-uri': virtual_switch2.uri,
+        })
+        self.assertIsInstance(virtual_switch2, FakedVirtualSwitch)
+        self.assertEqual(virtual_switch2.properties, virtual_switch2_out_props)
+        self.assertEqual(virtual_switch2.manager, cpc1.virtual_switches)
+
+    def test_virtual_switches_remove(self):
+        """Test remove() of FakedVirtualSwitchManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        virtual_switches = cpc1.virtual_switches.list()
+        virtual_switch1 = virtual_switches[0]
+        self.assertEqual(len(virtual_switches), 1)
+
+        # the function to be tested:
+        cpc1.virtual_switches.remove(virtual_switch1.oid)
+
+        virtual_switches = cpc1.virtual_switches.list()
+        self.assertEqual(len(virtual_switches), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -181,7 +181,7 @@ class AdapterManager(BaseManager):
 
         Returns:
 
-          Adapter:
+          :class:`~zhmcclient.Adapter`:
             The resource object for the new HiperSockets Adapter.
             The object will have its 'object-uri' property set as returned by
             the HMC, and will also have the input properties set.

--- a/zhmcclient_mock/__init__.py
+++ b/zhmcclient_mock/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+zhmcclient_mock - Unit test support for users of the zhmcclient package.
+"""
+
+from __future__ import absolute_import
+
+from ._hmc import *           # noqa: F401

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -1,0 +1,1014 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The `zhmcclient_mock` package provides a faked HMC with all resources that are
+relevant for the `zhmcclient` package. The faked HMC is implemented as a
+local Python object and maintains its resource state across operations.
+"""
+
+from __future__ import absolute_import
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+import six
+# from six.moves.urllib.parse import urlparse, parse_qsl
+
+# TODO: Move the resources into their own files.
+
+__all__ = ['FakedBaseResource', 'FakedBaseManager', 'FakedHmc',
+           'FakedActivationProfileManager', 'FakedActivationProfile',
+           'FakedAdapterManager', 'FakedAdapter',
+           'FakedCpcManager', 'FakedCpc',
+           'FakedHbaManager', 'FakedHba',
+           'FakedLparManager', 'FakedLpar',
+           'FakedNicManager', 'FakedNic',
+           'FakedPartitionManager', 'FakedPartition',
+           'FakedPortManager', 'FakedPort',
+           'FakedVirtualFunctionManager', 'FakedVirtualFunction',
+           'FakedVirtualSwitchManager', 'FakedVirtualSwitch',
+           ]
+
+
+class FakedBaseResource(object):
+    """
+    A base class for faked resource classes in the faked HMC.
+    """
+
+    def __init__(self, manager, properties):
+        self._manager = manager
+        self._properties = properties
+
+        if self.manager.oid_prop not in self.properties:
+            new_oid = self.manager._new_oid()
+            self.properties[self.manager.oid_prop] = new_oid
+        self._oid = self.properties[self.manager.oid_prop]
+
+        if self.manager.uri_prop not in self.properties:
+            new_uri = self.manager.base_uri + '/' + self.oid
+            self.properties[self.manager.uri_prop] = new_uri
+        self._uri = self.properties[self.manager.uri_prop]
+
+    @property
+    def manager(self):
+        """
+        The manager for this resource (a derived class of
+        :class:`~zhmcclient_mock.FakedBaseManager`).
+        """
+        return self._manager
+
+    @property
+    def properties(self):
+        """
+        The properties of this resource (a dictionary).
+        """
+        return self._properties
+
+    @property
+    def oid(self):
+        """
+        The object ID (property 'object-id' or 'element-id') of this resource.
+        """
+        return self._oid
+
+    @property
+    def uri(self):
+        """
+        The object URI (property 'object-uri' or 'element-uri') of this
+        resource.
+        """
+        return self._uri
+
+
+class FakedBaseManager(object):
+    """
+    A base class for manager classes for faked resources in the faked HMC.
+    """
+
+    api_root = '/api'  # root of all resource URIs
+    next_oid = 1  # next object ID, for auto-generating them
+
+    def __init__(self, parent, resource_class, base_uri, oid_prop, uri_prop):
+        self._parent = parent
+        self._resource_class = resource_class
+        self._base_uri = base_uri  # Base URI for resources of this type
+        self._oid_prop = oid_prop
+        self._uri_prop = uri_prop
+        self._resources = OrderedDict()  # Resource objects, by object ID
+
+    @property
+    def parent(self):
+        """
+        The parent (scoping resource) for this manager (an object of a derived
+        class of :class:`~zhmcclient_mock.FakedBaseResource`).
+        """
+        return self._parent
+
+    @property
+    def resource_class(self):
+        """
+        The resource class managed by this manager (a derived class of
+        :class:`~zhmcclient_mock.FakedBaseResource`).
+        """
+        return self._resource_class
+
+    @property
+    def base_uri(self):
+        """
+        The base URI for URIs of resources managed by this manager.
+        """
+        return self._base_uri
+
+    @property
+    def oid_prop(self):
+        """
+        The name of the resource property for the object ID ('object-id' or
+        'element-id').
+        """
+        return self._oid_prop
+
+    @property
+    def uri_prop(self):
+        """
+        The name of the resource property for the object URI ('object-uri' or
+        'element-uri').
+        """
+        return self._uri_prop
+
+    def _new_oid(self):
+        new_oid = self.next_oid
+        self.next_oid += 1
+        return str(new_oid)
+
+    def add(self, properties):
+        """
+        Add a faked resource to this manager.
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property (e.g. 'object-uri') or the
+            object ID property (e.g. 'object-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          FakedBaseResource: The faked resource object.
+        """
+        resource = self.resource_class(self, properties)
+        self._resources[resource.oid] = resource
+        return resource
+
+    def remove(self, oid):
+        """
+        Remove a faked resource from this manager.
+
+        Parameters:
+
+          oid (string):
+            The object ID of the resource (e.g. value of the 'object-uri'
+            property).
+        """
+        del self._resources[oid]
+
+    def list(self):
+        """
+        List the faked resources of this manager.
+
+        Returns:
+          list of FakedBaseResource: The faked resource objects of this
+            manager.
+        """
+        return list(six.itervalues(self._resources))
+
+    def lookup_by_oid(self, oid):
+        """
+        Look up a faked resource by its object ID.
+
+        Parameters:
+
+          oid (string):
+            The object ID of the faked resource (e.g. value of the 'object-uri'
+            property).
+
+        Returns:
+          FakedBaseResource: The faked resource object.
+
+        Raises:
+          KeyError: No resource found for this object ID.
+        """
+        return self._resources[oid]
+
+
+class FakedHmc(FakedBaseResource):
+    """
+    A faked HMC.
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common metrhods and attributes.
+
+    An object of this class represents a faked HMC that can have all faked
+    resources that are relevant for the zhmcclient package.
+
+    The Python API to this class and its child resource classes is not
+    compatible with the zhmcclient API. Instead, these classes serve as an
+    in-memory backend for a faked session class (see
+    :class:`zhmcclient_mock.FakedSession`) that replaces the
+    normal :class:`zhmcclient.Session` class.
+
+    Objects of this class should not be created by the user. Instead,
+    access the :attr:`zhmcclient_mock.FakedSession.hmc` attribute.
+    """
+
+    def __init__(self, hmc_name, hmc_version, api_version):
+        self.hmc_name = hmc_name
+        self.hmc_version = hmc_version
+        self.api_version = api_version
+        self.special_operations = {}  # user-provided operations
+        self.cpcs = FakedCpcManager(client=self)
+
+    def add_resources(self, resources):
+        """
+        Add faked resources to the faked HMC, from the provided resource
+        definitions.
+
+        Duplicate resource names in the same scope are not permitted.
+
+        Although this method is typically used to initially load the faked
+        HMC with resource state just once, it can be invoked multiple times.
+
+        Parameters:
+
+          resources (dict):
+            Definitions of faked resources to be added, see example below.
+
+        Example for 'resources' parameter::
+
+            resources = {
+                'cpcs': [  # name of manager attribute for this resource
+                    {
+                        'properties': {
+                            # object-id is not provided -> auto-generated
+                            # object-uri is not provided -> auto-generated
+                            'name': 'cpc_1',
+                            . . .  # more properties
+                        },
+                        'adapters': [  # name of manager attribute for this
+                                       # resource
+                            {
+                                'properties': {
+                                    'object-id': '123',
+                                    'object-uri': '/api/cpcs/../adapters/123',
+                                    'name': 'ad_1',
+                                    . . .  # more properties
+                                },
+                                'ports': [
+                                    {
+                                        'properties': {
+                                            # element-id is auto-generated
+                                            # element-uri is auto-generated
+                                            'name': 'port_1',
+                                            . . .  # more properties
+                                        }
+                                    },
+                                    . . .  # more Ports
+                                ],
+                            },
+                            . . .  # more Adapters
+                        ],
+                        . . .  # more CPC child resources of other types
+                    },
+                    . . .  # more CPCs
+                ]
+            }
+        """
+        for child_attr in resources:
+            child_list = resources[child_attr]
+            self._process_child_list(self, child_attr, child_list)
+
+    def _process_child_list(self, parent_resource, child_attr, child_list):
+        child_manager = getattr(parent_resource, child_attr, None)
+        if child_manager is None:
+            raise ValueError("Invalid child resource type specified in "
+                             "resource dictionary: {}".format(child_attr))
+        for child_dict in child_list:
+            # child_dict is a dict of 'properties' and grand child resources
+            properties = child_dict.get('properties', None)
+            if properties is None:
+                raise ValueError("A resource for resource type {} has no"
+                                 "properties specified.".format(child_attr))
+            child_resource = child_manager.add(properties)
+            for grandchild_attr in child_dict:
+                if grandchild_attr == 'properties':
+                    continue
+                grandchild_list = child_dict[grandchild_attr]
+                self._process_child_list(child_resource, grandchild_attr,
+                                         grandchild_list)
+
+    @staticmethod
+    def _assert_op_key(i, op, key):
+        if key not in op:
+            raise ValueError("Missing '{}' key in operations item #{}".
+                             format(key, i))
+
+    def get(self, uri, logon_required):
+        raise NotImplemented("TODO: Implement his method via the faked HMC.")
+
+    def post(self, uri, body, logon_required, wait_for_completion):
+        raise NotImplemented("TODO: Implement his method via the faked HMC.")
+
+    def delete(self, uri, logon_required):
+        raise NotImplemented("TODO: Implement his method via the faked HMC.")
+
+
+class FakedActivationProfileManager(FakedBaseManager):
+    """
+    A manager for faked Activation Profile resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc, profile_type):
+        activation_profiles = profile_type + '-activation-profiles'
+        super(FakedActivationProfileManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedActivationProfile,
+            base_uri=cpc.uri + '/' + activation_profiles,
+            oid_prop='object-id',
+            uri_prop='object-uri')
+        self._profile_type = profile_type
+
+    @property
+    def profile_type(self):
+        """
+        Type of the activation profile ('reset', 'image', 'load').
+        """
+        return self._profile_type
+
+
+class FakedActivationProfile(FakedBaseResource):
+    """
+    A faked Activation Profile resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedActivationProfile, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedAdapterManager(FakedBaseManager):
+    """
+    A manager for faked Adapter resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc):
+        super(FakedAdapterManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedAdapter,
+            base_uri=self.api_root + '/adapters',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedAdapter(FakedBaseResource):
+    """
+    A faked Adapter resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedAdapter, self).__init__(
+            manager=manager,
+            properties=properties)
+        self._ports = FakedPortManager(adapter=self)
+
+    @property
+    def ports(self):
+        """
+        The Port resources of this Adapter
+        (:class:`~zhmcclient_mock.FakedPort`).
+        """
+        return self._ports
+
+
+class FakedCpcManager(FakedBaseManager):
+    """
+    A manager for faked CPC resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, client):
+        super(FakedCpcManager, self).__init__(
+            parent=client,
+            resource_class=FakedCpc,
+            base_uri=self.api_root + '/cpcs',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedCpc(FakedBaseResource):
+    """
+    A faked CPC resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedCpc, self).__init__(
+            manager=manager,
+            properties=properties)
+        self._lpars = FakedLparManager(cpc=self)
+        self._partitions = FakedPartitionManager(cpc=self)
+        self._adapters = FakedAdapterManager(cpc=self)
+        self._virtual_switches = FakedVirtualSwitchManager(cpc=self)
+        self._reset_activation_profiles = FakedActivationProfileManager(
+            cpc=self, profile_type='reset')
+        self._image_activation_profiles = FakedActivationProfileManager(
+            cpc=self, profile_type='image')
+        self._load_activation_profiles = FakedActivationProfileManager(
+            cpc=self, profile_type='load')
+
+    @property
+    def lpars(self):
+        """
+        :class:`~zhmcclient_mock.FakedLparManager`: Access to the faked LPAR
+        resources of this CPC.
+        """
+        return self._lpars
+
+    @property
+    def partitions(self):
+        """
+        :class:`~zhmcclient_mock.FakedPartitionManager`: Access to the faked
+        Partition resources of this CPC.
+        """
+        return self._partitions
+
+    @property
+    def adapters(self):
+        """
+        :class:`~zhmcclient_mock.FakedAdapterManager`: Access to the faked
+        Adapter resources of this CPC.
+        """
+        return self._adapters
+
+    @property
+    def virtual_switches(self):
+        """
+        :class:`~zhmcclient_mock.FakedVirtualSwitchManager`: Access to the
+        faked Virtual Switch resources of this CPC.
+        """
+        return self._virtual_switches
+
+    @property
+    def reset_activation_profiles(self):
+        """
+        :class:`~zhmcclient_mock.FakedActivationProfileManager`: Access to the
+        faked Reset Activation Profile resources of this CPC.
+        """
+        return self._reset_activation_profiles
+
+    @property
+    def image_activation_profiles(self):
+        """
+        :class:`~zhmcclient_mock.FakedActivationProfileManager`: Access to the
+        faked Image Activation Profile resources of this CPC.
+        """
+        return self._image_activation_profiles
+
+    @property
+    def load_activation_profiles(self):
+        """
+        :class:`~zhmcclient_mock.FakedActivationProfileManager`: Access to the
+        faked Load Activation Profile resources of this CPC.
+        """
+        return self._load_activation_profiles
+
+
+class FakedHbaManager(FakedBaseManager):
+    """
+    A manager for faked HBA resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, partition):
+        super(FakedHbaManager, self).__init__(
+            parent=partition,
+            resource_class=FakedHba,
+            base_uri=partition.uri + '/hbas',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a faked HBA resource to this manager.
+
+        This method also updates the 'hba-uris' property in the parent
+        Partition resource (if it exists).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          :class:`zhmcclient_mock.FakedHba`: The faked resource object.
+        """
+        new_hba = super(FakedHbaManager, self).add(properties)
+        partition = self.parent
+        if 'hba-uris' in partition.properties:
+            partition.properties['hba-uris'].append(new_hba.uri)
+        return new_hba
+
+    def remove(self, oid):
+        """
+        Remove a faked HBA resource from this manager.
+
+        This method also updates the 'hba-uris' property in the parent
+        Partition resource (if it exists).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the faked HBA resource.
+        """
+        hba = self.lookup_by_oid(oid)
+        partition = self.parent
+        if 'hba-uris' in partition.properties:
+            del partition.properties['hba-uris'][hba.uri]
+        super(FakedHbaManager, self).remove(oid)  # deletes the resource
+
+
+class FakedHba(FakedBaseResource):
+    """
+    A faked HBA resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedHba, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedLparManager(FakedBaseManager):
+    """
+    A manager for faked LPAR resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc):
+        super(FakedLparManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedLpar,
+            base_uri=self.api_root + '/logical-partitions',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedLpar(FakedBaseResource):
+    """
+    A faked LPAR resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedLpar, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedNicManager(FakedBaseManager):
+    """
+    A manager for faked NIC resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, partition):
+        super(FakedNicManager, self).__init__(
+            parent=partition,
+            resource_class=FakedNic,
+            base_uri=partition.uri + '/nics',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a faked NIC resource to this manager.
+
+        This method also updates the 'nic-uris' property in the parent
+        Partition resource (if it exists).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          :class:`zhmcclient_mock.FakedNic`: The faked resource object.
+        """
+        new_nic = super(FakedNicManager, self).add(properties)
+        partition = self.parent
+        if 'nic-uris' in partition.properties:
+            partition.properties['nic-uris'].append(new_nic.uri)
+        return new_nic
+
+    def remove(self, oid):
+        """
+        Remove a faked NIC resource from this manager.
+
+        This method also updates the 'nic-uris' property in the parent
+        Partition resource (if it exists).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the faked NIC resource.
+        """
+        nic = self.lookup_by_oid(oid)
+        partition = self.parent
+        if 'nic-uris' in partition.properties:
+            del partition.properties['nic-uris'][nic.uri]
+        super(FakedNicManager, self).remove(oid)  # deletes the resource
+
+
+class FakedNic(FakedBaseResource):
+    """
+    A faked NIC resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedNic, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedPartitionManager(FakedBaseManager):
+    """
+    A manager for faked Partition resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc):
+        super(FakedPartitionManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedPartition,
+            base_uri=self.api_root + '/partitions',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedPartition(FakedBaseResource):
+    """
+    A faked Partition resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedPartition, self).__init__(
+            manager=manager,
+            properties=properties)
+        self._nics = FakedNicManager(partition=self)
+        self._hbas = FakedHbaManager(partition=self)
+        self._virtual_functions = FakedVirtualFunctionManager(partition=self)
+
+    @property
+    def nics(self):
+        """
+        :class:`~zhmcclient_mock.FakedNicManager`: Access to the faked NIC
+        resources of this Partition.
+        """
+        return self._nics
+
+    @property
+    def hbas(self):
+        """
+        :class:`~zhmcclient_mock.FakedHbaManager`: Access to the faked HBA
+        resources of this Partition.
+        """
+        return self._hbas
+
+    @property
+    def virtual_functions(self):
+        """
+        :class:`~zhmcclient_mock.FakedVirtualFunctionManager`: Access to the
+        faked Virtual Function resources of this Partition.
+        """
+        return self._virtual_functions
+
+
+class FakedPortManager(FakedBaseManager):
+    """
+    A manager for faked Adapter Port resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, adapter):
+        super(FakedPortManager, self).__init__(
+            parent=adapter,
+            resource_class=FakedPort,
+            base_uri=adapter.uri + '/ports',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a faked Port resource to this manager.
+
+        This method also updates the 'network-port-uris' or 'storage-port-uris'
+        property in the parent Adapter resource (whichever exists, gets
+        updated).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          :class:`zhmcclient_mock.FakedPort`: The resource object.
+        """
+        new_port = super(FakedPortManager, self).add(properties)
+        adapter = self.parent
+        if 'network-port-uris' in adapter.properties:
+            adapter.properties['network-port-uris'].append(new_port.uri)
+        elif 'storage-port-uris' in adapter.properties:
+            adapter.properties['storage-port-uris'].append(new_port.uri)
+        return new_port
+
+    def remove(self, oid):
+        """
+        Remove a faked Port resource from this manager.
+
+        This method also updates the 'network-port-uris' or 'storage-port-uris'
+        property in the parent Adapter resource (whichever exists, gets
+        updated).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the Port resource.
+        """
+        port = self.lookup_by_oid(oid)
+        adapter = self.parent
+        if 'network-port-uris' in adapter.properties:
+            del adapter.properties['network-port-uris'][port.uri]
+        elif 'storage-port-uris' in adapter.properties:
+            del adapter.properties['storage-port-uris'][port.uri]
+        super(FakedPortManager, self).remove(oid)  # deletes the resource
+
+
+class FakedPort(FakedBaseResource):
+    """
+    A faked Adapter Port resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedPort, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedVirtualFunctionManager(FakedBaseManager):
+    """
+    A manager for faked Virtual Function resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, partition):
+        super(FakedVirtualFunctionManager, self).__init__(
+            parent=partition,
+            resource_class=FakedVirtualFunction,
+            base_uri=partition.uri + '/virtual-functions',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a faked Virtual Function resource to this manager.
+
+        This method also updates the 'virtual-function-uris' property in the
+        parent Partition resource (if it exists).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          :class:`zhmcclient_mock.FakedVirtualFunction`: The faked resource
+            object.
+        """
+        new_virtual_function = super(FakedVirtualFunctionManager,
+                                     self).add(properties)
+        partition = self.parent
+        if 'virtual-function-uris' in partition.properties:
+            partition.properties['virtual-function-uris'].append(
+                new_virtual_function.uri)
+        return new_virtual_function
+
+    def remove(self, oid):
+        """
+        Remove a faked Virtual Function resource from this manager.
+
+        This method also updates the 'virtual-function-uris' property in the
+        parent Partition resource (if it exists).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the faked Virtual Function resource.
+        """
+        virtual_function = self.lookup_by_oid(oid)
+        partition = self.parent
+        if 'virtual-function-uris' in partition.properties:
+            vf_uris = partition.properties['virtual-function-uris']
+            del vf_uris[virtual_function.uri]
+        super(FakedVirtualFunctionManager, self).remove(oid)  # deletes res.
+
+
+class FakedVirtualFunction(FakedBaseResource):
+    """
+    A faked Virtual Function resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedVirtualFunction, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedVirtualSwitchManager(FakedBaseManager):
+    """
+    A manager for faked Virtual Switch resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc):
+        super(FakedVirtualSwitchManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedVirtualSwitch,
+            base_uri=self.api_root + '/virtual-switches',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedVirtualSwitch(FakedBaseResource):
+    """
+    A faked Virtual Switch resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedVirtualSwitch, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+URLS = (
+
+    # In all modes:
+    '/api/cpcs', 'CpcsHandler',
+    '/api/cpcs/(.*)', 'CpcHandler',
+    '/api/version', 'VersionHandler',
+
+    # Only in DPM mode:
+    '/api/cpcs/(.*)/operations/start', 'CpcStartHandler',
+    '/api/cpcs', 'CpcsHandler',
+    '/api/cpcs/(.*)', 'CpcHandler',
+    '/api/version', 'VersionHandler',
+
+    # Only in DPM mode:
+    '/api/cpcs/(.*)/operations/start', 'CpcStartHandler',
+    '/api/cpcs/(.*)/operations/stop', 'CpcStopHandler',
+    '/api/cpcs/(.*)/operations/export-port-names-list',
+    'CpcExportPortNamesListHandler',
+    '/api/cpcs/(.*)/adapters', 'AdaptersHandler',
+    '/api/adapters/(.*)', 'AdapterHandler',
+    '/api/adapters/(.*)/network-ports/(.*)', 'NetworkPortHandler',
+    '/api/adapters/(.*)/storage-ports/(.*)', 'StoragePortHandler',
+    '/api/cpcs/(.*)/partitions', 'PartitionsHandler',
+    '/api/partitions/(.*)', 'PartitionHandler',
+    '/api/partitions/(.*)/operations/start', 'PartitionStartHandler',
+    '/api/partitions/(.*)/operations/stop', 'PartitionStopHandler',
+    '/api/partitions/(.*)/operations/scsi-dump', 'PartitionScsiDumpHandler',
+    '/api/partitions/(.*)/operations/psw-restart',
+    'PartitionPswRestartHandler',
+    '/api/partitions/(.*)/operations/mount-iso-image',
+    'PartitionMountIsoImageHandler',
+    '/api/partitions/(.*)/operations/unmount-iso-image',
+    'PartitionUnmountIsoImageHandler',
+    '/api/partitions/(.*)/hbas', 'HbasHandler',
+    '/api/partitions/(.*)/hbas/(.*)', 'HbaHandler',
+    '/api/partitions/(.*)/hbas/(.*)/operations/reassign-storage-adapter-port',
+    'HbaReassignPortHandler',
+    '/api/partitions/(.*)/nics', 'NicsHandler',
+    '/api/partitions/(.*)/nics/(.*)', 'NicHandler',
+    '/api/partitions/(.*)/virtual-functions', 'VirtualFunctionsHandler',
+    '/api/partitions/(.*)/virtual-functions/(.*)', 'VirtualFunctionHandler',
+    '/api/cpcs/(.*)/virtual-switches', 'VirtualSwitchesHandler',
+    '/api/virtual-switches/(.*)', 'VirtualSwitchHandler',
+    '/api/virtual-switches/(.*)/operations/get-connected-vnics',
+    'VirtualSwitchGetVnicsHandler',
+
+    # Only in classic (or ensemble) mode:
+    # '/api/cpcs/(.*)/operations/activate', 'CpcActivateHandler',
+    # '/api/cpcs/(.*)/operations/deactivate', 'CpcDeactivateHandler',
+    '/api/cpcs/(.*)/operations/import-profiles', 'CpcImportProfilesHandler',
+    '/api/cpcs/(.*)/operations/export-profiles', 'CpcExportProfilesHandler',
+    '/api/cpcs/(.*)/logical-partitions', 'LparsHandler',
+    '/api/logical-partitions/(.*)', 'LparHandler',
+    '/api/logical-partitions/(.*)/operations/activate', 'LparActivateHandler',
+    '/api/logical-partitions/(.*)/operations/deactivate',
+    'LparDeactivateHandler',
+    '/api/logical-partitions/(.*)/operations/load', 'LparLoadHandler',
+    '/api/cpcs/(.*)/reset-activation-profiles', 'ResetActProfilesHandler',
+    '/api/cpcs/(.*)/reset-activation-profiles/(.*)', 'ResetActProfileHandler',
+    '/api/cpcs/(.*)/image-activation-profiles', 'ImageActProfilesHandler',
+    '/api/cpcs/(.*)/image-activation-profiles/(.*)', 'ImageActProfileHandler',
+    '/api/cpcs/(.*)/load-activation-profiles', 'LoadActProfilesHandler',
+    '/api/cpcs/(.*)/load-activation-profiles/(.*)', 'LoadActProfileHandler',
+)


### PR DESCRIPTION
This is stage 1 of the mocking support according to the design described in PR #144. This stage provides a faked HMC. This stage is now complete and covers all resource types supported by the zhmcclient.

The stages have been split for easier reviewing. However, the two PRs should be merged at the same time once both have been approved.

A separate stage 2 in PR #160 will provide a faked Session object that links the zhmcclient package with the faked HMC.

Details:

- Added support for a faked HMC that provides a local in-memory representation of an HMC. Its API is intended to be used by a future faked Session object (which is the reason it is not compatible with the external zhmcclient API).