### PR TITLE
Fixes #205: Improved zhmcclient debug log calls

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -74,6 +74,16 @@ Released: 2017-03-16
   and the ``min_api_version`` and ``api_version`` properties continue to
   provide the version strings.
 
+* Changed the names of the Python loggers as follows:
+
+  1. Logger 'zhmcclient.api' logs API calls made by the user of the package,
+     at log level DEBUG. Internal calls to API functions are no longer logged.
+
+  2. Logger 'zhmcclient.hmc' logs HMC operations. Their log level has been
+     changed from INFO to DEBUG.
+
+* Removed the log calls for the HMC request ID.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -153,6 +163,18 @@ Released: 2017-03-16
 
 * Experimental: In the CLI, added more supported table formats (plain,
   simple, psql, rst, mediawiki, html, LaTeX).
+
+* Improved the content of the log messages for logged API calls and HMC
+  operations to now contain the function call arguments and return values (for
+  API calls) and the HTTP request and response details (for HMC operations).
+  For HMC operations and API calls that contain the HMC password, the password
+  is hidden in the log message by replacing it with a few '*' characters.
+
+**Known Issues:**
+
+* See `list of open issues`_.
+
+.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
 
 
 Version 0.10.0

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -48,10 +48,11 @@ from __future__ import absolute_import
 
 from ._manager import BaseManager
 from ._resource import BaseResource
-from ._logging import _log_call
-
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['ActivationProfileManager', 'ActivationProfile']
+
+LOG = get_logger(__name__)
 
 
 class ActivationProfileManager(BaseManager):
@@ -125,7 +126,7 @@ class ActivationProfileManager(BaseManager):
         """
         return self._profile_type
 
-    @_log_call
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the Activation Profiles of this CPC, of the profile type
@@ -215,6 +216,7 @@ class ActivationProfile(BaseResource):
                                  (ActivationProfileManager, type(manager)))
         super(ActivationProfile, self).__init__(manager, uri, name, properties)
 
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this Activation Profile.

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -65,8 +65,11 @@ from __future__ import absolute_import
 from ._manager import BaseManager
 from ._resource import BaseResource
 from ._port import PortManager
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['AdapterManager', 'Adapter']
+
+LOG = get_logger(__name__)
 
 
 class AdapterManager(BaseManager):
@@ -117,6 +120,7 @@ class AdapterManager(BaseManager):
         """
         return self._parent
 
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the Adapters in this CPC.
@@ -176,6 +180,7 @@ class AdapterManager(BaseManager):
 
         return resource_obj_list
 
+    @logged_api_call
     def create_hipersocket(self, properties):
         """
         Create and configure a HiperSockets Adapter in this CPC.
@@ -258,6 +263,7 @@ class Adapter(BaseResource):
             self._ports = PortManager(self)
         return self._ports
 
+    @logged_api_call
     def delete(self):
         """
         Delete this Adapter.
@@ -278,6 +284,7 @@ class Adapter(BaseResource):
         """
         self.manager.session.delete(self.uri)
 
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this Adapter.

--- a/zhmcclient/_client.py
+++ b/zhmcclient/_client.py
@@ -19,8 +19,11 @@ Client class: A client to an HMC.
 from __future__ import absolute_import
 
 from ._cpc import CpcManager
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['Client']
+
+LOG = get_logger(__name__)
 
 
 class Client(object):
@@ -58,6 +61,7 @@ class Client(object):
         """
         return self._cpcs
 
+    @logged_api_call
     def version_info(self):
         """
         Returns API version information for the HMC.
@@ -79,6 +83,7 @@ class Client(object):
         return self._api_version['api-major-version'],\
             self._api_version['api-minor-version']
 
+    @logged_api_call
     def query_api_version(self):
         """
         The Query API Version operation returns information about

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -29,7 +29,9 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'DEFAULT_READ_RETRIES',
            'DEFAULT_MAX_REDIRECTS',
            'DEFAULT_OPERATION_TIMEOUT',
-           'DEFAULT_STATUS_TIMEOUT']
+           'DEFAULT_STATUS_TIMEOUT',
+           'HMC_LOGGER_NAME',
+           'API_LOGGER_NAME']
 
 
 #: Default HTTP connect timeout in seconds,
@@ -69,3 +71,9 @@ DEFAULT_OPERATION_TIMEOUT = 3600
 #: of the :class:`~zhmcclient.Lpar` class that change its status (e.g.
 #: :meth:`zhmcclient.Lpar.activate`)).
 DEFAULT_STATUS_TIMEOUT = 60
