### PR TITLE
Fixes #116: Increased minimum version of 'click-spinner' dependency to 0.1.7.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -53,6 +53,9 @@ Released: not yet
 * Added a minimum version requirement `>=4.0.0` for the dependency on the
   "decorate" Python package (issue #199).
 
+* Increased minimum version of "click-spinner" package to 0.1.7, in order to
+  pick up the fix for zhmcclient issue #116.
+
 **Enhancements:**
 
 * Fixed a discrepancy between documentation and actual behavior of the return

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ decorator>=4.0.0 # new BSD
 tabulate # MIT
 progressbar2 # BSD
 click # BSD
-click-spinner>=0.1.5 # MIT
+click-spinner>=0.1.7 # MIT
 click-repl # MIT
 stomp.py # Apache 


### PR DESCRIPTION
Please review and merge.