### PR TITLE
Fixes #197: Improved help of zhmc CLI.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -56,12 +56,24 @@ Released: not yet
 * Increased minimum version of "click-spinner" package to 0.1.7, in order to
   pick up the fix for zhmcclient issue #116.
 
+* Fixed CLI help text for multiple commands, where the text was incorrectly
+  flowed into a paragraph.
+
 **Enhancements:**
 
 * Fixed a discrepancy between documentation and actual behavior of the return
   value of all methods on resource classes that invoke asynchronous operations
   (i.e. all methods that have a `wait_for_completion` parameter). See also
   the corresponding incompatible change (issue #178).
+
+* In the CLI, added a 'help' command that displays help for interactive mode,
+  and a one-line hint that explains how to get help and how to exit
+  interactive mode (issue #197).
+
+* In the CLI, added support for command history. The history is stored in
+  the file `~/.zhmc_history`.
+
+* In the CLI, changed the prompt of the interactive mode to `zhmc> `.
 
 **Known Issues:**
 

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -73,6 +73,7 @@ def cpc_show(cmd_ctx, cpc):
     """
     Show details of a CPC.
 
+    \b
     Limitations:
       * In table format, the following properties are not shown:
         - ec-mcl-description
@@ -122,6 +123,7 @@ def cpc_update(cmd_ctx, cpc, **options):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
 
+    \b
     Limitations:
       * The --acceptable-status option does not support multiple values.
     """

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -78,6 +78,7 @@ def lpar_show(cmd_ctx, cpc, lpar):
     """
     Show details of an LPAR in a CPC.
 
+    \b
     Limitations:
       * In table format, the following properties are not shown:
         - program-status-word-information
@@ -133,6 +134,7 @@ def lpar_update(cmd_ctx, cpc, lpar, **options):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
 
+    \b
     Limitations:
       * The --acceptable-status option does not support multiple values.
       * The processor capping/sharing/weight related properties cannot be

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -26,6 +26,13 @@ import zhmcclient
 GENERAL_OPTIONS_METAVAR = '[GENERAL-OPTIONS]'
 COMMAND_OPTIONS_METAVAR = '[COMMAND-OPTIONS]'
 
+# File path of history file for interactive mode.
+# If the file name starts with tilde (which is handled by the shell, not by
+# the file system), it is properly expanded.
+REPL_HISTORY_FILE = '~/.zhmc_history'
+
+REPL_PROMPT = u'zhmc> '  # Must be Unicode
+
 
 def abort_if_false(ctx, param, value):
     # pylint: disable=unused-argument


### PR DESCRIPTION
Please review and merge.

Details:
- Added a 'help' command that displays help for interactive mode.
- When entering interactive mode, added a one-line hint that explains how to get help and how to exit interactive mode. This required to write our own repl() function.
- Because we now have our own repl() function, we can pass arguments to the click_repl.repl() function. Used that to add support for history of interactive mode commands, and to change the prompt to 'zhmc> '.
- Fixed incorrect reformatting of text areas in CLI help text by adding `\b` where needed.