### PR TITLE
Fixes #211: Fixes and improvements in mock support

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,7 +33,31 @@ Released: not yet
 
 * Added WWPN support in mocking framework (issue #212).
 
+* Fixed error in mock support where the `operation_timeout` argument to
+  `FakedSession.post()` was missing.
+
+* Fixed a bug in the unit test for the mock support, that caused incomplete
+  expected results not to be surfaced, and fixed the incomplete testcases.
+
 **Enhancements:**
+
+* Improved the mock support by adding the typical attributes of its superclass
+  `FakedBaseResource` to the `FakedHmc` class.
+
+* Improved the mock support by adding `__repr__()` methods to all `Faked*`
+  classes that return an object representation suitable for debugging.
+
+* In the mock support, the following resource properties are now auto-set if
+  not specified in the input properties:
+  - Cpc:
+    - 'dpm-enabled' is auto-set to `False`, if not specified.
+    - 'is-ensemble-member' is auto-set to `False`, if not specified.
+    - 'status' is auto-set, if not specified, as follows: If the
+      'dpm-enabled' property is `True`, it is set to 'active';
+      otherwise it is set to 'operating'.
+  - Partition: 'status' is auto-set to 'stopped', if not specified.
+  - Lpar: 'status' is auto-set to 'not-activated', if not specified.
+  - Adapter: 'status' is auto-set to 'active', if not specified.
 
 **Known Issues:**
 

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -55,12 +55,15 @@ class FakedHmcTests(unittest.TestCase):
         cpc1_in_props = {'name': 'cpc1'}
 
         # the function to be tested:
-        cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
+        cpc1 = self.hmc.cpcs.add(cpc1_in_props)
 
         cpc1_out_props = cpc1_in_props.copy()
         cpc1_out_props.update({
             'object-id': cpc1.oid,
             'object-uri': cpc1.uri,
+            'dpm-enabled': False,
+            'is-ensemble-member': False,
+            'status': 'operating',
         })
 
         # the function to be tested:
@@ -83,6 +86,9 @@ class FakedHmcTests(unittest.TestCase):
         cpc1_out_props.update({
             'object-id': cpc1.oid,
             'object-uri': cpc1.uri,
+            'dpm-enabled': False,
+            'is-ensemble-member': False,
+            'status': 'operating',
         })
 
         cpc2_in_props = {'name': 'cpc2'}
@@ -94,6 +100,9 @@ class FakedHmcTests(unittest.TestCase):
         cpc2_out_props.update({
             'object-id': cpc2.oid,
             'object-uri': cpc2.uri,
+            'dpm-enabled': False,
+            'is-ensemble-member': False,
+            'status': 'operating',
         })
 
         # the function to be tested:
@@ -145,6 +154,9 @@ class FakedHmcTests(unittest.TestCase):
         cpc1_out_props.update({
             'object-id': cpc1.oid,
             'object-uri': cpc1.uri,
+            'dpm-enabled': False,
+            'is-ensemble-member': False,
+            'status': 'operating',
         })
         self.assertIsInstance(cpc1, FakedCpc)
         self.assertEqual(cpc1.properties, cpc1_out_props)
@@ -153,22 +165,24 @@ class FakedHmcTests(unittest.TestCase):
         cpc1_adapters = cpc1.adapters.list()
 
         self.assertEqual(len(cpc1_adapters), 1)
-
         adapter1 = cpc1_adapters[0]
+
+        adapter1_ports = adapter1.ports.list()
+
+        self.assertEqual(len(adapter1_ports), 1)
+        port1 = adapter1_ports[0]
+
         adapter1_out_props = adapter1_in_props.copy()
         adapter1_out_props.update({
             'object-id': adapter1.oid,
             'object-uri': adapter1.uri,
+            'status': 'active',
+            'network-port-uris': [port1.uri],
         })
         self.assertIsInstance(adapter1, FakedAdapter)
         self.assertEqual(adapter1.properties, adapter1_out_props)
         self.assertEqual(adapter1.manager, cpc1.adapters)
 
-        adapter1_ports = adapter1.ports.list()
-
-        self.assertEqual(len(adapter1_ports), 1)
-
-        port1 = adapter1_ports[0]
         port1_out_props = port1_in_props.copy()
         port1_out_props.update({
             'element-id': port1.oid,
@@ -382,6 +396,9 @@ class FakedAdapterTests(unittest.TestCase):
         adapter1_out_props.update({
             'object-id': adapter1.oid,
             'object-uri': adapter1.uri,
+            'status': 'active',
+            'adapter-family': 'roce',
+            'network-port-uris': [],
         })
         self.assertIsInstance(adapter1, FakedAdapter)
         self.assertEqual(adapter1.properties, adapter1_out_props)
@@ -416,6 +433,8 @@ class FakedAdapterTests(unittest.TestCase):
         adapter2_out_props.update({
             'object-id': adapter2.oid,
             'object-uri': adapter2.uri,
+            'status': 'active',
+            'storage-port-uris': [],
         })
         self.assertIsInstance(adapter2, FakedAdapter)
         self.assertEqual(adapter2.properties, adapter2_out_props)
@@ -468,6 +487,9 @@ class FakedCpcTests(unittest.TestCase):
         cpc1_out_props.update({
             'object-id': cpc1.oid,
             'object-uri': cpc1.uri,
+            'dpm-enabled': False,
+            'is-ensemble-member': False,
+            'status': 'operating',
         })
         self.assertIsInstance(cpc1, FakedCpc)
         self.assertEqual(cpc1.properties, cpc1_out_props)
@@ -508,6 +530,9 @@ class FakedCpcTests(unittest.TestCase):
         cpc2_out_props.update({
             'object-id': cpc2.oid,
             'object-uri': cpc2.uri,
+            'dpm-enabled': False,
+            'is-ensemble-member': False,
+            'status': 'operating',
         })
         self.assertIsInstance(cpc2, FakedCpc)
         self.assertEqual(cpc2.properties, cpc2_out_props)
@@ -599,6 +624,8 @@ class FakedHbaTests(unittest.TestCase):
         hba1_out_props.update({
             'element-id': hba1.oid,
             'element-uri': hba1.uri,
+            'device-number': hba1.properties['device-number'],
+            'wwpn': hba1.properties['wwpn'],
         })
         self.assertIsInstance(hba1, FakedHba)
         self.assertEqual(hba1.properties, hba1_out_props)
@@ -617,6 +644,8 @@ class FakedHbaTests(unittest.TestCase):
             'element-id': '2',
             'name': 'hba2',
             'adapter-port-uri': '/api/adapters/1/storage-ports/1',
+            'device-number': '8001',
+            'wwpn': 'AFFEAFFE00008001',
         }
 
         # the function to be tested:
@@ -703,6 +732,7 @@ class FakedLparTests(unittest.TestCase):
         lpar1_out_props.update({
             'object-id': lpar1.oid,
             'object-uri': lpar1.uri,
+            'status': 'not-activated',
         })
         self.assertIsInstance(lpar1, FakedLpar)
         self.assertEqual(lpar1.properties, lpar1_out_props)
@@ -734,6 +764,7 @@ class FakedLparTests(unittest.TestCase):
         lpar2_out_props.update({
             'object-id': lpar2.oid,
             'object-uri': lpar2.uri,
+            'status': 'not-activated',
         })
         self.assertIsInstance(lpar2, FakedLpar)
         self.assertEqual(lpar2.properties, lpar2_out_props)
@@ -827,6 +858,7 @@ class FakedNicTests(unittest.TestCase):
         nic1_out_props.update({
             'element-id': nic1.oid,
             'element-uri': nic1.uri,
+            'device-number': nic1.properties['device-number'],
         })
         self.assertIsInstance(nic1, FakedNic)
         self.assertEqual(nic1.properties, nic1_out_props)
@@ -863,6 +895,7 @@ class FakedNicTests(unittest.TestCase):
         nic2_out_props.update({
             'element-id': nic2.oid,
             'element-uri': nic2.uri,
+            'device-number': nic2.properties['device-number'],
         })
         self.assertIsInstance(nic2, FakedNic)
         self.assertEqual(nic2.properties, nic2_out_props)
@@ -929,6 +962,10 @@ class FakedPartitionTests(unittest.TestCase):
         partition1_out_props.update({
             'object-id': partition1.oid,
             'object-uri': partition1.uri,
+            'status': 'stopped',
+            'hba-uris': [],
+            'nic-uris': [],
+            'virtual-function-uris': [],
         })
         self.assertIsInstance(partition1, FakedPartition)
         self.assertEqual(partition1.properties, partition1_out_props)
@@ -961,6 +998,10 @@ class FakedPartitionTests(unittest.TestCase):
         partition2_out_props.update({
             'object-id': partition2.oid,
             'object-uri': partition2.uri,
+            'status': 'stopped',
+            'hba-uris': [],
+            'nic-uris': [],
+            'virtual-function-uris': [],
         })
         self.assertIsInstance(partition2, FakedPartition)
         self.assertEqual(partition2.properties, partition2_out_props)
@@ -1148,6 +1189,7 @@ class FakedVirtualFunctionTests(unittest.TestCase):
         virtual_function1_out_props.update({
             'element-id': virtual_function1.oid,
             'element-uri': virtual_function1.uri,
+            'device-number': virtual_function1.properties['device-number'],
         })
         self.assertIsInstance(virtual_function1, FakedVirtualFunction)
         self.assertEqual(virtual_function1.properties,
@@ -1186,6 +1228,7 @@ class FakedVirtualFunctionTests(unittest.TestCase):
         virtual_function2_out_props.update({
             'element-id': virtual_function2.oid,
             'element-uri': virtual_function2.uri,
+            'device-number': virtual_function2.properties['device-number'],
         })
         self.assertIsInstance(virtual_function2, FakedVirtualFunction)
         self.assertEqual(virtual_function2.properties,

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -576,6 +576,7 @@ class GenericGetPropertiesHandlerTests(unittest.TestCase):
             'object-uri': '/api/cpcs/1',
             'name': 'cpc_1',
             'dpm-enabled': False,
+            'is-ensemble-member': False,
             'description': 'CPC #1 (classic mode)',
             'status': 'operating',
         }
@@ -678,6 +679,7 @@ class CpcHandlersTests(unittest.TestCase):
             'object-uri': '/api/cpcs/1',
             'name': 'cpc_1',
             'dpm-enabled': False,
+            'is-ensemble-member': False,
             'description': 'CPC #1 (classic mode)',
             'status': 'operating',
         }
@@ -822,12 +824,12 @@ class AdapterHandlersTests(unittest.TestCase):
                 {
                     'object-uri': '/api/adapters/2',
                     'name': 'fcp_2',
-                    # status not set in resource -> not in response
+                    'status': 'active',
                 },
                 {
                     'object-uri': '/api/adapters/3',
                     'name': 'roce_3',
-                    # status not set in resource -> not in response
+                    'status': 'active',
                 },
             ]
         }