+
+#: Name of the Python logger that logs HMC operations.
+HMC_LOGGER_NAME = 'zhmcclient.hmc'
+
+#: Name of the Python logger that logs zhmcclient API calls made by the user.
+API_LOGGER_NAME = 'zhmcclient.api'

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -49,10 +49,12 @@ from ._partition import PartitionManager
 from ._activation_profile import ActivationProfileManager
 from ._adapter import AdapterManager
 from ._virtual_switch import VirtualSwitchManager
-from ._logging import _log_call
+from ._logging import get_logger, logged_api_call
 from ._exceptions import HTTPError
 
 __all__ = ['CpcManager', 'Cpc']
+
+LOG = get_logger(__name__)
 
 
 class CpcManager(BaseManager):
@@ -91,7 +93,7 @@ class CpcManager(BaseManager):
 
         self._session = client.session
 
-    @_log_call
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the CPCs exposed by the HMC this client is connected to.
@@ -189,7 +191,6 @@ class Cpc(BaseResource):
         self._load_activation_profiles = None
 
     @property
-    @_log_call
     def lpars(self):
         """
         :class:`~zhmcclient.LparManager`: Access to the :term:`LPARs <LPAR>` in
@@ -201,7 +202,6 @@ class Cpc(BaseResource):
         return self._lpars
 
     @property
-    @_log_call
     def partitions(self):
         """
         :class:`~zhmcclient.PartitionManager`: Access to the
@@ -213,7 +213,6 @@ class Cpc(BaseResource):
         return self._partitions
 
     @property
-    @_log_call
     def adapters(self):
         """
         :class:`~zhmcclient.AdapterManager`: Access to the
@@ -225,7 +224,6 @@ class Cpc(BaseResource):
         return self._adapters
 
     @property
-    @_log_call
     def virtual_switches(self):
         """
         :class:`~zhmcclient.VirtualSwitchManager`: Access to the
@@ -245,7 +243,6 @@ class Cpc(BaseResource):
         return self.virtual_switches
 
     @property
-    @_log_call
     def reset_activation_profiles(self):
         """
         :class:`~zhmcclient.ActivationProfileManager`: Access to the
@@ -259,7 +256,6 @@ class Cpc(BaseResource):
         return self._reset_activation_profiles
 
     @property
-    @_log_call
     def image_activation_profiles(self):
         """
         :class:`~zhmcclient.ActivationProfileManager`: Access to the
@@ -273,7 +269,6 @@ class Cpc(BaseResource):
         return self._image_activation_profiles
 
     @property
-    @_log_call
     def load_activation_profiles(self):
         """
         :class:`~zhmcclient.ActivationProfileManager`: Access to the
@@ -287,7 +282,7 @@ class Cpc(BaseResource):
         return self._load_activation_profiles
 
     @property
-    @_log_call
+    @logged_api_call
     def dpm_enabled(self):
         """
         bool: Indicates whether this CPC is currently in DPM mode
@@ -333,6 +328,7 @@ class Cpc(BaseResource):
             else:
                 raise
 
+    @logged_api_call
     def start(self, wait_for_completion=True, operation_timeout=None):
         """
         Start this CPC, using the HMC operation "Start CPC".
@@ -387,6 +383,7 @@ class Cpc(BaseResource):
             operation_timeout=operation_timeout)
         return result
 
+    @logged_api_call
     def stop(self, wait_for_completion=True, operation_timeout=None):
         """
         Stop this CPC, using the HMC operation "Stop CPC".
@@ -441,7 +438,7 @@ class Cpc(BaseResource):
             operation_timeout=operation_timeout)
         return result
 
-    @_log_call
+    @logged_api_call
     def import_profiles(self, profile_area, wait_for_completion=True,
                         operation_timeout=None):
         """
@@ -507,7 +504,7 @@ class Cpc(BaseResource):
             operation_timeout=operation_timeout)
         return result
 
-    @_log_call
+    @logged_api_call
     def export_profiles(self, profile_area, wait_for_completion=True,
                         operation_timeout=None):
         """
@@ -572,6 +569,7 @@ class Cpc(BaseResource):
             operation_timeout=operation_timeout)
         return result
 
+    @logged_api_call
     def get_wwpns(self, partitions):
         """
         Return the WWPNs of the host ports (of the :term:`HBAs <HBA>`) of the

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -27,8 +27,11 @@ from __future__ import absolute_import
 
 from ._manager import BaseManager
 from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['HbaManager', 'Hba']
+
+LOG = get_logger(__name__)
 
 
 class HbaManager(BaseManager):
@@ -67,6 +70,7 @@ class HbaManager(BaseManager):
         """
         return self._parent
 
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the HBAs in this Partition.
@@ -118,6 +122,7 @@ class HbaManager(BaseManager):
                         resource_obj.pull_full_properties()
         return resource_obj_list
 
