### PR TITLE
Test with minimum & latest  versions of dependent Python packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
+env:
+  - PACKAGE_LEVEL=minimum
+  - PACKAGE_LEVEL=latest
 
 # commands to install dependencies
 install:
   - pip list
-  - pip install --upgrade pip
   - make install
   - pip list
   - make develop
@@ -33,4 +35,4 @@ script:
   - make test
 
 after_success:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 && $PACKAGE_LEVEL == latest ]]; then coveralls; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,15 @@ environment:
       PYTHON_ARCH: 64
       PYTHON_HOME: C:\Python36-x64
 
+configuration:
+# These values will become the values of the PACKAGE_LEVEL env.var.
+  - minimum
+  - latest
+
 install:
+
+  # Set PACKAGE_LEVEL for make
+  - set PACKAGE_LEVEL=%configuration%
 
   # Examine the environment
   - echo %PATH%

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,5 @@
+# Pip requirements file for development dependencies.
+#
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
@@ -5,20 +7,20 @@
 -r requirements.txt
 
 # Unit test:
-pytest>=2.4 # MIT
-pytest-cov # BSD
-mock # BSD
-requests-mock>=1.0 # Apache-2.0
-testfixtures # Apache-2.0
+pytest>=3.0.0 # MIT
+pytest-cov>=2.0.0 # BSD
+mock>=2.0.0 # BSD
+requests-mock>=1.0.0 # Apache-2.0
+testfixtures>=4.0.0 # Apache-2.0
 
 # Sphinx:
 # Note: The ordereddict package is a backport of collections.OrderedDict
 #       to Python 2.6 and earlier. OrderedDict is needed by GitPython, which
 #       is needed by sphinx-git.
-Sphinx>=1.3 # BSD
-ordereddict ; python_version < '2.7' # MIT
+Sphinx>=1.5.1 # BSD
+ordereddict>=1.0 ; python_version < '2.7' # MIT
 GitPython>=2.0.6 # BSD
-sphinx-git  # GPL
+sphinx-git>=10.0.0 # GPL
 
 # PyLint:
 # Astroid is used by Pylint. Astroid 1.3 and above, and Pylint 1.4
@@ -26,19 +28,17 @@ sphinx-git  # GPL
 # from Pypi in 2/2016 after being available for some time.
 # Therefore, we cannot use Pylint under Python 2.6.
 # Also, Pylint does not support Python 3.
-astroid ; python_version == '2.7'
-pylint ; python_version == '2.7'
+astroid>=1.0.0 ; python_version == '2.7'
+pylint>=1.0.0 ; python_version == '2.7'
 
 # Flake8:
 flake8>=2.0 # MIT
 
 # Twine: Needed for uploading to Pypi
-twine # Apache-2.0
+twine>=1.0.1 # Apache-2.0
 
 # Jupyter Notebook
-jupyter # BSD
+jupyter>=1.0.0 # BSD
 
 # Examples:
-PyYAML # MIT
-stomp.py # Apache
-
+PyYAML>=3.10 # MIT

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -1,0 +1,54 @@
+# Pip constraints file for runtime and development.
+#
+# This constraints file specifies constraints that match the minimum versions
+# specified in the requirements files for runtime and development. The reason
+# for this approach is that in the CI systems, we want to be able to test with
+# the minimum package versions in order to catch any incorrect minimum versions
+# (see zhmcclient issue #199 as one example where a minimum version was
+# missing).
+
+# Direct dependencies for runtime:
+
+setuptools===17.0
+six===1.9.0
+pbr===1.8.0
+requests===2.10.0
+decorator===4.0.0
+tabulate===0.7.1
+progressbar2===3.5.0
+click===6.0
+click-spinner===0.1.7
+click-repl===0.1.0
+stomp.py===4.0.0
+
+# Indirect dependencies for runtime:
+
+# From click-repl
+prompt_toolkit===1.0.0
+
+# From prompt_toolkit
+wcwidth===0.1.6
+
+# Direct dependencies for development:
+
+pytest===3.0.0
+pytest-cov===2.0.0
+mock===2.0.0
+requests-mock===1.0.0
+testfixtures===4.0.0
+
+Sphinx===1.5.1
+ordereddict===1.0 ; python_version < '2.7'
+GitPython===2.0.6
+sphinx-git===10.0.0
+
+astroid===1.0.0 ; python_version == '2.7'
+pylint===1.0.0 ; python_version == '2.7'
+
+flake8===2.0
+
+twine===1.0.1
+
+jupyter===1.0.0
+
+PyYAML===3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,27 @@
+# Pip requirements file for zhmcclient runtime dependencies.
+#
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-six # MIT
-pbr>=1.8 # Apache-2.0
+# Direct dependencies:
+
+setuptools>=17.0 # Python Software Foundation
+six>=1.9.0 # MIT
+pbr>=1.8.0 # Apache-2.0
 requests>=2.10.0 # Apache-2.0
 decorator>=4.0.0 # new BSD
-tabulate # MIT
-progressbar2 # BSD
-click # BSD
+tabulate>=0.7.1 # MIT
+progressbar2>=3.5.0 # BSD
+click>=6.0 # BSD
 click-spinner>=0.1.7 # MIT
-click-repl # MIT
-stomp.py # Apache 
+click-repl>=0.1.0 # MIT
+stomp.py>=4.0.0 # Apache
+
+# Indirect dependencies:
+
+# From click-repl
+prompt_toolkit>=1.0.0 # BSD
+
+# From prompt_toolkit
+wcwidth>=0.1.6 # MIT

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,8 @@ skip_install = true
 whitelist_externals =
     sh
 commands =
-    sh -c "export TESTCASES={posargs}; make -B clean install test"
-deps =
-    -r{toxinidir}/dev-requirements.txt
+    sh -c "echo Installing Python packages with PACKAGE_LEVEL=$PACKAGE_LEVEL"
+    sh -c "export TESTCASES={posargs}; make -B install develop clean test"
 
 [testenv:check]
 basepython = python2.7
@@ -30,16 +29,20 @@ commands =
 
 [testenv:py27]
 basepython = python2.7
+passenv = PACKAGE_LEVEL
 
 [testenv:py34]
 basepython = python3.4
+passenv = PACKAGE_LEVEL
 
 [testenv:py35]
 basepython = python3.5
+passenv = PACKAGE_LEVEL
 
 [testenv:py36]
 basepython = python3.6
+passenv = PACKAGE_LEVEL
 
 [testenv:pywin]
 basepython = {env:PYTHON_HOME:}\python.exe
-passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE PATH INCLUDE LIB
+passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE PATH INCLUDE LIB PACKAGE_LEVEL


### PR DESCRIPTION
Please review and merge.

This PR specifies minimum versions for all Python package requirements, for runtime and development, and it changes the Travis and Appveyor CI testing such that the tests are run for both the minimum versions and the latest versions of dependent Python packages.

For more details, see the commit message.