### PR TITLE
Add more output formats to the CLI

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -129,6 +129,9 @@ Released: not yet
 * Added a new module that defines public constants, and that defines
   default timeout and retry values.
 
+* Experimental: In the CLI, added more supported table formats (plain,
+  simple, psql, rst, mediawiki, html, LaTeX).
+
 **Known Issues:**
 
 * See `list of open issues`_.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -119,7 +119,8 @@ commands::
                                       ZHMC_HOST environment variable).
       -u, --userid TEXT               Username for the HMC (Default: ZHMC_USERID
                                       environment variable).
-      -o, --output-format [table|json]
+      -o, --output-format [[table|plain|simple|psql|rst|mediawiki|html|latex|
+                          json]]
                                       Output format (Default: table).
       -t, --timestats                 Show time statistics of HMC operations.
       --version                       Show the version of this command and exit.
@@ -296,3 +297,41 @@ options (listed by ``zhmc COMMAND --help``) must be specified after the
 (sub-)command, like shown here::
 
       $ zhmc [GENERAL-OPTIONS] COMMAND [ARGS...] [COMMAND-OPTIONS]
+
+.. _`Output formats`:
+
+Output formats
+--------------
+
+There are different output formats for the command results.
+This output format can be selected by the ``-o`` or
+``--output-format`` option. For example::
+
+      $ zhmc -o plain cpc list
+      /name      status
+      P0004711  operating
+      P0000815  operating
+
+* table: Maps to output format 'psql'. This is the default.
+
+* plain: Results in tables without borders.
+
+* simple: Corresponds to ``simple_tables`` in `Pandoc Markdown extensions`_.
+
+* psql: Results in tables formatted like Postgres' psql cli tables.
+
+* rst: Formats data like a simple table of the `reStructuredText`_ format .
+
+* mediawiki: Results in table markup used in `Wikipedia`_.
+
+* html: Results in tables formatted in standard HTML markup.
+
+* latex: Results in tables formatted in LaTeX markup.
+
+* json: Results in `JSON`_ format.
+
+.. _`Pandoc Markdown extensions`: http://johnmacfarlane.net/pandoc/README.html#tables
+.. _`reStructuredText`: http://docutils.sourceforge.net/docs/user/rst/quickref.html#tables
+.. _`Wikipedia`: http://www.mediawiki.org/wiki/Help:Tables
+.. _`JSON`: http://json.org/example.html
+

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -33,6 +33,9 @@ REPL_HISTORY_FILE = '~/.zhmc_history'
 
 REPL_PROMPT = u'zhmc> '  # Must be Unicode
 
+TABLE_FORMATS = ['table', 'plain', 'simple', 'psql', 'rst', 'mediawiki',
+                 'html', 'latex']
+
 
 def abort_if_false(ctx, param, value):
     # pylint: disable=unused-argument
@@ -217,8 +220,10 @@ def print_properties(properties, output_format, skip_list=None):
     """
     Print properties in the desired output format.
     """
-    if output_format == 'table':
-        print_properties_as_table(properties, skip_list)
+    if output_format in TABLE_FORMATS:
+        if output_format == 'table':
+            output_format = 'psql'
+        print_properties_as_table(properties, output_format, skip_list)
     elif output_format == 'json':
         print_properties_as_json(properties)
     else:
@@ -229,15 +234,17 @@ def print_resources(resources, output_format, show_list=None):
     """
     Print the properties of a list of resources in the desired output format.
     """
-    if output_format == 'table':
-        print_resources_as_table(resources, show_list)
+    if output_format in TABLE_FORMATS:
+        if output_format == 'table':
+            output_format = 'psql'
+        print_resources_as_table(resources, output_format, show_list)
     elif output_format == 'json':
         print_resources_as_json(resources, show_list)
     else:
         raise InvalidOutputFormatError(output_format)
 
 
-def print_properties_as_table(properties, skip_list=None):
+def print_properties_as_table(properties, table_format, skip_list=None):
     """
     Print properties in tabular output format.
 
@@ -246,6 +253,16 @@ def print_properties_as_table(properties, skip_list=None):
     Parameters:
 
       properties (dict): The properties.
+
+      table_format: Supported table formats are:
+         - "table" -> same like "psql"
+         - "plain"
+         - "simple"
+         - "psql"
+         - "rst"
+         - "mediawiki"
+         - "html"
+         - "latex"
 
       skip_list (iterable of string): The property names to be skipped.
         If `None`, all properties are shown.
@@ -261,10 +278,10 @@ def print_properties_as_table(properties, skip_list=None):
         value = properties[field]
         table.append((field, value))
     headers = ['Field Name', 'Value']
-    click.echo(tabulate(table, headers, tablefmt="psql"))
+    click.echo(tabulate(table, headers, tablefmt=table_format))
 
 
-def print_resources_as_table(resources, show_list=None):
+def print_resources_as_table(resources, table_format, show_list=None):
     """
     Print resources in tabular output format.
 
@@ -272,6 +289,16 @@ def print_resources_as_table(resources, show_list=None):
 
       resources (iterable of BaseResource):
         The resources.
+
+      table_format: Supported table formats are:
+         - "table" -> same like "psql"
+         - "plain"
+         - "simple"
+         - "psql"
+         - "rst"
+         - "mediawiki"
+         - "html"
+         - "latex"
 
       show_list (iterable of string):
         The property names to be shown. If a property is not in the resource
@@ -302,7 +329,7 @@ def print_resources_as_table(resources, show_list=None):
         click.echo("No resources.")
     else:
         sorted_table = sorted(table, key=lambda row: row[0])
-        click.echo(tabulate(sorted_table, headers, tablefmt="psql"))
+        click.echo(tabulate(sorted_table, headers, tablefmt=table_format))
 
 
 def print_properties_as_json(properties):

--- a/zhmccli/zhmccli.py
+++ b/zhmccli/zhmccli.py
@@ -20,7 +20,7 @@ import click_repl
 from prompt_toolkit.history import FileHistory
 
 from ._helper import CmdContext, GENERAL_OPTIONS_METAVAR, REPL_HISTORY_FILE, \
-    REPL_PROMPT
+    REPL_PROMPT, TABLE_FORMATS
 
 requests.packages.urllib3.disable_warnings()
 
@@ -38,7 +38,8 @@ DEFAULT_TIMESTATS = False
 @click.option('-u', '--userid', type=str, envvar='ZHMC_USERID',
               help="Username for the HMC "
                    "(Default: ZHMC_USERID environment variable).")
-@click.option('-o', '--output-format', type=click.Choice(['table', 'json']),
+@click.option('-o', '--output-format', type=click.Choice(TABLE_FORMATS +
+              ['json']),
               help='Output format (Default: {of}).'
               .format(of=DEFAULT_OUTPUT_FORMAT))
 @click.option('-t', '--timestats', type=str, is_flag=True,


### PR DESCRIPTION
The following output formats are supported
in the CLI now: plain, simple, psql, rst,
mediawiki, html, LaTeX.
The default output format is still 'table'.
'table' and 'psql' are the same output formats.
A new section 'output formats' are added to
to CLI documentation.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>