### PR TITLE
Fixes #178, fixes #63: Redesigned return value of async. operation methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,11 +27,35 @@ Released: not yet
 
 **Incompatible changes:**
 
+* Changed the return value of all methods on resource classes that invoke
+  asynchronous operations (i.e. all methods that have a `wait_for_completion`
+  parameter), as follows:
+
+  - For `wait_for_completion=True`, the JSON object in the 'job-results' field
+    is now returned, or `None` if not present (i.e. no result data).
+    Previously, the complete response was returned as a JSON object.
+
+  - For `wait_for_completion=False`, a new `Job` object is now returned that
+    allows checking and waiting for completion directly on the `Job` object.
+    Previously, the whole response of the 'Query Job Status' operation was
+    returned as a JSON object, and the job completion was checked on the
+    `Session` object, and one could not wait for completion.
+
+* Changed the default value of the `wait_for_completion` parameter of the
+  `Session.post()` method from `True` to `False`, in order to avoid
+  superfluos timestats entries. This method is not normally used by
+  users of the zhmcclient package.
+
 **Deprecations:**
 
 **Bug fixes:**
 
 **Enhancements:**
+
+* Fixed a discrepancy between documentation and actual behavior of the return
+  value of all methods on resource classes that invoke asynchronous operations
+  (i.e. all methods that have a `wait_for_completion` parameter). See also
+  the corresponding incompatible change (issue #178).
 
 **Known Issues:**
 

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -30,6 +30,10 @@ Session
    :members:
    :special-members: __str__
 
+.. autoclass:: zhmcclient.Job
+   :members:
+   :special-members: __str__
+
 
 .. _`Client`:
 

--- a/examples/async_operation_polling.py
+++ b/examples/async_operation_polling.py
@@ -100,24 +100,15 @@ status = lpar.get_property('status')
 print("Status of LPAR %s: %s" % (lpar.name, status))
 
 print("De-Activating LPAR %s (async.) ..." % lpar.name)
-job_obj = lpar.deactivate(wait_for_completion=False)
-job_uri = job_obj['job-uri']
-print("Job URI: %s" % job_uri)
-
-print("Retrieving job properties ...")
-job = session.query_job_status(job_uri)
-print("Job properties: %s" % job)
-
-while job['status'] != 'complete':
+job = lpar.deactivate(wait_for_completion=False)
+while True:
+    print("Retrieving job status ...")
+    job_status, _ = job.check_for_completion()
+    print("Job status: %s" % job_status)
+    if job_status == 'complete':
+        break
     time.sleep(1)
-    print("Retrieving job properties ...")
-    job = session.query_job_status(job_uri)
-    print("Job properties: %s" % job)
-
 print('De-Activation complete!')
-
-print('Deleting completed job ...')
-session.delete_completed_job_status(job_uri)
 
 print("Logging off ...")
 session.logoff()

--- a/examples/jms_notifications.py
+++ b/examples/jms_notifications.py
@@ -145,16 +145,14 @@ print("Status of partition %s: %s" % (partition.name, partition_status))
 
 if partition_status == 'active':
     print("Stopping partition %s asynchronously ..." % partition.name)
-    result = partition.stop(wait_for_completion=False)
+    job = partition.stop(wait_for_completion=False)
 elif partition_status in ('inactive', 'stopped'):
     print("Starting partition %s asynchronously ..." % partition.name)
-    result = partition.start(wait_for_completion=False)
+    job = partition.start(wait_for_completion=False)
 else:
     raise zhmcclient.Error("Cannot deal with partition status: %s" % \
                            partition_status)
-
-job_uri = result['job-uri']
-print("Waiting for completion of job %s ..." % job_uri)
+print("Waiting for completion of job %s ..." % job.uri)
 sys.stdout.flush()
 
 # Just for demo purposes, we show how a loop for processing multiple
@@ -173,7 +171,7 @@ while True:
 
         # This test is just for demo purposes, it should always be our job
         # given what we subscribed for.
-        if NOTI_DATA['job-uri'] == job_uri:
+        if NOTI_DATA['job-uri'] == job.uri:
             break
         else:
             print("Unexpected completion received for job %s" % \
@@ -184,8 +182,7 @@ while True:
         NOTI_DATA = None
         NOTI_LOCK.notifyAll()
 
-job_uri = NOTI_DATA['job-uri']
-print("Job has completed: %s" % job_uri)
+print("Job has completed: %s" % job.uri)
 sys.stdout.flush()
 
 conn.disconnect()

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -357,16 +357,13 @@ class Cpc(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 
@@ -402,16 +399,14 @@ class Cpc(BaseResource):
               accepted the request to perform the operation.
 
         Returns:
-          :term:`json object`:
 
-            If `wait_for_completion` is `True`, returns None.
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `True`, returns `None`.
+
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 
@@ -457,16 +452,13 @@ class Cpc(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 
@@ -512,16 +504,13 @@ class Cpc(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -194,16 +194,13 @@ class Lpar(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 
@@ -244,16 +241,13 @@ class Lpar(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 
@@ -298,16 +292,13 @@ class Lpar(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -314,16 +314,13 @@ class Partition(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 
@@ -361,16 +358,13 @@ class Partition(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 
@@ -458,16 +452,13 @@ class Partition(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 
@@ -505,16 +496,13 @@ class Partition(BaseResource):
 
         Returns:
 
-          :term:`json object`:
+          `None` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns None.
+            If `wait_for_completion` is `True`, returns `None`.
 
-            If `wait_for_completion` is `False`, returns a JSON object with a
-            member named ``job-uri``. The value of ``job-uri`` identifies the
-            job that was started, and can be used with the
-            :meth:`~zhmcclient.Session.query_job_status` method to determine
-            the status of the job and the result of the asynchronous HMC
-            operation, once the job has completed.
+            If `wait_for_completion` is `False`, returns a
+            :class:`~zhmcclient.Job` object representing the asynchronously
+            executing job on the HMC.
 
         Raises:
 


### PR DESCRIPTION
Please review and merge.

**Note the incompatible change of the return value of async methods.**

Motivation:
- This fixes a discrepancy between the documentation that states `None` is returned in case of `wait_for_completion=True`, and the code that returned the response of the 'Query Job Status' operation as a JSON object. See issue #178.
- Because the return value changes anyway, this change also improves the return value in case of `wait_for_completion=False`, by returning an object of a new `Job` class.

Details:
- Changed the return type of all methods on resource classes that invoke asynchronous operations (i.e. all methods that have a `wait_for_completion` parameter), as follows:
  - For `wait_for_completion=True`, the JSON object in the 'job-results' field is now returned, or `None` if not present (i.e. no result data). Previously, the complete response was returned as a JSON object.
  - For `wait_for_completion=False`, a new `Job` object is now returned that allows checking and waiting for completion directly on the `Job` object. Previously, the whole response of the 'Query Job Status' operation was returned as a JSON object, and the job completion was checked on the `Session` object, and one could not wait for completion.
- Updated documentation, unit test cases for the `_session` module, and the examples `async_job_polling.py` and `jms_notifications.py` to accomodate the changed return values.
- Changed default of the `wait_for_completion` parameter on the `Session.post()` methods from `True` to `False`, in order to avoid superfluos timestats entries for the async method + completion polling, if the method was synchronous or asynchronous with `wait_for_completion=False`.