+    @logged_api_call
     def create(self, properties):
         """
         Create and configure an HBA in this Partition.
@@ -194,6 +199,7 @@ class Hba(BaseResource):
                                  (HbaManager, type(manager)))
         super(Hba, self).__init__(manager, uri, name, properties)
 
+    @logged_api_call
     def delete(self):
         """
         Delete this HBA.
@@ -212,6 +218,7 @@ class Hba(BaseResource):
         """
         self.manager.session.delete(self._uri)
 
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this HBA.
@@ -240,6 +247,7 @@ class Hba(BaseResource):
         """
         self.manager.session.post(self._uri, body=properties)
 
+    @logged_api_call
     def reassign_port(self, port):
         """
         Reassign this HBA to a new underlying :term:`FCP port`.

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -75,6 +75,8 @@ import logging
 import inspect
 from decorator import decorate
 
+from ._constants import API_LOGGER_NAME
+
 
 def get_logger(name):
     """
@@ -125,8 +127,6 @@ def logged_api_call(func):
         raise TypeError("The @logged_api_call decorator must be used on a "
                         "function or method ")
 
-    loggername = 'zhmcclient.api'
-
     try:
         # We avoid the use of inspect.getouterframes() because it is slow,
         # and use the pointers up the stack frame, instead.
@@ -151,7 +151,7 @@ def logged_api_call(func):
         apifunc_str = '{owner}.{func}()'.format(owner=apifunc_owner,
                                                 func=func.__name__)
 
-    logger = get_logger(loggername)
+    logger = get_logger(API_LOGGER_NAME)
 
     def log_api_call(func, *args, **kwargs):
         """

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -13,23 +13,29 @@
 # limitations under the License.
 
 """
-This package logs calls to most of its public API and to some internal
-functions using the standard Python :mod:`py:logging` module, but doesn't
-output the log records by default.
+This package supports logging using the standard Python :mod:`py:logging`
+module. The logging support provides two :class:`~py:logging.Logger` objects:
 
-It uses one :class:`~py:logging.Logger` object for each module. The name of
-each such logger is the dotted module name (e.g. ``'zhmcclient._cpc'``).
-Because the module names of this package are internal, it is recommended to
-use the logger for the package (``'zhmcclient'``) in order to set up logging.
+* 'zhmcclient.api' for user-issued calls to zhmcclient API functions, at the
+  debug level. Internal calls to API functions are not logged.
 
-These loggers have a null-handler (see :class:`~py:logging.NullHandler`)
+* 'zhmcclient.hmc' for interactions between zhmcclient and the HMC, at the
+  debug level.
+
+In addition, there are loggers for each module with the module name, for
+situations like errors or warnings.
+
+For HMC operations and API calls that contain the HMC password, the password
+is hidden in the log message by replacing it with a few '*' characters.
+
+All these loggers have a null-handler (see :class:`~py:logging.NullHandler`)
 and have no log formatter (see :class:`~py:logging.Formatter`).
 
-If you want to turn on logging, add a log handler (see
-:meth:`~py:logging.Logger.addHandler`, and :mod:`py:logging.handlers` for the
-handlers included with Python) and set the log level (see
-:meth:`~py:logging.Logger.setLevel`, and :ref:`py:levels` for the defined
-levels).
+As a result, the loggers are silent by default. If you want to turn on logging,
+add a log handler (see :meth:`~py:logging.Logger.addHandler`, and
+:mod:`py:logging.handlers` for the handlers included with Python) and set the
+log level (see :meth:`~py:logging.Logger.setLevel`, and :ref:`py:levels` for
+the defined levels).
 
 If you want to change the default log message format, use
 :meth:`~py:logging.Handler.setFormatter`. Its ``form`` parameter is a format
@@ -38,8 +44,8 @@ section :ref:`py:logrecord-attributes`).
 
 Examples:
 
-* To output all log records of warning level or higher that are issued by this
-  package to ``stdout`` in a particular format, do this:
+* To output the log records for all HMC operations to ``stdout`` in a
+  particular format, do this:
 
   ::
 
@@ -48,9 +54,9 @@ Examples:
       handler = logging.StreamHandler()
       format_string = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
       handler.setFormatter(logging.Formatter(format_string))
-      logger = getLogger('zhmcclient')
+      logger = getLogger('zhmcclient.hmc')
       logger.addHandler(handler)
