### PR TITLE
Improved handling of network errors

### DIFF
--- a/design/network-errors.rst
+++ b/design/network-errors.rst
@@ -1,0 +1,380 @@
+.. Copyright 2017 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+================================================
+Design for handling network errors in zhmcclient
+================================================
+
+The zhmcclient package uses the Python
+`requests <https://pypi.python.org/pypi/requests/>`_ package for any HMC REST
+API calls, and the Python `stomp <https://pypi.python.org/pypi/stomp/>`_
+package for handling HMC JMS notifications.
+
+This design document covers error handling using the `requests` package.
+
+Some facts
+==========
+
+Layering of components
+----------------------
+
+The following picture shows the layering of components w.r.t. networking:
+
+::
+
+  +---------------------+
+  |                     |
+  |  application (py)   |
+  |                     |
+  +---------------------+
+  |                     |
+  |   zhmcclient (py)   |
+  |                     |
+  +---------------------+
+  |                     |
+  |    requests (py)    |
+  |                     |
+  +---------------------+
+  |                     |  - Handles HTTP connection keep-alive and pooling
+  |    urllib3 (py)     |  - Handles HTTP basic/digest authentication
+  |  (part of requests) |  - Handles HTTP request retrying
+  +---------------------+
+  |                     |
+  |    httplib (py)     |
+  |                     |
+  +---------------+     |
+  |               |     |
+  |  socket (py)  |     |
+  |               |     |
+  +---------------+-----+
+  |    _socket (py)     |
+  |                     |
+  |  _socketmodule.so   |
+  |                     |
+  +---------------------+  - Handles read timeouts ??
+  |     socket API      |  - Handles connection timeouts ??
+  |    TCP/IP stack     |  - Handles SSL certificate verification ??
+  |                     |  - Handles TCP packet retransmission
+  +---------------------+
+
+The following call flow for an HTTP GET request and response shows how these
+layers are used::
+
+    -> zhmcclient/_session.py(392): Session.get()
+      -> requests/sessions.py(501): Session.get()
+         -> requests/sessions.py(488)request()
+            -> requests/sessions.py(609)send()
+               -> requests/adapters.py(423)send()
+                  -> requests/packages/urllib3/connectionpool.py(600)urlopen()
+                     -> requests/packages/urllib3/connectionpool.py(356)_make_request()
+                        -> httplib.py(1022): HTTPConnection.request()
+                           -> httplib.py(1056): HTTPConnection._send_request()
+                              -> httplib.py(1018): HTTPConnection.endheaders()
+                                 -> httplib.py(869): HTTPConnection._send_output()
+                                    -> httplib.py(829): HTTPConnection.send()
+                                       -> _socketmodule.so: socket.connect(), if needed (not used by urllib3)
+                                       -> _socketmodule.so: socket.sendall()
+                     -> requests/packages/urllib3/connectionpool.py(379)_make_request()
+                        -> httplib.py(1089): HTTPConnection.getresponse()
+                           -> httplib.py(444): HTTPResponse.begin()
+                              -> httplib.py(400): HTTPResponse._read_status()
+                                 -> socket.py(424): _fileobject.readline()
+                                    -> _socketmodule.so: socket.recv()
+            -> requests/sessions.py(641)send()
+               -> requests/models.py(797)content()
+                  -> requests/models.py(719)generate()
+                     -> requests/packages/urllib3/response.py(432)stream()
+                        -> requests/packages/urllib3/response.py(380)read()
+                           -> httplib.py(602): HTTPResponse.read()
+                              -> socket.py(355): _fileobject.read()
+                                 -> _socketmodule.so: socket.recv()
+                           -> httplib.py(610): HTTPResponse.read()
+                              -> httplib.py(555): HTTPResponse.close()
+                                 -> socket.py(284): _fileobject.close()
+                                    -> socket.py(300): _fileobject.flush()
+                                       -> _socketmodule.so: socket.sendall(), if anything remaining
+                                    -> _socketmodule.so: socket.close()
+
+Timeouts
+--------
+
+There are hard coded timeouts in the TCP/IP stack.
+
+The `requests` package allows specifying two timeouts (on HTTP methods such as
+``get()``):
+
+* Connect timeout:
+
+  Number of seconds the `requests` package will wait for the
+  local machine to establish a TCP connection to a remote machine. This timeout
+  is passed to the ``connect()`` call on the socket.
+
+  The `requests` package recommends to set the connect timeout to slightly
+  larger than a multiple of 3 (seconds), which is the default TCP packet
+  retransmission window.
+
+  This timeout is indicated by raising a ``requests.exceptions.ConnectTimeout``
+  exception.
+
+* Read timeout:
+
+  Number of seconds the local machine will wait for the remote
+  machine to send a response at the socket level. Specifically, it's the number
+  of seconds that the local machine will wait *between* Bytes sent from the
+  remote machine. However, in 99.9% of cases, this is the time before the
+  remote machine sends the *first* Byte.
+
+  This timeout is indicated by raising a ``requests.exceptions.ReadTimeout``
+  exception.
+
+The zhmcclient package currently does not set any of these timeouts, so the
+default of waiting forever applies.
+
+**TBD:** Despite the fact that the `requests` connection timeout is not set,
+a connection attempt times out after 60 sec, by raising
+``requests.exceptions.ConnectionError``.
+It is not clear under which conditions this situation is indicated using
+``requests.exceptions.ConnectTimeout``.
+
+The zhmcclient itself supports two timeouts at a higher level (as of
+`PR #195 <https://github.com/zhmcclient/python-zhmcclient/pull/195>`_
+which is targeted for v0.11.0 of the `zhmcclient` package:
+
+* Operation timeout:
+
+  Number of seconds the client will wait for completion of asynchronous
+  HMC operations. This applies to ``Session.post()`` and to all resource
+  methods with a ``wait_for_completion`` parameter (i.e. the asynchronous
+  methods).
+
+  The operation timeout can be specified with the ``operation_timeout``
+  parameter on these methods, and defaults to no timeout.
+
+  This timeout is indicated by raising a ``zhmcclient.Timeout`` exception.
+
+* LPAR status timeout:
+
+  Number of seconds the client will wait for the LPAR status to take on the
+  value it is supposed to take on given the previous operation affecting
+  the LPAR status. This applies to the ``Lpar.activate/deactivate/load()``
+  methods. The HMC operations issued by these methods exhibit "deferred status"
+  behavior, which means that it takes a few seconds after successful completion
+  of the asynchronous job that executes the operation, until the new status can
+  be observed in the `status` property of the LPAR resource. These methods will
+  poll the LPAR status until the desired status value is reached.
+
+  The LPAR status timeout can be specified with the ``status_timeout``
+  parameter on these methods, and defaults to 1 hour.
+
+  This timeout is also indicated by raising a ``zhmcclient.Timeout`` exception.
+
+Reference material:
+
+* `Timeouts in requests package <http://docs.python-requests.org/en/master/user/advanced/#timeouts>`_
+
+Exceptions
+----------
+
+The `requests` package wrappers all exceptions of underlying components, except
+for programming errors (e.g. ``TypeError``, ``ValueError``, ``KeyError``), into
+exceptions that are derived from ``requests.exceptions.RequestException``.
+
+The ``requests.exceptions.RequestException`` exception is never raised itself.
+
+All exceptions derived from ``requests.exceptions.RequestException`` will have
+the following attributes:
+
+* ``exc.args[0]``:
+
+  - For ``HTTPError``, ``TooManyRedirects``, ``MissingSchema``,
+    ``InvalidSchema``, ``InvalidURL``, ``InvalidHeader``,
+    ``UnrewindableBodyError``:
+    An error message generated by the `requests` package.
+
+  - For ``ConnectionError``, ``ProxyError``, ``SSLError``, ``ConnectTimeout``,
+    ``ReadTimeout``, ``ChunkedEncodingError``, ``ContentDecodingError``,
+    ``RetryError``:
+    The underlying exception that was raised. This is not documented, though.
+
+  - For ``StreamConsumedError``: ``exc.args=None``.
+
+* ``exc.request`` - ``None``, or the ``requests.PreparedRequest`` object
+  representing the HTTP request.
+
+* ``exc.response`` - ``None``, or the ``requests.Response`` object representing
+  the HTTP response.
+
+The ``HTTPError`` exception is only raised when the caller requests that bad
+HTTP status codes should be returned as exceptions (via
+``Session.status_as_exception()``). The zhmcclient package does not do that, so
+this exception is never raised, and bad HTTP status codes are checked after
+the HTTP method (e.g. ``get()``) returns normally.
+
+The inheritance hierarchy of the exceptions of the `requests` package can be
+gathered from the
+`requests.exceptions source code <http://docs.python-requests.org/en/master/_modules/requests/exceptions/>`_.
+
+The `zhmcclient` package in turn wrappers the exceptions of the `requests`
+package into:
+
+* ``zhmcclient.HTTPError`` - caused by most bad HTTP status codes and
+  represents the parameters in the HMC error response. Some HTTP status codes
+  are automatically recovered, such as status 403 / reason 5 (API session token
+  expired) by re-logon, or status 202 by polling for asynchronous job
+  completion.
+
+* ``zhmcclient.ParseError`` - caused by invalid JSON in the HTTP response.
+
+* ``zhmcclient.AuthError`` - caused by HTTP status 403, when reason != 5, or
+  when reason == 5 and the resource did not require authentication. The latter
+  case is merely a check against unexpected behavior of the HMC and is not
+  really needed, or should be acted upon differently.
+
+* ``zhmcclient.ConnectionError`` - caused by all exceptions of the `requests`
+  package.
+
+Retries
+-------
+
+There are multiple levels of retries:
+
+- The TCP/IP stack retries sends on TCP sockets as part of its error recovery.
+
+- The `requests` package retries the sending of HTTP requests. Actually, this
+  is handled by the `urllib3` package, but can be controlled through the
+  `requests` package by setting an alternative transport adapter. Such adapters
+  are matched by shortest prefix match, so the following works::
+
+      s = requests.Session(.....)
+      s.mount('https://', HTTPAdapter(max_retries=10))
+      s.mount('http://', HTTPAdapter(max_retries=10))
+
+  This will replace the default transport adapters, which are set in
+  `requests.Session()`::
+
+      self.mount('https://', HTTPAdapter())
+      self.mount('http://', HTTPAdapter())
+
+  The default for max_retries is 0.
+
+Design changes
+==============
+
+The following design changes are proposed for the `zhmcclient` package:
+
+Proposal for timeouts
+---------------------
+
+**Proposal(DONE):** Start using the timeouts of the `requests` package, by
+setting them as attributes on the ``zhmcclient.Session`` object, with
+reasonable default values, and with the ability to override the default values
+when creating a ``Session`` object.
+
+The proposed default values are:
+
+* connect timeout: 60 s
+
+* read timeout: 120 s
+
+Having a read timeout assumes that the HMC REST operations all respond within
+a maximum time. The asynchronous REST operations all respond rather quickly,
+indicating what the job is that performs the asynchronous operation.
+Some synchronous REST operations sometimes take long, e.g. up to 45 seconds.
+That's why the read timeout should be a good bit larger than that.
+
+Also, the design for the timeouts for async operation completion and LPAR
+status transition introduced in
+`PR #195 <https://github.com/zhmcclient/python-zhmcclient/pull/195>`_ should
+be changed to be consistent with the way timeouts are defined in this design.
+
+**Proposal(TODO):** Change after merging PR #195.
+
+Proposal for exceptions
+-----------------------
+
+* ``zhmcclient.ConnectionError`` is currently raised for all exceptions of the
+  `requests` package. When we start supporting the timeouts of the `requests`
+  package, it is appropriate to distinguish timeouts from other errors. Also,
+  it might be useful to separate errors that are likely caused by the
+  networking environment (and that could therefore be retried) from errors that
+  are not going to recover by retrying. Further, it might be useful to
+  distinguish unrecoverable errors that need to be fixed on the client, from
+  unrecoverable errors that need to be fixed on the server.
+
+  **Proposal(DONE):** This proposal does not go as far as outlined above. It is
+  proposed to handle the `requests` exceptions raised from HTTP methods such as
+  ``get()``, as follows:
+
+  - ``TooManyRedirects``, ``MissingSchema``, ``InvalidSchema``, ``InvalidURL``,
+    ``InvalidHeader``, ``UnrewindableBodyError``, ``ConnectionError``,
+    ``ProxyError``, ``SSLError``, ``ChunkedEncodingError``,
+    ``ContentDecodingError``, ``StreamConsumedError``:
+
+    These will be wrappered using ``zhmcclient.ConnectionError`` as today,
+    but the exception message will be cleaned up as much as possible:
+
+    - If ``exc.args[0]`` is an ``Exception``, this is the underlying exception
+      that was wrapppered by the `requests` exception. Use that underlying
+      exception instead.
+
+    - Eliminate ``MaxRetryError`` and use the exception in its ``reason``
+      attribute instead.
+
+    - Eliminate the representation of objects in the exception message, e.g.
+      ``"NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x2922150>:
+      Failed to establish a new connection: [Errno 110] Connection timed out',)"``
+
+  - ``ConnectTimeout``, ``ResponseReadTimeout``, ``RequestRetriesExceeded``:
+
+    These will be wrappered by new exceptions ``zhmcclient.ConnectTimeout``,
+    ``zhmcclient.ReadTimeout``, ``zhmcclient.RetryError``.
+
+* As described above, ``zhmcclient.AuthError`` is also raised when the HMC
+  indicates "API session token expired" for an operation that does not require
+  logon (e.g. "Query API Version"). First, checking this is a bit overdoing it
+  because there is no harm if the HMC decides that session checking is
+  performed always, and second, the handling of this unexpected behavior as
+  by raising ``zhmcclient.AuthError`` is misleading for the user.
+
+  **Proposal(DONE):** It is proposed to not handle this situation also by
+  re-logon, i.e. to no longer make the behavior dependent on whether the
+  operation requires logon.
+
+* ``zhmcclient.VersionError`` currently stores the discovered version in
+  ``exc.args[1:2]``. It is not recommended to use ``exc.args[]`` for anything
+  else but the exception message, and to use additional instance attributes
+  for that, instead.
+
+  **Proposal(DONE):** It is proposed to store this information in additional
+  instance attributes, and to remove it from the ``exc.args[]`` array. This is
+  an incompatible change, but it is not very critical.
+
+No change is proposed for the other `zhmcclient` exceptions (``ParseError``,
+``HTTPError``).
+
+Proposal for retries
+--------------------
+
+**Proposal (TODO):** Start using the ``max_retries`` parameter of the
+``HTTPAdapter`` transport adapter, by setting the max retries after connect
+timeouts and read timeouts as attributes on the ``zhmcclient.Session`` object,
+with a reasonable default value, and with the ability to override the default
+value when creating a ``Session`` object.
+
+The proposed default values are:
+
+* connect retries: 3
+
+* read retries: 3

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,6 +46,12 @@ Released: not yet
   superfluos timestats entries. This method is not normally used by
   users of the zhmcclient package.
 
+* Removed the version strings from the ``args[]`` property of the
+  ``zhmcclient.VersionError`` exception class. They had been available as
+  ``args[1]`` and ``args[2]``. ``args[0]`` continues to be the error message,
+  and the ``min_api_version`` and ``api_version`` properties continue to
+  provide the version strings.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -60,6 +66,21 @@ Released: not yet
   flowed into a paragraph.
 
 **Enhancements:**
+
+* Added support for retry/timeout configuration of HTTP sessions, via
+  a new ``RetryTimeoutConfig`` class that can be specified for the ``Session``
+  object. The retry/timeout configuration can specify:
+
+  - HTTP connect timeout and number of retries.
+
+  - HTTP read timeout (of HTTP responses), and number of retries.
+
+  - Maximum number of HTTP redirects.
+
+* Added new exceptions ``zhmcclient.ConnectTimeout`` (for HTTP connect
+  timeout), ``zhmcclient.ResponseReadTimeout`` (for HTTP response read
+  timeout), and ``zhmcclient.RequestRetriesExceeded`` (for HTTP request retry
+  exceeded). They are all derived from ``zhmcclient.ConnectionError``.
 
 * Fixed a discrepancy between documentation and actual behavior of the return
   value of all methods on resource classes that invoke asynchronous operations
@@ -79,6 +100,13 @@ Released: not yet
   An HTML formatted error message may be in the response for some 4xx and
   5xx HTTP status codes (e.g. when the WS API is disabled). Such responses
   are raised as ``HTTPError`` exceptions with an artificial reason code of 999.
+
+* Fixed an incorrect use of the ``zhmcclient.AuthError`` exception and
+  unnecessary checking of HMC behavior, i.e. when the HMC fails with "API
+  session token expired" for an operation that does not require logon. This
+  error should never be returned for operations that do not require logon. If
+  it would be returned, it is now handled in the same way as when the operation
+  does require logon, i.e. by a re-logon.
 
 **Known Issues:**
 

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -45,29 +45,6 @@ Retry / timeout configuration
    :special-members: __str__
 
 
-.. _`Default retry-timeout configuration`:
-
-Default values for the retries and timeouts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This section defines the default values that will be used if the corresponding
-retry or timeout value is not specified at any level.
-
-Note that for technical limitations, the documentation shows these constants
-in the ``zhmcclient._session`` namespace, but they are available and should be
-used from the ``zhmcclient`` namespace.
-
-.. autodata:: zhmcclient._session.DEFAULT_CONNECT_TIMEOUT
-
-.. autodata:: zhmcclient._session.DEFAULT_CONNECT_RETRIES
-
-.. autodata:: zhmcclient._session.DEFAULT_READ_TIMEOUT
-
-.. autodata:: zhmcclient._session.DEFAULT_READ_RETRIES
-
-.. autodata:: zhmcclient._session.DEFAULT_MAX_REDIRECTS
-
-
 .. _`Client`:
 
 Client
@@ -152,6 +129,15 @@ Exceptions
 .. autoclass:: zhmcclient.NoUniqueMatch
    :members:
    :special-members: __str__
+
+
+.. _`Constants`:
+
+Constants
+---------
+
+.. automodule:: zhmcclient._constants
+   :members:
 
 
 .. _`Filtering`:

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -35,6 +35,39 @@ Session
    :special-members: __str__
 
 
+.. _`Retry-timeout configuration`:
+
+Retry / timeout configuration
+-----------------------------
+
+.. autoclass:: zhmcclient.RetryTimeoutConfig
+   :members:
+   :special-members: __str__
+
+
+.. _`Default retry-timeout configuration`:
+
+Default values for the retries and timeouts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section defines the default values that will be used if the corresponding
+retry or timeout value is not specified at any level.
+
+Note that for technical limitations, the documentation shows these constants
+in the ``zhmcclient._session`` namespace, but they are available and should be
+used from the ``zhmcclient`` namespace.
+
+.. autodata:: zhmcclient._session.DEFAULT_CONNECT_TIMEOUT
+
+.. autodata:: zhmcclient._session.DEFAULT_CONNECT_RETRIES
+
+.. autodata:: zhmcclient._session.DEFAULT_READ_TIMEOUT
+
+.. autodata:: zhmcclient._session.DEFAULT_READ_RETRIES
+
+.. autodata:: zhmcclient._session.DEFAULT_MAX_REDIRECTS
+
+
 .. _`Client`:
 
 Client
@@ -81,6 +114,18 @@ Exceptions
 .. autoclass:: zhmcclient.Error
 
 .. autoclass:: zhmcclient.ConnectionError
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.ConnectTimeout
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.ReadTimeout
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.RetriesExceeded
    :members:
    :special-members: __str__
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -99,7 +99,9 @@ class NumberArgsTestMixin(object):
 
     def test_good(self):
         """Test exception class with the allowable number of input arguments,
-        where the first argument is always a string."""
+        where the first argument is always a string.
+        Verify that the first argument is put into exc.args[0] and that no
+        other arguments are put there."""
 
         for nargs in range(self.min_args, self.max_args + 1):
             args = ['zaphod']
@@ -109,13 +111,12 @@ class NumberArgsTestMixin(object):
 
             self.assertTrue(isinstance(exc, Error))
             self.assertTrue(isinstance(exc.args, tuple))
-            self.assertEqual(len(exc.args), len(args),
-                             "Expected %d arguments, got: %r" %
-                             (len(args), exc.args))
-            for i, arg in enumerate(args):
-                self.assertEqual(exc.args[i], arg,
-                                 "For argument at index %d, expected %r, "
-                                 "got: %r" % (i, arg, exc.args[i]))
+            self.assertEqual(len(exc.args), 1,
+                             "Expected exc.args[] to have 1 item, got: %r" %
+                             exc.args)
+            self.assertEqual(exc.args[0], args[0],
+                             "For exc.args[0], expected %r, "
+                             "got: %r" % (args[0], exc.args[0]))
 
 
 class DetailsTestMixin(object):

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -22,6 +22,7 @@ For documentation, see TODO: Add link to RTD once available.
 from __future__ import absolute_import
 
 from ._version import *       # noqa: F401
+from ._constants import *     # noqa: F401
 from ._exceptions import *    # noqa: F401
 from ._manager import *       # noqa: F401
 from ._resource import *      # noqa: F401

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -1,0 +1,56 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Public constants.
+
+These constants are not meant to be changed by the user, they are made
+available for inspection and documentation purposes only.
+
+For technical reasons, the online documentation shows these constants in the
+``zhmcclient._constants`` namespace, but they are also available in the
+``zhmcclient`` namespace and should be used from there.
+"""
+
+__all__ = ['DEFAULT_CONNECT_TIMEOUT',
+           'DEFAULT_CONNECT_RETRIES',
+           'DEFAULT_READ_TIMEOUT',
+           'DEFAULT_READ_RETRIES',
+           'DEFAULT_MAX_REDIRECTS']
+
+
+#: Default HTTP connect timeout in seconds,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_CONNECT_TIMEOUT = 30
+
+#: Default number of HTTP connect retries,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_CONNECT_RETRIES = 3
+
+#: Default HTTP read timeout in seconds,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_READ_TIMEOUT = 30
+
+#: Default number of HTTP read retries,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_READ_RETRIES = 3
+
+#: Default max. number of HTTP redirects,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_MAX_REDIRECTS = 30

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -32,15 +32,12 @@ from ._exceptions import HTTPError, AuthError, ConnectionError, ParseError, \
     ConnectTimeout, ReadTimeout, RetriesExceeded
 from ._timestats import TimeStatsKeeper
 from ._logging import _get_logger, _log_call
+from ._constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_CONNECT_RETRIES, \
+    DEFAULT_READ_TIMEOUT, DEFAULT_READ_RETRIES, DEFAULT_MAX_REDIRECTS
 
 LOG = _get_logger(__name__)
 
-__all__ = ['Session', 'Job', 'RetryTimeoutConfig',
-           'DEFAULT_CONNECT_TIMEOUT',
-           'DEFAULT_CONNECT_RETRIES',
-           'DEFAULT_READ_TIMEOUT',
-           'DEFAULT_READ_RETRIES',
-           'DEFAULT_MAX_REDIRECTS']
+__all__ = ['Session', 'Job', 'RetryTimeoutConfig']
 
 _HMC_PORT = 6794
 _HMC_SCHEME = "https"
@@ -113,7 +110,7 @@ class RetryTimeoutConfig(object):
         """
         For all parameters, `None` means that this object does not specify a
         value for the parameter, and that a default value should be used
-        (see :ref:`Default retry-timeout configuration`).
+        (see :ref:`Constants`).
 
         All parameters are available as instance attributes.
 
@@ -173,36 +170,6 @@ class RetryTimeoutConfig(object):
                 value = getattr(override_config, attr)
             setattr(ret, attr, value)
         return ret
-
-
-#: Default HTTP connect timeout in seconds,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_CONNECT_TIMEOUT = 30
-
-
-#: Default number of HTTP connect retries,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_CONNECT_RETRIES = 3
-
-
-#: Default HTTP read timeout in seconds,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_READ_TIMEOUT = 30
-
-
-#: Default number of HTTP read retries,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_READ_RETRIES = 3
-
-
-#: Default max. number of HTTP redirects,
-#: if not specified in the ``retry_timeout_config`` init argument to
-#: :class:`~zhmcclient.Session`.
-DEFAULT_MAX_REDIRECTS = 30
 
 
 class Session(object):
@@ -297,8 +264,7 @@ class Session(object):
             default configuration will be used with the default values for all
             of its attributes.
 
-            See :ref:`Default retry-timeout configuration` for the default
-            values.
+            See :ref:`Constants` for the default values.
         """
         self._host = host
         self._userid = userid

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -26,14 +26,21 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 import requests
+from requests.packages import urllib3
 
-from ._exceptions import HTTPError, AuthError, ConnectionError, ParseError
+from ._exceptions import HTTPError, AuthError, ConnectionError, ParseError, \
+    ConnectTimeout, ReadTimeout, RetriesExceeded
 from ._timestats import TimeStatsKeeper
 from ._logging import _get_logger, _log_call
 
 LOG = _get_logger(__name__)
 
-__all__ = ['Session', 'Job']
+__all__ = ['Session', 'Job', 'RetryTimeoutConfig',
+           'DEFAULT_CONNECT_TIMEOUT',
+           'DEFAULT_CONNECT_RETRIES',
+           'DEFAULT_READ_TIMEOUT',
+           'DEFAULT_READ_RETRIES',
+           'DEFAULT_MAX_REDIRECTS']
 
 _HMC_PORT = 6794
 _HMC_SCHEME = "https"
@@ -41,6 +48,161 @@ _STD_HEADERS = {
     'Content-type': 'application/json',
     'Accept': '*/*'
 }
+
+
+def _handle_request_exc(exc):
+    """
+    Handle a :exc:`request.exceptions.RequestException` exception that was
+    raised.
+    """
+    if isinstance(exc, requests.exceptions.ConnectTimeout):
+        raise ConnectTimeout(_request_exc_message(exc), exc)
+    elif isinstance(exc, requests.exceptions.ReadTimeout):
+        raise ReadTimeout(_request_exc_message(exc), exc)
+    elif isinstance(exc, requests.exceptions.RetryError):
+        raise RetriesExceeded(_request_exc_message(exc), exc)
+    else:
+        raise ConnectionError(_request_exc_message(exc), exc)
+
+
+def _request_exc_message(exc):
+    """
+    Return a reasonable exception message from a
+    :exc:`request.exceptions.RequestException` exception.
+
+    The approach is to dig deep to the original reason, if the original
+    exception is present, skipping irrelevant exceptions such as
+    `urllib3.exceptions.MaxRetryError`, and eliminating useless object
+    representations such as the connection pool object in
+    `urllib3.exceptions.NewConnectionError`.
+
+    Parameters:
+      exc (:exc:`~request.exceptions.RequestException`): Exception
+
+    Returns:
+      string: A reasonable exception message from the specified exception.
+    """
+    if exc.args:
+        if isinstance(exc.args[0], Exception):
+            org_exc = exc.args[0]
+            if isinstance(org_exc, urllib3.exceptions.MaxRetryError):
+                reason_exc = org_exc.reason
+                message = str(reason_exc)
+            else:
+                message = str(org_exc.args[0])
+        else:
+            message = str(exc.args[0])
+
+        # Eliminate useless object repr at begin of the message
+        m = re.match(r'^(\(<[^>]+>, \'(.*)\'\)|<[^>]+>: (.*))$', message)
+        if m:
+            message = m.group(2) or m.group(3)
+    else:
+        message = ""
+    return message
+
+
+class RetryTimeoutConfig(object):
+    """
+    A configuration setting that specifies verious retry counts and timeout
+    durations.
+    """
+
+    def __init__(self, connect_timeout=None, connect_retries=None,
+                 read_timeout=None, read_retries=None, max_redirects=None):
+        """
+        For all parameters, `None` means that this object does not specify a
+        value for the parameter, and that a default value should be used
+        (see :ref:`Default retry-timeout configuration`).
+
+        All parameters are available as instance attributes.
+
+        Parameters:
+
+          connect_timeout (:term:`number`): Connect timeout in seconds.
+            This timeout applies to making a connection at the socket level.
+            The same socket connection is used for sending an HTTP request to
+            the HMC and for receiving its HTTP response.
+
+          connect_retries (:term:`integer`): Number of retries (after the
+            initial attempt) for connection-related issues. These retries are
+            performed for failed DNS lookups, failed socket connections, and
+            socket connection timeouts.
+
+          read_timeout (:term:`number`): Read timeout in seconds.
+            This timeout applies to reading at the socket level, when receiving
+            an HTTP response.
+
+          read_retries (:term:`integer`): Number of retries (after the
+            initial attempt) for read-related issues. These retries are
+            performed for failed socket reads and socket read timeouts.
+
+          max_redirects (:term:`integer`): Maximum number of HTTP redirects.
+        """
+        self.connect_timeout = connect_timeout
+        self.connect_retries = connect_retries
+        self.read_timeout = read_timeout
+        self.read_retries = read_retries
+        self.max_redirects = max_redirects
+
+    _attrs = ('connect_timeout', 'connect_retries', 'read_timeout',
+              'read_retries', 'max_redirects')
+
+    def override_with(self, override_config):
+        """
+        Return a new configuration object that represents the configuration
+        from this configuration object acting as a default, and the specified
+        configuration object overriding that default.
+
+        Parameters:
+
+          override_config (:class:`~zhmcclient.RetryTimeoutConfig`):
+            The configuration object overriding the defaults defined in this
+            configuration object.
+
+        Returns:
+
+          :class:`~zhmcclient.RetryTimeoutConfig`:
+            A new configuration object representing this configuration object,
+            overridden by the specified configuration object.
+        """
+        ret = RetryTimeoutConfig()
+        for attr in RetryTimeoutConfig._attrs:
+            value = getattr(self, attr)
+            if override_config and getattr(override_config, attr) is not None:
+                value = getattr(override_config, attr)
+            setattr(ret, attr, value)
+        return ret
+
+
+#: Default HTTP connect timeout in seconds,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_CONNECT_TIMEOUT = 30
+
+
+#: Default number of HTTP connect retries,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_CONNECT_RETRIES = 3
+
+
+#: Default HTTP read timeout in seconds,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_READ_TIMEOUT = 30
+
+
+#: Default number of HTTP read retries,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_READ_RETRIES = 3
+
+
+#: Default max. number of HTTP redirects,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+DEFAULT_MAX_REDIRECTS = 30
 
 
 class Session(object):
@@ -56,8 +218,16 @@ class Session(object):
     measurements, and to print the statistics.
     """
 
+    default_rt_config = RetryTimeoutConfig(
+        connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+        connect_retries=DEFAULT_CONNECT_RETRIES,
+        read_timeout=DEFAULT_READ_TIMEOUT,
+        read_retries=DEFAULT_READ_RETRIES,
+        max_redirects=DEFAULT_MAX_REDIRECTS,
+    )
+
     def __init__(self, host, userid=None, password=None, session_id=None,
-                 get_password=None):
+                 get_password=None, retry_timeout_config=None):
         """
         Creating a session object will not immediately cause a logon to be
         attempted; the logon is deferred until needed.
@@ -115,11 +285,27 @@ class Session(object):
 
             This mechanism can be used for example by command line interfaces
             for prompting for the password.
+
+          retry_timeout_config (:class:`~zhmcclient.RetryTimeoutConfig`):
+            The retry/timeout configuration for this session for use by any of
+            its HMC operations, overriding any defaults.
+
+            `None` for an attribute in that configuration object means that the
+            default value will be used for that attribute.
+
+            `None` for the entire `retry_timeout_config` parameter means that a
+            default configuration will be used with the default values for all
+            of its attributes.
+
+            See :ref:`Default retry-timeout configuration` for the default
+            values.
         """
         self._host = host
         self._userid = userid
         self._password = password
         self._get_password = get_password
+        self._retry_timeout_config = self.default_rt_config.override_with(
+            retry_timeout_config)
         self._base_url = "{scheme}://{host}:{port}".format(
             scheme=_HMC_SCHEME,
             host=self._host,
@@ -128,7 +314,7 @@ class Session(object):
         if session_id is not None:
             # Create a logged-on state (same state as in _do_logon())
             self._session_id = session_id
-            self._session = requests.Session()
+            self._session = self._new_session(self.retry_timeout_config)
             self._headers['X-API-Session'] = session_id
         else:
             # Create a logged-off state (same state as in _do_logoff())
@@ -168,6 +354,15 @@ class Session(object):
         bool: The function that returns the password as a string, or `None`.
         """
         return self._get_password
+
+    @property
+    def retry_timeout_config(self):
+        """
+        :class:`~zhmcclient.RetryTimeoutConfig`: The effective retry/timeout
+        configuration for this session for use by any of its HMC operations,
+        taking into account the defaults and the session-specific overrides.
+        """
+        return self._retry_timeout_config
 
     @property
     def base_url(self):
@@ -318,10 +513,32 @@ class Session(object):
             'password': self._password
         }
         self._headers.pop('X-API-Session', None)  # Just in case
