### PR TITLE
Added a JMS notification receiver and examples for os messages.

### DIFF
--- a/docs/notifications.rst
+++ b/docs/notifications.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016 IBM Corp. All Rights Reserved.
+.. Copyright 2017 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/notifications.rst
+++ b/docs/notifications.rst
@@ -13,21 +13,13 @@
 .. limitations under the License.
 ..
 
-zhmcclient - A pure Python client library for the z Systems HMC Web Services API
-********************************************************************************
+.. _`Notifications`:
 
-.. _GitHub project page: https://github.com/zhmcclient/python-zhmcclient
+Notifications
+=============
 
-.. toctree::
-   :maxdepth: 2
-   :numbered:
+.. automodule:: zhmcclient._notification
 
-   intro.rst
-   tutorial.rst
-   concepts.rst
-   general.rst
-   resources.rst
-   notifications.rst
-   cli.rst
-   development.rst
-   appendix.rst
+.. autoclass:: zhmcclient.NotificationReceiver
+   :members:
+   :special-members: __str__

--- a/examples/example_hmccreds.yaml
+++ b/examples/example_hmccreds.yaml
@@ -52,6 +52,13 @@ examples:
       hmc: "192.168.111.5"
       #loglevel: debug
       #timestats: yes
+   show_os_messages:
+      hmc: "192.168.111.5"
+      cpcname: P0000P30
+      partname: PART8
+      #loglevel: debug
+      #logmodule: zhmcclient._session
+      #timestats: yes
 
 "192.168.111.5":
    userid: ensadmin