-      logger.setLevel(logging.WARNING)
+      logger.setLevel(logging.DEBUG)
 
 * This example uses the :func:`~py:logging.basicConfig` convenience function
   that sets the same format and level as in the previous example, but for the
@@ -62,62 +68,92 @@ Examples:
       import logging
 
       format_string = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-      logging.basicConfig(format=format_string, level=logging.WARNING)
+      logging.basicConfig(format=format_string, level=logging.DEBUG)
 """
 
 import logging
 import inspect
-
 from decorator import decorate
 
 
-def _get_logger(name):
+def get_logger(name):
     """
     Return a :class:`~py:logging.Logger` object with the specified name.
 
-    A :class:`~py:logging.NullHandler` is added to the logger (if it does not
-    have one yet) in order for this library to be silent by default, and to
-    leave the definition of 'real' logging handlers to the user of this
-    library.
+    A :class:`~py:logging.NullHandler` handler is added to the logger if it
+    does not have any handlers yet. This prevents the propagation of log
+    requests up the Python logger hierarchy, and therefore causes this package
+    to be silent by default.
     """
     logger = logging.getLogger(name)
-    if not any([isinstance(h, logging.NullHandler) for h in logger.handlers]):
+    if not logger.handlers:
         logger.addHandler(logging.NullHandler())
-    # NOTE(markus_z): In case you want to test it locally, just replace the
-    # NullHandler with the StreamHandler and set the loglevel to INFO.
     return logger
 
 
-def _log_call(func):
+def logged_api_call(func):
     """
-    Function decorator that causes the decorated function to log calls to
-    itself to a logger.
+    Function decorator that causes the decorated API function or method to log
+    calls to itself to a logger.
 
     The logger's name is the dotted module name of the module defining the
     decorated function (e.g. 'zhmcclient._cpc').
-    """
-    mod = inspect.getmodule(func)
-    try:
-        modname = mod.__name__
-    except AttributeError:
-        raise TypeError("The _log_call decorator must be used on a function "
-                        "(and not on top of the property decorator)")
-    logger = _get_logger(modname)
-    if inspect.isfunction(func):
-        frames = inspect.getouterframes(inspect.currentframe())
-        callername = frames[1][3]
-        # At the time the decorator code gets control, the module has been
-        # loaded, but class definitions of decorated methods are not complete
-        # yet. Also, methods of the class are still functions at this point.
-        if callername == '<module>':
-            where = '{func}()'.format(func=func.__name__)
-        else:  # it is a class name or outer function name
-            where = '{caller}.{func}()'.format(caller=callername,
-                                               func=func.__name__)
-    else:
-        raise TypeError("The _log_call decorator must be used on a function")
 
-    def wrapper(func, *args, **kwargs):
+    Parameters:
+
+      func (function object): The original function being decorated.
+
+    Returns:
+
+      function object: The function wrappering the original function being
+        decorated.
+    """
+
+    # Note that in this decorator function, we are in a module loading context,
+    # where the decorated functions are being defined. When this decorator
+    # function is called, its call stack represents the definition of the
+    # decorated functions. Not all global definitions in the module have been
+    # defined yet, and methods of classes that are decorated with this
+    # decorator are still functions at this point (and not yet methods).
+
+    module = inspect.getmodule(func)
+    if not getattr(module, '__name__', None):
+        raise TypeError("The @logged_api_call decorator must be used on a "
+                        "function or method (and not on top of the @property "
+                        "decorator)")
+    if not inspect.isfunction(func):
+        raise TypeError("The @logged_api_call decorator must be used on a "
+                        "function or method ")
+
+    loggername = 'zhmcclient.api'
+
+    try:
+        # We avoid the use of inspect.getouterframes() because it is slow,
+        # and use the pointers up the stack frame, instead.
+
+        this_frame = inspect.currentframe()  # this decorator function here
+        apifunc_frame = this_frame.f_back  # the decorated API function
+
+        apifunc_owner = inspect.getframeinfo(apifunc_frame)[2]
+
+    finally:
+        # Recommended way to deal with frame objects to avoid ref cycles
+        del this_frame
+        del apifunc_frame
+
+    # TODO: For inner functions, show all outer levels instead of just one.
+
+    if apifunc_owner == '<module>':
+        # The decorated API function is defined globally (at module level)
+        apifunc_str = '{func}()'.format(func=func.__name__)
+    else:
+        # The decorated API function is defined in a class or in a function
+        apifunc_str = '{owner}.{func}()'.format(owner=apifunc_owner,
+                                                func=func.__name__)
+
+    logger = get_logger(loggername)
+
+    def log_api_call(func, *args, **kwargs):
         """
         Log entry to and exit from the decorated function, at the debug level.
 
@@ -127,10 +163,45 @@ def _log_call(func):
         turned on. Therefore, we do as much as possible in the decorator
         function, plus we use %-formatting and lazy interpolation provided by
         the log functions, in order to save resources in this function here.
+
+        Parameters:
+
+          func (function object): The decorated function.
+
+          *args: Any positional arguments for the decorated function.
+
+          **kwargs: Any keyword arguments for the decorated function.
         """