-        self._session = requests.Session()
+        self._session = self._new_session(self.retry_timeout_config)
         logon_res = self.post(logon_uri, logon_body, logon_required=False)
         self._session_id = logon_res['api-session']
         self._headers['X-API-Session'] = self._session_id
+
+    @staticmethod
+    def _new_session(retry_timeout_config):
+        """
+        Return a new `requests.Session` object.
+        """
+        retry = requests.packages.urllib3.Retry(
+            total=None,
+            connect=retry_timeout_config.connect_retries,
+            read=retry_timeout_config.read_retries,
+            redirect=retry_timeout_config.max_redirects)
+        # TODO: Pass method_whitelist=False to Retry()?
+        # This would cause retry for POST in addition to the default of GET and
+        # DELETE (the idempotent HTTP methods we use). The uncertainty is
+        # whether unintended duplicate execution of the POST can happen.
+
+        session = requests.Session()
+        session.mount('https://',
+                      requests.adapters.HTTPAdapter(max_retries=retry))
+        session.mount('http://',
+                      requests.adapters.HTTPAdapter(max_retries=retry))
+        return session
 
     def _do_logoff(self):
         """
@@ -389,11 +606,14 @@ class Session(object):
         stats = self.time_stats_keeper.get_stats('get ' + uri)
         stats.begin()
         req = self._session or requests
+        timeout = (self.retry_timeout_config.connect_timeout,
+                   self.retry_timeout_config.read_timeout)
         try:
-            result = req.get(url, headers=self.headers, verify=False)
+            result = req.get(url, headers=self.headers, verify=False,
+                             timeout=timeout)
             self._log_hmc_request_id(result)
         except requests.exceptions.RequestException as exc:
-            raise ConnectionError(exc.args[0], exc)
+            _handle_request_exc(exc)
         finally:
             stats.end()
 
@@ -404,13 +624,7 @@ class Session(object):
             reason = result_object.get('reason', None)
             if reason == 5:
                 # API session token expired: re-logon and retry
-                if logon_required:
-                    self._do_logon()
-                else:
-                    raise AuthError("API session token unexpectedly expired "
-                                    "for GET on a resource that does not "
-                                    "require authentication: {}".
-                                    format(uri), HTTPError(result_object))
+                self._do_logon()
                 return self.get(uri, logon_required)
             else:
                 msg = result_object.get('message', None)
@@ -447,6 +661,8 @@ class Session(object):
 
         If executing the operation reveals that the HMC session token is
         expired, this method re-logs on and retries the operation.
+
+        The timeout and retry
 
         Parameters:
 
@@ -521,6 +737,8 @@ class Session(object):
         url = self.base_url + uri
         self._log_http_method('POST', uri)
         req = self._session or requests
+        timeout = (self.retry_timeout_config.connect_timeout,
+                   self.retry_timeout_config.read_timeout)
         if wait_for_completion:
             stats_total = self.time_stats_keeper.get_stats(
                 'post ' + uri + '+completion')
@@ -531,14 +749,14 @@ class Session(object):
             try:
                 if body is None:
                     result = req.post(url, headers=self.headers,
-                                      verify=False)
+                                      verify=False, timeout=timeout)
                 else:
                     data = json.dumps(body)
                     result = req.post(url, data=data, headers=self.headers,
-                                      verify=False)
+                                      verify=False, timeout=timeout)
                 self._log_hmc_request_id(result)
             except requests.exceptions.RequestException as exc:
-                raise ConnectionError(exc.args[0], exc)
+                _handle_request_exc(exc)
             finally:
                 stats.end()
 
@@ -560,14 +778,7 @@ class Session(object):
                 reason = result_object.get('reason', None)
                 if reason == 5:
                     # API session token expired: re-logon and retry
-                    if logon_required:
-                        self._do_logon()
-                    else:
-                        raise AuthError(
-                            "API session token unexpectedly expired "
-                            "for POST on a resource that does not "
-                            "require authentication: {}".
-                            format(uri), HTTPError(result_object))
+                    self._do_logon()
                     return self.post(uri, body, logon_required)
                 else:
                     msg = result_object.get('message', None)
@@ -619,11 +830,14 @@ class Session(object):
         stats = self.time_stats_keeper.get_stats('delete ' + uri)
         stats.begin()
         req = self._session or requests
+        timeout = (self.retry_timeout_config.connect_timeout,
+                   self.retry_timeout_config.read_timeout)
         try:
-            result = req.delete(url, headers=self.headers, verify=False)
+            result = req.delete(url, headers=self.headers, verify=False,
+                                timeout=timeout)
             self._log_hmc_request_id(result)
         except requests.exceptions.RequestException as exc:
-            raise ConnectionError(exc.args[0], exc)
+            _handle_request_exc(exc)
         finally:
             stats.end()
 
@@ -634,13 +848,7 @@ class Session(object):
             reason = result_object.get('reason', None)
             if reason == 5:
                 # API session token expired: re-logon and retry
-                if logon_required:
-                    self._do_logon()
-                else:
-                    raise AuthError("API session token unexpectedly expired "
-                                    "for DELETE on a resource that does not "
-                                    "require authentication: {}".
-                                    format(uri), HTTPError(result_object))
+                self._do_logon()
                 self.delete(uri, logon_required)
                 return
             else:


### PR DESCRIPTION
This PR is now ready for code review and merging. It includes a design document in `design/network-errors.rst`.

It attempts to handle all network-related errors in the zhmcclient layer, if possible (e.g. timeouts, retries), so that the user of the package does not need to care about retries, and consider any raising of `zhmcclient.ConnectionError` to be not resolvable by user-level retrying.

The timeouts for async operation completion and LPAR status transition completion that were in an intermediate version of this PR have been removed again, so that this PR is now independent of PR #195 and needs to go in first. PR #195 will be changed to be based on this PR.