@@ -1004,6 +1006,7 @@ class PartitionHandlersTests(unittest.TestCase):
             'object-id': '2',
             'object-uri': '/api/partitions/2',
             'name': 'partition_2',
+            'status': 'stopped',
             'hba-uris': [],
             'nic-uris': [],
             'virtual-function-uris': [],

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -126,7 +126,7 @@ class FakedSession(zhmcclient.Session):
             raise zhmcclient.HTTPError(exc.response())
 
     def post(self, uri, body=None, logon_required=True,
-             wait_for_completion=True):
+             wait_for_completion=True, operation_timeout=None):
         """
         Perform the HTTP POST method against the resource identified by a URI,
         using a provided request body, on the faked HMC.
@@ -188,6 +188,18 @@ class FakedSession(zhmcclient.Session):
             * If `False`, this method will immediately return the result of the
               HTTP POST method, regardless of whether the operation is
               synchronous or asynchronous.
+
+          operation_timeout (:term:`number`):
+            Timeout in seconds, when waiting for completion of an asynchronous
+            operation. The special value 0 means that no timeout is set. `None`
+            means that the default async operation timeout of the session is
+            used.
+
+            For `wait_for_completion=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised when the timeout
+            expires.
+
+            For `wait_for_completion=False`, this parameter has no effect.
 
         Returns:
 


### PR DESCRIPTION
Please review and merge.

Details:
- Added the missing support for the `operation_timeout` argument to `FakedSession.post()`, in order to be compatible with the `Session.post()` that was changed recently.
- Added missing attributes of `FakedBaseResource` to `FakedHmc` by initializing the superclass and by tolerating `None` for the `manager` and `properties` arguments of `FakedBaseResource()`.
- Added `__repr__()` methods for all Faked* classes, that return a representation suitable for debugging.
- The FakedPartition/Lpar/Adapter/Cpc resources now auto-set a number of additional properties, if not specified in the input properties.