### PR TITLE
CLI: Add "metrics" command group

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,8 @@ Released: not yet
   the use of the metrics support. The metrics support caused an additional package
   requirement for the ``pytz`` package.
 
+* Added support for a "metrics" command to the zhmc CLI.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -138,6 +138,7 @@ commands:
       -o, --output-format [[table|plain|simple|psql|rst|mediawiki|html|latex|
                           json]]
                                       Output format (Default: table).
+      -x, --transpose                 Transpose the output table for metrics.
       -e, --error-format [msg|def]    Error message format (Default: msg).
       -t, --timestats                 Show time statistics of HMC operations.
       --log COMP=LEVEL,...            Set a component to a log level
@@ -160,6 +161,7 @@ commands:
       help       Show help message for interactive mode.
       info       Show information about the HMC.
       lpar       Command group for managing LPARs.
+      metrics    Command group for reporting metrics.
       nic        Command group for managing NICs.
       partition  Command group for managing partitions.
       port       Command group for managing adapter ports.
@@ -200,6 +202,7 @@ examples, an underscore ``_`` is shown as the cursor:
         --userid          Username for the HMC (Default: ZHMC_USERID environment variable).
         --password        Password for the HMC (Default: ZHMC_PASSWORD environment variable).
         --output-format   Output format (Default: table).
+        --transpose       Transpose the output table for metrics.
         --error-format    Error message format (Default: msg).
         --timestats       Show time statistics of HMC operations.
         --log             Set a component to a log level (COMP: [api|hmc|console|all], LEVEL: [error|warning|info|debug], Default: all=warning).

--- a/tests/unit/test_hba.py
+++ b/tests/unit/test_hba.py
@@ -334,7 +334,18 @@ class HbaTests(unittest.TestCase):
         adapter_uri = '/api/adapters/fake-adapter-id-1'
         adapter = Adapter(adapter_mgr, adapter_uri)
 