--- a/examples/show_os_messages.py
+++ b/examples/show_os_messages.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016 IBM Corp. All Rights Reserved.
+# Copyright 2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/show_os_messages.py
+++ b/examples/show_os_messages.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example that shows the OS messages of the OS in a Partition or LPAR.
+"""
+
+import sys
+import logging
+import yaml
+import requests.packages.urllib3
+
+import zhmcclient
+
+requests.packages.urllib3.disable_warnings()
+
+if len(sys.argv) != 2:
+    print("Usage: %s hmccreds.yaml" % sys.argv[0])
+    sys.exit(2)
+hmccreds_file = sys.argv[1]
+
+with open(hmccreds_file, 'r') as fp:
+    hmccreds = yaml.load(fp)
+
+examples = hmccreds.get("examples", None)
+if examples is None:
+    print("examples not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+show_os_messages = examples.get("show_os_messages", None)
+if show_os_messages is None:
+    print("show_os_messages not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+loglevel = show_os_messages.get("loglevel", None)
+if loglevel is not None:
+    level = getattr(logging, loglevel.upper(), None)
+    if level is None:
+        print("Invalid value for loglevel in credentials file %s: %s" % \
+              (hmccreds_file, loglevel))
+        sys.exit(1)
+    logmodule = show_os_messages.get("logmodule", None)
+    if logmodule is None:
+        logmodule = ''  # root logger
+    print("Logging for module %s with level %s" % (logmodule, loglevel))
+    handler = logging.StreamHandler()
+    format_string = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    handler.setFormatter(logging.Formatter(format_string))
+    logger = logging.getLogger(logmodule)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+
+hmc = show_os_messages["hmc"]
+cpcname = show_os_messages["cpcname"]
+partname = show_os_messages["partname"]
+
+cred = hmccreds.get(hmc, None)
+if cred is None:
+    print("Credentials for HMC %s not found in credentials file %s" % \
+          (hmc, hmccreds_file))
+    sys.exit(1)
+
+userid = cred['userid']
+password = cred['password']
+
+print(__doc__)
+
+print("Using HMC %s with userid %s ..." % (hmc, userid))
+session = zhmcclient.Session(hmc, userid, password)
+cl = zhmcclient.Client(session)
+
+timestats = show_os_messages.get("timestats", False)
+if timestats:
+    session.time_stats_keeper.enable()
+
+try:
+    cpc = cl.cpcs.find(name=cpcname)
+except zhmcclient.NotFound:
+    print("Could not find CPC %s on HMC %s" % (cpcname, hmc))
+    sys.exit(1)
+
+try:
+    if cpc.dpm_enabled:
+        partkind = "partition"
+        partition = cpc.partitions.find(name=partname)
+    else:
+        partkind = "LPAR"
+        partition = cpc.lpars.find(name=partname)
+except zhmcclient.NotFound:
+    print("Could not find %s %s on CPC %s" % (partkind, partname, cpcname))
+    sys.exit(1)
+
+print("Opening OS message channel for %s %s on CPC %s ..." %
+      (partkind, partname, cpcname))
+topic = partition.open_os_message_channel(include_refresh_messages=True)
+print("OS message channel topic: %s" % topic)
+
+receiver = zhmcclient.NotificationReceiver(topic, hmc, userid, password)
+print("Showing OS messages (including refresh messages) ...")
+
+try:
+    for headers, message in receiver.notifications():
+        print("HMC notification #%s:" % headers['session-sequence-nr'])
+        os_msg_list = message['os-messages']
+        for os_msg in os_msg_list:
+            msg_txt = os_msg['message-text'].strip('\n')
+            msg_id = os_msg['message-id']
+            print("OS message #%s:\n%s" % (msg_id, msg_txt))
+except KeyboardInterrupt:
+    print("Keyboard interrupt: Closing OS message channel...")
+    receiver.close()
+
+print("Logging off...")
+session.logoff()
+
+if timestats:
+    print(session.time_stats_keeper)
+
+print("Done.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ progressbar2 # BSD
 click # BSD
 click-spinner>=0.1.5 # MIT
 click-repl # MIT
+stomp.py # Apache 

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -39,3 +39,4 @@ from ._hba import *           # noqa: F401
 from ._virtual_function import *       # noqa: F401
 from ._virtual_switch import *         # noqa: F401
 from ._port import *          # noqa: F401
+from ._notification import *  # noqa: F401

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -298,3 +298,41 @@ class Lpar(BaseResource):
             self.uri + '/operations/load', body,
             wait_for_completion=wait_for_completion)
         return result
+
+    def open_os_message_channel(self, include_refresh_messages=True):
+        """
+        Open a JMS message channel to this LPAR's operating system, returning
+        the string "topic" representing the message channel.
+
+        Parameters:
+
+          include_refresh_messages (bool):
+            Boolean controlling whether refresh operating systems messages
+            should be sent, as follows:
+
+            * If `True`, refresh messages will be recieved when the user
+              connects to the topic. The default.
+
+            * If `False`, refresh messages will not be recieved when the user
+              connects to the topic.
+
+        Returns:
+
+          :term:`json object`:
+
+            Returns a JSON object with a member named ``topic-name``, a string
+            representing the os-message-notification JMS topic. The user can
+            connect to this topic to start the flow of operating system
+            messages.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'include-refresh-messages': include_refresh_messages}
+        result = self.manager.session.post(
+            self.uri + '/operations/open-os-message-channel', body)
+        return result

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -318,12 +318,11 @@ class Lpar(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          :term:`string`:
 
-            Returns a JSON object with a member named ``topic-name``, a string
-            representing the os-message-notification JMS topic. The user can
-            connect to this topic to start the flow of operating system
-            messages.
+            Returns a string representing the os-message-notification JMS
+            topic. The user can connect to this topic to start the flow of
+            operating system messages.
 
         Raises:
 
@@ -335,4 +334,4 @@ class Lpar(BaseResource):
         body = {'include-refresh-messages': include_refresh_messages}
         result = self.manager.session.post(
             self.uri + '/operations/open-os-message-channel', body)
-        return result
+        return result['topic-name']

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016 IBM Corp. All Rights Reserved.
+# Copyright 2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The HMC supports the publishing of notifications for specific topics. This
+includes for example asynchronous job completion, property or status changes,
+and operating system messages issued in an LPAR or DPM partition.
+
+The zhmcclient package supports receiving HMC notifications in an easy-to-use
+way, as shown in the following example that receives and displays OS messages
+for a DPM partition::
+
+    import zhmcclient
+
+    hmc = ...
+    userid = ...
+    password = ...
+
+    session = zhmcclient.Session(hmc, userid, password)
+    client = zhmcclient.Client(session)
+    cpc = client.cpcs.find(name=cpcname)
+    partition = cpc.partitions.find(name=partname)
+
+    topic = partition.open_os_message_channel(include_refresh_messages=True)
+
+    print("Subscribing for OS messages for partition %s on CPC %s..." %
+          (partition.name, cpc.name))
+
+    receiver = zhmcclient.NotificationReceiver(topic, hmc, userid, password)
+
+    try:
+        for headers, message in receiver.notifications():
+            print("HMC notification #%s:" % headers['session-sequence-nr'])
+            os_msg_list = message['os-messages']
+            for os_msg in os_msg_list:
+                msg_txt = os_msg['message-text'].strip('\\n')
+                msg_id = os_msg['message-id']
+                print("OS message #%s:\\n%s" % (msg_id, msg_txt))
+    except KeyboardInterrupt:
+        pass
+
+    print("Closing OS message channel...")
+    receiver.close()
+
+When running this example code in one terminal, and stopping or starting
+the partition in another terminal, one can monitor the shutdown or boot
+messages issued by the operating system. The following commands use the
+CLI of the zhmcclient package to do that::
+
+    $ zhmc partition stop <cpc-name> <partition-name>
+    $ zhmc partition start <cpc-name> <partition-name>
+"""
+
+import threading
+import stomp
+import json
+
+
+__all__ = ['NotificationReceiver']
+
+
+# Port on which the HMC issues JMS over STOMP messages:
+_STOMP_PORT = 61612
+
+
+class NotificationReceiver(object):
+    """
+    A class for receiving HMC notifications that are published to a particular
+    single HMC notification topic.
+
+    Creating an object of this class establishes a JMS session with the
+    HMC and subscribes for a particular HMC notification topic.
+
+    Notification topic strings are created by the HMC in context of a
+    particular client session (i.e. :class:`~zhmcclient.Session` object).
+    However, these topic strings can be used by any JMS message listener that
+    knows the topic string and that authenticates under some valid HMC userid.
+    The HMC userid used by the JMS listener does not need to be the one that
+    was used for the client session in which the notification topic was
+    originally created.
+    """
+
+    def __init__(self, topic, host, userid, password):
+        """
+        Parameters:
+
+          topic (:term:`string`): Name of the HMC notification topic.
+            Must not be `None`.
+
+          host (:term:`string`):
+            HMC host. For valid formats, see the
+            :attr:`~zhmcclient.Session.host` property.
+            Must not be `None`.
+
+          userid (:term:`string`):
+            Userid of the HMC user to be used.
+            Must not be `None`.
+
+          password (:term:`string`):
+            Password of the HMC user to be used.
+            Must not be `None`.
+        """
+        self._topic = topic
+        self._host = host
+        self._userid = userid
+        self._password = password
+
+        # Wait timeout to honor keyboard interrupts after this time:
+        self._wait_timeout = 10.0  # seconds
+
+        # Subscription ID. We use some value that allows to identify on the
+        # HMC that this is the zhmcclient, but otherwise we are not using
+        # this value ourselves.
+        self._sub_id = 'zhmcclient.%s' % id(self)
+
+        # Sync variables for thread-safe handover between listener thread and
+        # receiver thread:
+        self._handover_dict = {}
+        self._handover_cond = threading.Condition()
+
+        self._conn = stomp.Connection(
+            [(self._host, _STOMP_PORT)], use_ssl="SSL")
+        listener = _NotificationListener(self._handover_dict,
+                                         self._handover_cond)
+        self._conn.set_listener('', listener)
+        self._conn.start()
+        self._conn.connect(self._userid, self._password, wait=True)
+
+        dest = "/topic/" + topic
+        self._conn.subscribe(destination=dest, id=self._sub_id, ack='auto')
+
+    def notifications(self):
+        """
+        Generator method that yields all HMC notifications (= JMS messages)
+        received by this notification receiver.
+
+        Example::
+
+            receiver = zhmcclient.NotificationReceiver(topic, hmc, userid,
+                                                       password)
+            for headers, message in receiver.notifications():
+                . . .
+
+        Yields:
+          tuple(headers, message): One HMC notification as a tuple with the
+          items:
+
+          * headers (dict): The notification header fields.
+
+            Some important header fields (dict items) are:
+
+            * 'notification-type' (string): The HMC notification type (e.g.
+              'os-message', 'job-completion', or others).
+
+            * 'session-sequence-nr' (string): The sequence number of this HMC
+              notification within the session created by this notification
+              receiver object. This number starts at 0 when this receiver
+              object is created, and is incremented each time an HMC
+              notification is published to this receiver.
+
+            * 'class' (string): The class name of the HMC resource publishing
+              the HMC notification (e.g. 'partition').
+
+            * 'object-id' (string) or 'element-id' (string): The ID of the HMC
+              resource publishing the HMC notification.
+
+            For a complete list of notification header fields, see section
+            "Message format" in chapter 4. "Asynchronous notification" in the
+            :term:`HMC API` book.
+
+          * message (:term:`JSON object`): Body of the HMC notification,
+            converted into a JSON object.
+
+            The properties of the JSON object vary by notification type.
+
+            For a description of the JSON properties, see the sub-sections
+            for each notification type within section "Notification message
+            formats" in chapter 4. "Asynchronous notification" in the
+            :term:`HMC API` book.
+        """
+
+        while True:
+            with self._handover_cond:
+
+                # Wait until MessageListener has a new notification
+                while len(self._handover_dict) == 0:
+                    self._handover_cond.wait(self._wait_timeout)
+
+                # Process the notification
+                yield (self._handover_dict['headers'],
+                       self._handover_dict['message'])
+
+                # Indicate to MessageListener that we are ready for next
+                # notification
+                del self._handover_dict['headers']
+                del self._handover_dict['message']
+                self._handover_cond.notifyAll()
+
+    def close(self):
+        """
+        Close the JMS session with the HMC. This implicitly unsubscribes from
+        the notification topic this receiver was created for.
+        """
+        self._conn.disconnect()
+
+
+class _NotificationListener(object):
+    """
+    A notification listener class for use by the Python `stomp` package.
+
+    This is an internal class that does not need to be accessed or created by
+    the user. An object of this class is automatically created by the
+    :class:`~zhmcclient.NotificationReceiver` class, for its notification
+    topic.
+    """
+
+    def __init__(self, handover_dict, handover_cond):
+        """
+        Parameters:
+
+          handover_dict (dict): Dictionary for handing over the notification
+            header and message from this listener thread to the receiver
+            thread. Must initially be an empty dictionary.
+
+          handover_cond (threading.Condition): Condition object for handing
+            over the notification from this listener thread to the receiver
+            thread. Must initially be a new threading.Condition object.
+        """
+
+        # Sync variables for thread-safe handover between listener thread and
+        # receiver thread:
+        self._handover_dict = handover_dict  # keys: headers, message
+        self._handover_cond = handover_cond
+
+        # Wait timeout to honor keyboard interrupts after this time:
+        self._wait_timeout = 10.0  # seconds
+
+    def on_error(self, headers, message):
+        """
+        This event method should never be called, because the HMC does not
+        issue JMS errors.
+
+        For parameters, see
+        :meth:`~zhmcclient.NotificationListener.on_message`.
+        """
+        raise RuntimeError("Unexpectedly received a JMS error "
+                           "(JMS headers: %r)" % headers)
+
+    def on_message(self, headers, message):
+        """
+        Event method that gets called when this listener has received a JMS
+        message (representing an HMC notification).
+
+        Parameters:
+
+          headers (dict): JMS message headers, as described for `headers` tuple
+            item returned by the
+            :meth:`~zhmcclient.NotificationReceiver.notifications` method.
+
+          message (string): JMS message body as a string, which contains a
+            serialized JSON object. The JSON object is described in the
+            `message` tuple item returned by the
+            :meth:`~zhmcclient.NotificationReceiver.notifications` method).
+        """
+
+        with self._handover_cond:
+
+            # Wait until receiver has processed the previous notification
+            while len(self._handover_dict) > 0:
+                self._handover_cond.wait(self._wait_timeout)
+
+            # Indicate to receiver that there is a new notification
+            self._handover_dict['headers'] = headers
+            try:
+                msg_obj = json.loads(message)
+            except Exception:
+                raise  # TODO: Find better exception for this case
+            self._handover_dict['message'] = msg_obj
+            self._handover_cond.notifyAll()

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -527,3 +527,41 @@ class Partition(BaseResource):
         """
         self.manager.session.post(
             self.uri + '/operations/unmount-iso-image')