-        logger.debug("Entering %s", where)
+
+        # Note that in this function, we are in the context where the
+        # decorated function is actually called.
+
+        try:
+            # We avoid the use of inspect.getouterframes() because it is slow,
+            # and use the pointers up the stack frame, instead.
+
+            this_frame = inspect.currentframe()  # this function here
+            apifunc_frame = this_frame.f_back  # the decorated API function
+            apicaller_frame = apifunc_frame.f_back  # caller of API function
+
+            apicaller_module = inspect.getmodule(apicaller_frame)
+            apicaller_module_name = apicaller_module.__name__
+        finally:
+            # Recommended way to deal with frame objects to avoid ref cycles
+            del this_frame
+            del apifunc_frame
+            del apicaller_frame
+            del apicaller_module
+
+        # Log only if the caller is not from our package
+        log_it = (apicaller_module_name.split('.')[0] != 'zhmcclient')
+
+        if log_it:
+            logger.debug("==> %s, args: %.500r, kwargs: %.500r",
+                         apifunc_str, args, kwargs)
         result = func(*args, **kwargs)
-        logger.debug("Leaving %s", where)
+        if log_it:
+            logger.debug("<== %s, result: %.1000r", apifunc_str, result)
         return result
 
-    return decorate(func, wrapper)
+    return decorate(func, log_api_call)

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -31,12 +31,12 @@ import time
 
 from ._manager import BaseManager
 from ._resource import BaseResource
-from ._logging import _log_call, _get_logger
 from ._exceptions import StatusTimeout
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['LparManager', 'Lpar']
 
-LOG = _get_logger(__name__)
+LOG = get_logger(__name__)
 
 
 class LparManager(BaseManager):
@@ -83,7 +83,7 @@ class LparManager(BaseManager):
         """
         return self._parent
 
-    @_log_call
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the LPARs in this CPC.
@@ -173,7 +173,7 @@ class Lpar(BaseResource):
                                  (LparManager, type(manager)))
         super(Lpar, self).__init__(manager, uri, name, properties)
 
-    @_log_call
+    @logged_api_call
     def activate(self, wait_for_completion=True,
                  operation_timeout=None, status_timeout=None):
         """
@@ -254,7 +254,7 @@ class Lpar(BaseResource):
             self._wait_for_status("not-operating", status_timeout)
         return result
 
-    @_log_call
+    @logged_api_call
     def deactivate(self, wait_for_completion=True,
                    operation_timeout=None, status_timeout=None):
         """
@@ -334,7 +334,7 @@ class Lpar(BaseResource):
             self._wait_for_status("not-activated", status_timeout)
         return result
 
-    @_log_call
+    @logged_api_call
     def load(self, load_address, load_parameter="", wait_for_completion=True,
              operation_timeout=None, status_timeout=None):
         """
@@ -420,6 +420,7 @@ class Lpar(BaseResource):
             self._wait_for_status("operating", status_timeout)
         return result
 
+    @logged_api_call
     def open_os_message_channel(self, include_refresh_messages=True):
         """
         Open a JMS message channel to this LPAR's operating system, returning
@@ -457,6 +458,7 @@ class Lpar(BaseResource):
             self.uri + '/operations/open-os-message-channel', body)
         return result['topic-name']
 
+    @logged_api_call
     def send_os_command(self, os_command_text, is_priority=False):
         """
         Send a command to the operating system running in this LPAR.

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -29,9 +29,12 @@ from __future__ import absolute_import
 
 from requests.utils import quote
 
+from ._logging import get_logger, logged_api_call
 from ._exceptions import NotFound, NoUniqueMatch
 
 __all__ = ['BaseManager']
+
+LOG = get_logger(__name__)
 
 
 class BaseManager(object):
@@ -270,6 +273,7 @@ class BaseManager(object):
         """
         raise NotImplementedError
 
+    @logged_api_call
     def find(self, **filter_args):
         """
         Find exactly one resource that is managed by this manager, by matching
@@ -333,6 +337,7 @@ class BaseManager(object):
         else:
             return obj_list[0]
 
