### PR TITLE
Fixes #165: Added Python 3.6 to Travis CI and 3.4-3.6 to Appveyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 
 # commands to install dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,30 @@
 
 environment:
   matrix:
-    - PYTHON27: C:\Python27
-      PYTHON27_VERSION: 2.7.12
-      PYTHON27_ARCH: 32
+    - PYTHON_VERSION: 2.7
+      PYTHON_ARCH: 32
+      PYTHON_HOME: C:\Python27
+    - PYTHON_VERSION: 2.7
+      PYTHON_ARCH: 64
+      PYTHON_HOME: C:\Python27-x64
+    - PYTHON_VERSION: 3.4
+      PYTHON_ARCH: 32
+      PYTHON_HOME: C:\Python34
+#    - PYTHON_VERSION: 3.4
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python34-x64
+#    - PYTHON_VERSION: 3.5
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python35
+    - PYTHON_VERSION: 3.5
+      PYTHON_ARCH: 64
+      PYTHON_HOME: C:\Python35-x64
+#    - PYTHON_VERSION: 3.6
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python36
+    - PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 64
+      PYTHON_HOME: C:\Python36-x64
 
 install:
 
@@ -21,9 +42,9 @@ install:
   - choco source list
 
   # Add Python
-  - reg ADD HKCU\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
-  - reg ADD HKLM\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
-  - set PATH=%PYTHON27%;%PYTHON27%\Scripts;%PATH%
+  #- reg ADD HKCU\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
+  #- reg ADD HKLM\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%
 
   ## Install pip via get-pip.py - disabled because pip is already installed
   #- ps: (new-object System.Net.WebClient).Downloadfile('https://bootstrap.pypa.io/get-pip.py', 'C:\Users\appveyor\get-pip.py')
@@ -81,4 +102,4 @@ build: false
 before_test:
 
 test_script:
-  - tox -e pywin27
+  - tox -e pywin

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 
 [tox]
 minversion = 1.9
-envlist = py27,py34,py35,check
+envlist = py27,py34,py35,py36,check
 skip_missing_interpreters = true
 skipsdist = true
 
@@ -37,6 +37,9 @@ basepython = python3.4
 [testenv:py35]
 basepython = python3.5
 
-[testenv:pywin27]
-basepython = {env:PYTHON27:}\python.exe
+[testenv:py36]
+basepython = python3.6
+
+[testenv:pywin]
+basepython = {env:PYTHON_HOME:}\python.exe
 passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE PATH INCLUDE LIB


### PR DESCRIPTION
Please review.

Details:
- Added Python 3.6 environment to Travis control file.
- Enabled Appveyor control file to support multiple Python environments and added Python 3.4, 3.5, and 3.6 to it.
- Added 64-bit versions (of Python 2.7,3.4,3.5,3.6) to Appveyor control file.
- Disabled updating of Windows registry with Python install path.