### PR TITLE
Mocking support for zhmcclient, stage 2: Faked Session (partially).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ doc_dependent_files := \
     $(wildcard $(doc_conf_dir)/*.rst) \
     $(wildcard $(doc_conf_dir)/notebooks/*.ipynb) \
     $(wildcard $(package_name)/*.py) \
+    $(wildcard zhmcclient_mock/*.py) \
 
 # Flake8 config file
 flake8_rc_file := setup.cfg
@@ -87,8 +88,10 @@ pylint_rc_file := .pylintrc
 check_py_files := \
     setup.py \
     $(wildcard $(package_name)/*.py) \
+    $(wildcard zhmcclient_mock/*.py) \
     $(wildcard $(cli_package_name)/*.py) \
     $(wildcard tests/unit/*.py) \
+    $(wildcard tests/unit/zhmcclient_mock/*.py) \
     $(wildcard tests/function/*.py) \
     $(wildcard docs/notebooks/*.py) \
 
@@ -289,7 +292,7 @@ flake8.log: Makefile $(flake8_rc_file) $(check_py_files)
 	mv -f $@.tmp $@
 	@echo 'Done: Created Flake8 log file: $@'
 
-$(test_log_file): Makefile $(package_name)/*.py tests/unit/*.py tests/function/*.py .coveragerc
+$(test_log_file): Makefile $(package_name)/*.py zhmcclient_mock/*.py tests/unit/*.py tests/unit/zhmcclient_mock/*.py tests/function/*.py .coveragerc
 	rm -fv $@
 	bash -c 'set -o pipefail; PYTHONWARNINGS=default py.test --cov $(package_name) --cov-config .coveragerc --cov-report=html $(pytest_opts) -s 2>&1 |tee $@.tmp'
 	mv -f $@.tmp $@

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,6 @@ flake8.log: Makefile $(flake8_rc_file) $(check_py_files)
 
 $(test_log_file): Makefile $(package_name)/*.py zhmcclient_mock/*.py tests/unit/*.py tests/unit/zhmcclient_mock/*.py tests/function/*.py .coveragerc
 	rm -fv $@
-	bash -c 'set -o pipefail; PYTHONWARNINGS=default py.test --cov $(package_name) --cov-config .coveragerc --cov-report=html $(pytest_opts) -s 2>&1 |tee $@.tmp'
+	bash -c 'set -o pipefail; PYTHONWARNINGS=default py.test --cov $(package_name) --cov zhmcclient_mock --cov-config .coveragerc --cov-report=html $(pytest_opts) -s 2>&1 |tee $@.tmp'
 	mv -f $@.tmp $@
 	@echo 'Done: Created test log file: $@'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,5 +28,6 @@ zhmcclient - A pure Python client library for the z Systems HMC Web Services API
    general.rst
    resources.rst
    cli.rst
+   mocksupport.rst
    development.rst
    appendix.rst

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -1,0 +1,165 @@
+.. Copyright 2016 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _`Mock support`:
+
+Mock support
+============
+
+The zhmcclient PyPI package provides unit testing support for its users via its
+`zhmcclient_mock` Python package. This package allows users of
+the zhmcclient package to easily define a mocked environment that provides
+a faked HMC that is pre-populated with resource state as needed by the test
+case, and that supports all relevant operations.
+
+The mocked environment is set up by the user by using an instance of the
+:class:`zhmcclient_mock.FakedSession` class instead of the
+:class:`zhmcclient.Session` class when setting up the zhmcclient package
+in a unit test::
+
+    import unittest
+    import zhmcclient
+    import zhmcclient_mock
+
+    class MyTests(unittest.TestCase):
+
+        def setUp(self):
+
+            self.session = zhmcclient_mock.FakedSession(
+                'fake-host', 'fake-hmc', '2.13.1', '1.8')
+            self.session.hmc.add_resources({
+                'cpcs': [
+                    {
+                        'properties': {
+                            'name': 'cpc_1',
+                            'description': 'CPC #1',
+                        },
+                        'adapters': [
+                            {
+                                'properties': {
+                                    'name': 'osa_1',
+                                    'description': 'OSA #1',
+                                },
+                                'ports': [
+                                    {
+                                        'properties': {
+                                            'name': 'osa_1_1',
+                                            'description': 'OSA #1 Port #1',
+                                        },
+                                    },
+                                ]
+                            },
+                        ]
+                    },
+                ]
+            })
+            self.client = zhmcclient.Client(self.session)
+
+        def test_list(self):
+            cpcs = self.client.cpcs.list()
+            self.assertEqual(len(cpcs), 1)
+            self.assertEqual(cpcs[0].name, 'cpc_1')
+
+In this example, the faked HMC of the faked session is preloaded with a
+CPC that has one adapter with one port. For details on the format of
+the input dictionary, see :meth:`zhmcclient_mock.FakedHmc.add_resources`.
+
+It is also possible to add resources one by one, from top to bottom,
+by using add() methods on the resource manager classes, for example see
+:meth:`zhmcclient_mock.FakedBaseManager.add`.
+
+.. _`Faked session`:
+
+Faked session
+-------------
+
+TODO: Add the faked Session class.
+
+
+.. _`Faked HMC`:
+
+Faked HMC
+---------
+
+.. automodule:: zhmcclient_mock._hmc
+
+.. autoclass:: zhmcclient_mock.FakedHmc
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedActivationProfileManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedActivationProfile
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedAdapterManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedAdapter
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedCpcManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedCpc
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedHbaManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedHba
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedLparManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedLpar
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedNicManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedNic
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPartitionManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPartition
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPortManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPort
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedVirtualFunctionManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedVirtualFunction
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedVirtualSwitchManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedVirtualSwitch
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedBaseManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedBaseResource
+   :members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifier =
 packages =
     zhmcclient
     zhmccli
+    zhmcclient_mock
 scripts =
     tools/cpcinfo
     tools/cpcdata

--- a/tests/unit/zhmcclient_mock/test_example.py
+++ b/tests/unit/zhmcclient_mock/test_example.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example unit test for a user of the zhmcclient package.
+"""
+
+from __future__ import absolute_import, print_function
+
+import requests.packages.urllib3
+import unittest
+import zhmcclient
+import zhmcclient_mock
+
+
+class MyTests(unittest.TestCase):
+
+    @staticmethod
+    def create_session_1():
+        """
+        Demonstrate how to populate a faked session with resources defined
+        in a resource dictionary.
+        """
+        session = zhmcclient_mock.FakedSession('fake-host', 'fake-hmc',
+                                               '2.13.1', '1.8')
+        session.hmc.add_resources({
+            'cpcs': [
+                {
+                    'properties': {
+                        # object-id is auto-generated
+                        # object-uri is auto-generated
+                        'name': 'cpc_1',
+                        'dpm-enabled': False,
+                        'description': 'CPC #1',
+                    },
+                    'lpars': [
+                        {
+                            'properties': {
+                                # object-id is auto-generated
+                                # object-uri is auto-generated
+                                'name': 'lpar_1',
+                                'description': 'LPAR #1 in CPC #1',
+                            },
+                        },
+                    ],
+                },
+                {
+                    'properties': {
+                        # object-id is auto-generated
+                        # object-uri is auto-generated
+                        'name': 'cpc_2',
+                        'dpm-enabled': True,
+                        'description': 'CPC #2',
+                    },
+                    'partitions': [
+                        {
+                            'properties': {
+                                # object-id is auto-generated
+                                # object-uri is auto-generated
+                                'name': 'partition_1',
+                                'description': 'Partition #1 in CPC #2',
+                            },
+                        },
+                    ],
+                    'adapters': [
+                        {
+                            'properties': {
+                                # object-id is auto-generated
+                                # object-uri is auto-generated
+                                'name': 'osa_1',
+                                'description': 'OSA #1 in CPC #2',
+                                'type': 'osd',
+                            },
+                            'ports': [
+                                {
+                                    'properties': {
+                                        # element-id is auto-generated
+                                        # element-uri is auto-generated
+                                        'name': 'osa_1_port_1',
+                                        'description': 'Port #1 of OSA #1',
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        })
+        return session
+
+    @staticmethod
+    def create_session_2():
+        """
+        Demonstrate how to populate a faked session with resources one by one.
+        """
+        session = zhmcclient_mock.FakedSession('fake-host', 'fake-hmc',
+                                               '2.13.1', '1.8')
+        cpc1 = session.hmc.cpcs.add({
+            # object-id is auto-generated
+            # object-uri is auto-generated
+            'name': 'cpc_1',
+            'dpm-enabled': False,
+            'description': 'CPC #1',
+        })
+        cpc1.lpars.add({
+            # object-id is auto-generated
+            # object-uri is auto-generated
+            'name': 'lpar_1',
+            'description': 'LPAR #1 in CPC #1',
+        })
+        cpc2 = session.hmc.cpcs.add({
+            # object-id is auto-generated
+            # object-uri is auto-generated
+            'name': 'cpc_2',
+            'dpm-enabled': True,
+            'description': 'CPC #2',
+        })
+        cpc2.partitions.add({
+            # object-id is auto-generated
+            # object-uri is auto-generated
+            'name': 'partition_1',
+            'description': 'Partition #1 in CPC #2',
+        })
+        adapter1 = cpc2.adapters.add({
+            # object-id is auto-generated
+            # object-uri is auto-generated
+            'name': 'osa_1',
+            'description': 'OSA #1 in CPC #2',
+            'type': 'osd',
+        })
+        adapter1.ports.add({
+            # element-id is auto-generated
+            # element-uri is auto-generated
+            'name': 'osa_1_port_1',
+            'description': 'Port #1 of OSA #1',
+        })
+        return session
+
+    def check(self):
+        """
+        Check the faked session and its faked HMC.
+        """
+
+        self.assertEqual(self.session.host, 'fake-host')
+
+        self.assertEqual(self.client.version_info(), (1, 8))
+
+        cpcs = self.client.cpcs.list()
+        self.assertEqual(len(cpcs), 2)
+
+        cpc1 = cpcs[0]  # a CPC in classic mode
+        self.assertEqual(cpc1.get_property('name'), 'cpc_1')
+        self.assertFalse(cpc1.dpm_enabled)
+
+        lpars = cpc1.lpars.list()
+        self.assertEqual(len(lpars), 1)
+        lpar1 = lpars[0]
+        self.assertEqual(lpar1.get_property('name'), 'lpar_1')
+
+        cpc2 = cpcs[1]  # a CPC in DPM mode
+        self.assertEqual(cpc2.get_property('name'), 'cpc_2')
+        self.assertTrue(cpc2.dpm_enabled)
+
+        partitions = cpc2.partitions.list()
+        self.assertEqual(len(partitions), 1)
+        partition1 = partitions[0]
+        self.assertEqual(partition1.get_property('name'), 'partition_1')
+
+        adapters = cpc2.adapters.list()
+        self.assertEqual(len(adapters), 1)
+        adapter1 = adapters[0]
+        self.assertEqual(adapter1.get_property('name'), 'osa_1')
+
+        ports = adapter1.ports.list()
+        self.assertEqual(len(ports), 1)
+        port1 = ports[0]
+        self.assertEqual(port1.get_property('name'), 'osa_1_port_1')
+
+    def test_session_1(self):
+        self.session = self.create_session_1()
+        self.client = zhmcclient.Client(self.session)
+        self.check()
+
+    def test_session_2(self):
+        self.session = self.create_session_2()
+        self.client = zhmcclient.Client(self.session)
+        self.check()
+
+
+if __name__ == '__main__':
+    requests.packages.urllib3.disable_warnings()
+    unittest.main()

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -114,7 +114,7 @@ class FakedHmcTests(unittest.TestCase):
 
     def test_res_dict(self):
         cpc1_in_props = {'name': 'cpc1'}
-        adapter1_in_props = {'name': 'osa1'}
+        adapter1_in_props = {'name': 'osa1', 'adapter-family': 'hipersockets'}
         port1_in_props = {'name': 'osa1_1'}
 
         rd = {
@@ -219,7 +219,7 @@ class FakedActivationProfileTests(unittest.TestCase):
                               FakedActivationProfileManager)
         self.assertEqual(cpc1.reset_activation_profiles.profile_type, 'reset')
         self.assertRegexpMatches(cpc1.reset_activation_profiles.base_uri,
-                                 r'/api/cpcs/.*/reset-activation-profiles')
+                                 r'/api/cpcs/[^/]+/reset-activation-profiles')
 
         # Test image activation profiles
 
@@ -227,7 +227,7 @@ class FakedActivationProfileTests(unittest.TestCase):
                               FakedActivationProfileManager)
         self.assertEqual(cpc1.image_activation_profiles.profile_type, 'image')
         self.assertRegexpMatches(cpc1.image_activation_profiles.base_uri,
-                                 r'/api/cpcs/.*/image-activation-profiles')
+                                 r'/api/cpcs/[^/]+/image-activation-profiles')
 
         # Test load activation profiles
 
@@ -235,7 +235,7 @@ class FakedActivationProfileTests(unittest.TestCase):
                               FakedActivationProfileManager)
         self.assertEqual(cpc1.load_activation_profiles.profile_type, 'load')
         self.assertRegexpMatches(cpc1.load_activation_profiles.base_uri,
-                                 r'/api/cpcs/.*/load-activation-profiles')
+                                 r'/api/cpcs/[^/]+/load-activation-profiles')
 
     def test_profiles_list(self):
         """Test list() of FakedActivationProfileManager."""
@@ -250,8 +250,8 @@ class FakedActivationProfileTests(unittest.TestCase):
         resetprofile1 = resetprofiles[0]
         resetprofile1_out_props = self.resetprofile1_in_props.copy()
         resetprofile1_out_props.update({
-            'object-id': resetprofile1.oid,
-            'object-uri': resetprofile1.uri,
+            'element-id': resetprofile1.oid,
+            'element-uri': resetprofile1.uri,
         })
         self.assertIsInstance(resetprofile1, FakedActivationProfile)
         self.assertEqual(resetprofile1.properties, resetprofile1_out_props)
@@ -265,8 +265,8 @@ class FakedActivationProfileTests(unittest.TestCase):
         imageprofile1 = imageprofiles[0]
         imageprofile1_out_props = self.imageprofile1_in_props.copy()
         imageprofile1_out_props.update({
-            'object-id': imageprofile1.oid,
-            'object-uri': imageprofile1.uri,
+            'element-id': imageprofile1.oid,
+            'element-uri': imageprofile1.uri,
         })
         self.assertIsInstance(imageprofile1, FakedActivationProfile)
         self.assertEqual(imageprofile1.properties, imageprofile1_out_props)
@@ -280,8 +280,8 @@ class FakedActivationProfileTests(unittest.TestCase):
         loadprofile1 = loadprofiles[0]
         loadprofile1_out_props = self.loadprofile1_in_props.copy()
         loadprofile1_out_props.update({
-            'object-id': loadprofile1.oid,
-            'object-uri': loadprofile1.uri,
+            'element-id': loadprofile1.oid,
+            'element-uri': loadprofile1.uri,
         })
         self.assertIsInstance(loadprofile1, FakedActivationProfile)
         self.assertEqual(loadprofile1.properties, loadprofile1_out_props)
@@ -312,8 +312,8 @@ class FakedActivationProfileTests(unittest.TestCase):
 
         resetprofile2_out_props = resetprofile2_in_props.copy()
         resetprofile2_out_props.update({
-            'object-id': resetprofile2.oid,
-            'object-uri': resetprofile2.uri,
+            'element-id': resetprofile2.oid,
+            'element-uri': resetprofile2.uri,
         })
         self.assertIsInstance(resetprofile2, FakedActivationProfile)
         self.assertEqual(resetprofile2.properties, resetprofile2_out_props)