+    @logged_api_call
     def findall(self, **filter_args):
         """
         Find zero or more resources that are managed by this manager, by
@@ -390,6 +395,7 @@ class BaseManager(object):
             obj_list = self.list(filter_args=filter_args)
             return obj_list
 
+    @logged_api_call
     def find_by_name(self, name):
         """
         Find a resource by name (i.e. value of its 'name' resource property)
@@ -438,6 +444,7 @@ class BaseManager(object):
             properties=None)
         return obj
 
+    @logged_api_call
     def flush(self):
         """
         Flush the cached name-to-URI mapping.

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -28,8 +28,11 @@ from __future__ import absolute_import
 
 from ._manager import BaseManager
 from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['NicManager', 'Nic']
+
+LOG = get_logger(__name__)
 
 
 class NicManager(BaseManager):
@@ -68,6 +71,7 @@ class NicManager(BaseManager):
         """
         return self._parent
 
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the NICs in this Partition.
@@ -119,6 +123,7 @@ class NicManager(BaseManager):
                         resource_obj.pull_full_properties()
         return resource_obj_list
 
+    @logged_api_call
     def create(self, properties):
         """
         Create and configure a NIC in this Partition.
@@ -165,6 +170,7 @@ class NicManager(BaseManager):
         props.update(result)
         return Nic(self, props['element-uri'], None, props)
 
+    @logged_api_call
     def nic_object(self, nic_id):
         """
         Return a minimalistic :class:`~zhmcclient.Nic` object for a Nic in this
@@ -232,6 +238,7 @@ class Nic(BaseResource):
                                  (NicManager, type(manager)))
         super(Nic, self).__init__(manager, uri, name, properties)
 
+    @logged_api_call
     def delete(self):
         """
         Delete this NIC.
@@ -250,6 +257,7 @@ class Nic(BaseResource):
         """
         self.manager.session.delete(self._uri)
 
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this NIC.

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -67,8 +67,11 @@ import threading
 import stomp
 import json
 
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['NotificationReceiver']
+
+LOG = get_logger(__name__)
 
 
 # Port on which the HMC issues JMS over STOMP messages:
@@ -144,6 +147,7 @@ class NotificationReceiver(object):
         dest = "/topic/" + topic
         self._conn.subscribe(destination=dest, id=self._sub_id, ack='auto')
 
+    @logged_api_call
     def notifications(self):
         """
         Generator method that yields all HMC notifications (= JMS messages)
@@ -214,6 +218,7 @@ class NotificationReceiver(object):
                 del self._handover_dict['message']
                 self._handover_cond.notifyAll()
 
+    @logged_api_call
     def close(self):
         """
         Disconnect and close the JMS session with the HMC.

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -36,9 +36,11 @@ from ._resource import BaseResource
 from ._nic import NicManager
 from ._hba import HbaManager
 from ._virtual_function import VirtualFunctionManager
-from ._logging import _log_call
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['PartitionManager', 'Partition']
+
+LOG = get_logger(__name__)
 
 
 class PartitionManager(BaseManager):
@@ -86,6 +88,7 @@ class PartitionManager(BaseManager):
         """
         return self._parent
 
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the Partitions in this CPC.
@@ -146,6 +149,7 @@ class PartitionManager(BaseManager):
 
         return resource_obj_list
 
+    @logged_api_call
     def create(self, properties):
         """
         Create and configure a Partition in this CPC.
@@ -183,6 +187,7 @@ class PartitionManager(BaseManager):
         props.update(result)
         return Partition(self, props['object-uri'], None, props)
 
+    @logged_api_call
     def partition_object(self, part_id):
         """
         Return a minimalistic :class:`~zhmcclient.Partition` object for a
@@ -252,7 +257,6 @@ class Partition(BaseResource):
         self._virtual_functions = None
 
     @property
-    @_log_call
     def nics(self):
         """
         :class:`~zhmcclient.NicManager`: Access to the :term:`NICs <NIC>` in
@@ -264,7 +268,6 @@ class Partition(BaseResource):
         return self._nics
 
     @property
-    @_log_call
     def hbas(self):
         """
         :class:`~zhmcclient.HbaManager`: Access to the :term:`HBAs <HBA>` in
@@ -276,7 +279,6 @@ class Partition(BaseResource):
         return self._hbas
 
     @property
-    @_log_call
     def virtual_functions(self):
         """
         :class:`~zhmcclient.VirtualFunctionManager`: Access to the
@@ -287,6 +289,7 @@ class Partition(BaseResource):
             self._virtual_functions = VirtualFunctionManager(self)
         return self._virtual_functions
 