-        port_mgr = adapter.ports
+        with requests_mock.mock() as m:
+            mock_result_get_adapter = {
+                'parent': self.cpc.uri,
+                'name': 'adapter1',
+                'element-uri': adapter_uri,
+                'element-id': 'fake-adapter-id-1',
+                'class': 'adapter',
+                'adapter-family': 'ficon',
+            }
+            m.get(adapter_uri, json=mock_result_get_adapter)
+            port_mgr = adapter.ports
+
         port2_uri = '/api/adapters/fake-adapter-id-2/'\
                     'storage-ports/fake-port-id-2'
         port2 = Port(port_mgr, port2_uri)

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -53,6 +53,7 @@ class MyManager(BaseManager):
     def __init__(self, session):
         super(MyManager, self).__init__(
             resource_class=MyResource,
+            class_name='myresource',
             session=session,
             parent=None,  # a top-level resource
             base_uri='/api/myresources/',
@@ -165,6 +166,7 @@ class Manager1Tests(unittest.TestCase):
         """Test that BaseManager.list() raises NotImplementedError."""
         manager = BaseManager(
             resource_class=MyResource,
+            class_name='myresource',
             session=self.session,
             parent=None,  # a top-level resource
             base_uri='/api/myresources/',

--- a/tests/unit/test_port.py
+++ b/tests/unit/test_port.py
@@ -127,7 +127,9 @@ class PortTests(unittest.TestCase):
         """
         adapters = self.adapters
         for idy, adapter in enumerate(adapters):
-            port_mgr = adapter.ports
+            with requests_mock.mock() as m:
+                m.get(adapter.uri, json=adapter.properties)
+                port_mgr = adapter.ports
             ports = port_mgr.list(full_properties=False)
             if len(ports) != 0:
                 result_adapter = self.result['adapters'][idy]

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -50,6 +50,7 @@ class MyManager(BaseManager):
     def __init__(self, session):
         super(MyManager, self).__init__(
             resource_class=MyResource,
+            class_name='myresource',
             session=session,
             parent=None,  # a top-level resource
             base_uri='/api/myresources/',

--- a/zhmccli/__init__.py
+++ b/zhmccli/__init__.py
@@ -25,3 +25,4 @@ from ._cmd_hba import *        # noqa: F401
 from ._cmd_nic import *        # noqa: F401
 from ._cmd_vfunction import *  # noqa: F401
 from ._cmd_vswitch import *    # noqa: F401
+from ._cmd_metrics import *    # noqa: F401

--- a/zhmccli/_cmd_metrics.py
+++ b/zhmccli/_cmd_metrics.py
@@ -1,0 +1,422 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import click
+import time
+
+import zhmcclient
+from .zhmccli import cli
+from ._helper import print_properties, print_resources, \
+    COMMAND_OPTIONS_METAVAR
+from ._cmd_cpc import find_cpc
+
+# The number of seconds the client anticipates will elapse between Get
+# Metrics calls against this context. The minimum accepted value is 15.
+
+MIN_ANTICIPATED_FREQUENCY = 15
+
+
+@cli.group('metrics', options_metavar=COMMAND_OPTIONS_METAVAR)
+def metrics_group():
+    """
+    Command group for reporting metrics.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+
+
+@metrics_group.command('cpc', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_cpc(cmd_ctx, cpc, **options):
+    """
+    Report CPC specific metrics.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_cpc(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('partition', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_partition(cmd_ctx, cpc, **options):
+    """
+    Report Partitions specific metrics.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_partition(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('lpar', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_lpar(cmd_ctx, cpc, **options):
+    """
+    Report LPARs specific metrics.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_lpar(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('env', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_env(cmd_ctx, cpc, **options):
+    """
+    Report environmental data and power consumption for the CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_env(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('proc', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_proc(cmd_ctx, cpc, **options):
+    """
+    Report the processor usage for each physical CPC processor on the CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_proc(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('crypto', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_crypto(cmd_ctx, cpc, **options):
+    """
+    Report the adapter usage for each crypto on the CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_crypto(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('adapter', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_adapter(cmd_ctx, cpc, **options):
+    """
+    Report the adapter usage for each adapter on the DPM enabled CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_adapter(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('channel', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_channel(cmd_ctx, cpc, **options):
+    """
+    Report the channel usage for each channel on the CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_channel(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('flash', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_flash(cmd_ctx, cpc, **options):
+    """
+    Report the adapter usage for each Flash memory (Flash Express) adapter
+    on the CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_flash(cmd_ctx, cpc, options))
+
+
+@metrics_group.command('roce', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@click.pass_obj
+def metrics_roce(cmd_ctx, cpc, **options):
+    """
+    Report the adapter usage for each RoCE adapter on the CPC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_roce(cmd_ctx, cpc, options))
+
+
+def cmd_metrics_cpc(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY}
+    if cpc.dpm_enabled:
+        properties['metric-groups'] = ['dpm-system-usage-overview']
+    else:
+        properties['metric-groups'] = ['cpc-usage-overview']
+
+    mc = client.metrics_contexts.create(properties)
+    time.sleep(properties['anticipated-frequency-seconds'] + 1)
+    metrics_values = mc.get_metrics()
+    cv = zhmcclient.CollectedMetrics(mc, metrics_values)
+    for metrics in cv.metrics:
+        if metrics.uri == cpc.uri:
+            cmd_ctx.spinner.stop()
+            print_properties(metrics.properties, cmd_ctx.output_format)
+            break
+    mc.delete()
+
+
+def cmd_metrics_partition(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    if cpc.dpm_enabled:
+        properties = {
+            'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+            'metric-groups': ['partition-usage']
+        }
+        mc = client.metrics_contexts.create(properties)
+        time.sleep(properties['anticipated-frequency-seconds'] + 1)
+        metrics_rawdata = mc.get_metrics()
+        cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+        show_list = ['name']
+        for idx, metrics in enumerate(cv.metrics):
+            if idx == 0:
+                show_list += metrics.properties.keys()
+            metrics.properties['name'] = metrics.managed_object.name
+        cmd_ctx.spinner.stop()
+        # print(metrics_rawdata)
+        print_resources(cv.metrics, cmd_ctx.output_format, show_list)
+        mc.delete()
+    else:
+        cmd_ctx.spinner.stop()
+        click.echo("CPC is not in DPM mode.")
+
+
+def cmd_metrics_lpar(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    if not cpc.dpm_enabled:
+        properties = {
+            'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+            'metric-groups': ['logical-partition-usage']
+        }
+        mc = client.metrics_contexts.create(properties)
+        time.sleep(properties['anticipated-frequency-seconds'] + 1)
+        metrics_rawdata = mc.get_metrics()
+        cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+        show_list = ['name']
+        for idx, metrics in enumerate(cv.metrics):
+            if idx == 0:
+                show_list += metrics.properties.keys()
+            metrics.properties['name'] = metrics.managed_object.name
+        cmd_ctx.spinner.stop()
+        print_resources(cv.metrics, cmd_ctx.output_format, show_list)
+        mc.delete()
+    else:
+        cmd_ctx.spinner.stop()
+        click.echo("CPC is in DPM mode.")
+
+
+def cmd_metrics_env(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+                  'metric-groups': ['zcpc-environmentals-and-power']}
+    mc = client.metrics_contexts.create(properties)
+    time.sleep(properties['anticipated-frequency-seconds'] + 1)
+    metrics_rawdata = mc.get_metrics()
+    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+    for metrics in cv.metrics:
+        if metrics.uri == cpc.uri:
+            cmd_ctx.spinner.stop()
+            print_properties(metrics.properties, cmd_ctx.output_format)
+            break
+    mc.delete()
+
+
+def cmd_metrics_proc(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+                  'metric-groups': ['zcpc-processor-usage']}
+    mc = client.metrics_contexts.create(properties)
+    time.sleep(properties['anticipated-frequency-seconds'] + 1)
+    metrics_rawdata = mc.get_metrics()
+    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+    # print(metrics_rawdata)
+    cpc_metrics = []
+    for metrics in cv.metrics:
+        if metrics.uri == cpc.uri:
+            cpc_metrics.append(metrics)
+    cmd_ctx.spinner.stop()
+    # print(metrics_rawdata)
+    print_resources(cpc_metrics, cmd_ctx.output_format)
+    mc.delete()
+
+
+def cmd_metrics_crypto(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+                  'metric-groups': ['crypto-usage']}
+    mc = client.metrics_contexts.create(properties)
+    time.sleep(properties['anticipated-frequency-seconds'] + 1)
+    metrics_rawdata = mc.get_metrics()
+    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+    crypto_metrics = []
+    for metrics in cv.metrics:
+        if metrics.uri == cpc.uri:
+            crypto_metrics.append(metrics)
+    cmd_ctx.spinner.stop()
+#    print(metrics_rawdata)
+    print_resources(crypto_metrics, cmd_ctx.output_format)
+    mc.delete()
+
+
+def cmd_metrics_channel(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    if cpc.dpm_enabled:
+        cmd_ctx.spinner.stop()
+        click.echo("No channels available. CPC is in DPM mode.")
+        click.echo("Please use 'zhmc metrics adapter %s' instead." % cpc_name)
+        return
+
+    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+                  'metric-groups': ['channel-usage']}
+    mc = client.metrics_contexts.create(properties)
+    time.sleep(properties['anticipated-frequency-seconds'] + 1)
+    metrics_rawdata = mc.get_metrics()
+    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+    channel_metrics = []
+    for metrics in cv.metrics:
+        if metrics.uri == cpc.uri:
+            channel_metrics.append(metrics)
+    cmd_ctx.spinner.stop()
+    # print(metrics_rawdata)
+    print_resources(channel_metrics, cmd_ctx.output_format)
+    mc.delete()
+
+
+def cmd_metrics_adapter(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    if not cpc.dpm_enabled:
+        cmd_ctx.spinner.stop()
+        click.echo("No adapters available. CPC is not in DPM mode.")
+        click.echo("Please use 'zhmc metrics channel %s' instead." % cpc_name)
+        return
+
+    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+                  'metric-groups': ['adapter-usage']}
+    mc = client.metrics_contexts.create(properties)
+    time.sleep(properties['anticipated-frequency-seconds'] + 1)
+    metrics_rawdata = mc.get_metrics()
+    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+    adapter_metrics = []
+    for metrics in cv.metrics:
+        if metrics.uri == cpc.uri:
+            adapter_metrics.append(metrics)
+    cmd_ctx.spinner.stop()
+    print(metrics_rawdata)
+    print_resources(adapter_metrics, cmd_ctx.output_format)
+    mc.delete()
+
+
+def cmd_metrics_flash(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+                  'metric-groups': ['flash-memory-usage']}
+    mc = client.metrics_contexts.create(properties)
+    time.sleep(properties['anticipated-frequency-seconds'] + 1)
+    metrics_rawdata = mc.get_metrics()
+    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+    # print(metrics_rawdata)
+    flash_metrics = []
+    show_list = ['channel-id', 'adapter-usage']
+    for idx, metrics in enumerate(cv.metrics):
+        if idx == 0:
+            show_list += metrics.properties.keys()
+        if metrics.uri == cpc.uri:
+            flash_metrics.append(metrics)
+        #    print(metrics.properties)
+    cmd_ctx.spinner.stop()
+#    print(metrics_rawdata)
+    print_resources(flash_metrics, cmd_ctx.output_format, show_list)
+    mc.delete()
+
+
+def cmd_metrics_roce(cmd_ctx, cpc_name, options):
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    cpc = find_cpc(client, cpc_name)
+
+    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+                  'metric-groups': ['roce-usage']}
+    mc = client.metrics_contexts.create(properties)
+    time.sleep(properties['anticipated-frequency-seconds'] + 1)
+    metrics_rawdata = mc.get_metrics()
+    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
+    roce_metrics = []
+    for metrics in cv.metrics:
+        if metrics.uri == cpc.uri:
+            roce_metrics.append(metrics)
+    cmd_ctx.spinner.stop()
+    # print(metrics_rawdata)
+    print_resources(roce_metrics, cmd_ctx.output_format)
+    mc.delete()

--- a/zhmccli/_cmd_metrics.py
+++ b/zhmccli/_cmd_metrics.py
@@ -14,19 +14,289 @@
 
 from __future__ import absolute_import
 
-import click
 import time
+from collections import OrderedDict
+import json
+from tabulate import tabulate
+import click
 
 import zhmcclient
 from .zhmccli import cli
-from ._helper import print_properties, print_resources, \
-    COMMAND_OPTIONS_METAVAR
-from ._cmd_cpc import find_cpc
+from ._helper import COMMAND_OPTIONS_METAVAR, TABLE_FORMATS, \
+    raise_click_exception, InvalidOutputFormatError
+
 
 # The number of seconds the client anticipates will elapse between Get
 # Metrics calls against this context. The minimum accepted value is 15.
-
 MIN_ANTICIPATED_FREQUENCY = 15
+
+# Max number of retries for get_metrics() to obtain metrics data (1 sec each)
+GET_METRICS_MAX_RETRIES = 30
+
+# Debug control: Print MetricsResponse string
+DEBUG_METRICS_RESPONSE = False
+
+
+def wait_for_metrics(metric_context, metric_groups):
+    """
+    Repeat the retrieval of the metrics of a metrics context until at least one
+    of the specified metric group names has data.
+
+    Returns the MetricGroupValues object for the metric group that has data.
+    """
+    retries = 0
+    got_data = False
+    while not got_data:
+        mr_str = metric_context.get_metrics()
+        mr = zhmcclient.MetricsResponse(metric_context, mr_str)
+        for mg_values in mr.metric_group_values:
+            if mg_values.name in metric_groups:
+                got_data = True
+                if DEBUG_METRICS_RESPONSE:
+                    print("Debug: MetricsResponse:")
+                    print(mr_str)
+                break
+        if not got_data:
+            if retries > GET_METRICS_MAX_RETRIES:
+                if len(metric_groups) > 1:
+                    mg_txt = "one or more of the metric groups"
+                else:
+                    mg_txt = "metric group"
+                raise zhmcclient.Error(
+                    "Retrieving metrics data of {} {!r} exceeded {} retries.".
+                    format(mg_txt, metric_groups, GET_METRICS_MAX_RETRIES))
+            time.sleep(1)  # avoid hot spin loop
+            retries += 1
+    return mg_values
+
+
+def print_object_values(
+        object_values_list, metric_group_definition, resource_classes,
+        output_format, transposed):
+    """
+    Print a metric group for a list of resources in the desired output format.
+    """
+    if output_format in TABLE_FORMATS:
+        if output_format == 'table':
+            output_format = 'psql'
+        print_object_values_as_table(
+            object_values_list, metric_group_definition, resource_classes,
+            output_format, transposed)
+    elif output_format == 'json':
+        print_object_values_as_json(
+            object_values_list, metric_group_definition, resource_classes)
+    else:
+        raise InvalidOutputFormatError(output_format)
+
+
+def print_object_values_as_table(
+        object_values_list, metric_group_definition, resource_classes,
+        table_format, transposed):
+    """
+    Print a list of object values in a tabular output format.
+    """
+
+    metric_definitions = metric_group_definition.metric_definitions
+    sorted_metric_names = sorted(metric_definitions, key=lambda md: md.index)
+
+    table = list()
+    for i, ov in enumerate(object_values_list):
+
+        if i == 0:
+            headers = list()
+        row = list()
+
+        # Add resource names up to the CPC
+        res = ov.resource
+        while res:
+            if i == 0:
+                name_prop = res.manager.class_name + '-name'
+                headers.insert(0, name_prop)
+            row.insert(0, res.name)
+            res = res.manager.parent  # CPC has None as parent
+
+        # Add the metric values
+        for name in sorted_metric_names:
+            if i == 0:
+                m_def = metric_definitions[name]
+                header_str = name
+                if m_def.unit:
+                    header_str += u" [{}]".format(m_def.unit)
+                headers.append(header_str)
+            value = ov.metrics[name]
+            row.append(value)
+
+        table.append(row)
+
+    # Sort the table by the resource name columns
+    n_sort_cols = len(resource_classes)
+    table = sorted(table, key=lambda row: row[0:n_sort_cols])
+
+    if transposed:
+        table.insert(0, headers)
+        table = [list(col) for col in zip(*table)]
+        headers = []
+
+    if not table:
+        click.echo("No {} resources with metrics data.".
+                   format(metric_group_definition.resource_class))
+    else:
+        click.echo(tabulate(table, headers, tablefmt=table_format))
+
+
+def print_object_values_as_json(
+        object_values_list, metric_group_definition, resource_classes):
+    """
+    Print a list of object values in JSON output format.
+    """
+
+    metric_definitions = metric_group_definition.metric_definitions
+    sorted_metric_names = sorted(metric_definitions, key=lambda md: md.index)
+
+    json_obj = list()
+    for i, ov in enumerate(object_values_list):
+
+        resource_obj = OrderedDict()
+
+        # Add resource names up to the CPC
+        res = ov.resource
+        while res:
+            name_prop = res.manager.class_name + '-name'
+            resource_obj[name_prop] = res.name
+            res = res.manager.parent  # CPC has None as parent
+
+        # Add the metric values
+        for name in sorted_metric_names:
+            m_def = metric_definitions[name]
+            value = ov.metrics[name]
+            resource_obj[name] = OrderedDict(value=value, unit=m_def.unit)
+
+        json_obj.append(resource_obj)
+
+    json_str = json.dumps(json_obj)
+    click.echo(json_str)
+
+
+def print_metric_groups(cmd_ctx, client, metric_groups, resource_filter):
+    """
+    Retrieve and print metric groups.
+
+    Parameters:
+
+      client (Client): Client connected to the target HMC.
+
+      metric_groups (string or list of strings):
+        Name of the metric group(s) to be retrieved and printed.
+        If more than one metrics group is specified, they must all be for the
+        same resource class.
+
+      resource_filter (list):
+        Filter to narrow down the resources for which metrics are printed.
+        This is a list ordered by parent resources first. Each list item is a
+        tuple(class, name) where `class` is the resource class (e.g. 'cpc') and
+        `name` is the resource name or `None` (for no filtering by that
+        resource class). Valid combinations of resource classes are:
+
+        * Empty list: No filter in place.
+        * 'cpc': Only this CPC.
+        * 'cpc','partition': Only this partition in this CPC.
+        * 'cpc','logical-partition': Only this LPAR in this CPC.
+        * 'cpc','adapter': Only this adapter in this CPC.
+        * 'cpc','partition','nic': Only this NIC in this partition in this CPC.
+    """
+
+    if not isinstance(metric_groups, (list, tuple)):
+        metric_groups = [metric_groups]
+
+    properties = {
+        'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
+        'metric-groups': metric_groups,
+    }
+    mc = client.metrics_contexts.create(properties)
+    mg_values = wait_for_metrics(mc, metric_groups)
+    mg_def = mc.metric_group_definitions[mg_values.name]
+
+    filter_cpc = None
+    filter_partition = None
+    filter_lpar = None
+    filter_adapter = None
+    filter_nic = None
+    for r_class, r_name in resource_filter:
+        if r_class == 'cpc' and r_name:
+            filter_cpc = client.cpcs.find(name=r_name)
+        elif r_class == 'partition' and r_name:
+            assert filter_cpc
+            filter_partition = filter_cpc.partitions.find(name=r_name)
+        elif r_class == 'logical-partition' and r_name:
+            assert filter_cpc
+            filter_lpar = filter_cpc.lpars.find(name=r_name)
+        elif r_class == 'adapter' and r_name:
+            assert filter_cpc
+            filter_adapter = filter_cpc.adapters.find(name=r_name)
+        elif r_class == 'nic' and r_name:
+            assert filter_partition
+            filter_nic = filter_partition.nics.find(name=r_name)
+
+    resource_class = mg_def.resource_class
+
+    filtered_object_values = list()  # of MetricObjectValues
+    for ov in mg_values.object_values:
+        included = False
+        if resource_class == 'cpc':
+            if not filter_cpc:
+                included = True
+            elif ov.resource_uri == filter_cpc.uri:
+                included = True
+        elif resource_class == 'partition':
+            if not filter_cpc:
+                included = True
+            elif ov.resource.manager.cpc.uri == filter_cpc.uri:
+                if not filter_partition:
+                    included = True
+                elif ov.resource_uri == filter_partition.uri:
+                    included = True
+        elif resource_class == 'logical-partition':
+            if not filter_cpc:
+                included = True
+            elif ov.resource.manager.cpc.uri == filter_cpc.uri:
+                if not filter_lpar:
+                    included = True
+                elif ov.resource_uri == filter_lpar.uri:
+                    included = True
+        elif resource_class == 'adapter':
+            if not filter_cpc:
+                included = True
+            elif ov.resource.manager.cpc.uri == filter_cpc.uri:
+                if not filter_adapter:
+                    included = True
+                elif ov.resource_uri == filter_adapter.uri:
+                    included = True
+        elif resource_class == 'nic':
+            if not filter_cpc:
+                included = True
+            elif ov.resource.manager.partition.manager.cpc.uri == \
+                    filter_cpc.uri:
+                if not filter_partition:
+                    included = True
+                elif ov.resource.manager.partition.uri == filter_partition.uri:
+                    if not filter_nic:
+                        included = True
+                    elif ov.resource_uri == filter_nic.uri:
+                        included = True
+        else:
+            raise ValueError(
+                "Invalid resource class: {}".format(resource_class))
+
+        if included:
+            filtered_object_values.append(ov)
+
+    resource_classes = [f[0] for f in resource_filter]
+
+    cmd_ctx.spinner.stop()
+    print_object_values(filtered_object_values, mg_def, resource_classes,
+                        cmd_ctx.output_format, cmd_ctx.transpose)
+
+    mc.delete()
 
 
 @cli.group('metrics', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -41,11 +311,11 @@ def metrics_group():
 
 
 @metrics_group.command('cpc', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
 @click.pass_obj
 def metrics_cpc(cmd_ctx, cpc, **options):
     """
-    Report CPC specific metrics.
+    Report usage overview metrics for CPCs.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -55,39 +325,72 @@ def metrics_cpc(cmd_ctx, cpc, **options):
 
 
 @metrics_group.command('partition', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
+@click.argument('PARTITION', type=str, metavar='[PARTITION]', required=False)
 @click.pass_obj
-def metrics_partition(cmd_ctx, cpc, **options):
+def metrics_partition(cmd_ctx, cpc, partition, **options):
     """
-    Report Partitions specific metrics.
+    Report usage metrics for active partitions of CPCs in DPM mode.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_metrics_partition(cmd_ctx, cpc, options))
+    cmd_ctx.execute_cmd(
+        lambda: cmd_metrics_partition(cmd_ctx, cpc, partition, options))
 
 
 @metrics_group.command('lpar', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
+@click.argument('LPAR', type=str, metavar='[LPAR]', required=False)
 @click.pass_obj
-def metrics_lpar(cmd_ctx, cpc, **options):
+def metrics_lpar(cmd_ctx, cpc, lpar, **options):
     """
-    Report LPARs specific metrics.
+    Report usage metrics for active LPARs of CPCs in classic mode.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_metrics_lpar(cmd_ctx, cpc, options))
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_lpar(cmd_ctx, cpc, lpar, options))
+
+
+@metrics_group.command('adapter', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
+@click.argument('ADAPTER', type=str, metavar='[ADAPTER]', required=False)
+@click.pass_obj
+def metrics_adapter(cmd_ctx, cpc, adapter, **options):
+    """
+    Report usage metrics for active adapters of CPCs in DPM mode.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(
+        lambda: cmd_metrics_adapter(cmd_ctx, cpc, adapter, options))
+
+
+@metrics_group.command('channel', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
+@click.pass_obj
+def metrics_channel(cmd_ctx, cpc, **options):
+    """
+    Report usage metrics for all channels of CPCs in classic mode.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_metrics_channel(cmd_ctx, cpc, options))
 
 
 @metrics_group.command('env', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
 @click.pass_obj
 def metrics_env(cmd_ctx, cpc, **options):
     """
-    Report environmental data and power consumption for the CPC.
+    Report environmental and power consumption metrics for CPCs.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -97,11 +400,11 @@ def metrics_env(cmd_ctx, cpc, **options):
 
 
 @metrics_group.command('proc', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
 @click.pass_obj
 def metrics_proc(cmd_ctx, cpc, **options):
     """
-    Report the processor usage for each physical CPC processor on the CPC.
+    Report processor usage metrics for CPCs.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -111,11 +414,11 @@ def metrics_proc(cmd_ctx, cpc, **options):
 
 
 @metrics_group.command('crypto', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
 @click.pass_obj
 def metrics_crypto(cmd_ctx, cpc, **options):
     """
-    Report the adapter usage for each crypto on the CPC.
+    Report usage metrics for all active Crypto Express adapters of CPCs.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -124,41 +427,12 @@ def metrics_crypto(cmd_ctx, cpc, **options):
     cmd_ctx.execute_cmd(lambda: cmd_metrics_crypto(cmd_ctx, cpc, options))
 
 
-@metrics_group.command('adapter', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
-@click.pass_obj
-def metrics_adapter(cmd_ctx, cpc, **options):
-    """
-    Report the adapter usage for each adapter on the DPM enabled CPC.
-
-    In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified right after the
-    'zhmc' command name.
-    """
-    cmd_ctx.execute_cmd(lambda: cmd_metrics_adapter(cmd_ctx, cpc, options))
-
-
-@metrics_group.command('channel', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
-@click.pass_obj
-def metrics_channel(cmd_ctx, cpc, **options):
-    """
-    Report the channel usage for each channel on the CPC.
-
-    In addition to the command-specific options shown in this help text, the
-    general options (see 'zhmc --help') can also be specified right after the
-    'zhmc' command name.
-    """
-    cmd_ctx.execute_cmd(lambda: cmd_metrics_channel(cmd_ctx, cpc, options))
-
-
 @metrics_group.command('flash', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
 @click.pass_obj
 def metrics_flash(cmd_ctx, cpc, **options):
     """
-    Report the adapter usage for each Flash memory (Flash Express) adapter
-    on the CPC.
+    Report usage metrics for all active Flash Express adapters of CPCs.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -168,11 +442,11 @@ def metrics_flash(cmd_ctx, cpc, **options):
 
 
 @metrics_group.command('roce', options_metavar=COMMAND_OPTIONS_METAVAR)
-@click.argument('CPC', type=str, metavar='CPC')
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
 @click.pass_obj
 def metrics_roce(cmd_ctx, cpc, **options):
     """
-    Report the adapter usage for each RoCE adapter on the CPC.
+    Report usage metrics for all active RoCE adapters of CPCs.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'zhmc --help') can also be specified right after the
@@ -181,242 +455,220 @@ def metrics_roce(cmd_ctx, cpc, **options):
     cmd_ctx.execute_cmd(lambda: cmd_metrics_roce(cmd_ctx, cpc, options))
 
 
+@metrics_group.command('networkport', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
+@click.argument('ADAPTER', type=str, metavar='[ADAPTER]', required=False)
+@click.pass_obj
+def metrics_networkport(cmd_ctx, cpc, adapter, **options):
+    """
+    Report usage metrics for the ports of network adapters of CPCs in DPM mode.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(
+        lambda: cmd_metrics_networkport(cmd_ctx, cpc, adapter, options))
+
+
+@metrics_group.command('nic', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
+@click.argument('PARTITION', type=str, metavar='[PARTITION]', required=False)
+@click.argument('NIC', type=str, metavar='[NIC]', required=False)
+@click.pass_obj
+def metrics_nic(cmd_ctx, cpc, partition, nic, **options):
+    """
+    Report usage metrics for the NICs of partitions of CPCs in DPM mode.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(
+        lambda: cmd_metrics_nic(cmd_ctx, cpc, partition, nic, options))
+
+
 def cmd_metrics_cpc(cmd_ctx, cpc_name, options):
 
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
 
-    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY}
-    if cpc.dpm_enabled:
-        properties['metric-groups'] = ['dpm-system-usage-overview']
-    else:
-        properties['metric-groups'] = ['cpc-usage-overview']
+        metric_groups = ['dpm-system-usage-overview', 'cpc-usage-overview']
+        resource_filter = [
+            ('cpc', cpc_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_groups, resource_filter)
 
-    mc = client.metrics_contexts.create(properties)
-    time.sleep(properties['anticipated-frequency-seconds'] + 1)
-    metrics_values = mc.get_metrics()
-    cv = zhmcclient.CollectedMetrics(mc, metrics_values)
-    for metrics in cv.metrics:
-        if metrics.uri == cpc.uri:
-            cmd_ctx.spinner.stop()
-            print_properties(metrics.properties, cmd_ctx.output_format)
-            break
-    mc.delete()
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
 
 
-def cmd_metrics_partition(cmd_ctx, cpc_name, options):
+def cmd_metrics_partition(cmd_ctx, cpc_name, partition_name, options):
 
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
 
-    if cpc.dpm_enabled:
-        properties = {
-            'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-            'metric-groups': ['partition-usage']
-        }
-        mc = client.metrics_contexts.create(properties)
-        time.sleep(properties['anticipated-frequency-seconds'] + 1)
-        metrics_rawdata = mc.get_metrics()
-        cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-        show_list = ['name']
-        for idx, metrics in enumerate(cv.metrics):
-            if idx == 0:
-                show_list += metrics.properties.keys()
-            metrics.properties['name'] = metrics.managed_object.name
-        cmd_ctx.spinner.stop()
-        # print(metrics_rawdata)
-        print_resources(cv.metrics, cmd_ctx.output_format, show_list)
-        mc.delete()
-    else:
-        cmd_ctx.spinner.stop()
-        click.echo("CPC is not in DPM mode.")
+        metric_group = 'partition-usage'
+        resource_filter = [
+            ('cpc', cpc_name),
+            ('partition', partition_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
+
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
 
 
-def cmd_metrics_lpar(cmd_ctx, cpc_name, options):
+def cmd_metrics_lpar(cmd_ctx, cpc_name, lpar_name, options):
 
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
 
-    if not cpc.dpm_enabled:
-        properties = {
-            'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-            'metric-groups': ['logical-partition-usage']
-        }
-        mc = client.metrics_contexts.create(properties)
-        time.sleep(properties['anticipated-frequency-seconds'] + 1)
-        metrics_rawdata = mc.get_metrics()
-        cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-        show_list = ['name']
-        for idx, metrics in enumerate(cv.metrics):
-            if idx == 0:
-                show_list += metrics.properties.keys()
-            metrics.properties['name'] = metrics.managed_object.name
-        cmd_ctx.spinner.stop()
-        print_resources(cv.metrics, cmd_ctx.output_format, show_list)
-        mc.delete()
-    else:
-        cmd_ctx.spinner.stop()
-        click.echo("CPC is in DPM mode.")
+        metric_group = 'logical-partition-usage'
+        resource_filter = [
+            ('cpc', cpc_name),
+            ('logical-partition', lpar_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
+
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
 
 
-def cmd_metrics_env(cmd_ctx, cpc_name, options):
+def cmd_metrics_adapter(cmd_ctx, cpc_name, adapter_name, options):
 
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
 
-    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-                  'metric-groups': ['zcpc-environmentals-and-power']}
-    mc = client.metrics_contexts.create(properties)
-    time.sleep(properties['anticipated-frequency-seconds'] + 1)
-    metrics_rawdata = mc.get_metrics()
-    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-    for metrics in cv.metrics:
-        if metrics.uri == cpc.uri:
-            cmd_ctx.spinner.stop()
-            print_properties(metrics.properties, cmd_ctx.output_format)
-            break
-    mc.delete()
+        metric_group = 'adapter-usage'
+        resource_filter = [
+            ('cpc', cpc_name),
+            ('adapter', adapter_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
 
-
-def cmd_metrics_proc(cmd_ctx, cpc_name, options):
-
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
-
-    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-                  'metric-groups': ['zcpc-processor-usage']}
-    mc = client.metrics_contexts.create(properties)
-    time.sleep(properties['anticipated-frequency-seconds'] + 1)
-    metrics_rawdata = mc.get_metrics()
-    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-    # print(metrics_rawdata)
-    cpc_metrics = []
-    for metrics in cv.metrics:
-        if metrics.uri == cpc.uri:
-            cpc_metrics.append(metrics)
-    cmd_ctx.spinner.stop()
-    # print(metrics_rawdata)
-    print_resources(cpc_metrics, cmd_ctx.output_format)
-    mc.delete()
-
-
-def cmd_metrics_crypto(cmd_ctx, cpc_name, options):
-
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
-
-    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-                  'metric-groups': ['crypto-usage']}
-    mc = client.metrics_contexts.create(properties)
-    time.sleep(properties['anticipated-frequency-seconds'] + 1)
-    metrics_rawdata = mc.get_metrics()
-    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-    crypto_metrics = []
-    for metrics in cv.metrics:
-        if metrics.uri == cpc.uri:
-            crypto_metrics.append(metrics)
-    cmd_ctx.spinner.stop()
-#    print(metrics_rawdata)
-    print_resources(crypto_metrics, cmd_ctx.output_format)
-    mc.delete()
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
 
 
 def cmd_metrics_channel(cmd_ctx, cpc_name, options):
 
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
 
-    if cpc.dpm_enabled:
-        cmd_ctx.spinner.stop()
-        click.echo("No channels available. CPC is in DPM mode.")
-        click.echo("Please use 'zhmc metrics adapter %s' instead." % cpc_name)
-        return
+        metric_group = 'channel-usage'
+        resource_filter = [
+            ('cpc', cpc_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
 
-    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-                  'metric-groups': ['channel-usage']}
-    mc = client.metrics_contexts.create(properties)
-    time.sleep(properties['anticipated-frequency-seconds'] + 1)
-    metrics_rawdata = mc.get_metrics()
-    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-    channel_metrics = []
-    for metrics in cv.metrics:
-        if metrics.uri == cpc.uri:
-            channel_metrics.append(metrics)
-    cmd_ctx.spinner.stop()
-    # print(metrics_rawdata)
-    print_resources(channel_metrics, cmd_ctx.output_format)
-    mc.delete()
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
 
 
-def cmd_metrics_adapter(cmd_ctx, cpc_name, options):
+def cmd_metrics_env(cmd_ctx, cpc_name, options):
 
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
 
-    if not cpc.dpm_enabled:
-        cmd_ctx.spinner.stop()
-        click.echo("No adapters available. CPC is not in DPM mode.")
-        click.echo("Please use 'zhmc metrics channel %s' instead." % cpc_name)
-        return
+        metric_group = 'zcpc-environmentals-and-power'
+        resource_filter = [
+            ('cpc', cpc_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
 
-    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-                  'metric-groups': ['adapter-usage']}
-    mc = client.metrics_contexts.create(properties)
-    time.sleep(properties['anticipated-frequency-seconds'] + 1)
-    metrics_rawdata = mc.get_metrics()
-    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-    adapter_metrics = []
-    for metrics in cv.metrics:
-        if metrics.uri == cpc.uri:
-            adapter_metrics.append(metrics)
-    cmd_ctx.spinner.stop()
-    print(metrics_rawdata)
-    print_resources(adapter_metrics, cmd_ctx.output_format)
-    mc.delete()
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
+
+
+def cmd_metrics_proc(cmd_ctx, cpc_name, options):
+
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
+
+        metric_group = 'zcpc-processor-usage'
+        resource_filter = [
+            ('cpc', cpc_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
+
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
+
+
+def cmd_metrics_crypto(cmd_ctx, cpc_name, options):
+
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
+
+        metric_group = 'crypto-usage'
+        resource_filter = [
+            ('cpc', cpc_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
+
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
 
 
 def cmd_metrics_flash(cmd_ctx, cpc_name, options):
 
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
 
-    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-                  'metric-groups': ['flash-memory-usage']}
-    mc = client.metrics_contexts.create(properties)
-    time.sleep(properties['anticipated-frequency-seconds'] + 1)
-    metrics_rawdata = mc.get_metrics()
-    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-    # print(metrics_rawdata)
-    flash_metrics = []
-    show_list = ['channel-id', 'adapter-usage']
-    for idx, metrics in enumerate(cv.metrics):
-        if idx == 0:
-            show_list += metrics.properties.keys()
-        if metrics.uri == cpc.uri:
-            flash_metrics.append(metrics)
-        #    print(metrics.properties)
-    cmd_ctx.spinner.stop()
-#    print(metrics_rawdata)
-    print_resources(flash_metrics, cmd_ctx.output_format, show_list)
-    mc.delete()
+        metric_group = 'flash-memory-usage'
+        resource_filter = [
+            ('cpc', cpc_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
+
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
 
 
 def cmd_metrics_roce(cmd_ctx, cpc_name, options):
 
-    client = zhmcclient.Client(cmd_ctx.session)
-    cpc = find_cpc(client, cpc_name)
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
 
-    properties = {'anticipated-frequency-seconds': MIN_ANTICIPATED_FREQUENCY,
-                  'metric-groups': ['roce-usage']}
-    mc = client.metrics_contexts.create(properties)
-    time.sleep(properties['anticipated-frequency-seconds'] + 1)
-    metrics_rawdata = mc.get_metrics()
-    cv = zhmcclient.CollectedMetrics(mc, metrics_rawdata)
-    roce_metrics = []
-    for metrics in cv.metrics:
-        if metrics.uri == cpc.uri:
-            roce_metrics.append(metrics)
-    cmd_ctx.spinner.stop()
-    # print(metrics_rawdata)
-    print_resources(roce_metrics, cmd_ctx.output_format)
-    mc.delete()
+        metric_group = 'roce-usage'
+        resource_filter = [
+            ('cpc', cpc_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
+
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
+
+
+def cmd_metrics_networkport(cmd_ctx, cpc_name, adapter_name, options):
+
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
+
+        metric_group = 'network-physical-adapter-port'
+        resource_filter = [
+            ('cpc', cpc_name),
+            ('adapter', adapter_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
+
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)
+
+
+def cmd_metrics_nic(cmd_ctx, cpc_name, partition_name, nic_name, options):
+
+    try:
+        client = zhmcclient.Client(cmd_ctx.session)
+
+        metric_group = 'partition-attached-network-interface'
+        resource_filter = [
+            ('cpc', cpc_name),
+            ('partition', partition_name),
+            ('nic', nic_name),
+        ]
+        print_metric_groups(cmd_ctx, client, metric_group, resource_filter)
+
+    except zhmcclient.Error as exc:
+        raise_click_exception(exc, cmd_ctx.error_format)

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -69,12 +69,13 @@ class InvalidOutputFormatError(click.ClickException):
 
 class CmdContext(object):
 
-    def __init__(self, host, userid, password, output_format, error_format,
-                 timestats, session_id, get_password):
+    def __init__(self, host, userid, password, output_format, transpose,
+                 error_format, timestats, session_id, get_password):
         self._host = host
         self._userid = userid
         self._password = password
         self._output_format = output_format
+        self._transpose = transpose
         self._error_format = error_format
         self._timestats = timestats
         self._session_id = session_id
@@ -84,11 +85,12 @@ class CmdContext(object):
 
     def __repr__(self):
         ret = "CmdContext(at 0x%08x, host=%r, userid=%r, password=%r, " \
-            "output_format=%r, error_format=%r, session_id=%r, " \
-            "session=%r, ...)" % \
+            "output_format=%r, transpose=%r, error_format=%r, " \
+            "session_id=%r, session=%r, ...)" % \
             (id(self), self._host, self._userid,
              '...' if self._password else None, self._output_format,
-             self._error_format, self._session_id, self._session)
+             self._transpose, self._error_format, self._session_id,
+             self._session)
         return ret
 
     @property
@@ -111,6 +113,13 @@ class CmdContext(object):
         :term:`string`: Output format to be used.
         """
         return self._output_format
+
+    @property
+    def transpose(self):
+        """
+        bool: Transpose the output table.
+        """
+        return self._transpose
 
     @property
     def error_format(self):

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -102,6 +102,7 @@ class ActivationProfileManager(BaseManager):
 
         super(ActivationProfileManager, self).__init__(
             resource_class=ActivationProfile,
+            class_name='{}-activation-profile'.format(profile_type),
             session=cpc.manager.session,
             parent=cpc,
             base_uri='{}/{}-activation-profiles'.format(cpc.uri, profile_type),

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -110,6 +110,7 @@ class AdapterManager(BaseManager):
 
         super(AdapterManager, self).__init__(
             resource_class=Adapter,
+            class_name='adapter',
             session=cpc.manager.session,
             parent=cpc,
             base_uri='/api/adapters',
@@ -265,6 +266,14 @@ class Adapter(BaseResource):
         'hipersockets': 'network-ports',
     }
 
+    # Port type, dependent on adapter family
+    port_type_by_family = {
+        'ficon': 'storage',
+        'osa': 'network',
+        'roce': 'network',
+        'hipersockets': 'network',
+    }
+
     def __init__(self, manager, uri, name=None, properties=None):
         # This function should not go into the docs.
         #   manager (:class:`~zhmcclient.AdapterManager`):
@@ -293,7 +302,12 @@ class Adapter(BaseResource):
         """
         # We do here some lazy loading.
         if not self._ports:
-            self._ports = PortManager(self)
+            family = self.get_property('adapter-family')
+            try:
+                port_type = port_type_by_family[family]
+            except KeyError:
+                port_type = None
+            self._ports = PortManager(self, port_type)
         return self._ports
 
     @property

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -304,7 +304,7 @@ class Adapter(BaseResource):
         if not self._ports:
             family = self.get_property('adapter-family')
             try:
-                port_type = port_type_by_family[family]
+                port_type = self.port_type_by_family[family]
             except KeyError:
                 port_type = None
             self._ports = PortManager(self, port_type)

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -88,6 +88,7 @@ class CpcManager(BaseManager):
 
         super(CpcManager, self).__init__(
             resource_class=Cpc,
+            class_name='cpc',
             session=client.session,
             parent=None,
             base_uri='/api/cpcs',

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -59,6 +59,7 @@ class HbaManager(BaseManager):
 
         super(HbaManager, self).__init__(
             resource_class=Hba,
+            class_name='hba',
             session=partition.manager.session,
             parent=partition,
             base_uri='{}/hbas'.format(partition.uri),

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -71,6 +71,7 @@ class LparManager(BaseManager):
 
         super(LparManager, self).__init__(
             resource_class=Lpar,
+            class_name='logical-partition',
             session=cpc.manager.session,
             parent=cpc,
             base_uri='/api/logical-partitions',

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -182,7 +182,7 @@ class BaseManager(object):
     documented and may change incompatibly.
     """
 
-    def __init__(self, resource_class, session, parent, base_uri,
+    def __init__(self, resource_class, class_name, session, parent, base_uri,
                  oid_prop, uri_prop, name_prop, query_props,
                  list_has_name=True):
         # This method intentionally has no docstring, because it is internal.
@@ -190,6 +190,10 @@ class BaseManager(object):
         # Parameters:
         #   resource_class (class):
         #     Python class for the resources of this manager.
+        #     Must not be `None`.
+        #   class_name (string):
+        #     Resource class name (e.g. 'cpc' for a CPC resource). Must
+        #     be the value of the 'class' property of the resource.
         #     Must not be `None`.
         #   session (:class:`~zhmcclient.Session`):
         #     Session for this manager.
@@ -232,6 +236,7 @@ class BaseManager(object):
         # We want to surface precondition violations as early as possible,
         # so we test those that are not surfaced through the init code:
         assert resource_class is not None
+        assert class_name is not None
         assert session is not None
         assert base_uri is not None
         assert oid_prop is not None
@@ -240,6 +245,7 @@ class BaseManager(object):
         assert query_props is not None
 
         self._resource_class = resource_class
+        self._class_name = class_name
         self._session = session
         self._parent = parent
         self._base_uri = base_uri
@@ -260,6 +266,7 @@ class BaseManager(object):
         ret = (
             "{classname} at 0x{id:08x} (\n"
             "  _resource_class = {_resource_class!r}\n"
+            "  _class_name = {_class_name!r}\n"
             "  _session = {_session_classname} at 0x{_session_id:08x}\n"
             "  _parent = {_parent_classname} at 0x{_parent_id:08x}\n"
             "  _base_uri = {_base_uri!r}\n"
@@ -273,6 +280,7 @@ class BaseManager(object):
                 classname=self.__class__.__name__,
                 id=id(self),
                 _resource_class=self._resource_class,
+                _class_name=self._class_name,
                 _session_classname=self._session.__class__.__name__,
                 _session_id=id(self._session),
                 _parent_classname=self._parent.__class__.__name__,
@@ -524,6 +532,13 @@ class BaseManager(object):
         The Python class of the parent resource of this manager.
         """
         return self._resource_class
+
+    @property
+    def class_name(self):
+        """
+        The resource class name
+        """
+        return self._class_name
 
     @property
     def session(self):

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -60,6 +60,7 @@ class NicManager(BaseManager):
 
         super(NicManager, self).__init__(
             resource_class=Nic,
+            class_name='nic',
             session=partition.manager.session,
             parent=partition,
             base_uri='{}/nics'.format(partition.uri),

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -80,6 +80,7 @@ class PartitionManager(BaseManager):
 
         super(PartitionManager, self).__init__(
             resource_class=Partition,
+            class_name='partition',
             session=cpc.manager.session,
             parent=cpc,
             base_uri='/api/partitions',

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -46,15 +46,21 @@ class PortManager(BaseManager):
     :class:`~zhmcclient.Adapter` object).
     """
 
-    def __init__(self, adapter):
+    def __init__(self, adapter, port_type):
         # This function should not go into the docs.
         # Parameters:
         #   adapter (:class:`~zhmcclient.Adapter`):
         #     Adapter defining the scope for this manager.
+        #   port_type (string):
+        #     Type of Ports managed by this manager:
+        #     * `network`: Ports of a network adapter
+        #     * `storage`: Ports of a storage adapter
+        #     * None: Adapter family without ports
 
         super(PortManager, self).__init__(
             resource_class=Port,
             session=adapter.manager.session,
+            class_name='{}-port'.format(port_type) if port_type else None,
             parent=adapter,
             base_uri='',
             # TODO: Re-enable the following when unit/test_hba.py has been
@@ -66,6 +72,8 @@ class PortManager(BaseManager):
             query_props=[],
             list_has_name=False)
 
+        self._port_type = port_type
+
     @property
     def adapter(self):
         """
@@ -73,6 +81,17 @@ class PortManager(BaseManager):
         this manager.
         """
         return self._parent
+
+    @property
+    def port_type(self):
+        """
+        :term:`string`: Type of the Ports managed by this object:
+
+        * ``'network'`` - Ports of a network adapter
+        * ``'storage'`` - Ports of a storage adapter
+        * ``None`` - Adapter family without ports
+        """
+        return self._port_type
 
     @logged_api_call
     def list(self, full_properties=False, filter_args=None):

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -60,7 +60,7 @@ class PortManager(BaseManager):
         super(PortManager, self).__init__(
             resource_class=Port,
             session=adapter.manager.session,
-            class_name='{}-port'.format(port_type) if port_type else None,
+            class_name='{}-port'.format(port_type) if port_type else '',
             parent=adapter,
             base_uri='',
             # TODO: Re-enable the following when unit/test_hba.py has been

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -58,6 +58,7 @@ class VirtualFunctionManager(BaseManager):
         #     Partition defining the scope for this manager.
         super(VirtualFunctionManager, self).__init__(
             resource_class=VirtualFunction,
+            class_name='virtual-function',
             session=partition.manager.session,
             parent=partition,
             base_uri='{}/virtual-functions'.format(partition.uri),

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -70,6 +70,7 @@ class VirtualSwitchManager(BaseManager):
 
         super(VirtualSwitchManager, self).__init__(
             resource_class=VirtualSwitch,
+            class_name='virtual-switch',
             session=cpc.manager.session,
             parent=cpc,
             base_uri='/api/virtual-switches',


### PR DESCRIPTION
- Report CPC metrics: zhmc metrics cpc <CPC>
  This command provides metrics returned by the
  Metric Group 'cpc-usage-overview' for a not
  in DPM enabled CPC and provides metrics returned
  by the Metrics Group 'dpm-system-usage-overview'
  for a DPM enabled CPC.
- Report metrics of Partitions of a CPC:
  zhmc metrics partitions <CPC>
  This command provides metrics returned by the
  Metric Group 'partition-usage'.
- Report metrics of LPARs of a CPC:
  zhmc metrics lpars <CPC>
  This command provides metrics returned by the
  Metric Group 'logical-partition-usage'.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>