@@ -346,7 +346,7 @@ class FakedAdapterTests(unittest.TestCase):
     def setUp(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
-        self.adapter1_in_props = {'name': 'adapter1'}
+        self.adapter1_in_props = {'name': 'adapter1', 'type': 'roce'}
         rd = {
             'cpcs': [
                 {
@@ -397,7 +397,7 @@ class FakedAdapterTests(unittest.TestCase):
         adapters = cpc1.adapters.list()
         self.assertEqual(len(adapters), 1)
 
-        adapter2_in_props = {'name': 'adapter2'}
+        adapter2_in_props = {'name': 'adapter2', 'adapter-family': 'ficon'}
 
         # the function to be tested:
         new_adapter = cpc1.adapters.add(
@@ -533,7 +533,19 @@ class FakedHbaTests(unittest.TestCase):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.partition1_in_props = {'name': 'partition1'}
-        self.hba1_in_props = {'name': 'hba1'}
+        self.adapter1_in_props = {
+            'object-id': '1',
+            'name': 'fcp1',
+            'type': 'fcp',
+        }
+        self.port1_in_props = {
+            'element-id': '1',
+            'name': 'port1',
+        }
+        self.hba1_in_props = {
+            'name': 'hba1',
+            'adapter-port-uri': '/api/adapters/1/storage-ports/1',
+        }
         rd = {
             'cpcs': [
                 {
@@ -543,6 +555,14 @@ class FakedHbaTests(unittest.TestCase):
                             'properties': self.partition1_in_props,
                             'hbas': [
                                 {'properties': self.hba1_in_props},
+                            ],
+                        },
+                    ],
+                    'adapters': [
+                        {
+                            'properties': self.adapter1_in_props,
+                            'ports': [
+                                {'properties': self.port1_in_props},
                             ],
                         },
                     ],
@@ -561,7 +581,7 @@ class FakedHbaTests(unittest.TestCase):
 
         self.assertIsInstance(partition1.hbas, FakedHbaManager)
         self.assertRegexpMatches(partition1.hbas.base_uri,
-                                 r'/api/partitions/.*/hbas')
+                                 r'/api/partitions/[^/]+/hbas')
 
     def test_hbas_list(self):
         """Test list() of FakedHbaManager."""
@@ -593,7 +613,11 @@ class FakedHbaTests(unittest.TestCase):
         hbas = partition1.hbas.list()
         self.assertEqual(len(hbas), 1)
 
-        hba2_in_props = {'name': 'hba2'}
+        hba2_in_props = {
+            'element-id': '2',
+            'name': 'hba2',
+            'adapter-port-uri': '/api/adapters/1/storage-ports/1',
+        }
 
         # the function to be tested:
         new_hba = partition1.hbas.add(
@@ -737,7 +761,19 @@ class FakedNicTests(unittest.TestCase):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.partition1_in_props = {'name': 'partition1'}
-        self.nic1_in_props = {'name': 'nic1'}
+        self.nic1_in_props = {
+            'name': 'nic1',
+            'network-adapter-port-uri': '/api/adapters/1/network-ports/1',
+        }
+        self.adapter1_in_props = {
+            'object-id': '1',
+            'name': 'roce1',
+            'type': 'roce',
+        }
+        self.port1_in_props = {
+            'element-id': '1',
+            'name': 'port1',
+        }
         rd = {
             'cpcs': [
                 {
@@ -747,6 +783,14 @@ class FakedNicTests(unittest.TestCase):
                             'properties': self.partition1_in_props,
                             'nics': [
                                 {'properties': self.nic1_in_props},
+                            ],
+                        },
+                    ],
+                    'adapters': [
+                        {
+                            'properties': self.adapter1_in_props,
+                            'ports': [
+                                {'properties': self.port1_in_props},
                             ],
                         },
                     ],
@@ -765,7 +809,7 @@ class FakedNicTests(unittest.TestCase):
 
         self.assertIsInstance(partition1.nics, FakedNicManager)
         self.assertRegexpMatches(partition1.nics.base_uri,
-                                 r'/api/partitions/.*/nics')
+                                 r'/api/partitions/[^/]+/nics')
 
     def test_nics_list(self):
         """Test list() of FakedNicManager."""
@@ -797,7 +841,10 @@ class FakedNicTests(unittest.TestCase):
         nics = partition1.nics.list()
         self.assertEqual(len(nics), 1)
 
-        nic2_in_props = {'name': 'nic2'}
+        nic2_in_props = {
+            'name': 'nic2',
+            'network-adapter-port-uri': '/api/adapters/1/network-ports/1',
+        }
 
         # the function to be tested:
         new_nic = partition1.nics.add(
@@ -940,7 +987,7 @@ class FakedPortTests(unittest.TestCase):
     def setUp(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
-        self.adapter1_in_props = {'name': 'adapter1'}
+        self.adapter1_in_props = {'name': 'adapter1', 'adapter-family': 'osa'}
         self.port1_in_props = {'name': 'port1'}
         rd = {
             'cpcs': [
@@ -969,7 +1016,7 @@ class FakedPortTests(unittest.TestCase):
 
         self.assertIsInstance(adapter1.ports, FakedPortManager)
         self.assertRegexpMatches(adapter1.ports.base_uri,
-                                 r'/api/adapters/.*/ports')
+                                 r'/api/adapters/[^/]+/network-ports')
 
     def test_ports_list(self):
         """Test list() of FakedPortManager."""
@@ -1083,7 +1130,7 @@ class FakedVirtualFunctionTests(unittest.TestCase):
         self.assertIsInstance(partition1.virtual_functions,
                               FakedVirtualFunctionManager)
         self.assertRegexpMatches(partition1.virtual_functions.base_uri,
-                                 r'/api/partitions/.*/virtual-functions')
+                                 r'/api/partitions/[^/]+/virtual-functions')
 
     def test_virtual_functions_list(self):
         """Test list() of FakedVirtualFunctionManager."""

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -1,0 +1,1267 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _hmc module of the zhmcclient_mock package.
+"""
+
+from __future__ import absolute_import, print_function
+
+import unittest
+
+from zhmcclient_mock._hmc import FakedHmc, \
+    FakedActivationProfileManager, FakedActivationProfile, \
+    FakedAdapterManager, FakedAdapter, \
+    FakedCpcManager, FakedCpc, \
+    FakedHbaManager, FakedHba, \
+    FakedLparManager, FakedLpar, \
+    FakedNicManager, FakedNic, \
+    FakedPartitionManager, FakedPartition, \
+    FakedPortManager, FakedPort, \
+    FakedVirtualFunctionManager, FakedVirtualFunction, \
+    FakedVirtualSwitchManager, FakedVirtualSwitch
+
+
+class FakedHmcTests(unittest.TestCase):
+    """All tests for the zhmcclient_mock.FakedHmc class."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+
+    def test_hmc(self):
+        self.assertEqual(self.hmc.hmc_name, 'fake-hmc')
+        self.assertEqual(self.hmc.hmc_version, '2.13.1')
+        self.assertEqual(self.hmc.api_version, '1.8')
+        self.assertIsInstance(self.hmc.cpcs, FakedCpcManager)
+
+        # the function to be tested:
+        cpcs = self.hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 0)
+
+    def test_hmc_1_cpc(self):
+        cpc1_in_props = {'name': 'cpc1'}
+
+        # the function to be tested:
+        cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
+
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+
+        # the function to be tested:
+        cpcs = self.hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 1)
+        self.assertEqual(cpcs[0], cpc1)
+
+        self.assertIsInstance(cpc1, FakedCpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+
+    def test_hmc_2_cpcs(self):
+        cpc1_in_props = {'name': 'cpc1'}
+
+        # the function to be tested:
+        cpc1 = self.hmc.cpcs.add(cpc1_in_props)
+
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+
+        cpc2_in_props = {'name': 'cpc2'}
+
+        # the function to be tested:
+        cpc2 = self.hmc.cpcs.add(cpc2_in_props)
+
+        cpc2_out_props = cpc2_in_props.copy()
+        cpc2_out_props.update({
+            'object-id': cpc2.oid,
+            'object-uri': cpc2.uri,
+        })
+
+        # the function to be tested:
+        cpcs = self.hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 2)
+        # We expect the order of addition to be maintained:
+        self.assertEqual(cpcs[0], cpc1)
+        self.assertEqual(cpcs[1], cpc2)
+
+        self.assertIsInstance(cpc1, FakedCpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+
+        self.assertIsInstance(cpc2, FakedCpc)
+        self.assertEqual(cpc2.properties, cpc2_out_props)
+        self.assertEqual(cpc2.manager, self.hmc.cpcs)
+
+    def test_res_dict(self):
+        cpc1_in_props = {'name': 'cpc1'}
+        adapter1_in_props = {'name': 'osa1'}
+        port1_in_props = {'name': 'osa1_1'}
+
+        rd = {
+            'cpcs': [
+                {
+                    'properties': cpc1_in_props,
+                    'adapters': [
+                        {
+                            'properties': adapter1_in_props,
+                            'ports': [
+                                {'properties': port1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+
+        # the function to be tested:
+        self.hmc.add_resources(rd)
+
+        cpcs = self.hmc.cpcs.list()
+
+        self.assertEqual(len(cpcs), 1)
+
+        cpc1 = cpcs[0]
+        cpc1_out_props = cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+        self.assertIsInstance(cpc1, FakedCpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+
+        cpc1_adapters = cpc1.adapters.list()
+
+        self.assertEqual(len(cpc1_adapters), 1)
+
+        adapter1 = cpc1_adapters[0]
+        adapter1_out_props = adapter1_in_props.copy()
+        adapter1_out_props.update({
+            'object-id': adapter1.oid,
+            'object-uri': adapter1.uri,
+        })
+        self.assertIsInstance(adapter1, FakedAdapter)
+        self.assertEqual(adapter1.properties, adapter1_out_props)
+        self.assertEqual(adapter1.manager, cpc1.adapters)
+
+        adapter1_ports = adapter1.ports.list()
+
+        self.assertEqual(len(adapter1_ports), 1)
+
+        port1 = adapter1_ports[0]
+        port1_out_props = port1_in_props.copy()
+        port1_out_props.update({
+            'element-id': port1.oid,
+            'element-uri': port1.uri,
+        })
+        self.assertIsInstance(port1, FakedPort)
+        self.assertEqual(port1.properties, port1_out_props)
+        self.assertEqual(port1.manager, adapter1.ports)
+
+
+class FakedActivationProfileTests(unittest.TestCase):
+    """All tests for the FakedActivationProfileManager and
+    FakedActivationProfile classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.resetprofile1_in_props = {'name': 'resetprofile1'}
+        self.imageprofile1_in_props = {'name': 'imageprofile1'}
+        self.loadprofile1_in_props = {'name': 'loadprofile1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'reset_activation_profiles': [
+                        {'properties': self.resetprofile1_in_props},
+                    ],
+                    'image_activation_profiles': [
+                        {'properties': self.imageprofile1_in_props},
+                    ],
+                    'load_activation_profiles': [
+                        {'properties': self.loadprofile1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedActivationProfileManager:
+        self.hmc.add_resources(rd)
+
+    def test_profiles_attr(self):
+        """Test CPC '*_activation_profiles' attributes."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # Test reset activation profiles
+
+        self.assertIsInstance(cpc1.reset_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertEqual(cpc1.reset_activation_profiles.profile_type, 'reset')
+        self.assertRegexpMatches(cpc1.reset_activation_profiles.base_uri,
+                                 r'/api/cpcs/.*/reset-activation-profiles')
+
+        # Test image activation profiles
+
+        self.assertIsInstance(cpc1.image_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertEqual(cpc1.image_activation_profiles.profile_type, 'image')
+        self.assertRegexpMatches(cpc1.image_activation_profiles.base_uri,
+                                 r'/api/cpcs/.*/image-activation-profiles')
+
+        # Test load activation profiles
+
+        self.assertIsInstance(cpc1.load_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertEqual(cpc1.load_activation_profiles.profile_type, 'load')
+        self.assertRegexpMatches(cpc1.load_activation_profiles.base_uri,
+                                 r'/api/cpcs/.*/load-activation-profiles')
+
+    def test_profiles_list(self):
+        """Test list() of FakedActivationProfileManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # Test reset activation profiles
+
+        resetprofiles = cpc1.reset_activation_profiles.list()
+
+        self.assertEqual(len(resetprofiles), 1)
+        resetprofile1 = resetprofiles[0]
+        resetprofile1_out_props = self.resetprofile1_in_props.copy()
+        resetprofile1_out_props.update({
+            'object-id': resetprofile1.oid,
+            'object-uri': resetprofile1.uri,
+        })
+        self.assertIsInstance(resetprofile1, FakedActivationProfile)
+        self.assertEqual(resetprofile1.properties, resetprofile1_out_props)
+        self.assertEqual(resetprofile1.manager, cpc1.reset_activation_profiles)
+
+        # Test image activation profiles
+
+        imageprofiles = cpc1.image_activation_profiles.list()
+
+        self.assertEqual(len(imageprofiles), 1)
+        imageprofile1 = imageprofiles[0]
+        imageprofile1_out_props = self.imageprofile1_in_props.copy()
+        imageprofile1_out_props.update({
+            'object-id': imageprofile1.oid,
+            'object-uri': imageprofile1.uri,
+        })
+        self.assertIsInstance(imageprofile1, FakedActivationProfile)
+        self.assertEqual(imageprofile1.properties, imageprofile1_out_props)
+        self.assertEqual(imageprofile1.manager, cpc1.image_activation_profiles)
+
+        # Test load activation profiles
+
+        loadprofiles = cpc1.load_activation_profiles.list()
+
+        self.assertEqual(len(loadprofiles), 1)
+        loadprofile1 = loadprofiles[0]
+        loadprofile1_out_props = self.loadprofile1_in_props.copy()
+        loadprofile1_out_props.update({
+            'object-id': loadprofile1.oid,
+            'object-uri': loadprofile1.uri,
+        })
+        self.assertIsInstance(loadprofile1, FakedActivationProfile)
+        self.assertEqual(loadprofile1.properties, loadprofile1_out_props)
+        self.assertEqual(loadprofile1.manager, cpc1.load_activation_profiles)
+
+    def test_profiles_add(self):
+        """Test add() of FakedActivationProfileManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        resetprofiles = cpc1.reset_activation_profiles.list()
+        self.assertEqual(len(resetprofiles), 1)
+
+        resetprofile2_in_props = {'name': 'resetprofile2'}
+
+        # the function to be tested:
+        new_resetprofile = cpc1.reset_activation_profiles.add(
+            resetprofile2_in_props)
+
+        resetprofiles = cpc1.reset_activation_profiles.list()
+        self.assertEqual(len(resetprofiles), 2)
+
+        resetprofile2 = [p for p in resetprofiles
+                         if p.properties['name'] ==
+                         resetprofile2_in_props['name']][0]
+
+        self.assertEqual(new_resetprofile.properties, resetprofile2.properties)
+        self.assertEqual(new_resetprofile.manager, resetprofile2.manager)
+
+        resetprofile2_out_props = resetprofile2_in_props.copy()
+        resetprofile2_out_props.update({
+            'object-id': resetprofile2.oid,
+            'object-uri': resetprofile2.uri,
+        })
+        self.assertIsInstance(resetprofile2, FakedActivationProfile)
+        self.assertEqual(resetprofile2.properties, resetprofile2_out_props)
+        self.assertEqual(resetprofile2.manager, cpc1.reset_activation_profiles)
+
+        # Because we know that the image and load profile managers are of the
+        # same class, we don't need to test them.
+
+    def test_profiles_remove(self):
+        """Test remove() of FakedActivationProfileManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        resetprofiles = cpc1.reset_activation_profiles.list()
+        resetprofile1 = resetprofiles[0]
+        self.assertEqual(len(resetprofiles), 1)
+
+        # the function to be tested:
+        cpc1.reset_activation_profiles.remove(resetprofile1.oid)
+
+        resetprofiles = cpc1.reset_activation_profiles.list()
+        self.assertEqual(len(resetprofiles), 0)
+
+        # Because we know that the image and load profile managers are of the
+        # same class, we don't need to test them.
+
+
+class FakedAdapterTests(unittest.TestCase):
+    """All tests for the FakedAdapterManager and FakedAdapter classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.adapter1_in_props = {'name': 'adapter1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'adapters': [
+                        {'properties': self.adapter1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedAdapterManager:
+        self.hmc.add_resources(rd)
+
+    def test_adapters_attr(self):
+        """Test CPC 'adapters' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        self.assertIsInstance(cpc1.adapters, FakedAdapterManager)
+        self.assertRegexpMatches(cpc1.adapters.base_uri, r'/api/adapters')
+
+    def test_adapters_list(self):
+        """Test list() of FakedAdapterManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # the function to be tested:
+        adapters = cpc1.adapters.list()
+
+        self.assertEqual(len(adapters), 1)
+        adapter1 = adapters[0]
+        adapter1_out_props = self.adapter1_in_props.copy()
+        adapter1_out_props.update({
+            'object-id': adapter1.oid,
+            'object-uri': adapter1.uri,
+        })
+        self.assertIsInstance(adapter1, FakedAdapter)
+        self.assertEqual(adapter1.properties, adapter1_out_props)
+        self.assertEqual(adapter1.manager, cpc1.adapters)
+
+        # Quick check of child resources:
+        self.assertIsInstance(adapter1.ports, FakedPortManager)
+
+    def test_adapters_add(self):
+        """Test add() of FakedAdapterManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        self.assertEqual(len(adapters), 1)
+
+        adapter2_in_props = {'name': 'adapter2'}
+
+        # the function to be tested:
+        new_adapter = cpc1.adapters.add(
+            adapter2_in_props)
+
+        adapters = cpc1.adapters.list()
+        self.assertEqual(len(adapters), 2)
+
+        adapter2 = [a for a in adapters
+                    if a.properties['name'] == adapter2_in_props['name']][0]
+
+        self.assertEqual(new_adapter.properties, adapter2.properties)
+        self.assertEqual(new_adapter.manager, adapter2.manager)
+
+        adapter2_out_props = adapter2_in_props.copy()
+        adapter2_out_props.update({
+            'object-id': adapter2.oid,
+            'object-uri': adapter2.uri,
+        })
+        self.assertIsInstance(adapter2, FakedAdapter)
+        self.assertEqual(adapter2.properties, adapter2_out_props)
+        self.assertEqual(adapter2.manager, cpc1.adapters)
+
+    def test_adapters_remove(self):
+        """Test remove() of FakedAdapterManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+        self.assertEqual(len(adapters), 1)
+
+        # the function to be tested:
+        cpc1.adapters.remove(adapter1.oid)
+
+        adapters = cpc1.adapters.list()
+        self.assertEqual(len(adapters), 0)
+
+
+class FakedCpcTests(unittest.TestCase):
+    """All tests for the FakedCpcManager and FakedCpc classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                },
+            ]
+        }
+        # This already uses add() of FakedCpcManager:
+        self.hmc.add_resources(rd)
+
+    def test_cpcs_attr(self):
+        """Test HMC 'cpcs' attribute."""
+        self.assertIsInstance(self.hmc.cpcs, FakedCpcManager)
+        self.assertRegexpMatches(self.hmc.cpcs.base_uri, r'/api/cpcs')
+
+    def test_cpcs_list(self):
+        """Test list() of FakedCpcManager."""
+
+        # the function to be tested:
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        cpc1_out_props = self.cpc1_in_props.copy()
+        cpc1_out_props.update({
+            'object-id': cpc1.oid,
+            'object-uri': cpc1.uri,
+        })
+        self.assertIsInstance(cpc1, FakedCpc)
+        self.assertEqual(cpc1.properties, cpc1_out_props)
+        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+
+        # Quick check of child resources:
+        self.assertIsInstance(cpc1.lpars, FakedLparManager)
+        self.assertIsInstance(cpc1.partitions, FakedPartitionManager)
+        self.assertIsInstance(cpc1.adapters, FakedAdapterManager)
+        self.assertIsInstance(cpc1.virtual_switches, FakedVirtualSwitchManager)
+        self.assertIsInstance(cpc1.reset_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertIsInstance(cpc1.image_activation_profiles,
+                              FakedActivationProfileManager)
+        self.assertIsInstance(cpc1.load_activation_profiles,
+                              FakedActivationProfileManager)
+
+    def test_cpcs_add(self):
+        """Test add() of FakedCpcManager."""
+        cpcs = self.hmc.cpcs.list()
+        self.assertEqual(len(cpcs), 1)
+
+        cpc2_in_props = {'name': 'cpc2'}
+
+        # the function to be tested:
+        new_cpc = self.hmc.cpcs.add(cpc2_in_props)
+
+        cpcs = self.hmc.cpcs.list()
+        self.assertEqual(len(cpcs), 2)
+
+        cpc2 = [cpc for cpc in cpcs
+                if cpc.properties['name'] == cpc2_in_props['name']][0]
+
+        self.assertEqual(new_cpc.properties, cpc2.properties)
+        self.assertEqual(new_cpc.manager, cpc2.manager)
+
+        cpc2_out_props = cpc2_in_props.copy()
+        cpc2_out_props.update({
+            'object-id': cpc2.oid,
+            'object-uri': cpc2.uri,
+        })
+        self.assertIsInstance(cpc2, FakedCpc)
+        self.assertEqual(cpc2.properties, cpc2_out_props)
+        self.assertEqual(cpc2.manager, self.hmc.cpcs)
+
+    def test_cpcs_remove(self):
+        """Test remove() of FakedCpcManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        self.assertEqual(len(cpcs), 1)
+
+        # the function to be tested:
+        self.hmc.cpcs.remove(cpc1.oid)
+
+        cpcs = self.hmc.cpcs.list()
+        self.assertEqual(len(cpcs), 0)
+
+
+class FakedHbaTests(unittest.TestCase):
+    """All tests for the FakedHbaManager and FakedHba classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.partition1_in_props = {'name': 'partition1'}
+        self.hba1_in_props = {'name': 'hba1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'partitions': [
+                        {
+                            'properties': self.partition1_in_props,
+                            'hbas': [
+                                {'properties': self.hba1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedHbaManager:
+        self.hmc.add_resources(rd)
+
+    def test_hbas_attr(self):
+        """Test Partition 'hbas' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        self.assertIsInstance(partition1.hbas, FakedHbaManager)
+        self.assertRegexpMatches(partition1.hbas.base_uri,
+                                 r'/api/partitions/.*/hbas')
+
+    def test_hbas_list(self):
+        """Test list() of FakedHbaManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        # the function to be tested:
+        hbas = partition1.hbas.list()
+
+        self.assertEqual(len(hbas), 1)
+        hba1 = hbas[0]
+        hba1_out_props = self.hba1_in_props.copy()
+        hba1_out_props.update({
+            'element-id': hba1.oid,
+            'element-uri': hba1.uri,
+        })
+        self.assertIsInstance(hba1, FakedHba)
+        self.assertEqual(hba1.properties, hba1_out_props)
+        self.assertEqual(hba1.manager, partition1.hbas)
+
+    def test_hbas_add(self):
+        """Test add() of FakedHbaManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        hbas = partition1.hbas.list()
+        self.assertEqual(len(hbas), 1)
+
+        hba2_in_props = {'name': 'hba2'}
+
+        # the function to be tested:
+        new_hba = partition1.hbas.add(
+            hba2_in_props)
+
+        hbas = partition1.hbas.list()
+        self.assertEqual(len(hbas), 2)
+
+        hba2 = [hba for hba in hbas
+                if hba.properties['name'] == hba2_in_props['name']][0]
+
+        self.assertEqual(new_hba.properties, hba2.properties)
+        self.assertEqual(new_hba.manager, hba2.manager)
+
+        hba2_out_props = hba2_in_props.copy()
+        hba2_out_props.update({
+            'element-id': hba2.oid,
+            'element-uri': hba2.uri,
+        })
+        self.assertIsInstance(hba2, FakedHba)
+        self.assertEqual(hba2.properties, hba2_out_props)
+        self.assertEqual(hba2.manager, partition1.hbas)
+
+    def test_hbas_remove(self):
+        """Test remove() of FakedHbaManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        hbas = partition1.hbas.list()
+        hba1 = hbas[0]
+        self.assertEqual(len(hbas), 1)
+
+        # the function to be tested:
+        partition1.hbas.remove(hba1.oid)
+
+        hbas = partition1.hbas.list()
+        self.assertEqual(len(hbas), 0)
+
+    # TODO: Add testcases for updating 'hba-uris' parent property
+
+
+class FakedLparTests(unittest.TestCase):
+    """All tests for the FakedLparManager and FakedLpar classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.lpar1_in_props = {'name': 'lpar1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'lpars': [
+                        {'properties': self.lpar1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedLparManager:
+        self.hmc.add_resources(rd)
+
+    def test_lpars_attr(self):
+        """Test CPC 'lpars' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        self.assertIsInstance(cpc1.lpars, FakedLparManager)
+        self.assertRegexpMatches(cpc1.lpars.base_uri,
+                                 r'/api/logical-partitions')
+
+    def test_lpars_list(self):
+        """Test list() of FakedLparManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # the function to be tested:
+        lpars = cpc1.lpars.list()
+
+        self.assertEqual(len(lpars), 1)
+        lpar1 = lpars[0]
+        lpar1_out_props = self.lpar1_in_props.copy()
+        lpar1_out_props.update({
+            'object-id': lpar1.oid,
+            'object-uri': lpar1.uri,
+        })
+        self.assertIsInstance(lpar1, FakedLpar)
+        self.assertEqual(lpar1.properties, lpar1_out_props)
+        self.assertEqual(lpar1.manager, cpc1.lpars)
+
+    def test_lpars_add(self):
+        """Test add() of FakedLparManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        lpars = cpc1.lpars.list()
+        self.assertEqual(len(lpars), 1)
+
+        lpar2_in_props = {'name': 'lpar2'}
+
+        # the function to be tested:
+        new_lpar = cpc1.lpars.add(
+            lpar2_in_props)
+
+        lpars = cpc1.lpars.list()
+        self.assertEqual(len(lpars), 2)
+
+        lpar2 = [p for p in lpars
+                 if p.properties['name'] == lpar2_in_props['name']][0]
+
+        self.assertEqual(new_lpar.properties, lpar2.properties)
+        self.assertEqual(new_lpar.manager, lpar2.manager)
+
+        lpar2_out_props = lpar2_in_props.copy()
+        lpar2_out_props.update({
+            'object-id': lpar2.oid,
+            'object-uri': lpar2.uri,
+        })
+        self.assertIsInstance(lpar2, FakedLpar)
+        self.assertEqual(lpar2.properties, lpar2_out_props)
+        self.assertEqual(lpar2.manager, cpc1.lpars)
+
+    def test_lpars_remove(self):
+        """Test remove() of FakedLparManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        lpars = cpc1.lpars.list()
+        lpar1 = lpars[0]
+        self.assertEqual(len(lpars), 1)
+
+        # the function to be tested:
+        cpc1.lpars.remove(lpar1.oid)
+
+        lpars = cpc1.lpars.list()
+        self.assertEqual(len(lpars), 0)
+
+
+class FakedNicTests(unittest.TestCase):
+    """All tests for the FakedNicManager and FakedNic classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.partition1_in_props = {'name': 'partition1'}
+        self.nic1_in_props = {'name': 'nic1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'partitions': [
+                        {
+                            'properties': self.partition1_in_props,
+                            'nics': [
+                                {'properties': self.nic1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedNicManager:
+        self.hmc.add_resources(rd)
+
+    def test_nics_attr(self):
+        """Test Partition 'nics' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        self.assertIsInstance(partition1.nics, FakedNicManager)
+        self.assertRegexpMatches(partition1.nics.base_uri,
+                                 r'/api/partitions/.*/nics')
+
+    def test_nics_list(self):
+        """Test list() of FakedNicManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        # the function to be tested:
+        nics = partition1.nics.list()
+
+        self.assertEqual(len(nics), 1)
+        nic1 = nics[0]
+        nic1_out_props = self.nic1_in_props.copy()
+        nic1_out_props.update({
+            'element-id': nic1.oid,
+            'element-uri': nic1.uri,
+        })
+        self.assertIsInstance(nic1, FakedNic)
+        self.assertEqual(nic1.properties, nic1_out_props)
+        self.assertEqual(nic1.manager, partition1.nics)
+
+    def test_nics_add(self):
+        """Test add() of FakedNicManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        nics = partition1.nics.list()
+        self.assertEqual(len(nics), 1)
+
+        nic2_in_props = {'name': 'nic2'}
+
+        # the function to be tested:
+        new_nic = partition1.nics.add(
+            nic2_in_props)
+
+        nics = partition1.nics.list()
+        self.assertEqual(len(nics), 2)
+
+        nic2 = [nic for nic in nics
+                if nic.properties['name'] == nic2_in_props['name']][0]
+
+        self.assertEqual(new_nic.properties, nic2.properties)
+        self.assertEqual(new_nic.manager, nic2.manager)
+
+        nic2_out_props = nic2_in_props.copy()
+        nic2_out_props.update({
+            'element-id': nic2.oid,
+            'element-uri': nic2.uri,
+        })
+        self.assertIsInstance(nic2, FakedNic)
+        self.assertEqual(nic2.properties, nic2_out_props)
+        self.assertEqual(nic2.manager, partition1.nics)
+
+    def test_nics_remove(self):
+        """Test remove() of FakedNicManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        nics = partition1.nics.list()
+        nic1 = nics[0]
+        self.assertEqual(len(nics), 1)
+
+        # the function to be tested:
+        partition1.nics.remove(nic1.oid)
+
+        nics = partition1.nics.list()
+        self.assertEqual(len(nics), 0)
+
+    # TODO: Add testcases for updating 'nic-uris' parent property
+
+
+class FakedPartitionTests(unittest.TestCase):
+    """All tests for the FakedPartitionManager and FakedPartition classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.partition1_in_props = {'name': 'partition1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'partitions': [
+                        {'properties': self.partition1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedPartitionManager:
+        self.hmc.add_resources(rd)
+
+    def test_partitions_attr(self):
+        """Test CPC 'partitions' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        self.assertIsInstance(cpc1.partitions, FakedPartitionManager)
+        self.assertRegexpMatches(cpc1.partitions.base_uri, r'/api/partitions')
+
+    def test_partitions_list(self):
+        """Test list() of FakedPartitionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # the function to be tested:
+        partitions = cpc1.partitions.list()
+
+        self.assertEqual(len(partitions), 1)
+        partition1 = partitions[0]
+        partition1_out_props = self.partition1_in_props.copy()
+        partition1_out_props.update({
+            'object-id': partition1.oid,
+            'object-uri': partition1.uri,
+        })
+        self.assertIsInstance(partition1, FakedPartition)
+        self.assertEqual(partition1.properties, partition1_out_props)
+        self.assertEqual(partition1.manager, cpc1.partitions)
+
+    def test_partitions_add(self):
+        """Test add() of FakedPartitionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        self.assertEqual(len(partitions), 1)
+
+        partition2_in_props = {'name': 'partition2'}
+
+        # the function to be tested:
+        new_partition = cpc1.partitions.add(
+            partition2_in_props)
+
+        partitions = cpc1.partitions.list()
+        self.assertEqual(len(partitions), 2)
+
+        partition2 = [p for p in partitions
+                      if p.properties['name'] ==
+                      partition2_in_props['name']][0]
+
+        self.assertEqual(new_partition.properties, partition2.properties)
+        self.assertEqual(new_partition.manager, partition2.manager)
+
+        partition2_out_props = partition2_in_props.copy()
+        partition2_out_props.update({
+            'object-id': partition2.oid,
+            'object-uri': partition2.uri,
+        })
+        self.assertIsInstance(partition2, FakedPartition)
+        self.assertEqual(partition2.properties, partition2_out_props)
+        self.assertEqual(partition2.manager, cpc1.partitions)
+
+    def test_partitions_remove(self):
+        """Test remove() of FakedPartitionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        self.assertEqual(len(partitions), 1)
+
+        # the function to be tested:
+        cpc1.partitions.remove(partition1.oid)
+
+        partitions = cpc1.partitions.list()
+        self.assertEqual(len(partitions), 0)
+
+
+class FakedPortTests(unittest.TestCase):
+    """All tests for the FakedPortManager and FakedPort classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.adapter1_in_props = {'name': 'adapter1'}
+        self.port1_in_props = {'name': 'port1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'adapters': [
+                        {
+                            'properties': self.adapter1_in_props,
+                            'ports': [
+                                {'properties': self.port1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedPortManager:
+        self.hmc.add_resources(rd)
+
+    def test_ports_attr(self):
+        """Test Adapter 'ports' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+
+        self.assertIsInstance(adapter1.ports, FakedPortManager)
+        self.assertRegexpMatches(adapter1.ports.base_uri,
+                                 r'/api/adapters/.*/ports')
+
+    def test_ports_list(self):
+        """Test list() of FakedPortManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+
+        # the function to be tested:
+        ports = adapter1.ports.list()
+
+        self.assertEqual(len(ports), 1)
+        port1 = ports[0]
+        port1_out_props = self.port1_in_props.copy()
+        port1_out_props.update({
+            'element-id': port1.oid,
+            'element-uri': port1.uri,
+        })
+        self.assertIsInstance(port1, FakedPort)
+        self.assertEqual(port1.properties, port1_out_props)
+        self.assertEqual(port1.manager, adapter1.ports)
+
+    def test_ports_add(self):
+        """Test add() of FakedPortManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+        ports = adapter1.ports.list()
+        self.assertEqual(len(ports), 1)
+
+        port2_in_props = {'name': 'port2'}
+
+        # the function to be tested:
+        new_port = adapter1.ports.add(
+            port2_in_props)
+
+        ports = adapter1.ports.list()
+        self.assertEqual(len(ports), 2)
+
+        port2 = [p for p in ports
+                 if p.properties['name'] == port2_in_props['name']][0]
+
+        self.assertEqual(new_port.properties, port2.properties)
+        self.assertEqual(new_port.manager, port2.manager)
+
+        port2_out_props = port2_in_props.copy()
+        port2_out_props.update({
+            'element-id': port2.oid,
+            'element-uri': port2.uri,
+        })
+        self.assertIsInstance(port2, FakedPort)
+        self.assertEqual(port2.properties, port2_out_props)
+        self.assertEqual(port2.manager, adapter1.ports)
+
+    def test_ports_remove(self):
+        """Test remove() of FakedPortManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        adapters = cpc1.adapters.list()
+        adapter1 = adapters[0]
+        ports = adapter1.ports.list()
+        port1 = ports[0]
+        self.assertEqual(len(ports), 1)
+
+        # the function to be tested:
+        adapter1.ports.remove(port1.oid)
+
+        ports = adapter1.ports.list()
+        self.assertEqual(len(ports), 0)
+
+    # TODO: Add testcases for updating 'network-port-uris' and
+    #       'storage-port-uris' parent properties
+
+
+class FakedVirtualFunctionTests(unittest.TestCase):
+    """All tests for the FakedVirtualFunctionManager and FakedVirtualFunction
+    classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.partition1_in_props = {'name': 'partition1'}
+        self.virtual_function1_in_props = {'name': 'virtual_function1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'partitions': [
+                        {
+                            'properties': self.partition1_in_props,
+                            'virtual_functions': [
+                                {'properties':
+                                 self.virtual_function1_in_props},
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedVirtualFunctionManager:
+        self.hmc.add_resources(rd)
+
+    def test_virtual_functions_attr(self):
+        """Test CPC 'virtual_functions' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        self.assertIsInstance(partition1.virtual_functions,
+                              FakedVirtualFunctionManager)
+        self.assertRegexpMatches(partition1.virtual_functions.base_uri,
+                                 r'/api/partitions/.*/virtual-functions')
+
+    def test_virtual_functions_list(self):
+        """Test list() of FakedVirtualFunctionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+
+        # the function to be tested:
+        virtual_functions = partition1.virtual_functions.list()
+
+        self.assertEqual(len(virtual_functions), 1)
+        virtual_function1 = virtual_functions[0]
+        virtual_function1_out_props = self.virtual_function1_in_props.copy()
+        virtual_function1_out_props.update({
+            'element-id': virtual_function1.oid,
+            'element-uri': virtual_function1.uri,
+        })
+        self.assertIsInstance(virtual_function1, FakedVirtualFunction)
+        self.assertEqual(virtual_function1.properties,
+                         virtual_function1_out_props)
+        self.assertEqual(virtual_function1.manager,
+                         partition1.virtual_functions)
+
+    def test_virtual_functions_add(self):
+        """Test add() of FakedVirtualFunctionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        virtual_functions = partition1.virtual_functions.list()
+        self.assertEqual(len(virtual_functions), 1)
+
+        virtual_function2_in_props = {'name': 'virtual_function2'}
+
+        # the function to be tested:
+        new_virtual_function = partition1.virtual_functions.add(
+            virtual_function2_in_props)
+
+        virtual_functions = partition1.virtual_functions.list()
+        self.assertEqual(len(virtual_functions), 2)
+
+        virtual_function2 = [vf for vf in virtual_functions
+                             if vf.properties['name'] ==
+                             virtual_function2_in_props['name']][0]
+
+        self.assertEqual(new_virtual_function.properties,
+                         virtual_function2.properties)
+        self.assertEqual(new_virtual_function.manager,
+                         virtual_function2.manager)
+
+        virtual_function2_out_props = virtual_function2_in_props.copy()
+        virtual_function2_out_props.update({
+            'element-id': virtual_function2.oid,
+            'element-uri': virtual_function2.uri,
+        })
+        self.assertIsInstance(virtual_function2, FakedVirtualFunction)
+        self.assertEqual(virtual_function2.properties,
+                         virtual_function2_out_props)
+        self.assertEqual(virtual_function2.manager,
+                         partition1.virtual_functions)
+
+    def test_virtual_functions_remove(self):
+        """Test remove() of FakedVirtualFunctionManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        partitions = cpc1.partitions.list()
+        partition1 = partitions[0]
+        virtual_functions = partition1.virtual_functions.list()
+        virtual_function1 = virtual_functions[0]
+        self.assertEqual(len(virtual_functions), 1)
+
+        # the function to be tested:
+        partition1.virtual_functions.remove(virtual_function1.oid)
+
+        virtual_functions = partition1.virtual_functions.list()
+        self.assertEqual(len(virtual_functions), 0)
+
+    # TODO: Add testcases for updating 'virtual-function-uris' parent property
+
+
+class FakedVirtualSwitchTests(unittest.TestCase):
+    """All tests for the FakedVirtualSwitchManager and FakedVirtualSwitch
+    classes."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1_in_props = {'name': 'cpc1'}
+        self.virtual_switch1_in_props = {'name': 'virtual_switch1'}
+        rd = {
+            'cpcs': [
+                {
+                    'properties': self.cpc1_in_props,
+                    'virtual_switches': [
+                        {'properties': self.virtual_switch1_in_props},
+                    ],
+                },
+            ]
+        }
+        # This already uses add() of FakedVirtualSwitchManager:
+        self.hmc.add_resources(rd)
+
+    def test_virtual_switches_attr(self):
+        """Test CPC 'virtual_switches' attribute."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        self.assertIsInstance(cpc1.virtual_switches, FakedVirtualSwitchManager)
+        self.assertRegexpMatches(cpc1.virtual_switches.base_uri,
+                                 r'/api/virtual-switches')
+
+    def test_virtual_switches_list(self):
+        """Test list() of FakedVirtualSwitchManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+
+        # the function to be tested:
+        virtual_switches = cpc1.virtual_switches.list()
+
+        self.assertEqual(len(virtual_switches), 1)
+        virtual_switch1 = virtual_switches[0]
+        virtual_switch1_out_props = self.virtual_switch1_in_props.copy()
+        virtual_switch1_out_props.update({
+            'object-id': virtual_switch1.oid,
+            'object-uri': virtual_switch1.uri,
+        })
+        self.assertIsInstance(virtual_switch1, FakedVirtualSwitch)
+        self.assertEqual(virtual_switch1.properties, virtual_switch1_out_props)
+        self.assertEqual(virtual_switch1.manager, cpc1.virtual_switches)
+
+    def test_virtual_switches_add(self):
+        """Test add() of FakedVirtualSwitchManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        virtual_switches = cpc1.virtual_switches.list()
+        self.assertEqual(len(virtual_switches), 1)
+
+        virtual_switch2_in_props = {'name': 'virtual_switch2'}
+
+        # the function to be tested:
+        new_virtual_switch = cpc1.virtual_switches.add(
+            virtual_switch2_in_props)
+
+        virtual_switches = cpc1.virtual_switches.list()
+        self.assertEqual(len(virtual_switches), 2)
+
+        virtual_switch2 = [p for p in virtual_switches
+                           if p.properties['name'] ==
+                           virtual_switch2_in_props['name']][0]
+
+        self.assertEqual(new_virtual_switch.properties,
+                         virtual_switch2.properties)
+        self.assertEqual(new_virtual_switch.manager,
+                         virtual_switch2.manager)
+
+        virtual_switch2_out_props = virtual_switch2_in_props.copy()
+        virtual_switch2_out_props.update({
+            'object-id': virtual_switch2.oid,
+            'object-uri': virtual_switch2.uri,
+        })
+        self.assertIsInstance(virtual_switch2, FakedVirtualSwitch)
+        self.assertEqual(virtual_switch2.properties, virtual_switch2_out_props)
+        self.assertEqual(virtual_switch2.manager, cpc1.virtual_switches)
+
+    def test_virtual_switches_remove(self):
+        """Test remove() of FakedVirtualSwitchManager."""
+        cpcs = self.hmc.cpcs.list()
+        cpc1 = cpcs[0]
+        virtual_switches = cpc1.virtual_switches.list()
+        virtual_switch1 = virtual_switches[0]
+        self.assertEqual(len(virtual_switches), 1)
+
+        # the function to be tested:
+        cpc1.virtual_switches.remove(virtual_switch1.oid)
+
+        virtual_switches = cpc1.virtual_switches.list()
+        self.assertEqual(len(virtual_switches), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -1,0 +1,1638 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _urihandler module of the zhmcclient_mock package.
+"""
+
+from __future__ import absolute_import, print_function
+
+import requests.packages.urllib3
+import unittest
+from mock import MagicMock
+
+from zhmcclient_mock._hmc import FakedHmc
+from zhmcclient_mock._urihandler import HTTPError, InvalidResourceError, \
+    InvalidMethodError, CpcNotInDpmError, CpcInDpmError, \
+    UriHandler, \
+    GenericGetPropertiesHandler, GenericUpdatePropertiesHandler, \
+    VersionHandler, \
+    CpcsHandler, CpcHandler, CpcStartHandler, CpcStopHandler, \
+    CpcExportPortNamesListHandler, \
+    PartitionsHandler, PartitionHandler, PartitionStartHandler, \
+    PartitionStopHandler, \
+    HbasHandler, HbaHandler, \
+    NicsHandler, NicHandler, \
+    VirtualFunctionsHandler, VirtualFunctionHandler, \
+    AdaptersHandler, AdapterHandler, \
+    NetworkPortHandler, \
+    StoragePortHandler, \
+    VirtualSwitchesHandler, VirtualSwitchHandler, \
+    LparsHandler, LparHandler, LparActivateHandler, LparDeactivateHandler, \
+    LparLoadHandler, \
+    ResetActProfilesHandler, ResetActProfileHandler, \
+    ImageActProfilesHandler, ImageActProfileHandler, \
+    LoadActProfilesHandler, LoadActProfileHandler
+
+
+class HTTPErrorTests(unittest.TestCase):
+    """All tests for class HTTPError."""
+
+    def test_attributes(self):
+        method = 'GET'
+        uri = '/api/cpcs'
+        http_status = 500
+        reason = 42
+        message = "fake message"
+
+        exc = HTTPError(method, uri, http_status, reason, message)
+
+        self.assertEqual(exc.method, method)
+        self.assertEqual(exc.uri, uri)
+        self.assertEqual(exc.http_status, http_status)
+        self.assertEqual(exc.reason, reason)
+        self.assertEqual(exc.message, message)
+
+    def test_response(self):
+        method = 'GET'
+        uri = '/api/cpcs'
+        http_status = 500
+        reason = 42
+        message = "fake message"
+        expected_response = {
+            'request-method': method,
+            'request-uri': uri,
+            'http-status': http_status,
+            'reason': reason,
+            'message': message,
+        }
+        exc = HTTPError(method, uri, http_status, reason, message)
+
+        response = exc.response()
+
+        self.assertEqual(response, expected_response)
+
+
+class DummyHandler1(object):
+    pass
+
+
+class DummyHandler2(object):
+    pass
+
+
+class DummyHandler3(object):
+    pass
+
+
+class InvalidResourceErrorTests(unittest.TestCase):
+    """All tests for class InvalidResourceError."""
+
+    def test_attributes_with_handler(self):
+        method = 'GET'
+        uri = '/api/cpcs'
+        exp_http_status = 404
+        exp_reason = 1
+
+        exc = InvalidResourceError(method, uri, DummyHandler1)
+
+        self.assertEqual(exc.method, method)
+        self.assertEqual(exc.uri, uri)
+        self.assertEqual(exc.http_status, exp_http_status)
+        self.assertEqual(exc.reason, exp_reason)
+
+    def test_attributes_no_handler(self):
+        method = 'GET'
+        uri = '/api/cpcs'
+        exp_http_status = 404
+        exp_reason = 1
+
+        exc = InvalidResourceError(method, uri, None)
+
+        self.assertEqual(exc.method, method)
+        self.assertEqual(exc.uri, uri)
+        self.assertEqual(exc.http_status, exp_http_status)
+        self.assertEqual(exc.reason, exp_reason)
+
+
+class InvalidMethodErrorTests(unittest.TestCase):
+    """All tests for class InvalidMethodError."""
+
+    def test_attributes_with_handler(self):
+        method = 'DELETE'
+        uri = '/api/cpcs'
+        exp_http_status = 404
+        exp_reason = 1
+
+        exc = InvalidMethodError(method, uri, DummyHandler1)
+
+        self.assertEqual(exc.method, method)
+        self.assertEqual(exc.uri, uri)
+        self.assertEqual(exc.http_status, exp_http_status)
+        self.assertEqual(exc.reason, exp_reason)
+
+    def test_attributes_no_handler(self):
+        method = 'DELETE'
+        uri = '/api/cpcs'
+        exp_http_status = 404
+        exp_reason = 1
+
+        exc = InvalidMethodError(method, uri, None)
+
+        self.assertEqual(exc.method, method)
+        self.assertEqual(exc.uri, uri)
+        self.assertEqual(exc.http_status, exp_http_status)
+        self.assertEqual(exc.reason, exp_reason)
+
+
+class CpcNotInDpmErrorTests(unittest.TestCase):
+    """All tests for class CpcNotInDpmError."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
+
+    def test_attributes(self):
+        method = 'GET'
+        uri = '/api/cpcs/1/partitions'
+        exp_http_status = 409
+        exp_reason = 5
+
+        exc = CpcNotInDpmError(method, uri, self.cpc1)
+
+        self.assertEqual(exc.method, method)
+        self.assertEqual(exc.uri, uri)
+        self.assertEqual(exc.http_status, exp_http_status)
+        self.assertEqual(exc.reason, exp_reason)
+
+
+class CpcInDpmErrorTests(unittest.TestCase):
+    """All tests for class CpcInDpmError."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
+
+    def test_attributes(self):
+        method = 'GET'
+        uri = '/api/cpcs/1/logical-partitions'
+        exp_http_status = 409
+        exp_reason = 4
+
+        exc = CpcInDpmError(method, uri, self.cpc1)
+
+        self.assertEqual(exc.method, method)
+        self.assertEqual(exc.uri, uri)
+        self.assertEqual(exc.http_status, exp_http_status)
+        self.assertEqual(exc.reason, exp_reason)
+
+
+class UriHandlerHandlerEmptyTests(unittest.TestCase):
+    """All tests for UriHandler.handler() with empty URIs."""
+
+    def setUp(self):
+        self.uris = ()
+        self.urihandler = UriHandler(self.uris)
+
+    def test_uris_empty_1(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('/api/cpcs', 'GET')
+
+    def test_uris_empty_2(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('', 'GET')
+
+
+class UriHandlerHandlerSimpleTests(unittest.TestCase):
+    """All tests for UriHandler.handler() with a simple set of URIs."""
+
+    def setUp(self):
+        self.uris = (
+            ('/api/cpcs', DummyHandler1),
+            ('/api/cpcs/([^/]+)', DummyHandler2),
+            ('/api/cpcs/([^/]+)/child', DummyHandler3),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_ok1(self):
+        handler_class, uri_parms = self.urihandler.handler(
+            '/api/cpcs', 'GET')
+        self.assertEqual(handler_class, DummyHandler1)
+        self.assertEqual(len(uri_parms), 0)
+
+    def test_ok2(self):
+        handler_class, uri_parms = self.urihandler.handler(
+            '/api/cpcs/fake-id1', 'GET')
+        self.assertEqual(handler_class, DummyHandler2)
+        self.assertEqual(len(uri_parms), 1)
+        self.assertEqual(uri_parms[0], 'fake-id1')
+
+    def test_ok3(self):
+        handler_class, uri_parms = self.urihandler.handler(
+            '/api/cpcs/fake-id1/child', 'GET')
+        self.assertEqual(handler_class, DummyHandler3)
+        self.assertEqual(len(uri_parms), 1)
+        self.assertEqual(uri_parms[0], 'fake-id1')
+
+    def test_err_begin_missing(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('api/cpcs', 'GET')
+
+    def test_err_begin_extra(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('x/api/cpcs', 'GET')
+
+    def test_err_end_missing(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('/api/cpc', 'GET')
+
+    def test_err_end_extra(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('/api/cpcs_x', 'GET')
+
+    def test_err_end_slash(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('/api/cpcs/', 'GET')
+
+    def test_err_end2_slash(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('/api/cpcs/fake-id1/', 'GET')
+
+    def test_err_end2_missing(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('/api/cpcs/fake-id1/chil', 'GET')
+
+    def test_err_end2_extra(self):
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.handler('/api/cpcs/fake-id1/child_x', 'GET')
+
+
+class UriHandlerMethodTests(unittest.TestCase):
+    """All tests for get(), post(), delete() methods of class UriHandler."""
+
+    def setUp(self):
+        self.uris = (
+            ('/api/cpcs', DummyHandler1),
+            ('/api/cpcs/([^/]+)', DummyHandler2),
+        )
+        self.cpc1 = {
+            'object-id': '1',
+            'object-uri': '/api/cpcs/1',
+            'name': 'cpc1',
+        }
+        self.cpc2 = {
+            'object-id': '2',
+            'object-uri': '/api/cpcs/2',
+            'name': 'cpc2',
+        }
+        self.new_cpc = {
+            'object-id': '3',
+            'object-uri': '/api/cpcs/3',
+            'name': 'cpc3',
+        }
+        self.cpcs = {
+            'cpcs': [self.cpc1, self.cpc2]
+        }
+        DummyHandler1.get = staticmethod(MagicMock(
+            return_value=self.cpcs))
+        DummyHandler1.post = staticmethod(MagicMock(
+            return_value=self.new_cpc))
+        DummyHandler2.get = staticmethod(MagicMock(
+            return_value=self.cpc1))
+        DummyHandler2.delete = staticmethod(MagicMock(
+            return_value=None))
+        self.urihandler = UriHandler(self.uris)
+        self.hmc = 'fake-hmc-object'
+
+    def tearDown(self):
+        delattr(DummyHandler1, 'get')
+        delattr(DummyHandler1, 'post')
+        delattr(DummyHandler2, 'get')
+        delattr(DummyHandler2, 'delete')
+
+    def test_get_cpcs(self):
+
+        # the function to be tested
+        result = self.urihandler.get(self.hmc, '/api/cpcs', True)
+
+        self.assertEqual(result, self.cpcs)
+
+        DummyHandler1.get.assert_called_with(self.hmc, '/api/cpcs', tuple(),
+                                             True)
+        self.assertEqual(DummyHandler1.post.called, 0)
+        self.assertEqual(DummyHandler2.get.called, 0)
+        self.assertEqual(DummyHandler2.delete.called, 0)
+
+    def test_get_cpc1(self):
+
+        # the function to be tested
+        result = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+
+        self.assertEqual(result, self.cpc1)
+
+        self.assertEqual(DummyHandler1.get.called, 0)
+        self.assertEqual(DummyHandler1.post.called, 0)
+        DummyHandler2.get.assert_called_with(self.hmc, '/api/cpcs/1',
+                                             tuple('1'), True)
+        self.assertEqual(DummyHandler2.delete.called, 0)
+
+    def test_post_cpcs(self):
+
+        # the function to be tested
+        result = self.urihandler.post(self.hmc, '/api/cpcs', {}, True, True)
+
+        self.assertEqual(result, self.new_cpc)
+
+        self.assertEqual(DummyHandler1.get.called, 0)
+        DummyHandler1.post.assert_called_with(self.hmc, '/api/cpcs', tuple(),
+                                              {}, True, True)
+        self.assertEqual(DummyHandler2.get.called, 0)
+        self.assertEqual(DummyHandler2.delete.called, 0)
+
+    def test_delete_cpc2(self):
+
+        # the function to be tested
+        self.urihandler.delete(self.hmc, '/api/cpcs/2', True)
+
+        self.assertEqual(DummyHandler1.get.called, 0)
+        self.assertEqual(DummyHandler1.post.called, 0)
+        self.assertEqual(DummyHandler2.get.called, 0)
+        DummyHandler2.delete.assert_called_with(self.hmc, '/api/cpcs/2',
+                                                tuple('2'), True)
+
+
+def standard_test_hmc():
+    """
+    Return a FakedHmc object that is prepared with a few standard resources
+    for testing.
+    """
+    hmc_resources = {
+        'cpcs': [
+            {
+                'properties': {
+                    'object-id': '1',
+                    'name': 'cpc_1',
+                    'dpm-enabled': False,
+                    'description': 'CPC #1 (classic mode)',
+                    'status': 'operating',
+                },
+                'lpars': [
+                    {
+                        'properties': {
+                            'object-id': '1',
+                            'name': 'lpar_1',
+                            'description': 'LPAR #1 in CPC #1',
+                            'status': 'not-activated',
+                        },
+                    },
+                ],
+                'reset_activation_profiles': [
+                    {
+                        'properties': {
+                            'element-id': '1',
+                            'name': 'rap_1',
+                            'description': 'Reset profile #1 in CPC #1',
+                        },
+                    },
+                ],
+                'image_activation_profiles': [
+                    {
+                        'properties': {
+                            'element-id': '1',
+                            'name': 'iap_1',
+                            'description': 'Image profile #1 in CPC #1',
+                        },
+                    },
+                ],
+                'load_activation_profiles': [
+                    {
+                        'properties': {
+                            'element-id': '1',
+                            'name': 'lap_1',
+                            'description': 'Load profile #1 in CPC #1',
+                        },
+                    },
+                ],
+            },
+            {
+                'properties': {
+                    'object-id': '2',
+                    'name': 'cpc_2',
+                    'dpm-enabled': True,
+                    'description': 'CPC #2 (DPM mode)',
+                    'status': 'active',
+                },
+                'partitions': [
+                    {
+                        'properties': {
+                            'object-id': '1',
+                            'name': 'partition_1',
+                            'description': 'Partition #1 in CPC #2',
+                            'status': 'stopped',
+                            'hba-uris': [],   # updated automatically
+                            'nic-uris': [],   # updated automatically
+                            'virtual-function-uris': [],   # updated autom.
+                        },
+                        'hbas': [
+                            {
+                                'properties': {
+                                    'element-id': '1',
+                                    'name': 'hba_1',
+                                    'description': 'HBA #1 in Partition #1',
+                                    'adapter-port-uri':
+                                        '/api/adapters/2/storage-ports/1',
+                                    'wwpn': 'wwpn_1',
+                                },
+                            },
+                        ],
+                        'nics': [
+                            {
+                                'properties': {
+                                    'element-id': '1',
+                                    'name': 'nic_1',
+                                    'description': 'NIC #1 in Partition #1',
+                                    'network-adapter-port-uri':
+                                        '/api/adapters/3/network-ports/1',
+                                },
+                            },
+                        ],
+                        'virtual_functions': [
+                            {
+                                'properties': {
+                                    'element-id': '1',
+                                    'name': 'vf_1',
+                                    'description': 'VF #1 in Partition #1',
+                                },
+                            },
+                        ],
+                    },
+                ],
+                'adapters': [
+                    {
+                        'properties': {
+                            'object-id': '1',
+                            'name': 'osa_1',
+                            'description': 'OSA #1 in CPC #2',
+                            'adapter-family': 'osa',
+                            'network-port-uris': [],   # updated automatically
+                            'status': 'active',
+                        },
+                        'ports': [
+                            {
+                                'properties': {
+                                    'element-id': '1',
+                                    'name': 'osa_1_port_1',
+                                    'description': 'Port #1 of OSA #1',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        'properties': {
+                            'object-id': '2',
+                            'name': 'fcp_2',
+                            'description': 'FCP #2 in CPC #2',
+                            'adapter-family': 'ficon',
+                            'storage-port-uris': [],   # updated automatically
+                        },
+                        'ports': [
+                            {
+                                'properties': {
+                                    'element-id': '1',
+                                    'name': 'fcp_2_port_1',
+                                    'description': 'Port #1 of FCP #2',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        'properties': {
+                            'object-id': '3',
+                            'name': 'roce_3',
+                            'description': 'ROCE #3 in CPC #2',
+                            'adapter-family': 'roce',
+                            'network-port-uris': [],   # updated automatically
+                        },
+                        'ports': [
+                            {
+                                'properties': {
+                                    'element-id': '1',
+                                    'name': 'roce_3_port_1',
+                                    'description': 'Port #1 of ROCE #3',
+                                },
+                            },
+                        ],
+                    },
+                ],
+                'virtual_switches': [
+                    {
+                        'properties': {
+                            'object-id': '1',
+                            'name': 'vswitch_osa_1',
+                            'description': 'Vswitch for OSA #1 in CPC #2',
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+    hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+    hmc.add_resources(hmc_resources)
+    return hmc, hmc_resources
+
+
+class GenericGetPropertiesHandlerTests(unittest.TestCase):
+    """All tests for class GenericGetPropertiesHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)', GenericGetPropertiesHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_get(self):
+
+        # the function to be tested:
+        cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+
+        exp_cpc1 = {
+            'object-id': '1',
+            'object-uri': '/api/cpcs/1',
+            'name': 'cpc_1',
+            'dpm-enabled': False,
+            'description': 'CPC #1 (classic mode)',
+            'status': 'operating',
+        }
+        self.assertEqual(cpc1, exp_cpc1)
+
+
+class _GenericGetUpdatePropertiesHandler(GenericGetPropertiesHandler,
+                                         GenericUpdatePropertiesHandler):
+    pass
+
+
+class GenericUpdatePropertiesHandlerTests(unittest.TestCase):
+    """All tests for class GenericUpdatePropertiesHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)', _GenericGetUpdatePropertiesHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_update_verify(self):
+        update_cpc1 = {
+            'description': 'CPC #1 (updated)',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(self.hmc, '/api/cpcs/1', update_cpc1, True,
+                                    True)
+
+        self.assertEqual(resp, None)
+        cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+        self.assertEqual(cpc1['description'], 'CPC #1 (updated)')
+
+
+class VersionHandlerTests(unittest.TestCase):
+    """All tests for class VersionHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/version', VersionHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_get_version(self):
+
+        # the function to be tested:
+        resp = self.urihandler.get(self.hmc, '/api/version', True)
+
+        api_major, api_minor = self.hmc.api_version.split('.')
+        exp_resp = {
+            'hmc-name': self.hmc.hmc_name,
+            'hmc-version': self.hmc.hmc_version,
+            'api-major-version': int(api_major),
+            'api-minor-version': int(api_minor),
+        }
+        self.assertEqual(resp, exp_resp)
+
+
+class CpcHandlersTests(unittest.TestCase):
+    """All tests for classes CpcsHandler and CpcHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs', CpcsHandler),
+            ('/api/cpcs/([^/]+)', CpcHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        cpcs = self.urihandler.get(self.hmc, '/api/cpcs', True)
+
+        exp_cpcs = {  # properties reduced to those returned by List
+            'cpcs': [
+                {
+                    'object-uri': '/api/cpcs/1',
+                    'name': 'cpc_1',
+                    'status': 'operating',
+                },
+                {
+                    'object-uri': '/api/cpcs/2',
+                    'name': 'cpc_2',
+                    'status': 'active',
+                },
+            ]
+        }
+        self.assertEqual(cpcs, exp_cpcs)
+
+    def test_get(self):
+
+        # the function to be tested:
+        cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+
+        exp_cpc1 = {
+            'object-id': '1',
+            'object-uri': '/api/cpcs/1',
+            'name': 'cpc_1',
+            'dpm-enabled': False,
+            'description': 'CPC #1 (classic mode)',
+            'status': 'operating',
+        }
+        self.assertEqual(cpc1, exp_cpc1)
+
+    def test_update_verify(self):
+        update_cpc1 = {
+            'description': 'updated cpc #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/cpcs/1',
+                             update_cpc1, True, True)
+
+        cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+        self.assertEqual(cpc1['description'], 'updated cpc #1')
+
+
+class CpcStartStopHandlerTests(unittest.TestCase):
+    """All tests for classes CpcStartHandler and CpcStopHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)', CpcHandler),
+            ('/api/cpcs/([^/]+)/operations/start', CpcStartHandler),
+            ('/api/cpcs/([^/]+)/operations/stop', CpcStopHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_stop_classic(self):
+        # CPC1 is in classic mode
+        cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+        self.assertEqual(cpc1['status'], 'operating')
+
+        # the function to be tested:
+        with self.assertRaises(CpcNotInDpmError):
+            self.urihandler.post(self.hmc, '/api/cpcs/1/operations/stop',
+                                 None, True, True)
+
+        cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+        self.assertEqual(cpc1['status'], 'operating')
+
+    def test_start_classic(self):
+        # CPC1 is in classic mode
+        cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+        self.assertEqual(cpc1['status'], 'operating')
+
+        # the function to be tested:
+        with self.assertRaises(CpcNotInDpmError):
+            self.urihandler.post(self.hmc, '/api/cpcs/1/operations/start',
+                                 None, True, True)
+
+        cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+        self.assertEqual(cpc1['status'], 'operating')
+
+    def test_stop_start_dpm(self):
+        # CPC2 is in DPM mode
+        cpc2 = self.urihandler.get(self.hmc, '/api/cpcs/2', True)
+        self.assertEqual(cpc2['status'], 'active')
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/cpcs/2/operations/stop',
+                             None, True, True)
+
+        cpc2 = self.urihandler.get(self.hmc, '/api/cpcs/2', True)
+        self.assertEqual(cpc2['status'], 'not-operating')
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/cpcs/2/operations/start',
+                             None, True, True)
+
+        cpc2 = self.urihandler.get(self.hmc, '/api/cpcs/2', True)
+        self.assertEqual(cpc2['status'], 'active')
+
+
+class CpcExportPortNamesListHandlerTests(unittest.TestCase):
+    """All tests for class CpcExportPortNamesListHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs', CpcsHandler),
+            ('/api/cpcs/([^/]+)', CpcHandler),
+            ('/api/cpcs/([^/]+)/operations/export-port-names-list',
+             CpcExportPortNamesListHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_invoke_err_no_input(self):
+
+        # the function to be tested:
+        with self.assertRaises(HTTPError):
+            self.urihandler.post(
+                self.hmc, '/api/cpcs/2/operations/export-port-names-list',
+                None, True, True)
+
+    def test_invoke_ok(self):
+        operation_body = {
+            'partitions': [
+                '/api/partitions/1',
+            ]
+        }
+        exp_wwpn_list = [
+            'partition_1,2,,wwpn_1',
+        ]
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/cpcs/2/operations/export-port-names-list',
+            operation_body, True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('wwpn-list', resp)
+        wwpn_list = resp['wwpn-list']
+        self.assertEqual(wwpn_list, exp_wwpn_list)
+
+
+class AdapterHandlersTests(unittest.TestCase):
+    """All tests for classes AdaptersHandler and AdapterHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)/adapters', AdaptersHandler),
+            ('/api/adapters/([^/]+)', AdapterHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        adapters = self.urihandler.get(self.hmc, '/api/cpcs/2/adapters', True)
+
+        exp_adapters = {  # properties reduced to those returned by List
+            'adapters': [
+                {
+                    'object-uri': '/api/adapters/1',
+                    'name': 'osa_1',
+                    'status': 'active',
+                },
+                {
+                    'object-uri': '/api/adapters/2',
+                    'name': 'fcp_2',
+                    # status not set in resource -> not in response
+                },
+                {
+                    'object-uri': '/api/adapters/3',
+                    'name': 'roce_3',
+                    # status not set in resource -> not in response
+                },
+            ]
+        }
+        self.assertEqual(adapters, exp_adapters)
+
+    def test_get(self):
+
+        # the function to be tested:
+        adapter1 = self.urihandler.get(self.hmc, '/api/adapters/1', True)
+
+        exp_adapter1 = {
+            'object-id': '1',
+            'object-uri': '/api/adapters/1',
+            'name': 'osa_1',
+            'description': 'OSA #1 in CPC #2',
+            'status': 'active',
+            'adapter-family': 'osa',
+            'network-port-uris': ['/api/adapters/1/network-ports/1'],
+        }
+        self.assertEqual(adapter1, exp_adapter1)
+
+    def test_update_verify(self):
+        update_adapter1 = {
+            'description': 'updated adapter #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/adapters/1',
+                             update_adapter1, True, True)
+
+        adapter1 = self.urihandler.get(self.hmc, '/api/adapters/1', True)
+        self.assertEqual(adapter1['description'], 'updated adapter #1')
+
+
+class NetworkPortHandlersTests(unittest.TestCase):
+    """All tests for class NetworkPortHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/adapters/([^/]+)/network-ports/([^/]+)',
+             NetworkPortHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_get(self):
+
+        # the function to be tested:
+        port1 = self.urihandler.get(self.hmc,
+                                    '/api/adapters/1/network-ports/1', True)
+
+        exp_port1 = {
+            'element-id': '1',
+            'element-uri': '/api/adapters/1/network-ports/1',
+            'name': 'osa_1_port_1',
+            'description': 'Port #1 of OSA #1',
+        }
+        self.assertEqual(port1, exp_port1)
+
+    def test_update_verify(self):
+        update_port1 = {
+            'description': 'updated port #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/adapters/1/network-ports/1',
+                             update_port1, True, True)
+
+        port1 = self.urihandler.get(self.hmc,
+                                    '/api/adapters/1/network-ports/1', True)
+        self.assertEqual(port1['description'], 'updated port #1')
+
+
+class StoragePortHandlersTests(unittest.TestCase):
+    """All tests for class StoragePortHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/adapters/([^/]+)/storage-ports/([^/]+)',
+             StoragePortHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_get(self):
+
+        # the function to be tested:
+        port1 = self.urihandler.get(self.hmc,
+                                    '/api/adapters/2/storage-ports/1', True)
+
+        exp_port1 = {
+            'element-id': '1',
+            'element-uri': '/api/adapters/2/storage-ports/1',
+            'name': 'fcp_2_port_1',
+            'description': 'Port #1 of FCP #2',
+        }
+        self.assertEqual(port1, exp_port1)
+
+    def test_update_verify(self):
+        update_port1 = {
+            'description': 'updated port #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/adapters/2/storage-ports/1',
+                             update_port1, True, True)
+
+        port1 = self.urihandler.get(self.hmc,
+                                    '/api/adapters/2/storage-ports/1', True)
+        self.assertEqual(port1['description'], 'updated port #1')
+
+
+class PartitionHandlersTests(unittest.TestCase):
+    """All tests for classes PartitionsHandler and PartitionHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)/partitions', PartitionsHandler),
+            ('/api/partitions/([^/]+)', PartitionHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        partitions = self.urihandler.get(self.hmc, '/api/cpcs/2/partitions',
+                                         True)
+
+        exp_partitions = {  # properties reduced to those returned by List
+            'partitions': [
+                {
+                    'object-uri': '/api/partitions/1',
+                    'name': 'partition_1',
+                    'status': 'stopped',
+                },
+            ]
+        }
+        self.assertEqual(partitions, exp_partitions)
+
+    def test_get(self):
+
+        # the function to be tested:
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+
+        exp_partition1 = {
+            'object-id': '1',
+            'object-uri': '/api/partitions/1',
+            'name': 'partition_1',
+            'description': 'Partition #1 in CPC #2',
+            'status': 'stopped',
+            'hba-uris': ['/api/partitions/1/hbas/1'],
+            'nic-uris': ['/api/partitions/1/nics/1'],
+            'virtual-function-uris': ['/api/partitions/1/virtual-functions/1'],
+        }
+        self.assertEqual(partition1, exp_partition1)
+
+    def test_create_verify(self):
+        new_partition2 = {
+            'object-id': '2',
+            'name': 'partition_2',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(self.hmc, '/api/cpcs/2/partitions',
+                                    new_partition2, True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('object-uri', resp)
+        new_partition2_uri = resp['object-uri']
+        self.assertEqual(new_partition2_uri, '/api/partitions/2')
+
+        exp_partition2 = {
+            'object-id': '2',
+            'object-uri': '/api/partitions/2',
+            'name': 'partition_2',
+            'hba-uris': [],
+            'nic-uris': [],
+            'virtual-function-uris': [],
+        }
+
+        # the function to be tested:
+        partition2 = self.urihandler.get(self.hmc, '/api/partitions/2', True)
+
+        self.assertEqual(partition2, exp_partition2)
+
+    def test_update_verify(self):
+        update_partition1 = {
+            'description': 'updated partition #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/partitions/1',
+                             update_partition1, True, True)
+
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+        self.assertEqual(partition1['description'], 'updated partition #1')
+
+    def test_delete_verify(self):
+
+        self.urihandler.get(self.hmc, '/api/partitions/1', True)
+
+        # the function to be tested:
+        self.urihandler.delete(self.hmc, '/api/partitions/1', True)
+
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.get(self.hmc, '/api/partitions/1', True)
+
+
+class PartitionStartStopHandlerTests(unittest.TestCase):
+    """All tests for classes PartitionStartHandler and PartitionStopHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/partitions/([^/]+)', PartitionHandler),
+            ('/api/partitions/([^/]+)/operations/start',
+             PartitionStartHandler),
+            ('/api/partitions/([^/]+)/operations/stop', PartitionStopHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_start_stop(self):
+        # CPC2 is in DPM mode
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+        self.assertEqual(partition1['status'], 'stopped')
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/partitions/1/operations/start',
+                             None, True, True)
+
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+        self.assertEqual(partition1['status'], 'active')
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/partitions/1/operations/stop',
+                             None, True, True)
+
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+        self.assertEqual(partition1['status'], 'stopped')
+
+
+class HbaHandlerTests(unittest.TestCase):
+    """All tests for classes HbasHandler and HbaHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/partitions/([^/]+)', PartitionHandler),
+            ('/api/partitions/([^/]+)/hbas', HbasHandler),
+            ('/api/partitions/([^/]+)/hbas/([^/]+)', HbaHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+
+        hba_uris = partition1.get('hba-uris', [])
+
+        exp_hba_uris = [
+            '/api/partitions/1/hbas/1',
+        ]
+        self.assertEqual(hba_uris, exp_hba_uris)
+
+    def test_get(self):
+
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+        hba1_uri = partition1.get('hba-uris', [])[0]
+
+        # the function to be tested:
+        hba1 = self.urihandler.get(self.hmc, hba1_uri, True)
+
+        exp_hba1 = {
+            'element-id': '1',
+            'element-uri': '/api/partitions/1/hbas/1',
+            'name': 'hba_1',
+            'description': 'HBA #1 in Partition #1',
+            'adapter-port-uri': '/api/adapters/2/storage-ports/1',
+            'wwpn': 'wwpn_1',
+        }
+        self.assertEqual(hba1, exp_hba1)
+
+    def test_create_verify(self):
+        new_hba2 = {
+            'element-id': '2',
+            'name': 'hba_2',
+            'adapter-port-uri': '/api/adapters/2/storage-ports/1',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(self.hmc, '/api/partitions/1/hbas',
+                                    new_hba2, True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('element-uri', resp)
+        new_hba2_uri = resp['element-uri']
+        self.assertEqual(new_hba2_uri, '/api/partitions/1/hbas/2')
+
+        exp_hba2 = {
+            'element-id': '2',
+            'element-uri': '/api/partitions/1/hbas/2',
+            'name': 'hba_2',
+            'adapter-port-uri': '/api/adapters/2/storage-ports/1',
+        }
+
+        # the function to be tested:
+        hba2 = self.urihandler.get(self.hmc, '/api/partitions/1/hbas/2', True)
+
+        self.assertEqual(hba2, exp_hba2)
+
+    def test_update_verify(self):
+        update_hba1 = {
+            'description': 'updated hba #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/partitions/1/hbas/1',
+                             update_hba1, True, True)
+
+        hba1 = self.urihandler.get(self.hmc, '/api/partitions/1/hbas/1', True)
+        self.assertEqual(hba1['description'], 'updated hba #1')
+
+    def test_delete_verify(self):
+
+        self.urihandler.get(self.hmc, '/api/partitions/1/hbas/1', True)
+
+        # the function to be tested:
+        self.urihandler.delete(self.hmc, '/api/partitions/1/hbas/1', True)
+
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.get(self.hmc, '/api/partitions/1/hbas/1', True)
+
+
+class NicHandlerTests(unittest.TestCase):
+    """All tests for classes NicsHandler and NicHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/partitions/([^/]+)', PartitionHandler),
+            ('/api/partitions/([^/]+)/nics', NicsHandler),
+            ('/api/partitions/([^/]+)/nics/([^/]+)', NicHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+
+        nic_uris = partition1.get('nic-uris', [])
+
+        exp_nic_uris = [
+            '/api/partitions/1/nics/1',
+        ]
+        self.assertEqual(nic_uris, exp_nic_uris)
+
+    def test_get(self):
+
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+        nic1_uri = partition1.get('nic-uris', [])[0]
+
+        # the function to be tested:
+        nic1 = self.urihandler.get(self.hmc, nic1_uri, True)
+
+        exp_nic1 = {
+            'element-id': '1',
+            'element-uri': '/api/partitions/1/nics/1',
+            'name': 'nic_1',
+            'description': 'NIC #1 in Partition #1',
+            'network-adapter-port-uri': '/api/adapters/3/network-ports/1',
+        }
+        self.assertEqual(nic1, exp_nic1)
+
+    def test_create_verify(self):
+        new_nic2 = {
+            'element-id': '2',
+            'name': 'nic_2',
+            'network-adapter-port-uri': '/api/adapters/3/network-ports/1',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(self.hmc, '/api/partitions/1/nics',
+                                    new_nic2, True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('element-uri', resp)
+        new_nic2_uri = resp['element-uri']
+        self.assertEqual(new_nic2_uri, '/api/partitions/1/nics/2')
+
+        exp_nic2 = {
+            'element-id': '2',
+            'element-uri': '/api/partitions/1/nics/2',
+            'name': 'nic_2',
+            'network-adapter-port-uri': '/api/adapters/3/network-ports/1',
+        }
+
+        # the function to be tested:
+        nic2 = self.urihandler.get(self.hmc, '/api/partitions/1/nics/2', True)
+
+        self.assertEqual(nic2, exp_nic2)
+
+    def test_update_verify(self):
+        update_nic1 = {
+            'description': 'updated nic #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/partitions/1/nics/1',
+                             update_nic1, True, True)
+
+        nic1 = self.urihandler.get(self.hmc, '/api/partitions/1/nics/1', True)
+        self.assertEqual(nic1['description'], 'updated nic #1')
+
+    def test_delete_verify(self):
+
+        self.urihandler.get(self.hmc, '/api/partitions/1/nics/1', True)
+
+        # the function to be tested:
+        self.urihandler.delete(self.hmc, '/api/partitions/1/nics/1', True)
+
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.get(self.hmc, '/api/partitions/1/nics/1', True)
+
+
+class VirtualFunctionHandlerTests(unittest.TestCase):
+    """All tests for classes VirtualFunctionsHandler and
+    VirtualFunctionHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/partitions/([^/]+)', PartitionHandler),
+            ('/api/partitions/([^/]+)/virtual-functions',
+             VirtualFunctionsHandler),
+            ('/api/partitions/([^/]+)/virtual-functions/([^/]+)',
+             VirtualFunctionHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+
+        vf_uris = partition1.get('virtual-function-uris', [])
+
+        exp_vf_uris = [
+            '/api/partitions/1/virtual-functions/1',
+        ]
+        self.assertEqual(vf_uris, exp_vf_uris)
+
+    def test_get(self):
+
+        partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
+        vf1_uri = partition1.get('virtual-function-uris', [])[0]
+
+        # the function to be tested:
+        vf1 = self.urihandler.get(self.hmc, vf1_uri, True)
+
+        exp_vf1 = {
+            'element-id': '1',
+            'element-uri': '/api/partitions/1/virtual-functions/1',
+            'name': 'vf_1',
+            'description': 'VF #1 in Partition #1',
+        }
+        self.assertEqual(vf1, exp_vf1)
+
+    def test_create_verify(self):
+        new_vf2 = {
+            'element-id': '2',
+            'name': 'vf_2',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(self.hmc,
+                                    '/api/partitions/1/virtual-functions',
+                                    new_vf2, True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('element-uri', resp)
+        new_vf2_uri = resp['element-uri']
+        self.assertEqual(new_vf2_uri, '/api/partitions/1/virtual-functions/2')
+
+        exp_vf2 = {
+            'element-id': '2',
+            'element-uri': '/api/partitions/1/virtual-functions/2',
+            'name': 'vf_2',
+        }
+
+        # the function to be tested:
+        vf2 = self.urihandler.get(self.hmc,
+                                  '/api/partitions/1/virtual-functions/2',
+                                  True)
+
+        self.assertEqual(vf2, exp_vf2)
+
+    def test_update_verify(self):
+        update_vf1 = {
+            'description': 'updated vf #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/partitions/1/virtual-functions/1',
+                             update_vf1, True, True)
+
+        vf1 = self.urihandler.get(self.hmc,
+                                  '/api/partitions/1/virtual-functions/1',
+                                  True)
+        self.assertEqual(vf1['description'], 'updated vf #1')
+
+    def test_delete_verify(self):
+
+        self.urihandler.get(self.hmc, '/api/partitions/1/virtual-functions/1',
+                            True)
+
+        # the function to be tested:
+        self.urihandler.delete(self.hmc,
+                               '/api/partitions/1/virtual-functions/1', True)
+
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.get(self.hmc,
+                                '/api/partitions/1/virtual-functions/1', True)
+
+
+class VirtualSwitchHandlersTests(unittest.TestCase):
+    """All tests for classes VirtualSwitchesHandler and
+    VirtualSwitchHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)/virtual-switches', VirtualSwitchesHandler),
+            ('/api/virtual-switches/([^/]+)', VirtualSwitchHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        vswitches = self.urihandler.get(self.hmc,
+                                        '/api/cpcs/2/virtual-switches', True)
+
+        exp_vswitches = {  # properties reduced to those returned by List
+            'virtual-switches': [
+                {
+                    'object-uri': '/api/virtual-switches/1',
+                    'name': 'vswitch_osa_1',
+                    # status not set in resource -> not in response
+                },
+            ]
+        }
+        self.assertEqual(vswitches, exp_vswitches)
+
+    def test_get(self):
+
+        # the function to be tested:
+        vswitch1 = self.urihandler.get(self.hmc, '/api/virtual-switches/1',
+                                       True)
+
+        exp_vswitch1 = {
+            'object-id': '1',
+            'object-uri': '/api/virtual-switches/1',
+            'name': 'vswitch_osa_1',
+            'description': 'Vswitch for OSA #1 in CPC #2',
+        }
+        self.assertEqual(vswitch1, exp_vswitch1)
+
+
+class LparHandlersTests(unittest.TestCase):
+    """All tests for classes LparsHandler and LparHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)/logical-partitions', LparsHandler),
+            ('/api/logical-partitions/([^/]+)', LparHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        lpars = self.urihandler.get(self.hmc,
+                                    '/api/cpcs/1/logical-partitions', True)
+
+        exp_lpars = {  # properties reduced to those returned by List
+            'logical-partitions': [
+                {
+                    'object-uri': '/api/logical-partitions/1',
+                    'name': 'lpar_1',
+                    'status': 'not-activated',
+                },
+            ]
+        }
+        self.assertEqual(lpars, exp_lpars)
+
+    def test_get(self):
+
+        # the function to be tested:
+        lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
+                                    True)
+
+        exp_lpar1 = {
+            'object-id': '1',
+            'object-uri': '/api/logical-partitions/1',
+            'name': 'lpar_1',
+            'status': 'not-activated',
+            'description': 'LPAR #1 in CPC #1',
+        }
+        self.assertEqual(lpar1, exp_lpar1)
+
+
+class LparActLoadDeactHandlerTests(unittest.TestCase):
+    """All tests for classes LparActivateHandler, LparLoadHandler, and
+    LparDeactivateHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/logical-partitions/([^/]+)',
+             LparHandler),
+            ('/api/logical-partitions/([^/]+)/operations/activate',
+             LparActivateHandler),
+            ('/api/logical-partitions/([^/]+)/operations/deactivate',
+             LparDeactivateHandler),
+            ('/api/logical-partitions/([^/]+)/operations/load',
+             LparLoadHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_start_stop(self):
+        # CPC1 is in classic mode
+        lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
+                                    True)
+        self.assertEqual(lpar1['status'], 'not-activated')
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc,
+                             '/api/logical-partitions/1/operations/activate',
+                             None, True, True)
+
+        lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
+                                    True)
+        self.assertEqual(lpar1['status'], 'not-operating')
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc,
+                             '/api/logical-partitions/1/operations/load',
+                             None, True, True)
+
+        lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
+                                    True)
+        self.assertEqual(lpar1['status'], 'operating')
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc,
+                             '/api/logical-partitions/1/operations/deactivate',
+                             None, True, True)
+
+        lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
+                                    True)
+        self.assertEqual(lpar1['status'], 'not-activated')
+
+
+class ResetActProfileHandlersTests(unittest.TestCase):
+    """All tests for classes ResetActProfilesHandler and
+    ResetActProfileHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)/reset-activation-profiles',
+             ResetActProfilesHandler),
+            ('/api/cpcs/([^/]+)/reset-activation-profiles/([^/]+)',
+             ResetActProfileHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        raps = self.urihandler.get(self.hmc,
+                                   '/api/cpcs/1/reset-activation-profiles',
+                                   True)
+
+        exp_raps = {  # properties reduced to those returned by List
+            'reset-activation-profiles': [
+                {
+                    'element-uri': '/api/cpcs/1/reset-activation-profiles/1',
+                    'name': 'rap_1',
+                },
+            ]
+        }
+        self.assertEqual(raps, exp_raps)
+
+    def test_get(self):
+
+        # the function to be tested:
+        rap1 = self.urihandler.get(self.hmc,
+                                   '/api/cpcs/1/reset-activation-profiles/1',
+                                   True)
+
+        exp_rap1 = {
+            'element-id': '1',
+            'element-uri': '/api/cpcs/1/reset-activation-profiles/1',
+            'name': 'rap_1',
+            'description': 'Reset profile #1 in CPC #1',
+        }
+        self.assertEqual(rap1, exp_rap1)
+
+
+class ImageActProfileHandlersTests(unittest.TestCase):
+    """All tests for classes ImageActProfilesHandler and
+    ImageActProfileHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)/image-activation-profiles/([^/]+)',
+             ImageActProfileHandler),
+            ('/api/cpcs/([^/]+)/image-activation-profiles',
+             ImageActProfilesHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        iaps = self.urihandler.get(self.hmc,
+                                   '/api/cpcs/1/image-activation-profiles',
+                                   True)
+
+        exp_iaps = {  # properties reduced to those returned by List
+            'image-activation-profiles': [
+                {
+                    'element-uri': '/api/cpcs/1/image-activation-profiles/1',
+                    'name': 'iap_1',
+                },
+            ]
+        }
+        self.assertEqual(iaps, exp_iaps)
+
+    def test_get(self):
+
+        # the function to be tested:
+        iap1 = self.urihandler.get(self.hmc,
+                                   '/api/cpcs/1/image-activation-profiles/1',
+                                   True)
+
+        exp_iap1 = {
+            'element-id': '1',
+            'element-uri': '/api/cpcs/1/image-activation-profiles/1',
+            'name': 'iap_1',
+            'description': 'Image profile #1 in CPC #1',
+        }
+        self.assertEqual(iap1, exp_iap1)
+
+
+class LoadActProfileHandlersTests(unittest.TestCase):
+    """All tests for classes LoadActProfilesHandler and
+    LoadActProfileHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/cpcs/([^/]+)/load-activation-profiles/([^/]+)',
+             LoadActProfileHandler),
+            ('/api/cpcs/([^/]+)/load-activation-profiles',
+             LoadActProfilesHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        laps = self.urihandler.get(self.hmc,
+                                   '/api/cpcs/1/load-activation-profiles',
+                                   True)
+
+        exp_laps = {  # properties reduced to those returned by List
+            'load-activation-profiles': [
+                {
+                    'element-uri': '/api/cpcs/1/load-activation-profiles/1',
+                    'name': 'lap_1',
+                },
+            ]
+        }
+        self.assertEqual(laps, exp_laps)
+
+    def test_get(self):
+
+        # the function to be tested:
+        lap1 = self.urihandler.get(self.hmc,
+                                   '/api/cpcs/1/load-activation-profiles/1',
+                                   True)
+
+        exp_lap1 = {
+            'element-id': '1',
+            'element-uri': '/api/cpcs/1/load-activation-profiles/1',
+            'name': 'lap_1',
+            'description': 'Load profile #1 in CPC #1',
+        }
+        self.assertEqual(lap1, exp_lap1)
+
+
+if __name__ == '__main__':
+    requests.packages.urllib3.disable_warnings()
+    unittest.main()

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -181,7 +181,7 @@ class AdapterManager(BaseManager):
 
         Returns:
 
-          Adapter:
+          :class:`~zhmcclient.Adapter`:
             The resource object for the new HiperSockets Adapter.
             The object will have its 'object-uri' property set as returned by
             the HMC, and will also have the input properties set.

--- a/zhmcclient_mock/__init__.py
+++ b/zhmcclient_mock/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+zhmcclient_mock - Unit test support for users of the zhmcclient package.
+"""
+
+from __future__ import absolute_import
+
+from ._hmc import *           # noqa: F401

--- a/zhmcclient_mock/__init__.py
+++ b/zhmcclient_mock/__init__.py
@@ -18,4 +18,6 @@ zhmcclient_mock - Unit test support for users of the zhmcclient package.
 
 from __future__ import absolute_import
 
+from ._session import *       # noqa: F401
+from ._urihandler import *    # noqa: F401
 from ._hmc import *           # noqa: F401

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -1,0 +1,1014 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The `zhmcclient_mock` package provides a faked HMC with all resources that are
+relevant for the `zhmcclient` package. The faked HMC is implemented as a
+local Python object and maintains its resource state across operations.
+"""
+
+from __future__ import absolute_import
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+import six
+# from six.moves.urllib.parse import urlparse, parse_qsl
+
+# TODO: Move the resources into their own files.
+
+__all__ = ['FakedBaseResource', 'FakedBaseManager', 'FakedHmc',
+           'FakedActivationProfileManager', 'FakedActivationProfile',
+           'FakedAdapterManager', 'FakedAdapter',
+           'FakedCpcManager', 'FakedCpc',
+           'FakedHbaManager', 'FakedHba',
+           'FakedLparManager', 'FakedLpar',
+           'FakedNicManager', 'FakedNic',
+           'FakedPartitionManager', 'FakedPartition',
+           'FakedPortManager', 'FakedPort',
+           'FakedVirtualFunctionManager', 'FakedVirtualFunction',
+           'FakedVirtualSwitchManager', 'FakedVirtualSwitch',
+           ]
+
+
+class FakedBaseResource(object):
+    """
+    A base class for faked resource classes in the faked HMC.
+    """
+
+    def __init__(self, manager, properties):
+        self._manager = manager
+        self._properties = properties
+
+        if self.manager.oid_prop not in self.properties:
+            new_oid = self.manager._new_oid()
+            self.properties[self.manager.oid_prop] = new_oid
+        self._oid = self.properties[self.manager.oid_prop]
+
+        if self.manager.uri_prop not in self.properties:
+            new_uri = self.manager.base_uri + '/' + self.oid
+            self.properties[self.manager.uri_prop] = new_uri
+        self._uri = self.properties[self.manager.uri_prop]
+
+    @property
+    def manager(self):
+        """
+        The manager for this resource (a derived class of
+        :class:`~zhmcclient_mock.FakedBaseManager`).
+        """
+        return self._manager
+
+    @property
+    def properties(self):
+        """
+        The properties of this resource (a dictionary).
+        """
+        return self._properties
+
+    @property
+    def oid(self):
+        """
+        The object ID (property 'object-id' or 'element-id') of this resource.
+        """
+        return self._oid
+
+    @property
+    def uri(self):
+        """
+        The object URI (property 'object-uri' or 'element-uri') of this
+        resource.
+        """
+        return self._uri
+
+
+class FakedBaseManager(object):
+    """
+    A base class for manager classes for faked resources in the faked HMC.
+    """
+
+    api_root = '/api'  # root of all resource URIs
+    next_oid = 1  # next object ID, for auto-generating them
+
+    def __init__(self, parent, resource_class, base_uri, oid_prop, uri_prop):
+        self._parent = parent
+        self._resource_class = resource_class
+        self._base_uri = base_uri  # Base URI for resources of this type
+        self._oid_prop = oid_prop
+        self._uri_prop = uri_prop
+        self._resources = OrderedDict()  # Resource objects, by object ID
+
+    @property
+    def parent(self):
+        """
+        The parent (scoping resource) for this manager (an object of a derived
+        class of :class:`~zhmcclient_mock.FakedBaseResource`).
+        """
+        return self._parent
+
+    @property
+    def resource_class(self):
+        """
+        The resource class managed by this manager (a derived class of
+        :class:`~zhmcclient_mock.FakedBaseResource`).
+        """
+        return self._resource_class
+
+    @property
+    def base_uri(self):
+        """
+        The base URI for URIs of resources managed by this manager.
+        """
+        return self._base_uri
+
+    @property
+    def oid_prop(self):
+        """
+        The name of the resource property for the object ID ('object-id' or
+        'element-id').
+        """
+        return self._oid_prop
+
+    @property
+    def uri_prop(self):
+        """
+        The name of the resource property for the object URI ('object-uri' or
+        'element-uri').
+        """
+        return self._uri_prop
+
+    def _new_oid(self):
+        new_oid = self.next_oid
+        self.next_oid += 1
+        return str(new_oid)
+
+    def add(self, properties):
+        """
+        Add a faked resource to this manager.
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property (e.g. 'object-uri') or the
+            object ID property (e.g. 'object-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          FakedBaseResource: The faked resource object.
+        """
+        resource = self.resource_class(self, properties)
+        self._resources[resource.oid] = resource
+        return resource
+
+    def remove(self, oid):
+        """
+        Remove a faked resource from this manager.
+
+        Parameters:
+
+          oid (string):
+            The object ID of the resource (e.g. value of the 'object-uri'
+            property).
+        """
+        del self._resources[oid]
+
+    def list(self):
+        """
+        List the faked resources of this manager.
+
+        Returns:
+          list of FakedBaseResource: The faked resource objects of this
+            manager.
+        """
+        return list(six.itervalues(self._resources))
+
+    def lookup_by_oid(self, oid):
+        """
+        Look up a faked resource by its object ID.
+
+        Parameters:
+
+          oid (string):
+            The object ID of the faked resource (e.g. value of the 'object-uri'
+            property).
+
+        Returns:
+          FakedBaseResource: The faked resource object.
+
+        Raises:
+          KeyError: No resource found for this object ID.
+        """
+        return self._resources[oid]
+
+
+class FakedHmc(FakedBaseResource):
+    """
+    A faked HMC.
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common metrhods and attributes.
+
+    An object of this class represents a faked HMC that can have all faked
+    resources that are relevant for the zhmcclient package.
+
+    The Python API to this class and its child resource classes is not
+    compatible with the zhmcclient API. Instead, these classes serve as an
+    in-memory backend for a faked session class (see
+    :class:`zhmcclient_mock.FakedSession`) that replaces the
+    normal :class:`zhmcclient.Session` class.
+
+    Objects of this class should not be created by the user. Instead,
+    access the :attr:`zhmcclient_mock.FakedSession.hmc` attribute.
+    """
+
+    def __init__(self, hmc_name, hmc_version, api_version):
+        self.hmc_name = hmc_name
+        self.hmc_version = hmc_version
+        self.api_version = api_version
+        self.special_operations = {}  # user-provided operations
+        self.cpcs = FakedCpcManager(client=self)
+
+    def add_resources(self, resources):
+        """
+        Add faked resources to the faked HMC, from the provided resource
+        definitions.
+
+        Duplicate resource names in the same scope are not permitted.
+
+        Although this method is typically used to initially load the faked
+        HMC with resource state just once, it can be invoked multiple times.
+
+        Parameters:
+
+          resources (dict):
+            Definitions of faked resources to be added, see example below.
+
+        Example for 'resources' parameter::
+
+            resources = {
+                'cpcs': [  # name of manager attribute for this resource
+                    {
+                        'properties': {
+                            # object-id is not provided -> auto-generated
+                            # object-uri is not provided -> auto-generated
+                            'name': 'cpc_1',
+                            . . .  # more properties
+                        },
+                        'adapters': [  # name of manager attribute for this
+                                       # resource
+                            {
+                                'properties': {
+                                    'object-id': '123',
+                                    'object-uri': '/api/cpcs/../adapters/123',
+                                    'name': 'ad_1',
+                                    . . .  # more properties
+                                },
+                                'ports': [
+                                    {
+                                        'properties': {
+                                            # element-id is auto-generated
+                                            # element-uri is auto-generated
+                                            'name': 'port_1',
+                                            . . .  # more properties
+                                        }
+                                    },
+                                    . . .  # more Ports
+                                ],
+                            },
+                            . . .  # more Adapters
+                        ],
+                        . . .  # more CPC child resources of other types
+                    },
+                    . . .  # more CPCs
+                ]
+            }
+        """
+        for child_attr in resources:
+            child_list = resources[child_attr]
+            self._process_child_list(self, child_attr, child_list)
+
+    def _process_child_list(self, parent_resource, child_attr, child_list):
+        child_manager = getattr(parent_resource, child_attr, None)
+        if child_manager is None:
+            raise ValueError("Invalid child resource type specified in "
+                             "resource dictionary: {}".format(child_attr))
+        for child_dict in child_list:
+            # child_dict is a dict of 'properties' and grand child resources
+            properties = child_dict.get('properties', None)
+            if properties is None:
+                raise ValueError("A resource for resource type {} has no"
+                                 "properties specified.".format(child_attr))
+            child_resource = child_manager.add(properties)
+            for grandchild_attr in child_dict:
+                if grandchild_attr == 'properties':
+                    continue
+                grandchild_list = child_dict[grandchild_attr]
+                self._process_child_list(child_resource, grandchild_attr,
+                                         grandchild_list)
+
+    @staticmethod
+    def _assert_op_key(i, op, key):
+        if key not in op:
+            raise ValueError("Missing '{}' key in operations item #{}".
+                             format(key, i))
+
+    def get(self, uri, logon_required):
+        raise NotImplemented("TODO: Implement his method via the faked HMC.")
+
+    def post(self, uri, body, logon_required, wait_for_completion):
+        raise NotImplemented("TODO: Implement his method via the faked HMC.")
+
+    def delete(self, uri, logon_required):
+        raise NotImplemented("TODO: Implement his method via the faked HMC.")
+
+
+class FakedActivationProfileManager(FakedBaseManager):
+    """
+    A manager for faked Activation Profile resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc, profile_type):
+        activation_profiles = profile_type + '-activation-profiles'
+        super(FakedActivationProfileManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedActivationProfile,
+            base_uri=cpc.uri + '/' + activation_profiles,
+            oid_prop='object-id',
+            uri_prop='object-uri')
+        self._profile_type = profile_type
+
+    @property
+    def profile_type(self):
+        """
+        Type of the activation profile ('reset', 'image', 'load').
+        """
+        return self._profile_type
+
+
+class FakedActivationProfile(FakedBaseResource):
+    """
+    A faked Activation Profile resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedActivationProfile, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedAdapterManager(FakedBaseManager):
+    """
+    A manager for faked Adapter resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc):
+        super(FakedAdapterManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedAdapter,
+            base_uri=self.api_root + '/adapters',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedAdapter(FakedBaseResource):
+    """
+    A faked Adapter resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedAdapter, self).__init__(
+            manager=manager,
+            properties=properties)
+        self._ports = FakedPortManager(adapter=self)
+
+    @property
+    def ports(self):
+        """
+        The Port resources of this Adapter
+        (:class:`~zhmcclient_mock.FakedPort`).
+        """
+        return self._ports
+
+
+class FakedCpcManager(FakedBaseManager):
+    """
+    A manager for faked CPC resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, client):
+        super(FakedCpcManager, self).__init__(
+            parent=client,
+            resource_class=FakedCpc,
+            base_uri=self.api_root + '/cpcs',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedCpc(FakedBaseResource):
+    """
+    A faked CPC resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedCpc, self).__init__(
+            manager=manager,
+            properties=properties)
+        self._lpars = FakedLparManager(cpc=self)
+        self._partitions = FakedPartitionManager(cpc=self)
+        self._adapters = FakedAdapterManager(cpc=self)
+        self._virtual_switches = FakedVirtualSwitchManager(cpc=self)
+        self._reset_activation_profiles = FakedActivationProfileManager(
+            cpc=self, profile_type='reset')
+        self._image_activation_profiles = FakedActivationProfileManager(
+            cpc=self, profile_type='image')
+        self._load_activation_profiles = FakedActivationProfileManager(
+            cpc=self, profile_type='load')
+
+    @property
+    def lpars(self):
+        """
+        :class:`~zhmcclient_mock.FakedLparManager`: Access to the faked LPAR
+        resources of this CPC.
+        """
+        return self._lpars
+
+    @property
+    def partitions(self):
+        """
+        :class:`~zhmcclient_mock.FakedPartitionManager`: Access to the faked
+        Partition resources of this CPC.
+        """
+        return self._partitions
+
+    @property
+    def adapters(self):
+        """
+        :class:`~zhmcclient_mock.FakedAdapterManager`: Access to the faked
+        Adapter resources of this CPC.
+        """
+        return self._adapters
+
+    @property
+    def virtual_switches(self):
+        """
+        :class:`~zhmcclient_mock.FakedVirtualSwitchManager`: Access to the
+        faked Virtual Switch resources of this CPC.
+        """
+        return self._virtual_switches
+
+    @property
+    def reset_activation_profiles(self):
+        """
+        :class:`~zhmcclient_mock.FakedActivationProfileManager`: Access to the
+        faked Reset Activation Profile resources of this CPC.
+        """
+        return self._reset_activation_profiles
+
+    @property
+    def image_activation_profiles(self):
+        """
+        :class:`~zhmcclient_mock.FakedActivationProfileManager`: Access to the
+        faked Image Activation Profile resources of this CPC.
+        """
+        return self._image_activation_profiles
+
+    @property
+    def load_activation_profiles(self):
+        """
+        :class:`~zhmcclient_mock.FakedActivationProfileManager`: Access to the
+        faked Load Activation Profile resources of this CPC.
+        """
+        return self._load_activation_profiles
+
+
+class FakedHbaManager(FakedBaseManager):
+    """
+    A manager for faked HBA resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, partition):
+        super(FakedHbaManager, self).__init__(
+            parent=partition,
+            resource_class=FakedHba,
+            base_uri=partition.uri + '/hbas',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a faked HBA resource to this manager.
+
+        This method also updates the 'hba-uris' property in the parent
+        Partition resource (if it exists).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          :class:`zhmcclient_mock.FakedHba`: The faked resource object.
+        """
+        new_hba = super(FakedHbaManager, self).add(properties)
+        partition = self.parent
+        if 'hba-uris' in partition.properties:
+            partition.properties['hba-uris'].append(new_hba.uri)
+        return new_hba
+
+    def remove(self, oid):
+        """
+        Remove a faked HBA resource from this manager.
+
+        This method also updates the 'hba-uris' property in the parent
+        Partition resource (if it exists).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the faked HBA resource.
+        """
+        hba = self.lookup_by_oid(oid)
+        partition = self.parent
+        if 'hba-uris' in partition.properties:
+            del partition.properties['hba-uris'][hba.uri]
+        super(FakedHbaManager, self).remove(oid)  # deletes the resource
+
+
+class FakedHba(FakedBaseResource):
+    """
+    A faked HBA resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedHba, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedLparManager(FakedBaseManager):
+    """
+    A manager for faked LPAR resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc):
+        super(FakedLparManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedLpar,
+            base_uri=self.api_root + '/logical-partitions',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedLpar(FakedBaseResource):
+    """
+    A faked LPAR resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedLpar, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedNicManager(FakedBaseManager):
+    """
+    A manager for faked NIC resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, partition):
+        super(FakedNicManager, self).__init__(
+            parent=partition,
+            resource_class=FakedNic,
+            base_uri=partition.uri + '/nics',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a faked NIC resource to this manager.
+
+        This method also updates the 'nic-uris' property in the parent
+        Partition resource (if it exists).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          :class:`zhmcclient_mock.FakedNic`: The faked resource object.
+        """
+        new_nic = super(FakedNicManager, self).add(properties)
+        partition = self.parent
+        if 'nic-uris' in partition.properties:
+            partition.properties['nic-uris'].append(new_nic.uri)
+        return new_nic
+
+    def remove(self, oid):
+        """
+        Remove a faked NIC resource from this manager.
+
+        This method also updates the 'nic-uris' property in the parent
+        Partition resource (if it exists).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the faked NIC resource.
+        """
+        nic = self.lookup_by_oid(oid)
+        partition = self.parent
+        if 'nic-uris' in partition.properties:
+            del partition.properties['nic-uris'][nic.uri]
+        super(FakedNicManager, self).remove(oid)  # deletes the resource
+
+
+class FakedNic(FakedBaseResource):
+    """
+    A faked NIC resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedNic, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedPartitionManager(FakedBaseManager):
+    """
+    A manager for faked Partition resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc):
+        super(FakedPartitionManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedPartition,
+            base_uri=self.api_root + '/partitions',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedPartition(FakedBaseResource):
+    """
+    A faked Partition resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedPartition, self).__init__(
+            manager=manager,
+            properties=properties)
+        self._nics = FakedNicManager(partition=self)
+        self._hbas = FakedHbaManager(partition=self)
+        self._virtual_functions = FakedVirtualFunctionManager(partition=self)
+
+    @property
+    def nics(self):
+        """
+        :class:`~zhmcclient_mock.FakedNicManager`: Access to the faked NIC
+        resources of this Partition.
+        """
+        return self._nics
+
+    @property
+    def hbas(self):
+        """
+        :class:`~zhmcclient_mock.FakedHbaManager`: Access to the faked HBA
+        resources of this Partition.
+        """
+        return self._hbas
+
+    @property
+    def virtual_functions(self):
+        """
+        :class:`~zhmcclient_mock.FakedVirtualFunctionManager`: Access to the
+        faked Virtual Function resources of this Partition.
+        """
+        return self._virtual_functions
+
+
+class FakedPortManager(FakedBaseManager):
+    """
+    A manager for faked Adapter Port resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, adapter):
+        super(FakedPortManager, self).__init__(
+            parent=adapter,
+            resource_class=FakedPort,
+            base_uri=adapter.uri + '/ports',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a faked Port resource to this manager.
+
+        This method also updates the 'network-port-uris' or 'storage-port-uris'
+        property in the parent Adapter resource (whichever exists, gets
+        updated).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          :class:`zhmcclient_mock.FakedPort`: The resource object.
+        """
+        new_port = super(FakedPortManager, self).add(properties)
+        adapter = self.parent
+        if 'network-port-uris' in adapter.properties:
+            adapter.properties['network-port-uris'].append(new_port.uri)
+        elif 'storage-port-uris' in adapter.properties:
+            adapter.properties['storage-port-uris'].append(new_port.uri)
+        return new_port
+
+    def remove(self, oid):
+        """
+        Remove a faked Port resource from this manager.
+
+        This method also updates the 'network-port-uris' or 'storage-port-uris'
+        property in the parent Adapter resource (whichever exists, gets
+        updated).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the Port resource.
+        """
+        port = self.lookup_by_oid(oid)
+        adapter = self.parent
+        if 'network-port-uris' in adapter.properties:
+            del adapter.properties['network-port-uris'][port.uri]
+        elif 'storage-port-uris' in adapter.properties:
+            del adapter.properties['storage-port-uris'][port.uri]
+        super(FakedPortManager, self).remove(oid)  # deletes the resource
+
+
+class FakedPort(FakedBaseResource):
+    """
+    A faked Adapter Port resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedPort, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedVirtualFunctionManager(FakedBaseManager):
+    """
+    A manager for faked Virtual Function resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, partition):
+        super(FakedVirtualFunctionManager, self).__init__(
+            parent=partition,
+            resource_class=FakedVirtualFunction,
+            base_uri=partition.uri + '/virtual-functions',
+            oid_prop='element-id',
+            uri_prop='element-uri')
+
+    def add(self, properties):
+        """
+        Add a faked Virtual Function resource to this manager.
+
+        This method also updates the 'virtual-function-uris' property in the
+        parent Partition resource (if it exists).
+
+        Parameters:
+
+          properties (dict):
+            Resource properties. If the URI property ('element-uri') or the
+            object ID property ('element-id') are not specified, they
+            will be auto-generated.
+
+        Returns:
+          :class:`zhmcclient_mock.FakedVirtualFunction`: The faked resource
+            object.
+        """
+        new_virtual_function = super(FakedVirtualFunctionManager,
+                                     self).add(properties)
+        partition = self.parent
+        if 'virtual-function-uris' in partition.properties:
+            partition.properties['virtual-function-uris'].append(
+                new_virtual_function.uri)
+        return new_virtual_function
+
+    def remove(self, oid):
+        """
+        Remove a faked Virtual Function resource from this manager.
+
+        This method also updates the 'virtual-function-uris' property in the
+        parent Partition resource (if it exists).
+
+        Parameters:
+
+          oid (string):
+            The object ID of the faked Virtual Function resource.
+        """
+        virtual_function = self.lookup_by_oid(oid)
+        partition = self.parent
+        if 'virtual-function-uris' in partition.properties:
+            vf_uris = partition.properties['virtual-function-uris']
+            del vf_uris[virtual_function.uri]
+        super(FakedVirtualFunctionManager, self).remove(oid)  # deletes res.
+
+
+class FakedVirtualFunction(FakedBaseResource):
+    """
+    A faked Virtual Function resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedVirtualFunction, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+class FakedVirtualSwitchManager(FakedBaseManager):
+    """
+    A manager for faked Virtual Switch resources within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, cpc):
+        super(FakedVirtualSwitchManager, self).__init__(
+            parent=cpc,
+            resource_class=FakedVirtualSwitch,
+            base_uri=self.api_root + '/virtual-switches',
+            oid_prop='object-id',
+            uri_prop='object-uri')
+
+
+class FakedVirtualSwitch(FakedBaseResource):
+    """
+    A faked Virtual Switch resource within a faked HMC (see
+    :class:`zhmcclient_mock.FakedHmc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super(FakedVirtualSwitch, self).__init__(
+            manager=manager,
+            properties=properties)
+
+
+URLS = (
+
+    # In all modes:
+    '/api/cpcs', 'CpcsHandler',
+    '/api/cpcs/(.*)', 'CpcHandler',
+    '/api/version', 'VersionHandler',
+
+    # Only in DPM mode:
+    '/api/cpcs/(.*)/operations/start', 'CpcStartHandler',
+    '/api/cpcs', 'CpcsHandler',
+    '/api/cpcs/(.*)', 'CpcHandler',
+    '/api/version', 'VersionHandler',
+
+    # Only in DPM mode:
+    '/api/cpcs/(.*)/operations/start', 'CpcStartHandler',
+    '/api/cpcs/(.*)/operations/stop', 'CpcStopHandler',
+    '/api/cpcs/(.*)/operations/export-port-names-list',
+    'CpcExportPortNamesListHandler',
+    '/api/cpcs/(.*)/adapters', 'AdaptersHandler',
+    '/api/adapters/(.*)', 'AdapterHandler',
+    '/api/adapters/(.*)/network-ports/(.*)', 'NetworkPortHandler',
+    '/api/adapters/(.*)/storage-ports/(.*)', 'StoragePortHandler',
+    '/api/cpcs/(.*)/partitions', 'PartitionsHandler',
+    '/api/partitions/(.*)', 'PartitionHandler',
+    '/api/partitions/(.*)/operations/start', 'PartitionStartHandler',
+    '/api/partitions/(.*)/operations/stop', 'PartitionStopHandler',
+    '/api/partitions/(.*)/operations/scsi-dump', 'PartitionScsiDumpHandler',
+    '/api/partitions/(.*)/operations/psw-restart',
+    'PartitionPswRestartHandler',
+    '/api/partitions/(.*)/operations/mount-iso-image',
+    'PartitionMountIsoImageHandler',
+    '/api/partitions/(.*)/operations/unmount-iso-image',
+    'PartitionUnmountIsoImageHandler',
+    '/api/partitions/(.*)/hbas', 'HbasHandler',
+    '/api/partitions/(.*)/hbas/(.*)', 'HbaHandler',
+    '/api/partitions/(.*)/hbas/(.*)/operations/reassign-storage-adapter-port',
+    'HbaReassignPortHandler',
+    '/api/partitions/(.*)/nics', 'NicsHandler',
+    '/api/partitions/(.*)/nics/(.*)', 'NicHandler',
+    '/api/partitions/(.*)/virtual-functions', 'VirtualFunctionsHandler',
+    '/api/partitions/(.*)/virtual-functions/(.*)', 'VirtualFunctionHandler',
+    '/api/cpcs/(.*)/virtual-switches', 'VirtualSwitchesHandler',
+    '/api/virtual-switches/(.*)', 'VirtualSwitchHandler',
+    '/api/virtual-switches/(.*)/operations/get-connected-vnics',
+    'VirtualSwitchGetVnicsHandler',
+
+    # Only in classic (or ensemble) mode:
+    # '/api/cpcs/(.*)/operations/activate', 'CpcActivateHandler',
+    # '/api/cpcs/(.*)/operations/deactivate', 'CpcDeactivateHandler',
+    '/api/cpcs/(.*)/operations/import-profiles', 'CpcImportProfilesHandler',
+    '/api/cpcs/(.*)/operations/export-profiles', 'CpcExportProfilesHandler',
+    '/api/cpcs/(.*)/logical-partitions', 'LparsHandler',
+    '/api/logical-partitions/(.*)', 'LparHandler',
+    '/api/logical-partitions/(.*)/operations/activate', 'LparActivateHandler',
+    '/api/logical-partitions/(.*)/operations/deactivate',
+    'LparDeactivateHandler',
+    '/api/logical-partitions/(.*)/operations/load', 'LparLoadHandler',
+    '/api/cpcs/(.*)/reset-activation-profiles', 'ResetActProfilesHandler',
+    '/api/cpcs/(.*)/reset-activation-profiles/(.*)', 'ResetActProfileHandler',
+    '/api/cpcs/(.*)/image-activation-profiles', 'ImageActProfilesHandler',
+    '/api/cpcs/(.*)/image-activation-profiles/(.*)', 'ImageActProfileHandler',
+    '/api/cpcs/(.*)/load-activation-profiles', 'LoadActProfilesHandler',
+    '/api/cpcs/(.*)/load-activation-profiles/(.*)', 'LoadActProfileHandler',
+)

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -1,0 +1,259 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A faked Session class for the zhmcclient package.
+"""
+
+from __future__ import absolute_import
+
+import zhmcclient
+
+from ._hmc import FakedHmc
+from ._urihandler import UriHandler, HTTPError, URIS
+
+__all__ = ['FakedSession']
+
+
+class FakedSession(zhmcclient.Session):
+    """
+    A faked Session class for the zhmcclient package, that can be used as a
+    replacement for the :class:`zhmcclient.Session` class.
+
+    This class is derived from :class:`zhmcclient.Session`.
+
+    This class can be used by projects using the zhmcclient package for their
+    unit testing. It can also be used by unit tests of the zhmcclient package
+    itself.
+
+    This class provides a faked HMC with all of its resources that are relevant
+    for the zhmcclient.
+
+    The faked HMC provided by this class maintains its resource state in memory
+    as Python objects, and no communication happens to any real HMC. The
+    faked HMC implements all HMC operations that are relevant for the
+    zhmcclient package in a successful manner.
+
+    It is possible to populate the faked HMC with an initial resource state
+    (see :meth:`~zhmcclient_mock.FakedHmc.add_resources`).
+    """
+
+    def __init__(self, host, hmc_name, hmc_version, api_version):
+        """
+        Parameters:
+
+          host (:term:`string`):
+            HMC host.
+
+          hmc_name (:term:`string`):
+            HMC name. Used for result of Query Version Info operation.
+
+          hmc_version (:term:`string`):
+            HMC version string (e.g. '2.13.1'). Used for result of
+            Query Version Info operation.
+
+          api_version (:term:`string`):
+            HMC API version string (e.g. '1.8'). Used for result of
+            Query Version Info operation.
+        """
+        super(FakedSession, self).__init__(host)
+        self._hmc = FakedHmc(hmc_name, hmc_version, api_version)
+        self._urihandler = UriHandler(URIS)
+
+    @property
+    def hmc(self):
+        """
+        :class:`~zhmcclient_mock.FakedHmc`: The faked HMC provided by this
+        faked session.
+
+        The faked HMC supports being populated with initial resource state,
+        for example using its :meth:`zhmcclient_mock.FakedHmc.add_resources`
+        method.
+
+        As an alternative to providing an entire resource tree, the resources
+        can also be added one by one, from top to bottom, using the
+        :meth:`zhmcclient_mock.FakedBaseManager.add` methods of the
+        respective managers (the top-level manager for CPCs can be accessed
+        via ``hmc.cpcs``).
+        """
+        return self._hmc
+
+    def get(self, uri, logon_required=True):
+        """
+        Perform the HTTP GET method against the resource identified by a URI,
+        on the faked HMC.
+
+        Parameters:
+
+          uri (:term:`string`):
+            Relative URI path of the resource, e.g. "/api/session".
+            This URI is relative to the base URL of the session (see
+            the :attr:`~zhmcclient.Session.base_url` property).
+            Must not be `None`.
+
+          logon_required (bool):
+            Boolean indicating whether the operation requires that the session
+            is logged on to the HMC.
+
+            Because this is a faked HMC, this does not perform a real logon,
+            but it is still used to update the state in the faked HMC.
+
+        Returns:
+
+          :term:`json object` with the operation result.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError` (not implemented)
+          :exc:`~zhmcclient.AuthError` (not implemented)
+          :exc:`~zhmcclient.ConnectionError` (not implemented)
+        """
+        try:
+            return self._urihandler.get(self._hmc, uri, logon_required)
+        except HTTPError as exc:
+            raise zhmcclient.HTTPError(exc.response())
+
+    def post(self, uri, body=None, logon_required=True,
+             wait_for_completion=True):
+        """
+        Perform the HTTP POST method against the resource identified by a URI,
+        using a provided request body, on the faked HMC.
+
+        HMC operations using HTTP POST are either synchronous or asynchronous.
+        Asynchronous operations return the URI of an asynchronously executing
+        job that can be queried for status and result.
+
+        Examples for synchronous operations:
+
+        * With no response body: "Logon", "Update CPC Properties"
+        * With a response body: "Create Partition"
+
+        Examples for asynchronous operations:
+
+        * With no ``job-results`` field in the completed job status response:
+          "Start Partition"
+        * With a ``job-results`` field in the completed job status response
+          (under certain conditions): "Activate a Blade", or "Set CPC Power
+          Save"
+
+        The `wait_for_completion` parameter of this method can be used to deal
+        with asynchronous HMC operations in a synchronous way.
+
+        Parameters:
+
+          uri (:term:`string`):
+            Relative URI path of the resource, e.g. "/api/session".
+            This URI is relative to the base URL of the session (see the
+            :attr:`~zhmcclient.Session.base_url` property).
+            Must not be `None`.
+
+          body (:term:`json object`):
+            JSON object to be used as the HTTP request body (payload).
+            `None` means the same as an empty dictionary, namely that no HTTP
+            body is included in the request.
+
+          logon_required (bool):
+            Boolean indicating whether the operation requires that the session
+            is logged on to the HMC. For example, the "Logon" operation does
+            not require that.
+
+            Because this is a faked HMC, this does not perform a real logon,
+            but it is still used to update the state in the faked HMC.
+
+          wait_for_completion (bool):
+            Boolean controlling whether this method should wait for completion
+            of the requested HMC operation, as follows:
+
+            * If `True`, this method will wait for completion of the requested
+              operation, regardless of whether the operation is synchronous or
+              asynchronous.
+
+              This will cause an additional entry in the time statistics to be
+              created for the asynchronous operation and waiting for its
+              completion. This entry will have a URI that is the targeted URI,
+              appended with "+completion".
+
+            * If `False`, this method will immediately return the result of the
+              HTTP POST method, regardless of whether the operation is
+              synchronous or asynchronous.
+
+        Returns:
+
+          :term:`json object`:
+
+            If `wait_for_completion` is `True`, returns a JSON object
+            representing the response body of the synchronous operation, or the
+            response body of the completed job that performed the asynchronous
+            operation. If a synchronous operation has no response body, `None`
+            is returned.
+
+            If `wait_for_completion` is `False`, returns a JSON object
+            representing the response body of the synchronous or asynchronous
+            operation. In case of an asynchronous operation, the JSON object
+            will have a member named ``job-uri``, whose value can be used with
+            the :meth:`~zhmcclient.Session.query_job_status` method to
+            determine the status of the job and the result of the original
+            operation, once the job has completed.
+
+            See the section in the :term:`HMC API` book about the specific HMC
+            operation and about the 'Query Job Status' operation, for a
+            description of the members of the returned JSON objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError` (not implemented)
+          :exc:`~zhmcclient.AuthError` (not implemented)
+          :exc:`~zhmcclient.ConnectionError` (not implemented)
+        """
+        try:
+            return self._urihandler.post(self._hmc, uri, body, logon_required,
+                                         wait_for_completion)
+        except HTTPError as exc:
+            raise zhmcclient.HTTPError(exc.response())
+
+    def delete(self, uri, logon_required=True):
+        """
+        Perform the HTTP DELETE method against the resource identified by a
+        URI, on the faked HMC.
+
+        Parameters:
+
+          uri (:term:`string`):
+            Relative URI path of the resource, e.g.
+            "/api/session/{session-id}".
+            This URI is relative to the base URL of the session (see
+            the :attr:`~zhmcclient.Session.base_url` property).
+            Must not be `None`.
+
+          logon_required (bool):
+            Boolean indicating whether the operation requires that the session
+            is logged on to the HMC. For example, for the logoff operation, it
+            does not make sense to first log on.
+
+            Because this is a faked HMC, this does not perform a real logon,
+            but it is still used to update the state in the faked HMC.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError` (not implemented)
+          :exc:`~zhmcclient.AuthError` (not implemented)
+          :exc:`~zhmcclient.ConnectionError` (not implemented)
+        """
+        try:
+            self._urihandler.delete(self._hmc, uri, logon_required)
+        except HTTPError as exc:
+            raise zhmcclient.HTTPError(exc.response())

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -1,0 +1,783 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A utility class that handles HTTP methods against HMC URIs, based on the
+faked HMC.
+
+Note: At this point, the following HTTP methods needed by the zhmcclient
+have not been implemented yet::
+
+    POST     /api/partitions/([^/]+)/operations/scsi-dump
+    POST     /api/partitions/([^/]+)/operations/psw-restart
+    POST     /api/partitions/([^/]+)/operations/mount-iso-image
+    POST     /api/partitions/([^/]+)/operations/unmount-iso-image
+    POST     /api/partitions/([^/]+)/hbas/([^/]+)/operations/reassign-
+               storage-adapter-port
+    POST     /api/virtual-switches/([^/]+)/operations/get-connected-vnics
+    POST     /api/cpcs/([^/]+)/operations/import-profiles
+    POST     /api/cpcs/([^/]+)/operations/export-profiles
+"""
+
+from __future__ import absolute_import
+
+import re
+
+__all__ = ['UriHandler', 'HTTPError', 'URIS']
+
+
+class HTTPError(Exception):
+
+    def __init__(self, method, uri, http_status, reason, message):
+        self.method = method
+        self.uri = uri
+        self.http_status = http_status
+        self.reason = reason
+        self.message = message
+
+    def response(self):
+        return {
+            'request-method': self.method,
+            'request-uri': self.uri,
+            'http-status': self.http_status,
+            'reason': self.reason,
+            'message': self.message,
+        }
+
+
+class InvalidResourceError(HTTPError):
+
+    def __init__(self, method, uri, handler_class=None):
+        if handler_class is not None:
+            handler_txt = "handler class %s" % handler_class.__name__
+        else:
+            handler_txt = "no handler class"
+        super(InvalidResourceError, self).__init__(
+            method, uri,
+            http_status=404,
+            reason=1,
+            message="Unknown resource with URI: %s (%s)" % (uri, handler_txt))
+
+
+class InvalidMethodError(HTTPError):
+
+    def __init__(self, method, uri, handler_class=None):
+        if handler_class is not None:
+            handler_txt = "handler class %s" % handler_class.__name__
+        else:
+            handler_txt = "no handler class"
+        super(InvalidMethodError, self).__init__(
+            method, uri,
+            http_status=404,
+            reason=1,
+            message="Invalid HTTP method %s on URI: %s %s" %
+            (method, uri, handler_txt))
+
+
+class CpcNotInDpmError(HTTPError):
+
+    def __init__(self, method, uri, cpc):
+        super(CpcNotInDpmError, self).__init__(
+            method, uri,
+            http_status=409,
+            reason=5,
+            message="CPC is not in DPM mode: %s" % cpc.uri)
+
+
+class CpcInDpmError(HTTPError):
+
+    def __init__(self, method, uri, cpc):
+        super(CpcInDpmError, self).__init__(
+            method, uri,
+            http_status=409,
+            reason=4,
+            message="CPC is in DPM mode: %s" % cpc.uri)
+
+
+class UriHandler(object):
+    """
+    Handle HTTP methods against a set of known URIs and invoke respective
+    handlers.
+    """
+
+    def __init__(self, uris):
+        self._uri_handlers = []  # tuple of (regexp-pattern, handler-name)
+        for uri, handler_class in uris:
+            uri_pattern = re.compile('^' + uri + '$')
+            tup = (uri_pattern, handler_class)
+            self._uri_handlers.append(tup)
+
+    def handler(self, uri, method):
+        for uri_pattern, handler_class in self._uri_handlers:
+            m = uri_pattern.match(uri)
+            if m:
+                uri_parms = m.groups()
+                return handler_class, uri_parms
+        raise InvalidResourceError(method, uri)
+
+    def get(self, hmc, uri, logon_required):
+        handler_class, uri_parms = self.handler(uri, 'GET')
+        if not getattr(handler_class, 'get', None):
+            raise InvalidMethodError('GET', uri, handler_class)
+        return handler_class.get(hmc, uri, uri_parms, logon_required)
+
+    def post(self, hmc, uri, body, logon_required, wait_for_completion):
+        handler_class, uri_parms = self.handler(uri, 'POST')
+        if not getattr(handler_class, 'post', None):
+            raise InvalidMethodError('POST', uri, handler_class)
+        return handler_class.post(hmc, uri, uri_parms, body, logon_required,
+                                  wait_for_completion)
+
+    def delete(self, hmc, uri, logon_required):
+        handler_class, uri_parms = self.handler(uri, 'DELETE')
+        if not getattr(handler_class, 'delete', None):
+            raise InvalidMethodError('DELETE', uri, handler_class)
+        handler_class.delete(hmc, uri, uri_parms, logon_required)
+
+
+class GenericGetPropertiesHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: Get <resource> Properties."""
+        try:
+            resource = hmc.lookup_by_uri(uri)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        return resource.properties
+
+
+class GenericUpdatePropertiesHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Update <resource> Properties."""
+        assert wait_for_completion is True  # async not supported yet
+        try:
+            resource = hmc.lookup_by_uri(uri)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        resource.update(body)
+
+
+class VersionHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        api_major, api_minor = hmc.api_version.split('.')
+        return {
+            'hmc-name': hmc.hmc_name,
+            'hmc-version': hmc.hmc_version,
+            'api-major-version': int(api_major),
+            'api-minor-version': int(api_minor),
+        }
+
+
+class CpcsHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: List CPCs."""
+        result_cpcs = []
+        for cpc in hmc.cpcs.list():
+            result_cpc = {}
+            for prop in cpc.properties:
+                if prop in ('object-uri', 'name', 'status'):
+                    result_cpc[prop] = cpc.properties[prop]
+            result_cpcs.append(result_cpc)
+        return {'cpcs': result_cpcs}
+
+
+class CpcHandler(GenericGetPropertiesHandler,
+                 GenericUpdatePropertiesHandler):
+    pass
+
+
+class CpcStartHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Start CPC (requires DPM mode)."""
+        assert wait_for_completion is True  # async not supported yet
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+        cpc.properties['status'] = 'active'
+
+
+class CpcStopHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Stop CPC (requires DPM mode)."""
+        assert wait_for_completion is True  # async not supported yet
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+        cpc.properties['status'] = 'not-operating'
+
+
+class CpcExportPortNamesListHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Export WWPN List (requires DPM mode)."""
+        assert wait_for_completion is True  # this operation is always synchr.
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+
+        if body is None or 'partitions' not in body:
+            raise HTTPError('POST', uri, 400,
+                            149,  # TODO: Maybe use different reason?
+                            "No 'partitions' property provided in request "
+                            "body.")
+        partition_uris = body['partitions']
+        if len(partition_uris) == 0:
+            raise HTTPError('POST', uri, 400, 149,
+                            "'partitions' property provided in request "
+                            "body is empty.")
+
+        wwpn_list = []
+        for partition_uri in partition_uris:
+            partition = hmc.lookup_by_uri(partition_uri)
+            partition_cpc = partition.manager.parent
+            if partition_cpc.oid != cpc_oid:
+                raise HTTPError('POST', uri, 400,
+                                149,  # TODO: Maybe use different reason?
+                                "Partition with object ID %s specified in "
+                                "'partitions' property is not in CPC with "
+                                "object ID %s." % (partition.oid, cpc_oid))
+            partition_name = partition.properties.get('name', '')
+            for hba in partition.hbas.list():
+                port_uri = hba.properties['adapter-port-uri']
+                port = hmc.lookup_by_uri(port_uri)
+                adapter = port.manager.parent
+                devno = hba.properties.get('device-number', '')
+                wwpn = hba.properties.get('wwpn', '')
+                wwpn_str = '%s,%s,%s,%s' % (partition_name, adapter.oid,
+                                            devno, wwpn)
+                wwpn_list.append(wwpn_str)
+        return {
+            'wwpn-list': wwpn_list
+        }
+
+
+class AdaptersHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: List Adapters of a CPC."""
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        if not cpc.dpm_enabled:
+            raise InvalidResourceError('GET', uri)  # in List: not found
+        result_adapters = []
+        for adapter in cpc.adapters.list():
+            result_adapter = {}
+            for prop in adapter.properties:
+                if prop in ('object-uri', 'name', 'status'):
+                    result_adapter[prop] = adapter.properties[prop]
+            result_adapters.append(result_adapter)
+        return {'adapters': result_adapters}
+
+
+class AdapterHandler(GenericGetPropertiesHandler,
+                     GenericUpdatePropertiesHandler):
+    pass
+
+
+class NetworkPortHandler(GenericGetPropertiesHandler,
+                         GenericUpdatePropertiesHandler):
+    pass
+
+
+class StoragePortHandler(GenericGetPropertiesHandler,
+                         GenericUpdatePropertiesHandler):
+    pass
+
+
+class PartitionsHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: List Partitions of a CPC."""
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        if not cpc.dpm_enabled:
+            raise InvalidResourceError('GET', uri)  # in List: not found
+        result_partitions = []
+        for partition in cpc.partitions.list():
+            result_partition = {}
+            for prop in partition.properties:
+                if prop in ('object-uri', 'name', 'status'):
+                    result_partition[prop] = partition.properties[prop]
+            result_partitions.append(result_partition)
+        return {'partitions': result_partitions}
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Create Partition."""
+        assert wait_for_completion is True  # async not supported yet
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+        new_partition = cpc.partitions.add(body)
+        return {'object-uri': new_partition.uri}
+
+
+class PartitionHandler(GenericGetPropertiesHandler,
+                       GenericUpdatePropertiesHandler):
+
+    @staticmethod
+    def delete(hmc, uri, uri_parms, logon_required):
+        """Operation: Delete Partition."""
+        try:
+            partition = hmc.lookup_by_uri(uri)
+        except KeyError:
+            raise InvalidResourceError('DELETE', uri)
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('DELETE', uri, cpc)
+        partition.manager.remove(partition.oid)
+
+
+class PartitionStartHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Start Partition (requires DPM mode)."""
+        assert wait_for_completion is True  # async not supported yet
+        partition_uri = uri.split('/operations/')[0]
+        try:
+            partition = hmc.lookup_by_uri(partition_uri)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+        partition.properties['status'] = 'active'
+
+
+class PartitionStopHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Start Partition (requires DPM mode)."""
+        assert wait_for_completion is True  # async not supported yet
+        partition_uri = uri.split('/operations/')[0]
+        try:
+            partition = hmc.lookup_by_uri(partition_uri)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+        partition.properties['status'] = 'stopped'
+
+
+class HbasHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Create HBA."""
+        assert wait_for_completion is True  # async not supported yet
+        partition_uri = re.sub('/hbas$', '', uri)
+        try:
+            partition = hmc.lookup_by_uri(partition_uri)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+        new_hba = partition.hbas.add(body)
+        return {'element-uri': new_hba.uri}
+
+
+class HbaHandler(GenericGetPropertiesHandler,
+                 GenericUpdatePropertiesHandler):
+
+    @staticmethod
+    def delete(hmc, uri, uri_parms, logon_required):
+        """Operation: Delete HBA."""
+        try:
+            hba = hmc.lookup_by_uri(uri)
+        except KeyError:
+            raise InvalidResourceError('DELETE', uri)
+        partition = hba.manager.parent
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('DELETE', uri, cpc)
+        partition.hbas.remove(hba.oid)
+
+
+class NicsHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Create NIC."""
+        assert wait_for_completion is True  # async not supported yet
+        partition_uri = re.sub('/nics$', '', uri)
+        try:
+            partition = hmc.lookup_by_uri(partition_uri)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+        new_nic = partition.nics.add(body)
+        return {'element-uri': new_nic.uri}
+
+
+class NicHandler(GenericGetPropertiesHandler,
+                 GenericUpdatePropertiesHandler):
+
+    @staticmethod
+    def delete(hmc, uri, uri_parms, logon_required):
+        """Operation: Delete NIC."""
+        try:
+            nic = hmc.lookup_by_uri(uri)
+        except KeyError:
+            raise InvalidResourceError('DELETE', uri)
+        partition = nic.manager.parent
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('DELETE', uri, cpc)
+        partition.nics.remove(nic.oid)
+
+
+class VirtualFunctionsHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Create Virtual Function"""
+        assert wait_for_completion is True  # async not supported yet
+        partition_uri = re.sub('/virtual-functions$', '', uri)
+        try:
+            partition = hmc.lookup_by_uri(partition_uri)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('POST', uri, cpc)
+        new_vf = partition.virtual_functions.add(body)
+        return {'element-uri': new_vf.uri}
+
+
+class VirtualFunctionHandler(GenericGetPropertiesHandler,
+                             GenericUpdatePropertiesHandler):
+
+    @staticmethod
+    def delete(hmc, uri, uri_parms, logon_required):
+        """Operation: Delete Virtual Function."""
+        try:
+            vf = hmc.lookup_by_uri(uri)
+        except KeyError:
+            raise InvalidResourceError('DELETE', uri)
+        partition = vf.manager.parent
+        cpc = partition.manager.parent
+        if not cpc.dpm_enabled:
+            raise CpcNotInDpmError('DELETE', uri, cpc)
+        partition.virtual_functions.remove(vf.oid)
+
+
+class VirtualSwitchesHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: List Virtual Switches of a CPC."""
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        if not cpc.dpm_enabled:
+            raise InvalidResourceError('GET', uri)  # in List: not found
+        result_vswitches = []
+        for vswitch in cpc.virtual_switches.list():
+            result_vswitch = {}
+            for prop in vswitch.properties:
+                if prop in ('object-uri', 'name', 'type'):
+                    result_vswitch[prop] = vswitch.properties[prop]
+            result_vswitches.append(result_vswitch)
+        return {'virtual-switches': result_vswitches}
+
+
+class VirtualSwitchHandler(GenericGetPropertiesHandler,
+                           GenericUpdatePropertiesHandler):
+    pass
+
+
+class LparsHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: List Logical Partitions of CPC."""
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        if cpc.dpm_enabled:
+            raise InvalidResourceError('GET', uri)  # in List: not found
+        result_lpars = []
+        for lpar in cpc.lpars.list():
+            result_lpar = {}
+            for prop in lpar.properties:
+                if prop in ('object-uri', 'name', 'status'):
+                    result_lpar[prop] = lpar.properties[prop]
+            result_lpars.append(result_lpar)
+        return {'logical-partitions': result_lpars}
+
+
+class LparHandler(GenericGetPropertiesHandler,
+                  GenericUpdatePropertiesHandler):
+    pass
+
+
+class LparActivateHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Activate Logical Partition (requires classic mode)."""
+        assert wait_for_completion is True  # async not supported yet
+        lpar_uri = uri.split('/operations/')[0]
+        try:
+            lpar = hmc.lookup_by_uri(lpar_uri)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        cpc = lpar.manager.parent
+        if cpc.dpm_enabled:
+            raise CpcInDpmError('POST', uri, cpc)
+        lpar.properties['status'] = 'not-operating'
+
+
+class LparDeactivateHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Deactivate Logical Partition (requires classic mode)."""
+        assert wait_for_completion is True  # async not supported yet
+        lpar_uri = uri.split('/operations/')[0]
+        try:
+            lpar = hmc.lookup_by_uri(lpar_uri)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        cpc = lpar.manager.parent
+        if cpc.dpm_enabled:
+            raise CpcInDpmError('POST', uri, cpc)
+        lpar.properties['status'] = 'not-activated'
+
+
+class LparLoadHandler(object):
+
+    @staticmethod
+    def post(hmc, uri, uri_parms, body, logon_required, wait_for_completion):
+        """Operation: Load Logical Partition (requires classic mode)."""
+        assert wait_for_completion is True  # async not supported yet
+        lpar_uri = uri.split('/operations/')[0]
+        try:
+            lpar = hmc.lookup_by_uri(lpar_uri)
+        except KeyError:
+            raise InvalidResourceError('POST', uri)
+        cpc = lpar.manager.parent
+        if cpc.dpm_enabled:
+            raise CpcInDpmError('POST', uri, cpc)
+        lpar.properties['status'] = 'operating'
+
+
+class ResetActProfilesHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: List Reset Activation Profiles."""
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        if cpc.dpm_enabled:
+            raise InvalidResourceError('GET', uri)  # in List: not found
+        result_profiles = []
+        for profile in cpc.reset_activation_profiles.list():
+            result_profile = {}
+            for prop in profile.properties:
+                if prop in ('element-uri', 'name'):
+                    result_profile[prop] = profile.properties[prop]
+            result_profiles.append(result_profile)
+        return {'reset-activation-profiles': result_profiles}
+
+
+class ResetActProfileHandler(GenericGetPropertiesHandler,
+                             GenericUpdatePropertiesHandler):
+    pass
+
+
+class ImageActProfilesHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: List Image Activation Profiles."""
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        if cpc.dpm_enabled:
+            raise InvalidResourceError('GET', uri)  # in List: not found
+        result_profiles = []
+        for profile in cpc.image_activation_profiles.list():
+            result_profile = {}
+            for prop in profile.properties:
+                if prop in ('element-uri', 'name'):
+                    result_profile[prop] = profile.properties[prop]
+            result_profiles.append(result_profile)
+        return {'image-activation-profiles': result_profiles}
+
+
+class ImageActProfileHandler(GenericGetPropertiesHandler,
+                             GenericUpdatePropertiesHandler):
+    pass
+
+
+class LoadActProfilesHandler(object):
+
+    @staticmethod
+    def get(hmc, uri, uri_parms, logon_required):
+        """Operation: List Load Activation Profiles."""
+        cpc_oid = uri_parms[0]
+        try:
+            cpc = hmc.cpcs.lookup_by_oid(cpc_oid)
+        except KeyError:
+            raise InvalidResourceError('GET', uri)
+        if cpc.dpm_enabled:
+            raise InvalidResourceError('GET', uri)  # in List: not found
+        result_profiles = []
+        for profile in cpc.load_activation_profiles.list():
+            result_profile = {}
+            for prop in profile.properties:
+                if prop in ('element-uri', 'name'):
+                    result_profile[prop] = profile.properties[prop]
+            result_profiles.append(result_profile)
+        return {'load-activation-profiles': result_profiles}
+
+
+class LoadActProfileHandler(GenericGetPropertiesHandler,
+                            GenericUpdatePropertiesHandler):
+    pass
+
+
+# URIs to be handled
+URIS = (
+
+    # In all modes:
+
+    ('/api/version', VersionHandler),
+
+    ('/api/cpcs', CpcsHandler),
+    ('/api/cpcs/([^/]+)', CpcHandler),
+
+    # Only in DPM mode:
+
+    ('/api/cpcs/([^/]+)/operations/start', CpcStartHandler),
+    ('/api/cpcs/([^/]+)/operations/stop', CpcStopHandler),
+    ('/api/cpcs/([^/]+)/operations/export-port-names-list',
+     CpcExportPortNamesListHandler),
+
+    ('/api/cpcs/([^/]+)/adapters', AdaptersHandler),
+    ('/api/adapters/([^/]+)', AdapterHandler),
+
+    ('/api/adapters/([^/]+)/network-ports/([^/]+)', NetworkPortHandler),
+
+    ('/api/adapters/([^/]+)/storage-ports/([^/]+)', StoragePortHandler),
+
+    ('/api/cpcs/([^/]+)/partitions', PartitionsHandler),
+    ('/api/partitions/([^/]+)', PartitionHandler),
+    ('/api/partitions/([^/]+)/operations/start', PartitionStartHandler),
+    ('/api/partitions/([^/]+)/operations/stop', PartitionStopHandler),
+    # ('/api/partitions/([^/]+)/operations/scsi-dump',
+    #  PartitionScsiDumpHandler),
+    # ('/api/partitions/([^/]+)/operations/psw-restart',
+    #  PartitionPswRestartHandler),
+    # ('/api/partitions/([^/]+)/operations/mount-iso-image',
+    #  PartitionMountIsoImageHandler),
+    # ('/api/partitions/([^/]+)/operations/unmount-iso-image',
+    #  PartitionUnmountIsoImageHandler),
+
+    ('/api/partitions/([^/]+)/hbas', HbasHandler),
+    ('/api/partitions/([^/]+)/hbas/([^/]+)', HbaHandler),
+    # ('/api/partitions/([^/]+)/hbas/([^/]+)/operations/'\
+    #  'reassign-storage-adapter-port', HbaReassignPortHandler),
+
+    ('/api/partitions/([^/]+)/nics', NicsHandler),
+    ('/api/partitions/([^/]+)/nics/([^/]+)', NicHandler),
+
+    ('/api/partitions/([^/]+)/virtual-functions', VirtualFunctionsHandler),
+    ('/api/partitions/([^/]+)/virtual-functions/([^/]+)',
+     VirtualFunctionHandler),
+
+    ('/api/cpcs/([^/]+)/virtual-switches', VirtualSwitchesHandler),
+    ('/api/virtual-switches/([^/]+)', VirtualSwitchHandler),
+    # ('/api/virtual-switches/([^/]+)/operations/get-connected-vnics',
+    #  VirtualSwitchGetVnicsHandler),
+
+    # Only in classic (or ensemble) mode:
+
+    # ('/api/cpcs/([^/]+)/operations/import-profiles',
+    #  CpcImportProfilesHandler),
+    # ('/api/cpcs/([^/]+)/operations/export-profiles',
+    #  CpcExportProfilesHandler),
+
+    ('/api/cpcs/([^/]+)/logical-partitions', LparsHandler),
+    ('/api/logical-partitions/([^/]+)', LparHandler),
+    ('/api/logical-partitions/([^/]+)/operations/activate',
+     LparActivateHandler),
+    ('/api/logical-partitions/([^/]+)/operations/deactivate',
+     LparDeactivateHandler),
+    ('/api/logical-partitions/([^/]+)/operations/load', LparLoadHandler),
+
+    ('/api/cpcs/([^/]+)/reset-activation-profiles', ResetActProfilesHandler),
+    ('/api/cpcs/([^/]+)/reset-activation-profiles/([^/]+)',
+     ResetActProfileHandler),
+
+    ('/api/cpcs/([^/]+)/image-activation-profiles', ImageActProfilesHandler),
+    ('/api/cpcs/([^/]+)/image-activation-profiles/([^/]+)',
+     ImageActProfileHandler),
+
+    ('/api/cpcs/([^/]+)/load-activation-profiles', LoadActProfilesHandler),
+    ('/api/cpcs/([^/]+)/load-activation-profiles/([^/]+)',
+     LoadActProfileHandler),
+)


### PR DESCRIPTION
This is stage 2 of the mocking support according to the design described in PR #144. 

Stage 1 is provided in PR #159.

The stages have been split for easier reviewing. However, the stages should be merged together once both have been approved.

At this point, the implementation of stage 2 of the mock support does not yet cover all operations supported by the zhmcclient. Missing are:

* For DPM mode:
```
    POST     /api/partitions/([^/]+)/operations/scsi-dump
    POST     /api/partitions/([^/]+)/operations/psw-restart
    POST     /api/partitions/([^/]+)/operations/mount-iso-image
    POST     /api/partitions/([^/]+)/operations/unmount-iso-image
    POST     /api/partitions/([^/]+)/hbas/([^/]+)/operations/reassign-
                  storage-adapter-port
    POST     /api/virtual-switches/([^/]+)/operations/get-connected-vnics
```
* For classic mode:
```
    POST     /api/cpcs/([^/]+)/operations/import-profiles
    POST     /api/cpcs/([^/]+)/operations/export-profiles
```