### PR TITLE
Fixes #6, Fixes #191: Timeout support for async methods; deferred status polling for LPAR

### DIFF
--- a/design/network-errors.rst
+++ b/design/network-errors.rst
@@ -1,0 +1,380 @@
+.. Copyright 2017 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+================================================
+Design for handling network errors in zhmcclient
+================================================
+
+The zhmcclient package uses the Python
+`requests <https://pypi.python.org/pypi/requests/>`_ package for any HMC REST
+API calls, and the Python `stomp <https://pypi.python.org/pypi/stomp/>`_
+package for handling HMC JMS notifications.
+
+This design document covers error handling using the `requests` package.
+
+Some facts
+==========
+
+Layering of components
+----------------------
+
+The following picture shows the layering of components w.r.t. networking:
+
+::
+
+  +---------------------+
+  |                     |
+  |  application (py)   |
+  |                     |
+  +---------------------+
+  |                     |
+  |   zhmcclient (py)   |
+  |                     |
+  +---------------------+
+  |                     |
+  |    requests (py)    |
+  |                     |
+  +---------------------+
+  |                     |  - Handles HTTP connection keep-alive and pooling
+  |    urllib3 (py)     |  - Handles HTTP basic/digest authentication
+  |  (part of requests) |  - Handles HTTP request retrying
+  +---------------------+
+  |                     |
+  |    httplib (py)     |
+  |                     |
+  +---------------+     |
+  |               |     |
+  |  socket (py)  |     |
+  |               |     |
+  +---------------+-----+
+  |    _socket (py)     |
+  |                     |
+  |  _socketmodule.so   |
+  |                     |
+  +---------------------+  - Handles read timeouts ??
+  |     socket API      |  - Handles connection timeouts ??
+  |    TCP/IP stack     |  - Handles SSL certificate verification ??
+  |                     |  - Handles TCP packet retransmission
+  +---------------------+
+
+The following call flow for an HTTP GET request and response shows how these
+layers are used::
+
+    -> zhmcclient/_session.py(392): Session.get()
+      -> requests/sessions.py(501): Session.get()
+         -> requests/sessions.py(488)request()
+            -> requests/sessions.py(609)send()
+               -> requests/adapters.py(423)send()
+                  -> requests/packages/urllib3/connectionpool.py(600)urlopen()
+                     -> requests/packages/urllib3/connectionpool.py(356)_make_request()
+                        -> httplib.py(1022): HTTPConnection.request()
+                           -> httplib.py(1056): HTTPConnection._send_request()
+                              -> httplib.py(1018): HTTPConnection.endheaders()
+                                 -> httplib.py(869): HTTPConnection._send_output()
+                                    -> httplib.py(829): HTTPConnection.send()
+                                       -> _socketmodule.so: socket.connect(), if needed (not used by urllib3)
+                                       -> _socketmodule.so: socket.sendall()
+                     -> requests/packages/urllib3/connectionpool.py(379)_make_request()
+                        -> httplib.py(1089): HTTPConnection.getresponse()
+                           -> httplib.py(444): HTTPResponse.begin()
+                              -> httplib.py(400): HTTPResponse._read_status()
+                                 -> socket.py(424): _fileobject.readline()
+                                    -> _socketmodule.so: socket.recv()
+            -> requests/sessions.py(641)send()
+               -> requests/models.py(797)content()
+                  -> requests/models.py(719)generate()
+                     -> requests/packages/urllib3/response.py(432)stream()
+                        -> requests/packages/urllib3/response.py(380)read()
+                           -> httplib.py(602): HTTPResponse.read()
+                              -> socket.py(355): _fileobject.read()
+                                 -> _socketmodule.so: socket.recv()
+                           -> httplib.py(610): HTTPResponse.read()
+                              -> httplib.py(555): HTTPResponse.close()
+                                 -> socket.py(284): _fileobject.close()
+                                    -> socket.py(300): _fileobject.flush()
+                                       -> _socketmodule.so: socket.sendall(), if anything remaining
+                                    -> _socketmodule.so: socket.close()
+
+Timeouts
+--------
+
+There are hard coded timeouts in the TCP/IP stack.
+
+The `requests` package allows specifying two timeouts (on HTTP methods such as
+``get()``):
+
+* Connect timeout:
+
+  Number of seconds the `requests` package will wait for the
+  local machine to establish a TCP connection to a remote machine. This timeout
+  is passed to the ``connect()`` call on the socket.
+
+  The `requests` package recommends to set the connect timeout to slightly
+  larger than a multiple of 3 (seconds), which is the default TCP packet
+  retransmission window.
+
+  This timeout is indicated by raising a ``requests.exceptions.ConnectTimeout``
+  exception.
+
+* Read timeout:
+
+  Number of seconds the local machine will wait for the remote
+  machine to send a response at the socket level. Specifically, it's the number
+  of seconds that the local machine will wait *between* Bytes sent from the
+  remote machine. However, in 99.9% of cases, this is the time before the
+  remote machine sends the *first* Byte.
+
+  This timeout is indicated by raising a ``requests.exceptions.ReadTimeout``
+  exception.
+
+The zhmcclient package currently does not set any of these timeouts, so the
+default of waiting forever applies.
+
+**TBD:** Despite the fact that the `requests` connection timeout is not set,
+a connection attempt times out after 60 sec, by raising
+``requests.exceptions.ConnectionError``.
+It is not clear under which conditions this situation is indicated using
+``requests.exceptions.ConnectTimeout``.
+
+The zhmcclient itself supports two timeouts at a higher level (as of
+`PR #195 <https://github.com/zhmcclient/python-zhmcclient/pull/195>`_
+which is targeted for v0.11.0 of the `zhmcclient` package:
+
+* Operation timeout:
+
+  Number of seconds the client will wait for completion of asynchronous
+  HMC operations. This applies to ``Session.post()`` and to all resource
+  methods with a ``wait_for_completion`` parameter (i.e. the asynchronous
+  methods).
+
+  The operation timeout can be specified with the ``operation_timeout``
+  parameter on these methods, and defaults to no timeout.
+
+  This timeout is indicated by raising a ``zhmcclient.Timeout`` exception.
+
+* LPAR status timeout:
+
+  Number of seconds the client will wait for the LPAR status to take on the
+  value it is supposed to take on given the previous operation affecting
+  the LPAR status. This applies to the ``Lpar.activate/deactivate/load()``
+  methods. The HMC operations issued by these methods exhibit "deferred status"
+  behavior, which means that it takes a few seconds after successful completion
+  of the asynchronous job that executes the operation, until the new status can
+  be observed in the `status` property of the LPAR resource. These methods will
+  poll the LPAR status until the desired status value is reached.
+
+  The LPAR status timeout can be specified with the ``status_timeout``
+  parameter on these methods, and defaults to 1 hour.
+
+  This timeout is also indicated by raising a ``zhmcclient.Timeout`` exception.
+
+Reference material:
+
+* `Timeouts in requests package <http://docs.python-requests.org/en/master/user/advanced/#timeouts>`_
+
+Exceptions
+----------
+
+The `requests` package wrappers all exceptions of underlying components, except
+for programming errors (e.g. ``TypeError``, ``ValueError``, ``KeyError``), into
+exceptions that are derived from ``requests.exceptions.RequestException``.
+
+The ``requests.exceptions.RequestException`` exception is never raised itself.
+
+All exceptions derived from ``requests.exceptions.RequestException`` will have
+the following attributes:
+
+* ``exc.args[0]``:
+
+  - For ``HTTPError``, ``TooManyRedirects``, ``MissingSchema``,
+    ``InvalidSchema``, ``InvalidURL``, ``InvalidHeader``,
+    ``UnrewindableBodyError``:
+    An error message generated by the `requests` package.
+
+  - For ``ConnectionError``, ``ProxyError``, ``SSLError``, ``ConnectTimeout``,
+    ``ReadTimeout``, ``ChunkedEncodingError``, ``ContentDecodingError``,
+    ``RetryError``:
+    The underlying exception that was raised. This is not documented, though.
+
+  - For ``StreamConsumedError``: ``exc.args=None``.
+
+* ``exc.request`` - ``None``, or the ``requests.PreparedRequest`` object
+  representing the HTTP request.
+
+* ``exc.response`` - ``None``, or the ``requests.Response`` object representing
+  the HTTP response.
+
+The ``HTTPError`` exception is only raised when the caller requests that bad
+HTTP status codes should be returned as exceptions (via
+``Session.status_as_exception()``). The zhmcclient package does not do that, so
+this exception is never raised, and bad HTTP status codes are checked after
+the HTTP method (e.g. ``get()``) returns normally.
+
+The inheritance hierarchy of the exceptions of the `requests` package can be
+gathered from the
+`requests.exceptions source code <http://docs.python-requests.org/en/master/_modules/requests/exceptions/>`_.
+
+The `zhmcclient` package in turn wrappers the exceptions of the `requests`
+package into:
+
+* ``zhmcclient.HTTPError`` - caused by most bad HTTP status codes and
+  represents the parameters in the HMC error response. Some HTTP status codes
+  are automatically recovered, such as status 403 / reason 5 (API session token
+  expired) by re-logon, or status 202 by polling for asynchronous job
+  completion.
+
+* ``zhmcclient.ParseError`` - caused by invalid JSON in the HTTP response.
+
+* ``zhmcclient.AuthError`` - caused by HTTP status 403, when reason != 5, or
+  when reason == 5 and the resource did not require authentication. The latter
+  case is merely a check against unexpected behavior of the HMC and is not
+  really needed, or should be acted upon differently.
+
+* ``zhmcclient.ConnectionError`` - caused by all exceptions of the `requests`
+  package.
+
+Retries
+-------
+
+There are multiple levels of retries:
+
+- The TCP/IP stack retries sends on TCP sockets as part of its error recovery.
+
+- The `requests` package retries the sending of HTTP requests. Actually, this
+  is handled by the `urllib3` package, but can be controlled through the
+  `requests` package by setting an alternative transport adapter. Such adapters
+  are matched by shortest prefix match, so the following works::
+
+      s = requests.Session(.....)
+      s.mount('https://', HTTPAdapter(max_retries=10))
+      s.mount('http://', HTTPAdapter(max_retries=10))
+
+  This will replace the default transport adapters, which are set in
+  `requests.Session()`::
+
+      self.mount('https://', HTTPAdapter())
+      self.mount('http://', HTTPAdapter())
+
+  The default for max_retries is 0.
+
+Design changes
+==============
+
+The following design changes are proposed for the `zhmcclient` package:
+
+Proposal for timeouts
+---------------------
+
+**Proposal(DONE):** Start using the timeouts of the `requests` package, by
+setting them as attributes on the ``zhmcclient.Session`` object, with
+reasonable default values, and with the ability to override the default values
+when creating a ``Session`` object.
+
+The proposed default values are:
+
+* connect timeout: 60 s
+
+* read timeout: 120 s
+
+Having a read timeout assumes that the HMC REST operations all respond within
+a maximum time. The asynchronous REST operations all respond rather quickly,
+indicating what the job is that performs the asynchronous operation.
+Some synchronous REST operations sometimes take long, e.g. up to 45 seconds.
+That's why the read timeout should be a good bit larger than that.
+
+Also, the design for the timeouts for async operation completion and LPAR
+status transition introduced in
+`PR #195 <https://github.com/zhmcclient/python-zhmcclient/pull/195>`_ should
+be changed to be consistent with the way timeouts are defined in this design.
+
+**Proposal(TODO):** Change after merging PR #195.
+
+Proposal for exceptions
+-----------------------
+
+* ``zhmcclient.ConnectionError`` is currently raised for all exceptions of the
+  `requests` package. When we start supporting the timeouts of the `requests`
+  package, it is appropriate to distinguish timeouts from other errors. Also,
+  it might be useful to separate errors that are likely caused by the
+  networking environment (and that could therefore be retried) from errors that
+  are not going to recover by retrying. Further, it might be useful to
+  distinguish unrecoverable errors that need to be fixed on the client, from
+  unrecoverable errors that need to be fixed on the server.
+
+  **Proposal(DONE):** This proposal does not go as far as outlined above. It is
+  proposed to handle the `requests` exceptions raised from HTTP methods such as
+  ``get()``, as follows:
+
+  - ``TooManyRedirects``, ``MissingSchema``, ``InvalidSchema``, ``InvalidURL``,
+    ``InvalidHeader``, ``UnrewindableBodyError``, ``ConnectionError``,
+    ``ProxyError``, ``SSLError``, ``ChunkedEncodingError``,
+    ``ContentDecodingError``, ``StreamConsumedError``:
+
+    These will be wrappered using ``zhmcclient.ConnectionError`` as today,
+    but the exception message will be cleaned up as much as possible:
+
+    - If ``exc.args[0]`` is an ``Exception``, this is the underlying exception
+      that was wrapppered by the `requests` exception. Use that underlying
+      exception instead.
+
+    - Eliminate ``MaxRetryError`` and use the exception in its ``reason``
+      attribute instead.
+
+    - Eliminate the representation of objects in the exception message, e.g.
+      ``"NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x2922150>:
+      Failed to establish a new connection: [Errno 110] Connection timed out',)"``
+
+  - ``ConnectTimeout``, ``ResponseReadTimeout``, ``RequestRetriesExceeded``:
+
+    These will be wrappered by new exceptions ``zhmcclient.ConnectTimeout``,
+    ``zhmcclient.ReadTimeout``, ``zhmcclient.RetryError``.
+
+* As described above, ``zhmcclient.AuthError`` is also raised when the HMC
+  indicates "API session token expired" for an operation that does not require
+  logon (e.g. "Query API Version"). First, checking this is a bit overdoing it
+  because there is no harm if the HMC decides that session checking is
+  performed always, and second, the handling of this unexpected behavior as
+  by raising ``zhmcclient.AuthError`` is misleading for the user.
+
+  **Proposal(DONE):** It is proposed to not handle this situation also by
+  re-logon, i.e. to no longer make the behavior dependent on whether the
+  operation requires logon.
+
+* ``zhmcclient.VersionError`` currently stores the discovered version in
+  ``exc.args[1:2]``. It is not recommended to use ``exc.args[]`` for anything
+  else but the exception message, and to use additional instance attributes
+  for that, instead.
+
+  **Proposal(DONE):** It is proposed to store this information in additional
+  instance attributes, and to remove it from the ``exc.args[]`` array. This is
+  an incompatible change, but it is not very critical.
+
+No change is proposed for the other `zhmcclient` exceptions (``ParseError``,
+``HTTPError``).
+
+Proposal for retries
+--------------------
+
+**Proposal (TODO):** Start using the ``max_retries`` parameter of the
+``HTTPAdapter`` transport adapter, by setting the max retries after connect
+timeouts and read timeouts as attributes on the ``zhmcclient.Session`` object,
+with a reasonable default value, and with the ability to override the default
+value when creating a ``Session`` object.
+
+The proposed default values are:
+
+* connect retries: 3
+
+* read retries: 3

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -108,6 +108,30 @@ Released: not yet
   it would be returned, it is now handled in the same way as when the operation
   does require logon, i.e. by a re-logon.
 
+* Added exception class `TimeoutError` that is used to indicate asynchronous
+  operation timeouts and LPAR deferred status polling timeouts (issues #6 and
+  #191).
+
+* Added support for deferred status polling to the
+  `Lpar.activate/deactivate/load()` methods. The HMC operations issued by these
+  methods exhibit "deferred status" behavior, which means that it takes a few
+  seconds after successful completion of the asynchronous job that executes the
+  operation, until the new status can be observed in the 'status' property of
+  the LPAR resource. These methods will poll the LPAR status until the desired
+  status value is reached. A status timeout can be specified via a new
+  `status_timeout` parameter to these methods, which defaults to 1 hour
+  (issue #191).
+
+* Added operation timeout support to `Session.post()` and to all resource
+  methods with a `wait_for_completion` parameter (i.e. the asynchronous
+  methods). The operation timeout on the asynchronous methods can be specified
+  via a new `operation_timeout` parameter, which defaults to no timeout
+  (issue #6).
+
+* Added a new module that defines public constants, and that defines the
+  default timeout values for the operation timeout and the status timeout
+  (issues #6 and #191).
+
 **Known Issues:**
 
 * See `list of open issues`_.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -108,10 +108,6 @@ Released: not yet
   it would be returned, it is now handled in the same way as when the operation
   does require logon, i.e. by a re-logon.
 
-* Added exception class `TimeoutError` that is used to indicate asynchronous
-  operation timeouts and LPAR deferred status polling timeouts (issues #6 and
-  #191).
-
 * Added support for deferred status polling to the
   `Lpar.activate/deactivate/load()` methods. The HMC operations issued by these
   methods exhibit "deferred status" behavior, which means that it takes a few
@@ -119,18 +115,19 @@ Released: not yet
   operation, until the new status can be observed in the 'status' property of
   the LPAR resource. These methods will poll the LPAR status until the desired
   status value is reached. A status timeout can be specified via a new
-  `status_timeout` parameter to these methods, which defaults to 1 hour
+  `status_timeout` parameter to these methods, which defaults to 60 seconds.
+  If the timeout expires, a new `StatusTimeout` exception is raised
   (issue #191).
 
 * Added operation timeout support to `Session.post()` and to all resource
   methods with a `wait_for_completion` parameter (i.e. the asynchronous
   methods). The operation timeout on the asynchronous methods can be specified
-  via a new `operation_timeout` parameter, which defaults to no timeout
+  via a new `operation_timeout` parameter, which defaults to 3600 seconds.
+  If the timeout expires, a new `OperationTimeout` exception is raised
   (issue #6).
 
-* Added a new module that defines public constants, and that defines the
-  default timeout values for the operation timeout and the status timeout
-  (issues #6 and #191).
+* Added a new module that defines public constants, and that defines
+  default timeout and retry values.
 
 **Known Issues:**
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,6 +46,12 @@ Released: not yet
   superfluos timestats entries. This method is not normally used by
   users of the zhmcclient package.
 
+* Removed the version strings from the ``args[]`` property of the
+  ``zhmcclient.VersionError`` exception class. They had been available as
+  ``args[1]`` and ``args[2]``. ``args[0]`` continues to be the error message,
+  and the ``min_api_version`` and ``api_version`` properties continue to
+  provide the version strings.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -60,6 +66,21 @@ Released: not yet
   flowed into a paragraph.
 
 **Enhancements:**
+
+* Added support for retry/timeout configuration of HTTP sessions, via
+  a new ``RetryTimeoutConfig`` class that can be specified for the ``Session``
+  object. The retry/timeout configuration can specify:
+
+  - HTTP connect timeout and number of retries.
+
+  - HTTP read timeout (of HTTP responses), and number of retries.
+
+  - Maximum number of HTTP redirects.
+
+* Added new exceptions ``zhmcclient.ConnectTimeout`` (for HTTP connect
+  timeout), ``zhmcclient.ResponseReadTimeout`` (for HTTP response read
+  timeout), and ``zhmcclient.RequestRetriesExceeded`` (for HTTP request retry
+  exceeded). They are all derived from ``zhmcclient.ConnectionError``.
 
 * Fixed a discrepancy between documentation and actual behavior of the return
   value of all methods on resource classes that invoke asynchronous operations
@@ -79,6 +100,13 @@ Released: not yet
   An HTML formatted error message may be in the response for some 4xx and
   5xx HTTP status codes (e.g. when the WS API is disabled). Such responses
   are raised as ``HTTPError`` exceptions with an artificial reason code of 999.
+
+* Fixed an incorrect use of the ``zhmcclient.AuthError`` exception and
+  unnecessary checking of HMC behavior, i.e. when the HMC fails with "API
+  session token expired" for an operation that does not require logon. This
+  error should never be returned for operations that do not require logon. If
+  it would be returned, it is now handled in the same way as when the operation
+  does require logon, i.e. by a re-logon.
 
 **Known Issues:**
 

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -122,7 +122,11 @@ Exceptions
    :members:
    :special-members: __str__
 
-.. autoclass:: zhmcclient.TimeoutError
+.. autoclass:: zhmcclient.OperationTimeout
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.StatusTimeout
    :members:
    :special-members: __str__
 

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -45,29 +45,6 @@ Retry / timeout configuration
    :special-members: __str__
 
 
-.. _`Default retry-timeout configuration`:
-
-Default values for the retries and timeouts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This section defines the default values that will be used if the corresponding
-retry or timeout value is not specified at any level.
-
-Note that for technical limitations, the documentation shows these constants
-in the ``zhmcclient._session`` namespace, but they are available and should be
-used from the ``zhmcclient`` namespace.
-
-.. autodata:: zhmcclient._session.DEFAULT_CONNECT_TIMEOUT
-
-.. autodata:: zhmcclient._session.DEFAULT_CONNECT_RETRIES
-
-.. autodata:: zhmcclient._session.DEFAULT_READ_TIMEOUT
-
-.. autodata:: zhmcclient._session.DEFAULT_READ_RETRIES
-
-.. autodata:: zhmcclient._session.DEFAULT_MAX_REDIRECTS
-
-
 .. _`Client`:
 
 Client
@@ -152,6 +129,15 @@ Exceptions
 .. autoclass:: zhmcclient.NoUniqueMatch
    :members:
    :special-members: __str__
+
+
+.. _`Constants`:
+
+Constants
+---------
+
+.. automodule:: zhmcclient._constants
+   :members:
 
 
 .. _`Filtering`:

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -122,6 +122,10 @@ Exceptions
    :members:
    :special-members: __str__
 
+.. autoclass:: zhmcclient.TimeoutError
+   :members:
+   :special-members: __str__
+
 .. autoclass:: zhmcclient.NotFound
    :members:
    :special-members: __str__

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -35,6 +35,39 @@ Session
    :special-members: __str__
 
 
+.. _`Retry-timeout configuration`:
+
+Retry / timeout configuration
+-----------------------------
+
+.. autoclass:: zhmcclient.RetryTimeoutConfig
+   :members:
+   :special-members: __str__
+
+
+.. _`Default retry-timeout configuration`:
+
+Default values for the retries and timeouts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section defines the default values that will be used if the corresponding
+retry or timeout value is not specified at any level.
+
+Note that for technical limitations, the documentation shows these constants
+in the ``zhmcclient._session`` namespace, but they are available and should be
+used from the ``zhmcclient`` namespace.
+
+.. autodata:: zhmcclient._session.DEFAULT_CONNECT_TIMEOUT
+
+.. autodata:: zhmcclient._session.DEFAULT_CONNECT_RETRIES
+
+.. autodata:: zhmcclient._session.DEFAULT_READ_TIMEOUT
+
+.. autodata:: zhmcclient._session.DEFAULT_READ_RETRIES
+
+.. autodata:: zhmcclient._session.DEFAULT_MAX_REDIRECTS
+
+
 .. _`Client`:
 
 Client
@@ -81,6 +114,18 @@ Exceptions
 .. autoclass:: zhmcclient.Error
 
 .. autoclass:: zhmcclient.ConnectionError
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.ConnectTimeout
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.ReadTimeout
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.RetriesExceeded
    :members:
    :special-members: __str__
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -99,7 +99,9 @@ class NumberArgsTestMixin(object):
 
     def test_good(self):
         """Test exception class with the allowable number of input arguments,
-        where the first argument is always a string."""
+        where the first argument is always a string.
+        Verify that the first argument is put into exc.args[0] and that no
+        other arguments are put there."""
 
         for nargs in range(self.min_args, self.max_args + 1):
             args = ['zaphod']
@@ -109,13 +111,12 @@ class NumberArgsTestMixin(object):
 
             self.assertTrue(isinstance(exc, Error))
             self.assertTrue(isinstance(exc.args, tuple))
-            self.assertEqual(len(exc.args), len(args),
-                             "Expected %d arguments, got: %r" %
-                             (len(args), exc.args))
-            for i, arg in enumerate(args):
-                self.assertEqual(exc.args[i], arg,
-                                 "For argument at index %d, expected %r, "
-                                 "got: %r" % (i, arg, exc.args[i]))
+            self.assertEqual(len(exc.args), 1,
+                             "Expected exc.args[] to have 1 item, got: %r" %
+                             exc.args)
+            self.assertEqual(exc.args[0], args[0],
+                             "For exc.args[0], expected %r, "
+                             "got: %r" % (args[0], exc.args[0]))
 
 
 class DetailsTestMixin(object):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -22,8 +22,10 @@ from __future__ import absolute_import, print_function
 import unittest
 import requests
 import requests_mock
+import time
+import json
 
-from zhmcclient import Session, ParseError, Job, HTTPError
+from zhmcclient import Session, ParseError, Job, HTTPError, TimeoutError
 
 
 class SessionTests(unittest.TestCase):
@@ -380,6 +382,110 @@ class JobTests(unittest.TestCase):
             self.assertEqual(cm.exception.http_status, 500)
             self.assertEqual(cm.exception.reason, 42)
             self.assertEqual(cm.exception.message, 'bla')
+
+    def test_wait_complete1_success_result(self):
+        """Test wait_for_completion() with successful complete job with a
+        result."""
+        with requests_mock.mock() as m:
+            self.mock_server_1(m)
+            session = Session('fake-host', 'fake-user', 'fake-pw')
+            job = Job(session, self.job_uri)
+            exp_oper_result = {
+                'foo': 'bar',
+            }
+            query_job_status_result = {
+                'status': 'complete',
+                'job-status-code': 200,
+                # 'job-reason-code' omitted because HTTP status good
+                'job-results': exp_oper_result,
+            }
+            m.get(self.job_uri, json=query_job_status_result)
+            m.delete(self.job_uri)
+
+            oper_result = job.wait_for_completion()
+
+            self.assertEqual(oper_result, exp_oper_result)
+
+    def test_wait_complete3_success_result(self):
+        """Test wait_for_completion() with successful complete job with a
+        result."""
+        with requests_mock.mock() as m:
+            self.mock_server_1(m)
+            session = Session('fake-host', 'fake-user', 'fake-pw')
+            job = Job(session, self.job_uri)
+            exp_oper_result = {
+                'foo': 'bar',
+            }
+            m.get(self.job_uri,
+                  [
+                      {'text': result_running_callback},
+                      {'text': result_complete_callback},
+                  ])
+            m.delete(self.job_uri)
+
+            oper_result = job.wait_for_completion()
+
+            self.assertEqual(oper_result, exp_oper_result)
+
+    def test_wait_complete3_timeout(self):
+        """Test wait_for_completion() with timeout."""
+        with requests_mock.mock() as m:
+            self.mock_server_1(m)
+            session = Session('fake-host', 'fake-user', 'fake-pw')
+            job = Job(session, self.job_uri)
+            m.get(self.job_uri,
+                  [
+                      {'text': result_running_callback},
+                      {'text': result_running_callback},
+                      {'text': result_complete_callback},
+                  ])
+            m.delete(self.job_uri)
+
+            # Here we provoke a timeout, by setting the timeout to less than
+            # the time it would take to return the completed job status.
+            # The time it would take is the sum of the following:
+            # - 2 * 1 s (1 s is the sleep time in Job.wait_for_completion(),
+            #   and this happens before each repeated status retrieval)
+            # - 3 * 1 s (1 s is the sleep time in result_*_callback() in this
+            #   module, and this happens in each mocked status retrieval)
+            # Because status completion is given priority over achieving the
+            # timeout duration, the timeout value needed to provoke the
+            # timeout exception needs to be shorter by the last status
+            # retrieval (the one that completes the job), so 3 s is the
+            # boundary for the timeout value.
+            timeout = 2.9
+            try:
+                start_time = time.time()
+                job.wait_for_completion(timeout=timeout)
+                duration = time.time() - start_time
+                self.fail("No TimeoutError raised. Actual duration: %s s, "
+                          "timeout: %s s" % (duration, timeout))
+            except TimeoutError as exc:
+                msg = exc.args[0]
+                self.assertTrue(msg.startswith(
+                    "Waiting for completion of job"))
+
+
+def result_running_callback(request, context):
+    job_result_running = {
+        'status': 'running',
+    }
+    time.sleep(1)
+    return json.dumps(job_result_running)
+
+
+def result_complete_callback(request, context):
+    exp_oper_result = {
+        'foo': 'bar',
+    }
+    job_result_complete = {
+        'status': 'complete',
+        'job-status-code': 200,
+        # 'job-reason-code' omitted because HTTP status good
+        'job-results': exp_oper_result,
+    }
+    time.sleep(1)
+    return json.dumps(job_result_complete)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -25,7 +25,7 @@ import requests_mock
 import time
 import json
 
-from zhmcclient import Session, ParseError, Job, HTTPError, TimeoutError
+from zhmcclient import Session, ParseError, Job, HTTPError, OperationTimeout
 
 
 class SessionTests(unittest.TestCase):
@@ -453,14 +453,14 @@ class JobTests(unittest.TestCase):
             # timeout exception needs to be shorter by the last status
             # retrieval (the one that completes the job), so 3 s is the
             # boundary for the timeout value.
-            timeout = 2.9
+            operation_timeout = 2.9
             try:
                 start_time = time.time()
-                job.wait_for_completion(timeout=timeout)
+                job.wait_for_completion(operation_timeout=operation_timeout)
                 duration = time.time() - start_time
-                self.fail("No TimeoutError raised. Actual duration: %s s, "
-                          "timeout: %s s" % (duration, timeout))
-            except TimeoutError as exc:
+                self.fail("No OperationTimeout raised. Actual duration: %s s, "
+                          "timeout: %s s" % (duration, operation_timeout))
+            except OperationTimeout as exc:
                 msg = exc.args[0]
                 self.assertTrue(msg.startswith(
                     "Waiting for completion of job"))

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -22,6 +22,7 @@ For documentation, see TODO: Add link to RTD once available.
 from __future__ import absolute_import
 
 from ._version import *       # noqa: F401
+from ._constants import *     # noqa: F401
 from ._exceptions import *    # noqa: F401
 from ._manager import *       # noqa: F401
 from ._resource import *      # noqa: F401

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -28,8 +28,8 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'DEFAULT_READ_TIMEOUT',
            'DEFAULT_READ_RETRIES',
            'DEFAULT_MAX_REDIRECTS',
-           'DEFAULT_ASYNC_OPERATION_TIMEOUT',
-           'DEFAULT_LPAR_STATUS_TIMEOUT']
+           'DEFAULT_OPERATION_TIMEOUT',
+           'DEFAULT_STATUS_TIMEOUT']
 
 
 #: Default HTTP connect timeout in seconds,
@@ -62,11 +62,10 @@ DEFAULT_MAX_REDIRECTS = 30
 #: resource objects (e.g. :meth:`zhmcclient.Partition.start`), in the
 #: :meth:`zhmcclient.Job.wait_for_completion` method, and in the
 #: low level method :meth:`zhmcclient.Session.post`.
-DEFAULT_ASYNC_OPERATION_TIMEOUT = None
+DEFAULT_OPERATION_TIMEOUT = 3600
 
 #: Default timeout in seconds for waiting for completion of deferred status
 #: changes for LPARs. This is used as a default value in asynchronous methods
 #: of the :class:`~zhmcclient.Lpar` class that change its status (e.g.
 #: :meth:`zhmcclient.Lpar.activate`)).
-DEFAULT_LPAR_STATUS_TIMEOUT = 3600
-
+DEFAULT_STATUS_TIMEOUT = 60

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -27,7 +27,9 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'DEFAULT_CONNECT_RETRIES',
            'DEFAULT_READ_TIMEOUT',
            'DEFAULT_READ_RETRIES',
-           'DEFAULT_MAX_REDIRECTS']
+           'DEFAULT_MAX_REDIRECTS',
+           'DEFAULT_ASYNC_OPERATION_TIMEOUT',
+           'DEFAULT_LPAR_STATUS_TIMEOUT']
 
 
 #: Default HTTP connect timeout in seconds,
@@ -54,3 +56,17 @@ DEFAULT_READ_RETRIES = 3
 #: if not specified in the ``retry_timeout_config`` init argument to
 #: :class:`~zhmcclient.Session`.
 DEFAULT_MAX_REDIRECTS = 30
+
+#: Default timeout in seconds for waiting for completion of an asynchronous
+#: HMC operation. This is used as a default value in asynchronous methods on
+#: resource objects (e.g. :meth:`zhmcclient.Partition.start`), in the
+#: :meth:`zhmcclient.Job.wait_for_completion` method, and in the
+#: low level method :meth:`zhmcclient.Session.post`.
+DEFAULT_ASYNC_OPERATION_TIMEOUT = None
+
+#: Default timeout in seconds for waiting for completion of deferred status
+#: changes for LPARs. This is used as a default value in asynchronous methods
+#: of the :class:`~zhmcclient.Lpar` class that change its status (e.g.
+#: :meth:`zhmcclient.Lpar.activate`)).
+DEFAULT_LPAR_STATUS_TIMEOUT = 3600
+

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -1,0 +1,56 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Public constants.
+
+These constants are not meant to be changed by the user, they are made
+available for inspection and documentation purposes only.
+
+For technical reasons, the online documentation shows these constants in the
+``zhmcclient._constants`` namespace, but they are also available in the
+``zhmcclient`` namespace and should be used from there.
+"""
+
+__all__ = ['DEFAULT_CONNECT_TIMEOUT',
+           'DEFAULT_CONNECT_RETRIES',
+           'DEFAULT_READ_TIMEOUT',
+           'DEFAULT_READ_RETRIES',
+           'DEFAULT_MAX_REDIRECTS']
+
+
+#: Default HTTP connect timeout in seconds,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_CONNECT_TIMEOUT = 30
+
+#: Default number of HTTP connect retries,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_CONNECT_RETRIES = 3
+
+#: Default HTTP read timeout in seconds,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_READ_TIMEOUT = 30
+
+#: Default number of HTTP read retries,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_READ_RETRIES = 3
+
+#: Default max. number of HTTP redirects,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_MAX_REDIRECTS = 30

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -45,7 +45,7 @@ DEFAULT_CONNECT_RETRIES = 3
 #: Default HTTP read timeout in seconds,
 #: if not specified in the ``retry_timeout_config`` init argument to
 #: :class:`~zhmcclient.Session`.
-DEFAULT_READ_TIMEOUT = 30
+DEFAULT_READ_TIMEOUT = 300
 
 #: Default number of HTTP read retries,
 #: if not specified in the ``retry_timeout_config`` init argument to

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -51,7 +51,6 @@ from ._adapter import AdapterManager
 from ._virtual_switch import VirtualSwitchManager
 from ._logging import _log_call
 from ._exceptions import HTTPError
-from ._constants import DEFAULT_ASYNC_OPERATION_TIMEOUT
 
 __all__ = ['CpcManager', 'Cpc']
 
@@ -334,8 +333,7 @@ class Cpc(BaseResource):
             else:
                 raise
 
-    def start(self, wait_for_completion=True,
-              operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
+    def start(self, wait_for_completion=True, operation_timeout=None):
         """
         Start this CPC, using the HMC operation "Start CPC".
 
@@ -358,9 +356,11 @@ class Cpc(BaseResource):
 
           operation_timeout (:term:`number`):
             Timeout in seconds, for waiting for completion of the asynchronous
-            job performing the operation. `None` means that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
         Returns:
 
@@ -378,17 +378,16 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while waiting
-            for completion of the operation.
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/start',
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         return result
 
-    def stop(self, wait_for_completion=True,
-             operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
+    def stop(self, wait_for_completion=True, operation_timeout=None):
         """
         Stop this CPC, using the HMC operation "Stop CPC".
 
@@ -411,9 +410,11 @@ class Cpc(BaseResource):
 
           operation_timeout (:term:`number`):
             Timeout in seconds, for waiting for completion of the asynchronous
-            job performing the operation. `None` means that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
         Returns:
 
@@ -431,18 +432,18 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while waiting
-            for completion of the operation.
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/stop',
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         return result
 
     @_log_call
     def import_profiles(self, profile_area, wait_for_completion=True,
-                        operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
+                        operation_timeout=None):
         """
         Import activation profiles and/or system activity profiles for this CPC
         from the SE hard drive into the CPC using the HMC operation
@@ -473,9 +474,11 @@ class Cpc(BaseResource):
 
           operation_timeout (:term:`number`):
             Timeout in seconds, for waiting for completion of the asynchronous
-            job performing the operation. `None` means that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
         Returns:
 
@@ -493,20 +496,20 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while waiting
-            for completion of the operation.
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
         """
         body = {'profile-area': profile_area}
         result = self.manager.session.post(
             self.uri + '/operations/import-profiles',
             body,
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         return result
 
     @_log_call
     def export_profiles(self, profile_area, wait_for_completion=True,
-                        operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
+                        operation_timeout=None):
         """
         Export activation profiles and/or system activity profiles from this
         CPC to the SE hard drive using the HMC operation "Export Profiles".
@@ -536,9 +539,11 @@ class Cpc(BaseResource):
 
           operation_timeout (:term:`number`):
             Timeout in seconds, for waiting for completion of the asynchronous
-            job performing the operation. `None` means that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
         Returns:
 
@@ -556,7 +561,7 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
         """
         body = {'profile-area': profile_area}
@@ -564,7 +569,7 @@ class Cpc(BaseResource):
             self.uri + '/operations/export-profiles',
             body,
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         return result
 
     def get_wwpns(self, partitions):

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -51,7 +51,7 @@ from ._adapter import AdapterManager
 from ._virtual_switch import VirtualSwitchManager
 from ._logging import _log_call
 from ._exceptions import HTTPError
-
+from ._constants import DEFAULT_ASYNC_OPERATION_TIMEOUT
 
 __all__ = ['CpcManager', 'Cpc']
 
@@ -334,7 +334,8 @@ class Cpc(BaseResource):
             else:
                 raise
 
-    def start(self, wait_for_completion=True):
+    def start(self, wait_for_completion=True,
+              operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
         """
         Start this CPC, using the HMC operation "Start CPC".
 
@@ -355,6 +356,12 @@ class Cpc(BaseResource):
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
 
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. `None` means that no timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+
         Returns:
 
           `None` or :class:`~zhmcclient.Job`:
@@ -371,13 +378,17 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while waiting
+            for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/start',
-            wait_for_completion=wait_for_completion)
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
         return result
 
-    def stop(self, wait_for_completion=True):
+    def stop(self, wait_for_completion=True,
+             operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
         """
         Stop this CPC, using the HMC operation "Stop CPC".
 
@@ -398,6 +409,12 @@ class Cpc(BaseResource):
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
 
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. `None` means that no timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+
         Returns:
 
           `None` or :class:`~zhmcclient.Job`:
@@ -414,14 +431,18 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while waiting
+            for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/stop',
-            wait_for_completion=wait_for_completion)
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
         return result
 
     @_log_call
-    def import_profiles(self, profile_area, wait_for_completion=True):
+    def import_profiles(self, profile_area, wait_for_completion=True,
+                        operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
         """
         Import activation profiles and/or system activity profiles for this CPC
         from the SE hard drive into the CPC using the HMC operation
@@ -450,6 +471,12 @@ class Cpc(BaseResource):
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
 
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. `None` means that no timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+
         Returns:
 
           `None` or :class:`~zhmcclient.Job`:
@@ -466,15 +493,20 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while waiting
+            for completion of the operation.
         """
         body = {'profile-area': profile_area}
         result = self.manager.session.post(
-            self.uri + '/operations/import-profiles', body,
-            wait_for_completion=wait_for_completion)
+            self.uri + '/operations/import-profiles',
+            body,
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
         return result
 
     @_log_call
-    def export_profiles(self, profile_area, wait_for_completion=True):
+    def export_profiles(self, profile_area, wait_for_completion=True,
+                        operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
         """
         Export activation profiles and/or system activity profiles from this
         CPC to the SE hard drive using the HMC operation "Export Profiles".
@@ -502,6 +534,12 @@ class Cpc(BaseResource):
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
 
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. `None` means that no timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+
         Returns:
 
           `None` or :class:`~zhmcclient.Job`:
@@ -518,11 +556,15 @@ class Cpc(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
         """
         body = {'profile-area': profile_area}
         result = self.manager.session.post(
-            self.uri + '/operations/export-profiles', body,
-            wait_for_completion=wait_for_completion)
+            self.uri + '/operations/export-profiles',
+            body,
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
         return result
 
     def get_wwpns(self, partitions):

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -21,7 +21,7 @@ import re
 
 __all__ = ['Error', 'ConnectionError', 'ConnectTimeout', 'ReadTimeout',
            'RetriesExceeded', 'AuthError', 'ParseError', 'VersionError',
-           'HTTPError', 'AsyncOperationTimeout', 'ResourceStatusTimeout',
+           'HTTPError', 'OperationTimeout', 'StatusTimeout',
            'NoUniqueMatch', 'NotFound']
 
 
@@ -441,7 +441,7 @@ class HTTPError(Error):
                       self.request_method, self.request_uri)
 
 
-class AsyncOperationTimeout(Error):
+class OperationTimeout(Error):
     """
     This exception indicates that the waiting for completion of an asynchronous
     HMC operation has timed out.
@@ -451,7 +451,7 @@ class AsyncOperationTimeout(Error):
     pass
 
 
-class ResourceStatusTimeout(Error):
+class StatusTimeout(Error):
     """
     This exception indicates that the waiting for reaching a desired resource
     status has timed out.

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -21,7 +21,8 @@ import re
 
 __all__ = ['Error', 'ConnectionError', 'ConnectTimeout', 'ReadTimeout',
            'RetriesExceeded', 'AuthError', 'ParseError', 'VersionError',
-           'HTTPError', 'NoUniqueMatch', 'NotFound']
+           'HTTPError', 'AsyncOperationTimeout', 'ResourceStatusTimeout',
+           'NoUniqueMatch', 'NotFound']
 
 
 class Error(Exception):
@@ -438,6 +439,26 @@ class HTTPError(Error):
                "request_method={}, request_uri={}, ...)".\
                format(self.http_status, self.reason, self.message,
                       self.request_method, self.request_uri)
+
+
+class AsyncOperationTimeout(Error):
+    """
+    This exception indicates that the waiting for completion of an asynchronous
+    HMC operation has timed out.
+
+    Derived from :exc:`~zhmcclient.Error`.
+    """
+    pass
+
+
+class ResourceStatusTimeout(Error):
+    """
+    This exception indicates that the waiting for reaching a desired resource
+    status has timed out.
+
+    Derived from :exc:`~zhmcclient.Error`.
+    """
+    pass
 
 
 class NoUniqueMatch(Error):

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -32,9 +32,7 @@ import time
 from ._manager import BaseManager
 from ._resource import BaseResource
 from ._logging import _log_call, _get_logger
-from ._exceptions import AsyncOperationTimeout
-from ._constants import DEFAULT_ASYNC_OPERATION_TIMEOUT, \
-    DEFAULT_LPAR_STATUS_TIMEOUT
+from ._exceptions import StatusTimeout
 
 __all__ = ['LparManager', 'Lpar']
 
@@ -215,7 +213,7 @@ class Lpar(BaseResource):
             timeout is set. `None` means that the default async operation
             timeout of the session is used. If the timeout expires when
             `wait_for_completion=True`, a
-            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
           status_timeout (:term:`number`):
             Timeout in seconds, for waiting that the status of the LPAR has
@@ -223,7 +221,7 @@ class Lpar(BaseResource):
             The special value 0 means that no timeout is set. `None` means that
             the default async operation timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.ResourceStatusTimeout` is raised.
+            :exc:`~zhmcclient.StatusTimeout` is raised.
 
         Returns:
 
@@ -241,20 +239,18 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
-          :exc:`~zhmcclient.ResourceStatusTimeout`: The timeout expired while
+          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
             waiting for the desired LPAR status.
         """
         body = {}
-        # TODO: Determine effective timeout
         result = self.manager.session.post(
             self.uri + '/operations/activate',
             body,
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         if wait_for_completion:
-            # TODO: Determine effective timeout
             self._wait_for_status("not-operating", status_timeout)
         return result
 
@@ -297,7 +293,7 @@ class Lpar(BaseResource):
             timeout is set. `None` means that the default async operation
             timeout of the session is used. If the timeout expires when
             `wait_for_completion=True`, a
-            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
           status_timeout (:term:`number`):
             Timeout in seconds, for waiting that the status of the LPAR has
@@ -305,7 +301,7 @@ class Lpar(BaseResource):
             The special value 0 means that no timeout is set. `None` means that
             the default async operation timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.ResourceStatusTimeout` is raised.
+            :exc:`~zhmcclient.StatusTimeout` is raised.
 
         Returns:
 
@@ -323,20 +319,18 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
-          :exc:`~zhmcclient.ResourceStatusTimeout`: The timeout expired while
+          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
             waiting for the desired LPAR status.
         """
         body = {'force': True}
-        # TODO: Determine effective timeout
         result = self.manager.session.post(
             self.uri + '/operations/deactivate',
             body,
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         if wait_for_completion:
-            # TODO: Determine effective timeout
             self._wait_for_status("not-activated", status_timeout)
         return result
 
@@ -383,7 +377,7 @@ class Lpar(BaseResource):
             timeout is set. `None` means that the default async operation
             timeout of the session is used. If the timeout expires when
             `wait_for_completion=True`, a
-            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
           status_timeout (:term:`number`):
             Timeout in seconds, for waiting that the status of the LPAR has
@@ -391,7 +385,7 @@ class Lpar(BaseResource):
             The special value 0 means that no timeout is set. `None` means that
             the default async operation timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.ResourceStatusTimeout` is raised.
+            :exc:`~zhmcclient.StatusTimeout` is raised.
 
         Returns:
 
@@ -409,22 +403,20 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
-          :exc:`~zhmcclient.ResourceStatusTimeout`: The timeout expired while
+          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
             waiting for the desired LPAR status.
         """
         body = {'load-address': load_address}
         if load_parameter != "":
             body['load-parameter'] = load_parameter
-        # TODO: Determine effective timeout
         result = self.manager.session.post(
             self.uri + '/operations/load',
             body,
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         if wait_for_completion:
-            # TODO: Determine effective timeout
             self._wait_for_status("operating", status_timeout)
         return result
 
@@ -499,7 +491,7 @@ class Lpar(BaseResource):
         self.manager.session.post(
             self.uri + '/operations/send-os-cmd', body)
 
-    def _wait_for_status(self, status, timeout=None):
+    def _wait_for_status(self, status, status_timeout=None):
         """
         Wait until the status of this LPAR has a desired value.
 
@@ -524,12 +516,12 @@ class Lpar(BaseResource):
             :term:`HMC API` book (as of its version 2.13.1) is partly
             confusing.
 
-          timeout (:term:`number`):
+          status_timeout (:term:`number`):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status. The special value 0 means that no
             timeout is set.
             If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.ResourceStatusTimeout` is raised.
+            :exc:`~zhmcclient.StatusTimeout` is raised.
 
         Raises:
 
@@ -537,10 +529,14 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.ResourceStatusTimeout`: The timeout expired while
+          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
             waiting for the desired LPAR status.
         """
-        end_time = time.time() + timeout if timeout > 0 else None
+        if status_timeout is None:
+            status_timeout = \
+                self.manager.session.retry_timeout_config.status_timeout
+        if status_timeout > 0:
+            end_time = time.time() + status_timeout
         while True:
 
             # Fastest way to get actual status value:
@@ -558,9 +554,11 @@ class Lpar(BaseResource):
                          "this was a temporary condition)".
                          format(this_lpar.name, this_lpar.manager.cpc.name,
                                 status))
-            if end_time is not None and time.time() > end_time:
-                raise ResourceStatusTimeout(
+
+            if status_timeout > 0 and time.time() > end_time:
+                raise StatusTimeout(
                     "Waiting for LPAR {} to reach status '{}' timed out after "
                     "{} s - current status is '{}'".
-                    format(self.name, status, timeout, actual_status))
+                    format(self.name, status, status_timeout, actual_status))
+
             time.sleep(1)  # Avoid hot spin loop

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -27,9 +27,14 @@ CPCs in DPM mode have :term:`Partition` resources, instead.
 
 from __future__ import absolute_import
 
+import time
+
 from ._manager import BaseManager
 from ._resource import BaseResource
 from ._logging import _log_call
+from ._exceptions import AsyncOperationTimeout
+from ._constants import DEFAULT_ASYNC_OPERATION_TIMEOUT, \
+    DEFAULT_LPAR_STATUS_TIMEOUT
 
 __all__ = ['LparManager', 'Lpar']
 
@@ -169,10 +174,19 @@ class Lpar(BaseResource):
         super(Lpar, self).__init__(manager, uri, name, properties)
 
     @_log_call
-    def activate(self, wait_for_completion=True):
+    def activate(self, wait_for_completion=True,
+                 operation_timeout=None, status_timeout=None):
         """
         Activate (start) this LPAR, using the HMC operation "Activate Logical
         Partition".
+
+        This HMC operation has deferred status behavior: If the asynchronous
+        job on the HMC is complete, it takes a few seconds until the LPAR
+        status has reached the desired value. If `wait_for_completion=True`,
+        this method repeatedly checks the status of the LPAR after the HMC
+        operation has completed, and waits until the status is in the desired
+        state "non-operating" (which indicates that the LPAR is active but
+        no operating system is running).
 
         Authorization requirements:
 
@@ -187,10 +201,27 @@ class Lpar(BaseResource):
             of the requested asynchronous HMC operation, as follows:
 
             * If `True`, this method will wait for completion of the
-              asynchronous job performing the operation.
+              asynchronous job performing the operation, and for the status
+              becoming "non-operating".
 
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
+
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+
+          status_timeout (:term:`number`):
+            Timeout in seconds, for waiting that the status of the LPAR has
+            reached the desired status, after the HMC operation has completed.
+            The special value 0 means that no timeout is set. `None` means that
+            the default async operation timeout of the session is used.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.ResourceStatusTimeout` is raised.
 
         Returns:
 
@@ -208,18 +239,36 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
+          :exc:`~zhmcclient.ResourceStatusTimeout`: The timeout expired while
+            waiting for the desired LPAR status.
         """
         body = {}
+        # TODO: Determine effective timeout
         result = self.manager.session.post(
-            self.uri + '/operations/activate', body,
-            wait_for_completion=wait_for_completion)
+            self.uri + '/operations/activate',
+            body,
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
+        if wait_for_completion:
+            # TODO: Determine effective timeout
+            self._wait_for_status("non-operating", status_timeout)
         return result
 
     @_log_call
-    def deactivate(self, wait_for_completion=True):
+    def deactivate(self, wait_for_completion=True,
+                   operation_timeout=None, status_timeout=None):
         """
         De-activate (stop) this LPAR, using the HMC operation "Deactivate
         Logical Partition".
+
+        This HMC operation has deferred status behavior: If the asynchronous
+        job on the HMC is complete, it takes a few seconds until the LPAR
+        status has reached the desired value. If `wait_for_completion=True`,
+        this method repeatedly checks the status of the LPAR after the HMC
+        operation has completed, and waits until the status is in the desired
+        state "not-activated".
 
         Authorization requirements:
 
@@ -234,10 +283,27 @@ class Lpar(BaseResource):
             of the requested asynchronous HMC operation, as follows:
 
             * If `True`, this method will wait for completion of the
-              asynchronous job performing the operation.
+              asynchronous job performing the operation, and for the status
+              becoming "non-activated".
 
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
+
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+
+          status_timeout (:term:`number`):
+            Timeout in seconds, for waiting that the status of the LPAR has
+            reached the desired status, after the HMC operation has completed.
+            The special value 0 means that no timeout is set. `None` means that
+            the default async operation timeout of the session is used.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.ResourceStatusTimeout` is raised.
 
         Returns:
 
@@ -255,18 +321,36 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
+          :exc:`~zhmcclient.ResourceStatusTimeout`: The timeout expired while
+            waiting for the desired LPAR status.
         """
         body = {'force': True}
+        # TODO: Determine effective timeout
         result = self.manager.session.post(
-            self.uri + '/operations/deactivate', body,
-            wait_for_completion=wait_for_completion)
+            self.uri + '/operations/deactivate',
+            body,
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
+        if wait_for_completion:
+            # TODO: Determine effective timeout
+            self._wait_for_status("not-activated", status_timeout)
         return result
 
     @_log_call
-    def load(self, load_address, load_parameter="", wait_for_completion=True):
+    def load(self, load_address, load_parameter="", wait_for_completion=True,
+             operation_timeout=None, status_timeout=None):
         """
         Load (boot) this LPAR from a load address (boot device), using the HMC
         operation "Load Logical Partition".
+
+        This HMC operation has deferred status behavior: If the asynchronous
+        job on the HMC is complete, it takes a few seconds until the LPAR
+        status has reached the desired value. If `wait_for_completion=True`,
+        this method repeatedly checks the status of the LPAR after the HMC
+        operation has completed, and waits until the status is in the desired
+        state "operating".
 
         Authorization requirements:
 
@@ -285,10 +369,27 @@ class Lpar(BaseResource):
             of the requested asynchronous HMC operation, as follows:
 
             * If `True`, this method will wait for completion of the
-              asynchronous job performing the operation.
+              asynchronous job performing the operation, and for the status
+              becoming "operating".
 
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
+
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.AsyncOperationTimeout` is raised.
+
+          status_timeout (:term:`number`):
+            Timeout in seconds, for waiting that the status of the LPAR has
+            reached the desired status, after the HMC operation has completed.
+            The special value 0 means that no timeout is set. `None` means that
+            the default async operation timeout of the session is used.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.ResourceStatusTimeout` is raised.
 
         Returns:
 
@@ -306,13 +407,23 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.AsyncOperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
+          :exc:`~zhmcclient.ResourceStatusTimeout`: The timeout expired while
+            waiting for the desired LPAR status.
         """
         body = {'load-address': load_address}
         if load_parameter != "":
             body['load-parameter'] = load_parameter
+        # TODO: Determine effective timeout
         result = self.manager.session.post(
-            self.uri + '/operations/load', body,
-            wait_for_completion=wait_for_completion)
+            self.uri + '/operations/load',
+            body,
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
+        if wait_for_completion:
+            # TODO: Determine effective timeout
+            self._wait_for_status("operating", status_timeout)
         return result
 
     def open_os_message_channel(self, include_refresh_messages=True):
@@ -385,3 +496,59 @@ class Lpar(BaseResource):
                 'operating-system-command-text': os_command_text}
         self.manager.session.post(
             self.uri + '/operations/send-os-cmd', body)
+
+    def _wait_for_status(self, status, timeout=None):
+        """
+        Wait until the status of this LPAR has a desired value.
+
+        Parameters:
+
+          status (:term:`string`):
+            Desired LPAR status to reach.
+
+            Possible LPAR status values are:
+            * ``"not-activated"`` - The LPAR is not active.
+            * ``"not-operating" - The LPAR is active but no operating system is
+              running in the LPAR.
+            * ``"operating"`` - The LPAR is active and an operating system is
+              running in the LPAR.
+            * ``"exceptions"`` - The LPAR or its CPC has one or more unusual
+              conditions.
+
+            Note that the description of LPAR status values in the
+            :term:`HMC API` book (as of its version 2.13.1) is confusing and
+            partly incorrect.
+
+          timeout (:term:`number`):
+            Timeout in seconds, for waiting that the status of the LPAR has
+            reached the desired status. The special value 0 means that no
+            timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.ResourceStatusTimeout` is raised.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.ResourceStatusTimeout`: The timeout expired while
+            waiting for the desired LPAR status.
+        """
+        end_time = time.time() + timeout if timeout > 0 else None
+        while True:
+
+            # Fastest way to get actual property values:
+            lpars = self.manager.cpc.lpars.list(
+                filter_args={'name': self.name})
+            assert len(lpars) == 0
+            this_lpar = lpars[0]
+            actual_status = this_lpar.get_property('status')
+            if actual_status == status:
+                return
+            if end_time is not None and time.time() > end_time:
+                raise ResourceStatusTimeout(
+                    "Waiting for LPAR {} to reach status '{}' timed out after "
+                    "{} s - current status is '{}'".
+                    format(self.name, status, timeout, actual_status))
+            time.sleep(1)  # Avoid hot spin loop

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -37,7 +37,6 @@ from ._nic import NicManager
 from ._hba import HbaManager
 from ._virtual_function import VirtualFunctionManager
 from ._logging import _log_call
-from ._constants import DEFAULT_ASYNC_OPERATION_TIMEOUT
 
 __all__ = ['PartitionManager', 'Partition']
 
@@ -288,8 +287,7 @@ class Partition(BaseResource):
             self._virtual_functions = VirtualFunctionManager(self)
         return self._virtual_functions
 
-    def start(self, wait_for_completion=True,
-              operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
+    def start(self, wait_for_completion=True, operation_timeout=None):
         """
         Start (activate) this Partition, using the HMC operation "Start
         Partition".
@@ -316,9 +314,11 @@ class Partition(BaseResource):
 
           operation_timeout (:term:`number`):
             Timeout in seconds, for waiting for completion of the asynchronous
-            job performing the operation. `None` means that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.TimeoutError` is raised.
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
         Returns:
 
@@ -336,17 +336,16 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.TimeoutError`: The timeout expired while waiting
-            for completion of the operation.
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/start',
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         return result
 
-    def stop(self, wait_for_completion=True,
-             operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
+    def stop(self, wait_for_completion=True, operation_timeout=None):
         """
         Stop (deactivate) this Partition, using the HMC operation "Stop
         Partition".
@@ -370,9 +369,11 @@ class Partition(BaseResource):
 
           operation_timeout (:term:`number`):
             Timeout in seconds, for waiting for completion of the asynchronous
-            job performing the operation. `None` means that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.TimeoutError` is raised.
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
         Returns:
 
@@ -390,13 +391,13 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.TimeoutError`: The timeout expired while waiting
-            for completion of the operation.
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/stop',
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         return result
 
     def delete(self):
@@ -444,7 +445,7 @@ class Partition(BaseResource):
         self.manager.session.post(self.uri, body=properties)
 
     def dump_partition(self, parameters, wait_for_completion=True,
-                       operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
+                       operation_timeout=None):
         """
         Dump this Partition, by loading a standalone dump program from a SCSI
         device and starting its execution, using the HMC operation
@@ -474,9 +475,11 @@ class Partition(BaseResource):
 
           operation_timeout (:term:`number`):
             Timeout in seconds, for waiting for completion of the asynchronous
-            job performing the operation. `None` means that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.TimeoutError` is raised.
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
         Returns:
 
@@ -494,18 +497,17 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.TimeoutError`: The timeout expired while waiting
-            for completion of the operation.
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/scsi-dump',
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout,
+            operation_timeout=operation_timeout,
             body=parameters)
         return result
 
-    def psw_restart(self, wait_for_completion=True,
-                    operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
+    def psw_restart(self, wait_for_completion=True, operation_timeout=None):
         """
         Initiates a PSW restart for this Partition, using the HMC operation
         'Perform PSW Restart'.
@@ -529,9 +531,11 @@ class Partition(BaseResource):
 
           operation_timeout (:term:`number`):
             Timeout in seconds, for waiting for completion of the asynchronous
-            job performing the operation. `None` means that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.TimeoutError` is raised.
+            job performing the operation. The special value 0 means that no
+            timeout is set. `None` means that the default async operation
+            timeout of the session is used. If the timeout expires when
+            `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
 
         Returns:
 
@@ -549,13 +553,13 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
-          :exc:`~zhmcclient.TimeoutError`: The timeout expired while waiting
-            for completion of the operation.
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
+            waiting for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/psw-restart',
             wait_for_completion=wait_for_completion,
-            timeout=operation_timeout)
+            operation_timeout=operation_timeout)
         return result
 
     def mount_iso_image(self, properties):

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -37,6 +37,7 @@ from ._nic import NicManager
 from ._hba import HbaManager
 from ._virtual_function import VirtualFunctionManager
 from ._logging import _log_call
+from ._constants import DEFAULT_ASYNC_OPERATION_TIMEOUT
 
 __all__ = ['PartitionManager', 'Partition']
 
@@ -287,7 +288,8 @@ class Partition(BaseResource):
             self._virtual_functions = VirtualFunctionManager(self)
         return self._virtual_functions
 
-    def start(self, wait_for_completion=True):
+    def start(self, wait_for_completion=True,
+              operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
         """
         Start (activate) this Partition, using the HMC operation "Start
         Partition".
@@ -312,6 +314,12 @@ class Partition(BaseResource):
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
 
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. `None` means that no timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.TimeoutError` is raised.
+
         Returns:
 
           `None` or :class:`~zhmcclient.Job`:
@@ -328,13 +336,17 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.TimeoutError`: The timeout expired while waiting
+            for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/start',
-            wait_for_completion=wait_for_completion)
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
         return result
 
-    def stop(self, wait_for_completion=True):
+    def stop(self, wait_for_completion=True,
+             operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
         """
         Stop (deactivate) this Partition, using the HMC operation "Stop
         Partition".
@@ -356,6 +368,12 @@ class Partition(BaseResource):
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
 
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. `None` means that no timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.TimeoutError` is raised.
+
         Returns:
 
           `None` or :class:`~zhmcclient.Job`:
@@ -372,10 +390,13 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.TimeoutError`: The timeout expired while waiting
+            for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/stop',
-            wait_for_completion=wait_for_completion)
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
         return result
 
     def delete(self):
@@ -422,7 +443,8 @@ class Partition(BaseResource):
         """
         self.manager.session.post(self.uri, body=properties)
 
-    def dump_partition(self, parameters, wait_for_completion=True):
+    def dump_partition(self, parameters, wait_for_completion=True,
+                       operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
         """
         Dump this Partition, by loading a standalone dump program from a SCSI
         device and starting its execution, using the HMC operation
@@ -450,6 +472,12 @@ class Partition(BaseResource):
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
 
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. `None` means that no timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.TimeoutError` is raised.
+
         Returns:
 
           `None` or :class:`~zhmcclient.Job`:
@@ -466,13 +494,18 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.TimeoutError`: The timeout expired while waiting
+            for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/scsi-dump',
-            wait_for_completion=wait_for_completion, body=parameters)
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout,
+            body=parameters)
         return result
 
-    def psw_restart(self, wait_for_completion=True):
+    def psw_restart(self, wait_for_completion=True,
+                    operation_timeout=DEFAULT_ASYNC_OPERATION_TIMEOUT):
         """
         Initiates a PSW restart for this Partition, using the HMC operation
         'Perform PSW Restart'.
@@ -494,6 +527,12 @@ class Partition(BaseResource):
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
 
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for completion of the asynchronous
+            job performing the operation. `None` means that no timeout is set.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.TimeoutError` is raised.
+
         Returns:
 
           `None` or :class:`~zhmcclient.Job`:
@@ -510,10 +549,13 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.TimeoutError`: The timeout expired while waiting
+            for completion of the operation.
         """
         result = self.manager.session.post(
             self.uri + '/operations/psw-restart',
-            wait_for_completion=wait_for_completion)
+            wait_for_completion=wait_for_completion,
+            timeout=operation_timeout)
         return result
 
     def mount_iso_image(self, properties):

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -32,15 +32,12 @@ from ._exceptions import HTTPError, AuthError, ConnectionError, ParseError, \
     ConnectTimeout, ReadTimeout, RetriesExceeded
 from ._timestats import TimeStatsKeeper
 from ._logging import _get_logger, _log_call
+from ._constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_CONNECT_RETRIES, \
+    DEFAULT_READ_TIMEOUT, DEFAULT_READ_RETRIES, DEFAULT_MAX_REDIRECTS
 
 LOG = _get_logger(__name__)
 
-__all__ = ['Session', 'Job', 'RetryTimeoutConfig',
-           'DEFAULT_CONNECT_TIMEOUT',
-           'DEFAULT_CONNECT_RETRIES',
-           'DEFAULT_READ_TIMEOUT',
-           'DEFAULT_READ_RETRIES',
-           'DEFAULT_MAX_REDIRECTS']
+__all__ = ['Session', 'Job', 'RetryTimeoutConfig']
 
 _HMC_PORT = 6794
 _HMC_SCHEME = "https"
@@ -113,7 +110,7 @@ class RetryTimeoutConfig(object):
         """
         For all parameters, `None` means that this object does not specify a
         value for the parameter, and that a default value should be used
-        (see :ref:`Default retry-timeout configuration`).
+        (see :ref:`Constants`).
 
         All parameters are available as instance attributes.
 
@@ -173,36 +170,6 @@ class RetryTimeoutConfig(object):
                 value = getattr(override_config, attr)
             setattr(ret, attr, value)
         return ret
-
-
-#: Default HTTP connect timeout in seconds,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_CONNECT_TIMEOUT = 30
-
-
-#: Default number of HTTP connect retries,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_CONNECT_RETRIES = 3
-
-
-#: Default HTTP read timeout in seconds,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_READ_TIMEOUT = 30
-
-
-#: Default number of HTTP read retries,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_READ_RETRIES = 3
-
-
-#: Default max. number of HTTP redirects,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_MAX_REDIRECTS = 30
 
 
 class Session(object):
@@ -297,8 +264,7 @@ class Session(object):
             default configuration will be used with the default values for all
             of its attributes.
 
-            See :ref:`Default retry-timeout configuration` for the default
-            values.
+            See :ref:`Constants` for the default values.
         """
         self._host = host
         self._userid = userid

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -26,14 +26,21 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 import requests
+from requests.packages import urllib3
 
-from ._exceptions import HTTPError, AuthError, ConnectionError, ParseError
+from ._exceptions import HTTPError, AuthError, ConnectionError, ParseError, \
+    ConnectTimeout, ReadTimeout, RetriesExceeded
 from ._timestats import TimeStatsKeeper
 from ._logging import _get_logger, _log_call
 
 LOG = _get_logger(__name__)
 
-__all__ = ['Session', 'Job']
+__all__ = ['Session', 'Job', 'RetryTimeoutConfig',
+           'DEFAULT_CONNECT_TIMEOUT',
+           'DEFAULT_CONNECT_RETRIES',
+           'DEFAULT_READ_TIMEOUT',
+           'DEFAULT_READ_RETRIES',
+           'DEFAULT_MAX_REDIRECTS']
 
 _HMC_PORT = 6794
 _HMC_SCHEME = "https"
@@ -41,6 +48,161 @@ _STD_HEADERS = {
     'Content-type': 'application/json',
     'Accept': '*/*'
 }
+
+
+def _handle_request_exc(exc):
+    """
+    Handle a :exc:`request.exceptions.RequestException` exception that was
+    raised.
+    """
+    if isinstance(exc, requests.exceptions.ConnectTimeout):
+        raise ConnectTimeout(_request_exc_message(exc), exc)
+    elif isinstance(exc, requests.exceptions.ReadTimeout):
+        raise ReadTimeout(_request_exc_message(exc), exc)
+    elif isinstance(exc, requests.exceptions.RetryError):
+        raise RetriesExceeded(_request_exc_message(exc), exc)
+    else:
+        raise ConnectionError(_request_exc_message(exc), exc)
+
+
+def _request_exc_message(exc):
+    """
+    Return a reasonable exception message from a
+    :exc:`request.exceptions.RequestException` exception.
+
+    The approach is to dig deep to the original reason, if the original
+    exception is present, skipping irrelevant exceptions such as
+    `urllib3.exceptions.MaxRetryError`, and eliminating useless object
+    representations such as the connection pool object in
+    `urllib3.exceptions.NewConnectionError`.
+
+    Parameters:
+      exc (:exc:`~request.exceptions.RequestException`): Exception
+
+    Returns:
+      string: A reasonable exception message from the specified exception.
+    """
+    if exc.args:
+        if isinstance(exc.args[0], Exception):
+            org_exc = exc.args[0]
+            if isinstance(org_exc, urllib3.exceptions.MaxRetryError):
+                reason_exc = org_exc.reason
+                message = str(reason_exc)
+            else:
+                message = str(org_exc.args[0])
+        else:
+            message = str(exc.args[0])
+
+        # Eliminate useless object repr at begin of the message
+        m = re.match(r'^(\(<[^>]+>, \'(.*)\'\)|<[^>]+>: (.*))$', message)
+        if m:
+            message = m.group(2) or m.group(3)
+    else:
+        message = ""
+    return message
+
+
+class RetryTimeoutConfig(object):
+    """
+    A configuration setting that specifies verious retry counts and timeout
+    durations.
+    """
+
+    def __init__(self, connect_timeout=None, connect_retries=None,
+                 read_timeout=None, read_retries=None, max_redirects=None):
+        """
+        For all parameters, `None` means that this object does not specify a
+        value for the parameter, and that a default value should be used
+        (see :ref:`Default retry-timeout configuration`).
+
+        All parameters are available as instance attributes.
+
+        Parameters:
+
+          connect_timeout (:term:`number`): Connect timeout in seconds.
+            This timeout applies to making a connection at the socket level.
+            The same socket connection is used for sending an HTTP request to
+            the HMC and for receiving its HTTP response.
+
+          connect_retries (:term:`integer`): Number of retries (after the
+            initial attempt) for connection-related issues. These retries are
+            performed for failed DNS lookups, failed socket connections, and
+            socket connection timeouts.
+
+          read_timeout (:term:`number`): Read timeout in seconds.
+            This timeout applies to reading at the socket level, when receiving
+            an HTTP response.
+
+          read_retries (:term:`integer`): Number of retries (after the
+            initial attempt) for read-related issues. These retries are
+            performed for failed socket reads and socket read timeouts.
+
+          max_redirects (:term:`integer`): Maximum number of HTTP redirects.
+        """
+        self.connect_timeout = connect_timeout
+        self.connect_retries = connect_retries
+        self.read_timeout = read_timeout
+        self.read_retries = read_retries
+        self.max_redirects = max_redirects
+
+    _attrs = ('connect_timeout', 'connect_retries', 'read_timeout',
+              'read_retries', 'max_redirects')
+
+    def override_with(self, override_config):
+        """
+        Return a new configuration object that represents the configuration
+        from this configuration object acting as a default, and the specified
+        configuration object overriding that default.
+
+        Parameters:
+
+          override_config (:class:`~zhmcclient.RetryTimeoutConfig`):
+            The configuration object overriding the defaults defined in this
+            configuration object.
+
+        Returns:
+
+          :class:`~zhmcclient.RetryTimeoutConfig`:
+            A new configuration object representing this configuration object,
+            overridden by the specified configuration object.
+        """
+        ret = RetryTimeoutConfig()
+        for attr in RetryTimeoutConfig._attrs:
+            value = getattr(self, attr)
+            if override_config and getattr(override_config, attr) is not None:
+                value = getattr(override_config, attr)
+            setattr(ret, attr, value)
+        return ret
+
+
+#: Default HTTP connect timeout in seconds,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_CONNECT_TIMEOUT = 30
+
+
+#: Default number of HTTP connect retries,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_CONNECT_RETRIES = 3
+
+
+#: Default HTTP read timeout in seconds,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_READ_TIMEOUT = 30
+
+
+#: Default number of HTTP read retries,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_READ_RETRIES = 3
+
+
+#: Default max. number of HTTP redirects,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_MAX_REDIRECTS = 30
 
 
 class Session(object):
@@ -56,8 +218,16 @@ class Session(object):
     measurements, and to print the statistics.
     """
 
+    default_rt_config = RetryTimeoutConfig(
+        connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+        connect_retries=DEFAULT_CONNECT_RETRIES,
+        read_timeout=DEFAULT_READ_TIMEOUT,
+        read_retries=DEFAULT_READ_RETRIES,
+        max_redirects=DEFAULT_MAX_REDIRECTS,
+    )
+
     def __init__(self, host, userid=None, password=None, session_id=None,
-                 get_password=None):
+                 get_password=None, retry_timeout_config=None):
         """
         Creating a session object will not immediately cause a logon to be
         attempted; the logon is deferred until needed.
@@ -115,11 +285,27 @@ class Session(object):
 
             This mechanism can be used for example by command line interfaces
             for prompting for the password.
+
+          retry_timeout_config (:class:`~zhmcclient.RetryTimeoutConfig`):
+            The retry/timeout configuration for this session for use by any of
+            its HMC operations, overriding any defaults.
+
+            `None` for an attribute in that configuration object means that the
+            default value will be used for that attribute.
+
+            `None` for the entire `retry_timeout_config` parameter means that a
+            default configuration will be used with the default values for all
+            of its attributes.
+
+            See :ref:`Default retry-timeout configuration` for the default
+            values.
         """
         self._host = host
         self._userid = userid
         self._password = password
         self._get_password = get_password
+        self._retry_timeout_config = self.default_rt_config.override_with(
+            retry_timeout_config)
         self._base_url = "{scheme}://{host}:{port}".format(
             scheme=_HMC_SCHEME,
             host=self._host,
@@ -128,7 +314,7 @@ class Session(object):
         if session_id is not None:
             # Create a logged-on state (same state as in _do_logon())
             self._session_id = session_id
-            self._session = requests.Session()
+            self._session = self._new_session(self.retry_timeout_config)
             self._headers['X-API-Session'] = session_id
         else:
             # Create a logged-off state (same state as in _do_logoff())
@@ -168,6 +354,15 @@ class Session(object):
         bool: The function that returns the password as a string, or `None`.
         """
         return self._get_password
+
+    @property
+    def retry_timeout_config(self):
+        """
+        :class:`~zhmcclient.RetryTimeoutConfig`: The effective retry/timeout
+        configuration for this session for use by any of its HMC operations,
+        taking into account the defaults and the session-specific overrides.
+        """
+        return self._retry_timeout_config
 
     @property
     def base_url(self):
@@ -318,10 +513,32 @@ class Session(object):
             'password': self._password
         }
         self._headers.pop('X-API-Session', None)  # Just in case
-        self._session = requests.Session()
+        self._session = self._new_session(self.retry_timeout_config)
         logon_res = self.post(logon_uri, logon_body, logon_required=False)
         self._session_id = logon_res['api-session']
         self._headers['X-API-Session'] = self._session_id
+
+    @staticmethod
+    def _new_session(retry_timeout_config):
+        """
+        Return a new `requests.Session` object.
+        """
+        retry = requests.packages.urllib3.Retry(
+            total=None,
+            connect=retry_timeout_config.connect_retries,
+            read=retry_timeout_config.read_retries,
+            redirect=retry_timeout_config.max_redirects)
+        # TODO: Pass method_whitelist=False to Retry()?
+        # This would cause retry for POST in addition to the default of GET and
+        # DELETE (the idempotent HTTP methods we use). The uncertainty is
+        # whether unintended duplicate execution of the POST can happen.
+
+        session = requests.Session()
+        session.mount('https://',
+                      requests.adapters.HTTPAdapter(max_retries=retry))
+        session.mount('http://',
+                      requests.adapters.HTTPAdapter(max_retries=retry))
+        return session
 
     def _do_logoff(self):
         """
@@ -389,11 +606,14 @@ class Session(object):
         stats = self.time_stats_keeper.get_stats('get ' + uri)
         stats.begin()
         req = self._session or requests
+        timeout = (self.retry_timeout_config.connect_timeout,
+                   self.retry_timeout_config.read_timeout)
         try:
-            result = req.get(url, headers=self.headers, verify=False)
+            result = req.get(url, headers=self.headers, verify=False,
+                             timeout=timeout)
             self._log_hmc_request_id(result)
         except requests.exceptions.RequestException as exc:
-            raise ConnectionError(exc.args[0], exc)
+            _handle_request_exc(exc)
         finally:
             stats.end()
 
@@ -404,13 +624,7 @@ class Session(object):
             reason = result_object.get('reason', None)
             if reason == 5:
                 # API session token expired: re-logon and retry
-                if logon_required:
-                    self._do_logon()
-                else:
-                    raise AuthError("API session token unexpectedly expired "
-                                    "for GET on a resource that does not "
-                                    "require authentication: {}".
-                                    format(uri), HTTPError(result_object))
+                self._do_logon()
                 return self.get(uri, logon_required)
             else:
                 msg = result_object.get('message', None)
@@ -447,6 +661,8 @@ class Session(object):
 
         If executing the operation reveals that the HMC session token is
         expired, this method re-logs on and retries the operation.
+
+        The timeout and retry
 
         Parameters:
 
@@ -521,6 +737,8 @@ class Session(object):
         url = self.base_url + uri
         self._log_http_method('POST', uri)
         req = self._session or requests
+        timeout = (self.retry_timeout_config.connect_timeout,
+                   self.retry_timeout_config.read_timeout)
         if wait_for_completion:
             stats_total = self.time_stats_keeper.get_stats(
                 'post ' + uri + '+completion')
@@ -531,14 +749,14 @@ class Session(object):
             try:
                 if body is None:
                     result = req.post(url, headers=self.headers,
-                                      verify=False)
+                                      verify=False, timeout=timeout)
                 else:
                     data = json.dumps(body)
                     result = req.post(url, data=data, headers=self.headers,
-                                      verify=False)
+                                      verify=False, timeout=timeout)
                 self._log_hmc_request_id(result)
             except requests.exceptions.RequestException as exc:
-                raise ConnectionError(exc.args[0], exc)
+                _handle_request_exc(exc)
             finally:
                 stats.end()
 
@@ -560,14 +778,7 @@ class Session(object):
                 reason = result_object.get('reason', None)
                 if reason == 5:
                     # API session token expired: re-logon and retry
-                    if logon_required:
-                        self._do_logon()
-                    else:
-                        raise AuthError(
-                            "API session token unexpectedly expired "
-                            "for POST on a resource that does not "
-                            "require authentication: {}".
-                            format(uri), HTTPError(result_object))
+                    self._do_logon()
                     return self.post(uri, body, logon_required)
                 else:
                     msg = result_object.get('message', None)
@@ -619,11 +830,14 @@ class Session(object):
         stats = self.time_stats_keeper.get_stats('delete ' + uri)
         stats.begin()
         req = self._session or requests
+        timeout = (self.retry_timeout_config.connect_timeout,
+                   self.retry_timeout_config.read_timeout)
         try:
-            result = req.delete(url, headers=self.headers, verify=False)
+            result = req.delete(url, headers=self.headers, verify=False,
+                                timeout=timeout)
             self._log_hmc_request_id(result)
         except requests.exceptions.RequestException as exc:
-            raise ConnectionError(exc.args[0], exc)
+            _handle_request_exc(exc)
         finally:
             stats.end()
 
@@ -634,13 +848,7 @@ class Session(object):
             reason = result_object.get('reason', None)
             if reason == 5:
                 # API session token expired: re-logon and retry
-                if logon_required:
-                    self._do_logon()
-                else:
-                    raise AuthError("API session token unexpectedly expired "
-                                    "for DELETE on a resource that does not "
-                                    "require authentication: {}".
-                                    format(uri), HTTPError(result_object))
+                self._do_logon()
                 self.delete(uri, logon_required)
                 return
             else:


### PR DESCRIPTION
Please review and merge.

Please focus on the changes at the API, more than on the implementation code.

Good questions would be, for example:

- The new `TimeoutError` class is used for both async operation timeouts and status polling timeouts, and it does not have a machine-readable way to distinguish these cases. This affects only the `Lpar.activate/dectivate/load()` methods. Is this good enough?
- Are the default timeouts right (see the new `_constants.py` module)?
- The use of `Lpar.activate/dectivate/load()` with `wait_for_completion=False` returns a Job object that can handle the waiting for job completion, but not the waiting for deferred status update. On the one hand, this may be what you expect from an asynchronous job, on the other hand, it is not consistent with the `wait_for_completion=True` case, where both is done by the zhmcclient library.

Details, from the commit message:

- Added exception class `TimeoutError` that is used to indicate operation timeout and status polling timeout.
- Added support for deferred status polling to the `Lpar.activate/deactivate/load()` methods.i
  Background: The HMC operations issued by these methods exhibit show deferred status ibehavior, which means that it takes a few seconds after successful completion of the async job that executes the operation, until the new status can be observed in the 'status' property of the LPAR resource.
  These methods will poll the LPAR status until the desired status value is reached. A status timeout can be specified via a new `status_timeout` parameter to these methods, which defaults to 1h. The long timeout duration means this is just a last resort.
- Added operation timeout support to `Session.post()` and to all resource methods with a `wait_for_completion` parameter (i.e. the asynchronous methods). The operation timeout on the async methods can be specified via a new `operation_timeout` parameter, which defaults to no timeout.
- Added a new module `_constants` to define the default timeout values for the operation timeout and the status timeout.