### PR TITLE
Added send_os_command method to partition and lpar

### DIFF
--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -351,3 +351,37 @@ class Lpar(BaseResource):
         result = self.manager.session.post(
             self.uri + '/operations/open-os-message-channel', body)
         return result['topic-name']
+
+    def send_os_command(self, os_command_text, is_priority=False):
+        """
+        Send a command to the operating system running in this LPAR.
+
+        Parameters:
+
+          os_command_text (string): The text of the operating system command.
+
+          is_priority (bool):
+            Boolean controlling whether this is a priority operating system
+            command, as follows:
+
+            * If `true`, this message is treated as a priority operating
+              system command.
+
+            * If `false`, this message is not treated as a priority
+              operating system command. The default.
+
+        Returns:
+
+          None
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'is-priority': is_priority,
+                'operating-system-command-text': os_command_text}
+        self.manager.session.post(
+            self.uri + '/operations/send-os-cmd', body)

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -364,10 +364,10 @@ class Lpar(BaseResource):
             Boolean controlling whether this is a priority operating system
             command, as follows:
 
-            * If `true`, this message is treated as a priority operating
+            * If `True`, this message is treated as a priority operating
               system command.
 
-            * If `false`, this message is not treated as a priority
+            * If `False`, this message is not treated as a priority
               operating system command. The default.
 
         Returns:

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -605,3 +605,37 @@ class Partition(BaseResource):
         result = self.manager.session.post(
             self.uri + '/operations/open-os-message-channel', body)
         return result['topic-name']
+
+    def send_os_command(self, os_command_text, is_priority=False):
+        """
+        Send a command to the operating system running in this partition.
+
+        Parameters:
+
+          os_command_text (string): The text of the operating system command.
+
+          is_priority (bool):
+            Boolean controlling whether this is a priority operating system
+            command, as follows:
+
+            * If `true`, this message is treated as a priority operating
+              system command.
+
+            * If `false`, this message is not treated as a priority
+              operating system command. The default.
+
+        Returns:
+
+          None
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'is-priority': is_priority,
+                'operating-system-command-text': os_command_text}
+        self.manager.session.post(
+            self.uri + '/operations/send-os-cmd', body)

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -618,10 +618,10 @@ class Partition(BaseResource):
             Boolean controlling whether this is a priority operating system
             command, as follows:
 
-            * If `true`, this message is treated as a priority operating
+            * If `True`, this message is treated as a priority operating
               system command.
 
-            * If `false`, this message is not treated as a priority
+            * If `False`, this message is not treated as a priority
               operating system command. The default.
 
         Returns:


### PR DESCRIPTION
send_os_message allows the client to send messages to the object's operating
system. The method takes in a string for the command and and optional boolean
to indicate a priority. The method returns nothing because the HMC API returns
a response with no content. A status code 409 is returned from the API if the
message interface is not available.

Signed-off-by: Andrew Brezovsky <abrezovsky@gmail.com>