### PR TITLE
Added automatic devno setting for NIC, HBA, VF in mock support

### DIFF
--- a/tests/unit/zhmcclient_mock/test_idpool.py
+++ b/tests/unit/zhmcclient_mock/test_idpool.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit test cases for the _idpool module of the zhmcclient_mock package.
+"""
+
+from __future__ import absolute_import, print_function
+
+import requests.packages.urllib3
+import unittest
+
+from zhmcclient_mock._idpool import IdPool
+
+
+class IdPoolTests(unittest.TestCase):
+    """All tests for class IdPool."""
+
+    def test_init_error_1(self):
+
+        with self.assertRaises(ValueError):
+            IdPool(7, 6)
+
+    def test_invalid_free_error_1(self):
+
+        pool = IdPool(5, 5)
+
+        with self.assertRaises(ValueError):
+            pool.free(4)  # not in range
+
+        with self.assertRaises(ValueError):
+            pool.free(5)  # in range but not allocated
+
+        with self.assertRaises(ValueError):
+            pool.free(6)  # not in range
+
+    def test_invalid_free_error_2(self):
+
+        pool = IdPool(5, 5)
+
+        pool.free_if_allocated(4)  # not in range (= not allocated)
+
+        pool.free_if_allocated(5)  # in range but not allocated
+
+        pool.free_if_allocated(6)  # not in range (= not allocated)
+
+    def _test_exhausting_for_lo_hi(self, lowest, highest):
+        start = lowest
+        end = highest + 1
+
+        pool = IdPool(lowest, highest)
+
+        # Exhaust the pool
+        id_list = []
+        for i in range(start, end):
+            id = pool.alloc()
+            id_list.append(id)
+
+        # Verify uniqueness of the ID values
+        id_set = set(id_list)
+        self.assertEqual(len(id_set), len(id_list))
+
+        # Verify that the pool is exhausted
+        with self.assertRaises(ValueError):
+            pool.alloc()
+
+    def _test_free_for_lo_hi(self, lowest, highest):
+        start = lowest
+        end = highest + 1
+
+        pool = IdPool(lowest, highest)
+
+        # Exhaust the pool
+        id_list1 = []
+        for i in range(start, end):
+            id = pool.alloc()
+            id_list1.append(id)
+
+        # Return everything to the pool
+        for id in id_list1:
+            pool.free(id)
+
+        # Verify that nothing is used in the pool
+        self.assertEqual(len(pool._used), 0)
+
+        # Exhaust the pool
+        id_list2 = []
+        for i in range(start, end):
+            id = pool.alloc()
+            id_list2.append(id)
+
+        # Verify that the same ID values came back as last time
+        self.assertEqual(set(id_list1), set(id_list2))
+
+        # Verify that the pool is exhausted
+        with self.assertRaises(ValueError):
+            pool.alloc()
+
+    def _test_all_for_lo_hi(self, lowest, highest):
+        self._test_exhausting_for_lo_hi(lowest, highest)
+        self._test_free_for_lo_hi(lowest, highest)
+
+    def test_all(self):
+        # Knowing that the chunk size is 10, we focus on the sizes and range
+        # boundaries around that
+        self._test_all_for_lo_hi(0, 0)
+        self._test_all_for_lo_hi(0, 1)
+        self._test_all_for_lo_hi(0, 9)
+        self._test_all_for_lo_hi(0, 10)
+        self._test_all_for_lo_hi(0, 11)
+        self._test_all_for_lo_hi(0, 19)
+        self._test_all_for_lo_hi(0, 20)
+        self._test_all_for_lo_hi(0, 21)
+        self._test_all_for_lo_hi(3, 3)
+        self._test_all_for_lo_hi(3, 4)
+        self._test_all_for_lo_hi(3, 9)
+        self._test_all_for_lo_hi(3, 10)
+        self._test_all_for_lo_hi(3, 11)
+        self._test_all_for_lo_hi(3, 12)
+        self._test_all_for_lo_hi(3, 13)
+        self._test_all_for_lo_hi(3, 14)
+        self._test_all_for_lo_hi(9, 9)
+        self._test_all_for_lo_hi(9, 10)
+        self._test_all_for_lo_hi(9, 11)
+        self._test_all_for_lo_hi(9, 18)
+        self._test_all_for_lo_hi(9, 19)
+        self._test_all_for_lo_hi(9, 20)
+        self._test_all_for_lo_hi(10, 10)
+        self._test_all_for_lo_hi(10, 11)
+        self._test_all_for_lo_hi(10, 19)
+        self._test_all_for_lo_hi(10, 20)
+        self._test_all_for_lo_hi(10, 21)
+        self._test_all_for_lo_hi(11, 11)
+        self._test_all_for_lo_hi(11, 12)
+        self._test_all_for_lo_hi(11, 20)
+        self._test_all_for_lo_hi(11, 21)
+        self._test_all_for_lo_hi(11, 22)
+
+
+if __name__ == '__main__':
+    requests.packages.urllib3.disable_warnings()
+    unittest.main()

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -454,6 +454,7 @@ def standard_test_hmc():
                                     'adapter-port-uri':
                                         '/api/adapters/2/storage-ports/1',
                                     'wwpn': 'wwpn_1',
+                                    'device-number': '1001',
                                 },
                             },
                         ],
@@ -465,6 +466,7 @@ def standard_test_hmc():
                                     'description': 'NIC #1 in Partition #1',
                                     'network-adapter-port-uri':
                                         '/api/adapters/3/network-ports/1',
+                                    'device-number': '2001',
                                 },
                             },
                         ],
@@ -474,6 +476,7 @@ def standard_test_hmc():
                                     'element-id': '1',
                                     'name': 'vf_1',
                                     'description': 'VF #1 in Partition #1',
+                                    'device-number': '3001',
                                 },
                             },
                         ],
@@ -779,7 +782,7 @@ class CpcExportPortNamesListHandlerTests(unittest.TestCase):
             ]
         }
         exp_wwpn_list = [
-            'partition_1,2,,wwpn_1',
+            'partition_1,2,1001,wwpn_1',
         ]
 
         # the function to be tested:
@@ -1106,6 +1109,7 @@ class HbaHandlerTests(unittest.TestCase):
             'description': 'HBA #1 in Partition #1',
             'adapter-port-uri': '/api/adapters/2/storage-ports/1',
             'wwpn': 'wwpn_1',
+            'device-number': '1001',
         }
         self.assertEqual(hba1, exp_hba1)
 
@@ -1125,15 +1129,16 @@ class HbaHandlerTests(unittest.TestCase):
         new_hba2_uri = resp['element-uri']
         self.assertEqual(new_hba2_uri, '/api/partitions/1/hbas/2')
 
+        # the function to be tested:
+        hba2 = self.urihandler.get(self.hmc, '/api/partitions/1/hbas/2', True)
+
         exp_hba2 = {
             'element-id': '2',
             'element-uri': '/api/partitions/1/hbas/2',
             'name': 'hba_2',
             'adapter-port-uri': '/api/adapters/2/storage-ports/1',
+            'device-number': hba2['device-number'],  # auto-generated
         }
-
-        # the function to be tested:
-        hba2 = self.urihandler.get(self.hmc, '/api/partitions/1/hbas/2', True)
 
         self.assertEqual(hba2, exp_hba2)
 
@@ -1198,6 +1203,7 @@ class NicHandlerTests(unittest.TestCase):
             'name': 'nic_1',
             'description': 'NIC #1 in Partition #1',
             'network-adapter-port-uri': '/api/adapters/3/network-ports/1',
+            'device-number': '2001',
         }
         self.assertEqual(nic1, exp_nic1)
 
@@ -1217,15 +1223,16 @@ class NicHandlerTests(unittest.TestCase):
         new_nic2_uri = resp['element-uri']
         self.assertEqual(new_nic2_uri, '/api/partitions/1/nics/2')
 
+        # the function to be tested:
+        nic2 = self.urihandler.get(self.hmc, '/api/partitions/1/nics/2', True)
+
         exp_nic2 = {
             'element-id': '2',
             'element-uri': '/api/partitions/1/nics/2',
             'name': 'nic_2',
             'network-adapter-port-uri': '/api/adapters/3/network-ports/1',
+            'device-number': nic2['device-number'],  # auto-generated
         }
-
-        # the function to be tested:
-        nic2 = self.urihandler.get(self.hmc, '/api/partitions/1/nics/2', True)
 
         self.assertEqual(nic2, exp_nic2)
 
@@ -1292,6 +1299,7 @@ class VirtualFunctionHandlerTests(unittest.TestCase):
             'element-uri': '/api/partitions/1/virtual-functions/1',
             'name': 'vf_1',
             'description': 'VF #1 in Partition #1',
+            'device-number': '3001',
         }
         self.assertEqual(vf1, exp_vf1)
 
@@ -1311,16 +1319,17 @@ class VirtualFunctionHandlerTests(unittest.TestCase):
         new_vf2_uri = resp['element-uri']
         self.assertEqual(new_vf2_uri, '/api/partitions/1/virtual-functions/2')
 
-        exp_vf2 = {
-            'element-id': '2',
-            'element-uri': '/api/partitions/1/virtual-functions/2',
-            'name': 'vf_2',
-        }
-
         # the function to be tested:
         vf2 = self.urihandler.get(self.hmc,
                                   '/api/partitions/1/virtual-functions/2',
                                   True)
+
+        exp_vf2 = {
+            'element-id': '2',
+            'element-uri': '/api/partitions/1/virtual-functions/2',
+            'name': 'vf_2',
+            'device-number': vf2['device-number'],  # auto-generated
+        }
 
         self.assertEqual(vf2, exp_vf2)
 

--- a/zhmcclient_mock/__init__.py
+++ b/zhmcclient_mock/__init__.py
@@ -21,3 +21,4 @@ from __future__ import absolute_import
 from ._session import *       # noqa: F401
 from ._urihandler import *    # noqa: F401
 from ._hmc import *           # noqa: F401
+from ._idpool import *        # noqa: F401

--- a/zhmcclient_mock/_idpool.py
+++ b/zhmcclient_mock/_idpool.py
@@ -1,0 +1,123 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The :class:`~zhmcclient_mock.IdPool` class provides a pool of integer ID values
+from a defined value range. This is used for example to manage automatically
+allocated device numbers.
+"""
+
+from __future__ import absolute_import
+
+__all__ = ['IdPool']
+
+
+class IdPool(object):
+    """
+    A pool of integer ID values from a defined value range.
+
+    The IDs can be allocated from and returned to the pool.
+
+    The pool is optimized for memory consumption, by only materializing ID
+    values as needed.
+    """
+
+    def __init__(self, lowest, highest):
+        """
+        Parameters:
+
+          lowest (integer): Lowest value of the ID value range.
+
+          highest (integer): Highest value of the ID value range.
+        """
+
+        if lowest > highest:
+            raise ValueError("Lowest value %d is higher than highest %d" %
+                             (lowest, highest))
+
+        # ID value range, using slice semantics (end points past the highest)
+        self._range_start = lowest
+        self._range_end = highest + 1
+
+        # The ID values in use.
+        self._used = set()
+
+        # Free pool: The ID values that are free and materialized.
+        self._free = set()
+
+        # Start of new free ID values to be materialized when the free pool is
+        # expanded.
+        self._expand_start = lowest
+
+        # Expansion chunk size: Number of new free ID values to be materialized
+        # when the free pool is expanded.
+        self._expand_len = 10
+
+    def _expand(self):
+        """
+        Expand the free pool, if possible.
+
+        If out of capacity w.r.t. the defined ID value range, ValueError is
+        raised.
+        """
+        assert not self._free  # free pool is empty
+        expand_end = self._expand_start + self._expand_len
+        if expand_end > self._range_end:
+            # This happens if the size of the value range is not a multiple
+            # of the expansion chunk size.
+            expand_end = self._range_end
+        if self._expand_start == expand_end:
+            raise ValueError("Out of capacity in ID pool")
+        self._free = set(range(self._expand_start, expand_end))
+        self._expand_start = expand_end
+
+    def alloc(self):
+        """
+        Allocate an ID value and return it.
+
+        Raises:
+            ValueError: Out of capacity in ID pool.
+        """
+        if not self._free:
+            self._expand()
+        id = self._free.pop()
+        self._used.add(id)
+        return id
+
+    def free(self, id):
+        """
+        Free an ID value.
+
+        The ID value must be allocated.
+
+        Raises:
+            ValueError: ID value to be freed is not currently allocated.
+        """
+        self._free_impl(id, fail_if_not_allocated=True)
+
+    def free_if_allocated(self, id):
+        """
+        Free an ID value, if it is currently allocated.
+
+        If the specified ID value is not currently allocated, nothing happens.
+        """
+        self._free_impl(id, fail_if_not_allocated=False)
+
+    def _free_impl(self, id, fail_if_not_allocated):
+        if id in self._used:
+            self._used.remove(id)
+            self._free.add(id)
+        elif fail_if_not_allocated:
+            raise ValueError("ID value to be freed is not currently "
+                             "allocated: %d" % id)


### PR DESCRIPTION
Details:
- Added an IdPool class that can allocate and free integer ID values. This is used for devno allocation in faked partitions.
- Added unit test cases for the new IdPool class.
- Added automatic setting of the 'device-number' property when not specified by the caller, for faked HBA, NIC and VF resources, in the value range of 0x8000 to 0xFFFF.