+    @logged_api_call
     def start(self, wait_for_completion=True, operation_timeout=None):
         """
         Start (activate) this Partition, using the HMC operation "Start
@@ -345,6 +348,7 @@ class Partition(BaseResource):
             operation_timeout=operation_timeout)
         return result
 
+    @logged_api_call
     def stop(self, wait_for_completion=True, operation_timeout=None):
         """
         Stop (deactivate) this Partition, using the HMC operation "Stop
@@ -400,6 +404,7 @@ class Partition(BaseResource):
             operation_timeout=operation_timeout)
         return result
 
+    @logged_api_call
     def delete(self):
         """
         Delete this Partition.
@@ -418,6 +423,7 @@ class Partition(BaseResource):
         """
         self.manager.session.delete(self.uri)
 
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this Partition.
@@ -444,6 +450,7 @@ class Partition(BaseResource):
         """
         self.manager.session.post(self.uri, body=properties)
 
+    @logged_api_call
     def dump_partition(self, parameters, wait_for_completion=True,
                        operation_timeout=None):
         """
@@ -507,6 +514,7 @@ class Partition(BaseResource):
             body=parameters)
         return result
 
+    @logged_api_call
     def psw_restart(self, wait_for_completion=True, operation_timeout=None):
         """
         Initiates a PSW restart for this Partition, using the HMC operation
@@ -562,6 +570,7 @@ class Partition(BaseResource):
             operation_timeout=operation_timeout)
         return result
 
+    @logged_api_call
     def mount_iso_image(self, properties):
         """
         Upload an ISO image and associate it to this Partition
@@ -595,6 +604,7 @@ class Partition(BaseResource):
             self.uri + '/operations/mount-iso-image',
             wait_for_completion=True, body=properties)
 
+    @logged_api_call
     def unmount_iso_image(self):
         """
         Unmount the currently mounted ISO from this Partition using the HMC
@@ -615,6 +625,7 @@ class Partition(BaseResource):
         self.manager.session.post(
             self.uri + '/operations/unmount-iso-image')
 
+    @logged_api_call
     def open_os_message_channel(self, include_refresh_messages=True):
         """
         Open a JMS message channel to this partition's operating system,
@@ -652,6 +663,7 @@ class Partition(BaseResource):
             self.uri + '/operations/open-os-message-channel', body)
         return result['topic-name']
 
+    @logged_api_call
     def send_os_command(self, os_command_text, is_priority=False):
         """
         Send a command to the operating system running in this partition.

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -24,8 +24,11 @@ from __future__ import absolute_import
 
 from ._manager import BaseManager
 from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['PortManager', 'Port']
+
+LOG = get_logger(__name__)
 
 
 class PortManager(BaseManager):
@@ -62,6 +65,7 @@ class PortManager(BaseManager):
         """
         return self._parent
 
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the Ports of this Adapter.
@@ -154,6 +158,7 @@ class Port(BaseResource):
                                  (PortManager, type(manager)))
         super(Port, self).__init__(manager, uri, name, properties)
 
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this Port.

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -22,7 +22,11 @@ by the HMC.
 from __future__ import absolute_import
 import time
 
+from ._logging import get_logger, logged_api_call
+
 __all__ = ['BaseResource']
+
+LOG = get_logger(__name__)
 
 
 class BaseResource(object):
@@ -185,6 +189,7 @@ class BaseResource(object):
         """
         return self._properties_timestamp
 
+    @logged_api_call
     def pull_full_properties(self):
         """
         Retrieve the full set of resource properties and cache them in this
@@ -206,6 +211,7 @@ class BaseResource(object):
         self._properties_timestamp = int(time.time())
         self._full_properties = True
 
+    @logged_api_call
     def get_property(self, name):
         """
         Return the value of a resource property.
@@ -245,6 +251,7 @@ class BaseResource(object):
             self.pull_full_properties()
             return self._properties[name]
 
+    @logged_api_call
     def prop(self, name, default=None):
         """
         Return the value of a resource property, applying a default if it

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -34,13 +34,13 @@ from ._timestats import TimeStatsKeeper
 from ._logging import get_logger, logged_api_call
 from ._constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_CONNECT_RETRIES, \
     DEFAULT_READ_TIMEOUT, DEFAULT_READ_RETRIES, DEFAULT_MAX_REDIRECTS, \
-    DEFAULT_OPERATION_TIMEOUT, DEFAULT_STATUS_TIMEOUT
+    DEFAULT_OPERATION_TIMEOUT, DEFAULT_STATUS_TIMEOUT, \
+    HMC_LOGGER_NAME
 
 __all__ = ['Session', 'Job', 'RetryTimeoutConfig']
 
 LOG = get_logger(__name__)
 
