### PR TITLE
Mitigated multiple coveralls comments per Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ script:
   - make test
 
 after_success:
-  - coveralls
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi


### PR DESCRIPTION
Please review.

This PR mitigates the current issue that coveralls posts too many coverage comments, by invoking coveralls in the Travis control file only for python 2.7.