### PR TITLE
Fixed display of CLI spinner in output

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,8 @@ Released: not yet
 * Fixed a bug in the unit test for the mock support, that caused incomplete
   expected results not to be surfaced, and fixed the incomplete testcases.
 
+* Fixed in the CLI that the spinner character was part of the output.
+
 **Enhancements:**
 
 * Improved the mock support by adding the typical attributes of its superclass

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -206,6 +206,8 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
         show_list.extend([
             'object-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(adapters, cmd_ctx.output_format, show_list)
 
 
@@ -219,6 +221,7 @@ def cmd_adapter_show(cmd_ctx, cpc_name, adapter_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     print_properties(adapter.properties, cmd_ctx.output_format)
 
 
@@ -236,6 +239,7 @@ def cmd_adapter_update(cmd_ctx, cpc_name, adapter_name, options):
     properties = options_to_properties(options, name_map)
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating adapter %s." %
                    adapter_name)
         return
@@ -245,6 +249,7 @@ def cmd_adapter_update(cmd_ctx, cpc_name, adapter_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     if 'name' in properties and properties['name'] != adapter_name:
         click.echo("Adapter %s has been renamed to %s and was updated." %
                    (adapter_name, properties['name']))
@@ -268,6 +273,7 @@ def cmd_adapter_create_hipersocket(cmd_ctx, cpc_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo("New HiperSockets adapter %s has been created." %
                new_adapter.properties['name'])
 
@@ -282,4 +288,5 @@ def cmd_adapter_delete_hipersocket(cmd_ctx, cpc_name, adapter_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('HiperSockets adapter %s has been deleted.' % adapter_name)

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -159,6 +159,8 @@ def cmd_cpc_list(cmd_ctx, options):
         show_list.extend([
             'object-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(cpcs, cmd_ctx.output_format, show_list)
 
 
@@ -179,6 +181,8 @@ def cmd_cpc_show(cmd_ctx, cpc_name):
         'network1-ipv6-info',
         'auto-start-list',
     )
+
+    cmd_ctx.spinner.stop()
     print_properties(cpc.properties, cmd_ctx.output_format, skip_list)
 
 
@@ -214,6 +218,7 @@ def cmd_cpc_update(cmd_ctx, cpc_name, options):
             options['wait-ends-slice']
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating CPC %s." % cpc_name)
         return
 
@@ -221,6 +226,8 @@ def cmd_cpc_update(cmd_ctx, cpc_name, options):
         cpc.update_properties(properties)
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    cmd_ctx.spinner.stop()
 
     # Name changes are not supported for CPCs.
     click.echo("CPC %s has been updated." % cpc_name)

--- a/zhmccli/_cmd_hba.py
+++ b/zhmccli/_cmd_hba.py
@@ -174,6 +174,8 @@ def cmd_hba_list(cmd_ctx, cpc_name, partition_name, options):
         show_list.extend([
             'element-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(hbas, cmd_ctx.output_format, show_list)
 
 
@@ -187,6 +189,7 @@ def cmd_hba_show(cmd_ctx, cpc_name, partition_name, hba_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     print_properties(hba.properties, cmd_ctx.output_format)
 
 
@@ -223,6 +226,7 @@ def cmd_hba_create(cmd_ctx, cpc_name, partition_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo("New HBA %s has been created." %
                new_hba.properties['name'])
 
@@ -236,6 +240,7 @@ def cmd_hba_update(cmd_ctx, cpc_name, partition_name, hba_name, options):
     properties = options_to_properties(options)
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating HBA %s." % hba_name)
         return
 
@@ -244,6 +249,7 @@ def cmd_hba_update(cmd_ctx, cpc_name, partition_name, hba_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     if 'name' in properties and properties['name'] != hba_name:
         click.echo("HBA %s has been renamed to %s and was updated." %
                    (hba_name, properties['name']))
@@ -261,4 +267,5 @@ def cmd_hba_delete(cmd_ctx, cpc_name, partition_name, hba_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('HBA %s has been deleted.' % hba_name)

--- a/zhmccli/_cmd_info.py
+++ b/zhmccli/_cmd_info.py
@@ -43,4 +43,6 @@ def cmd_info(cmd_ctx):
         api_version = client.query_api_version()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    cmd_ctx.spinner.stop()
     print_properties(api_version, cmd_ctx.output_format)

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -221,6 +221,8 @@ def cmd_lpar_list(cmd_ctx, cpc_name, options):
         show_list.extend([
             'object-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(lpars, cmd_ctx.output_format, show_list)
 
 
@@ -237,6 +239,8 @@ def cmd_lpar_show(cmd_ctx, cpc_name, lpar_name):
     skip_list = (
         'program-status-word-information',
     )
+
+    cmd_ctx.spinner.stop()
     print_properties(lpar.properties, cmd_ctx.output_format, skip_list)
 
 
@@ -252,6 +256,7 @@ def cmd_lpar_update(cmd_ctx, cpc_name, lpar_name, options):
     properties = options_to_properties(options, name_map)
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating LPAR %s." % lpar_name)
         return
 
@@ -260,6 +265,7 @@ def cmd_lpar_update(cmd_ctx, cpc_name, lpar_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     # LPARs cannot be renamed.
     click.echo("LPAR %s has been updated." % lpar_name)
 
@@ -274,6 +280,7 @@ def cmd_lpar_activate(cmd_ctx, cpc_name, lpar_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('Activation of LPAR %s is complete.' % lpar_name)
 
 
@@ -287,6 +294,7 @@ def cmd_lpar_deactivate(cmd_ctx, cpc_name, lpar_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('Deactivation of LPAR %s is complete.' % lpar_name)
 
 
@@ -300,4 +308,5 @@ def cmd_lpar_load(cmd_ctx, cpc_name, lpar_name, load_address):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('Loading of LPAR %s is complete.' % lpar_name)

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -205,6 +205,8 @@ def cmd_nic_list(cmd_ctx, cpc_name, partition_name, options):
         show_list.extend([
             'element-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(nics, cmd_ctx.output_format, show_list)
 
 
@@ -218,6 +220,7 @@ def cmd_nic_show(cmd_ctx, cpc_name, partition_name, nic_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     print_properties(nic.properties, cmd_ctx.output_format)
 
 
@@ -280,6 +283,7 @@ def cmd_nic_create(cmd_ctx, cpc_name, partition_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo("New NIC %s has been created." %
                new_nic.properties['name'])
 
@@ -340,6 +344,7 @@ def cmd_nic_update(cmd_ctx, cpc_name, partition_name, nic_name, options):
         pass
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating NIC %s." % nic_name)
         return
 
@@ -348,6 +353,7 @@ def cmd_nic_update(cmd_ctx, cpc_name, partition_name, nic_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     if 'name' in properties and properties['name'] != nic_name:
         click.echo("NIC %s has been renamed to %s and was updated." %
                    (nic_name, properties['name']))
@@ -365,4 +371,5 @@ def cmd_nic_delete(cmd_ctx, cpc_name, partition_name, nic_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('NIC %s has been deleted.' % nic_name)

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -266,6 +266,8 @@ def cmd_partition_list(cmd_ctx, cpc_name, options):
         show_list.extend([
             'object-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(partitions, cmd_ctx.output_format, show_list)
 
 
@@ -279,6 +281,7 @@ def cmd_partition_show(cmd_ctx, cpc_name, partition_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     print_properties(partition.properties, cmd_ctx.output_format)
 
 
@@ -292,6 +295,7 @@ def cmd_partition_start(cmd_ctx, cpc_name, partition_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('Partition %s has been started.' % partition_name)
 
 
@@ -305,6 +309,7 @@ def cmd_partition_stop(cmd_ctx, cpc_name, partition_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('Partition %s has been stopped.' % partition_name)
 
 
@@ -353,6 +358,7 @@ def cmd_partition_create(cmd_ctx, cpc_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo("New partition %s has been created." %
                new_partition.properties['name'])
 
@@ -437,6 +443,7 @@ def cmd_partition_update(cmd_ctx, cpc_name, partition_name, options):
         pass
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating partition %s." %
                    partition_name)
         return
@@ -446,6 +453,7 @@ def cmd_partition_update(cmd_ctx, cpc_name, partition_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     if 'name' in properties and properties['name'] != partition_name:
         click.echo("Partition %s has been renamed to %s and was updated." %
                    (partition_name, properties['name']))
@@ -463,4 +471,5 @@ def cmd_partition_delete(cmd_ctx, cpc_name, partition_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('Partition %s has been deleted.' % partition_name)

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -126,6 +126,8 @@ def cmd_port_list(cmd_ctx, cpc_name, adapter_name, options):
         show_list.extend([
             'element-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(ports, cmd_ctx.output_format, show_list)
 
 
@@ -139,6 +141,7 @@ def cmd_port_show(cmd_ctx, cpc_name, adapter_name, port_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     print_properties(port.properties, cmd_ctx.output_format)
 
 
@@ -151,6 +154,7 @@ def cmd_port_update(cmd_ctx, cpc_name, adapter_name, port_name, options):
     properties = options_to_properties(options)
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating port %s." % port_name)
         return
 
@@ -159,5 +163,6 @@ def cmd_port_update(cmd_ctx, cpc_name, adapter_name, port_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     # Adapter ports cannot be renamed.
     click.echo("Port %s has been updated." % port_name)

--- a/zhmccli/_cmd_session.py
+++ b/zhmccli/_cmd_session.py
@@ -64,6 +64,8 @@ def cmd_session_create(cmd_ctx):
         session.logon(verify=True)
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    cmd_ctx.spinner.stop()
     click.echo("export ZHMC_HOST=%s" % session.host)
     click.echo("export ZHMC_USERID=%s" % session.userid)
     click.echo("export ZHMC_SESSION_ID=%s" % session.session_id)
@@ -76,4 +78,6 @@ def cmd_session_delete(cmd_ctx):
         session.logoff()
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+
+    cmd_ctx.spinner.stop()
     click.echo("unset ZHMC_SESSION_ID")

--- a/zhmccli/_cmd_vfunction.py
+++ b/zhmccli/_cmd_vfunction.py
@@ -184,6 +184,8 @@ def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name, options):
         show_list.extend([
             'element-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(vfunctions, cmd_ctx.output_format, show_list)
 
 
@@ -198,6 +200,7 @@ def cmd_vfunction_show(cmd_ctx, cpc_name, partition_name, vfunction_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     print_properties(vfunction.properties, cmd_ctx.output_format)
 
 
@@ -226,6 +229,7 @@ def cmd_vfunction_create(cmd_ctx, cpc_name, partition_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo("New virtual function %s has been created." %
                new_vfunction.properties['name'])
 
@@ -255,6 +259,7 @@ def cmd_vfunction_update(cmd_ctx, cpc_name, partition_name, vfunction_name,
         properties['adapter-uri'] = adapter.uri
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating virtual function "
                    "%s." % vfunction_name)
         return
@@ -264,6 +269,7 @@ def cmd_vfunction_update(cmd_ctx, cpc_name, partition_name, vfunction_name,
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     if 'name' in properties and properties['name'] != vfunction_name:
         click.echo("Virtual function %s has been renamed to %s and was "
                    "updated." % (vfunction_name, properties['name']))
@@ -282,4 +288,5 @@ def cmd_vfunction_delete(cmd_ctx, cpc_name, partition_name, vfunction_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     click.echo('Virtual function %s has been deleted.' % vfunction_name)

--- a/zhmccli/_cmd_vswitch.py
+++ b/zhmccli/_cmd_vswitch.py
@@ -129,6 +129,8 @@ def cmd_vswitch_list(cmd_ctx, cpc_name, options):
         show_list.extend([
             'object-uri',
         ])
+
+    cmd_ctx.spinner.stop()
     print_resources(vswitches, cmd_ctx.output_format, show_list)
 
 
@@ -142,6 +144,7 @@ def cmd_vswitch_show(cmd_ctx, cpc_name, vswitch_name):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     print_properties(vswitch.properties, cmd_ctx.output_format)
 
 
@@ -154,6 +157,7 @@ def cmd_vswitch_update(cmd_ctx, cpc_name, vswitch_name, options):
     properties = options_to_properties(options)
 
     if not properties:
+        cmd_ctx.spinner.stop()
         click.echo("No properties specified for updating virtual switch %s." %
                    vswitch_name)
         return
@@ -163,6 +167,7 @@ def cmd_vswitch_update(cmd_ctx, cpc_name, vswitch_name, options):
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
+    cmd_ctx.spinner.stop()
     if 'name' in properties and properties['name'] != vswitch_name:
         click.echo("Virtual switch %s has been renamed to %s and was "
                    "updated." % (vswitch_name, properties['name']))


### PR DESCRIPTION
The CLI spinner is correctly stopped but still appears with one character in the output. The reason for that is that it is still spinning while the output is written, and is stopped only after that. So the printing of the spinner character and the printing of the actual output interfere.

This change stops the spinner already before the output is written, so the spinner code itself cleans up the spinner characters.

Please review and merge.