-HMC_LOGGER_NAME = 'zhmcclient.hmc'
 HMC_LOG = get_logger(HMC_LOGGER_NAME)
 
 _HMC_PORT = 6794

--- a/zhmcclient/_timestats.py
+++ b/zhmcclient/_timestats.py
@@ -45,7 +45,11 @@ from __future__ import absolute_import
 import time
 import copy
 
+from ._logging import get_logger, logged_api_call
+
 __all__ = ['TimeStatsKeeper', 'TimeStats']
+
+LOG = get_logger(__name__)
 
 
 class TimeStats(object):
@@ -130,6 +134,7 @@ class TimeStats(object):
         """
         return self._max
 
+    @logged_api_call
     def reset(self):
         """
         Reset the time statistics data for the operation.
@@ -139,6 +144,7 @@ class TimeStats(object):
         self._min = float('inf')
         self._max = float(0)
 
+    @logged_api_call
     def begin(self):
         """
         This method must be called before invoking the operation.
@@ -156,6 +162,7 @@ class TimeStats(object):
         if self.keeper.enabled:
             self._begin_time = time.time()
 
+    @logged_api_call
     def end(self):
         """
         This method must be called after the operation returns.
@@ -227,18 +234,21 @@ class TimeStatsKeeper(object):
         """
         return self._enabled
 
+    @logged_api_call
     def enable(self):
         """
         Enable the statistics keeper.
         """
         self._enabled = True
 
+    @logged_api_call
     def disable(self):
         """
         Disable the statistics keeper.
         """
         self._enabled = False
 
+    @logged_api_call
     def get_stats(self, name):
         """
         Get the time statistics for a name.
@@ -261,6 +271,7 @@ class TimeStatsKeeper(object):
             self._time_stats[name] = TimeStats(self, name)
         return self._time_stats[name]
 
+    @logged_api_call
     def snapshot(self):
         """
         Return a snapshot of the time statistics of this keeper.

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -26,8 +26,11 @@ from __future__ import absolute_import
 
 from ._manager import BaseManager
 from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['VirtualFunctionManager', 'VirtualFunction']
+
+LOG = get_logger(__name__)
 
 
 class VirtualFunctionManager(BaseManager):
@@ -66,6 +69,7 @@ class VirtualFunctionManager(BaseManager):
         """
         return self._parent
 
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the Virtual Functions of this Partition.
@@ -117,6 +121,7 @@ class VirtualFunctionManager(BaseManager):
                         resource_obj.pull_full_properties()
         return resource_obj_list
 
+    @logged_api_call
     def create(self, properties):
         """
         Create a Virtual Function in this Partition.
@@ -189,6 +194,7 @@ class VirtualFunction(BaseResource):
                                  (VirtualFunctionManager, type(manager)))
         super(VirtualFunction, self).__init__(manager, uri, name, properties)
 
+    @logged_api_call
     def delete(self):
         """
         Delete this Virtual Function.
@@ -207,6 +213,7 @@ class VirtualFunction(BaseResource):
         """
         self.manager.session.delete(self._uri)
 
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this Virtual Function.

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -30,8 +30,11 @@ import re
 
 from ._manager import BaseManager
 from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
 
 __all__ = ['VirtualSwitchManager', 'VirtualSwitch']
+
+LOG = get_logger(__name__)
 
 
 class VirtualSwitchManager(BaseManager):
@@ -79,6 +82,7 @@ class VirtualSwitchManager(BaseManager):
         """
         return self._parent
 
+    @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
         List the Virtual Switches in this CPC.
@@ -172,6 +176,7 @@ class VirtualSwitch(BaseResource):
                                  (VirtualSwitchManager, type(manager)))
         super(VirtualSwitch, self).__init__(manager, uri, name, properties)
 
+    @logged_api_call
     def get_connected_nics(self):
         """
         List the :term:`NICs <NIC>` connected to this Virtual Switch.
@@ -222,6 +227,7 @@ class VirtualSwitch(BaseResource):
             nic_list.append(nic)
         return nic_list
 
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this Virtual Switch.


### PR DESCRIPTION
This PR is done, but it needs review to confirm that it is what we want.

With this change, there are now only two sets of log calls made:

1. API calls made by the user. Internal calls to API functions (made by zhmcclient itself) are not logged. The logger name for that is `zhmcclient.api`.
2. HMC operations. The logger name for that is `zhmcclient.hmc`.
3. There could be error and warning logs with the usual loggers that are named after the module names, but there are no such log calls currently.

For more details, see the commit message.