### PR TITLE
Improved example lpar_operations

### DIFF
--- a/examples/example_hmccreds.yaml
+++ b/examples/example_hmccreds.yaml
@@ -11,7 +11,6 @@ examples:
    lpar_operations:
       hmc: "192.168.111.5"
       cpcname: P0000P30
-      cpcstatus: service-required
       lparname: PART8
       loaddev: "5172"
       deactivate: yes

--- a/examples/lpar_operations.py
+++ b/examples/lpar_operations.py
@@ -96,8 +96,8 @@ print("Finding LPAR by name=%s ..." % lparname)
 # We use list() instead of find() because find(name=..) is optimized by using
 # the name-to-uri cache and therefore returns an Lpar object with only a
 # minimal set of properties, and particularly no 'status' property.
-# That would drive an extra "Get Partition Properties" operation when the
-# status property is accessed.
+# That would drive an extra "Get Logical Partition Properties" operation when
+# the status property is accessed.
 lpars = cpc.lpars.list(filter_args={'name': lparname})
 if len(lpars) != 1:
     print("Could not find LPAR %s in CPC %s" % (lparname, cpc.name))


### PR DESCRIPTION
Please review and merge.

Reason for this change was to have better displaying of the behavior that sometimes after LPAR activation, the status does not update for some time, or not at all.

Details:
 - Added retry loops when retrieving status, until desired status is achieved.
- Changed refresh from pull_full_properties() to using list(), because we just want to use the 'status' property.
- Removed "cpcstatus" input parameter, because when the CPC name is provided, it does not really make sense to filter by status in addition.