+
+    def open_os_message_channel(self, include_refresh_messages=True):
+        """
+        Open a JMS message channel to this partition's operating system,
+        returning the string "topic" representing the message channel.
+
+        Parameters:
+
+          include_refresh_messages (bool):
+            Boolean controlling whether refresh operating systems messages
+            should be sent, as follows:
+
+            * If `True`, refresh messages will be recieved when the user
+              connects to the topic. The default.
+
+            * If `False`, refresh messages will not be recieved when the user
+              connects to the topic.
+
+        Returns:
+
+          :term:`json object`:
+
+            Returns a JSON object with a member named ``topic-name``, a string
+            representing the os-message-notification JMS topic. The user can
+            connect to this topic to start the flow of operating system
+            messages.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'include-refresh-messages': include_refresh_messages}
+        result = self.manager.session.post(
+            self.uri + '/operations/open-os-message-channel', body)
+        return result

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -547,12 +547,11 @@ class Partition(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          :term:`string`:
 
-            Returns a JSON object with a member named ``topic-name``, a string
-            representing the os-message-notification JMS topic. The user can
-            connect to this topic to start the flow of operating system
-            messages.
+            Returns a string representing the os-message-notification JMS
+            topic. The user can connect to this topic to start the flow of
+            operating system messages.
 
         Raises:
 
@@ -564,4 +563,4 @@ class Partition(BaseResource):
         body = {'include-refresh-messages': include_refresh_messages}
         result = self.manager.session.post(
             self.uri + '/operations/open-os-message-channel', body)
-        return result
+        return result['topic-name']


### PR DESCRIPTION
Please review.

Testcases are not yet part of this PR, but I wanted to get the API of the `NotificationReceiver` class reviewed as soon as possible.

Details:
- Added a NotificationReceiver class that is a general purpose JMS message / notification receiver.
- Added a chapter 'Notifications' to the documentation, describing the new class.
- Added an example show_os_messages.py that uses the new open_os_message_channel() method added in a previous commit, and the new notification receiver, to display the OS messages of a partition or LPAR.