### PR TITLE
Added open_os_message_channel() method to lpar and partition classes

### DIFF
--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -298,3 +298,41 @@ class Lpar(BaseResource):
             self.uri + '/operations/load', body,
             wait_for_completion=wait_for_completion)
         return result
+
+    def open_os_message_channel(self, include_refresh_messages=True):
+        """
+        Open a JMS message channel to this LPAR's operating system, returning
+        the string "topic" representing the message channel.
+
+        Parameters:
+
+          include_refresh_messages (bool):
+            Boolean controlling whether refresh operating systems messages
+            should be sent, as follows:
+
+            * If `True`, refresh messages will be recieved when the user
+              connects to the topic. The default.
+
+            * If `False`, refresh messages will not be recieved when the user
+              connects to the topic.
+
+        Returns:
+
+          :term:`json object`:
+
+            Returns a JSON object with a member named ``topic-name``, a string
+            representing the os-message-notification JMS topic. The user can
+            connect to this topic to start the flow of operating system
+            messages.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'include-refresh-messages': include_refresh_messages}
+        result = self.manager.session.post(
+            self.uri + '/operations/open-os-message-channel', body)
+        return result

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -318,12 +318,11 @@ class Lpar(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          :term:`string`:
 
-            Returns a JSON object with a member named ``topic-name``, a string
-            representing the os-message-notification JMS topic. The user can
-            connect to this topic to start the flow of operating system
-            messages.
+            Returns a string representing the os-message-notification JMS
+            topic. The user can connect to this topic to start the flow of
+            operating system messages.
 
         Raises:
 
@@ -335,4 +334,4 @@ class Lpar(BaseResource):
         body = {'include-refresh-messages': include_refresh_messages}
         result = self.manager.session.post(
             self.uri + '/operations/open-os-message-channel', body)
-        return result
+        return result['topic-name']

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -527,3 +527,41 @@ class Partition(BaseResource):
         """
         self.manager.session.post(
             self.uri + '/operations/unmount-iso-image')
+
+    def open_os_message_channel(self, include_refresh_messages=True):
+        """
+        Open a JMS message channel to this partition's operating system,
+        returning the string "topic" representing the message channel.
+
+        Parameters:
+
+          include_refresh_messages (bool):
+            Boolean controlling whether refresh operating systems messages
+            should be sent, as follows:
+
+            * If `True`, refresh messages will be recieved when the user
+              connects to the topic. The default.
+
+            * If `False`, refresh messages will not be recieved when the user
+              connects to the topic.
+
+        Returns:
+
+          :term:`json object`:
+
+            Returns a JSON object with a member named ``topic-name``, a string
+            representing the os-message-notification JMS topic. The user can
+            connect to this topic to start the flow of operating system
+            messages.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'include-refresh-messages': include_refresh_messages}
+        result = self.manager.session.post(
+            self.uri + '/operations/open-os-message-channel', body)
+        return result

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -547,12 +547,11 @@ class Partition(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          :term:`string`:
 
-            Returns a JSON object with a member named ``topic-name``, a string
-            representing the os-message-notification JMS topic. The user can
-            connect to this topic to start the flow of operating system
-            messages.
+            Returns a string representing the os-message-notification JMS
+            topic. The user can connect to this topic to start the flow of
+            operating system messages.
 
         Raises:
 
@@ -564,4 +563,4 @@ class Partition(BaseResource):
         body = {'include-refresh-messages': include_refresh_messages}
         result = self.manager.session.post(
             self.uri + '/operations/open-os-message-channel', body)
-        return result
+        return result['topic-name']


### PR DESCRIPTION
Added support for open-os-message-channel HMC API operation to the
lpar and partition classes. This is the minimum level of support for interaction with
operating system messages. The message channel will stay open until the API
session is terminated. #148 

Signed-off-by: Andrew Brezovsky <abrezovsky@gmail.com>