### PR TITLE
Fixed minor doc build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,9 @@ doc_build_dir := build_doc
 # Directory where Sphinx conf.py is located
 doc_conf_dir := docs
 
-# Paper format for the Sphinx LaTex/PDF builder.
-# Valid values: a4, letter
-doc_paper_format := a4
-
 # Documentation generator command
 doc_cmd := sphinx-build
-doc_opts := -v -d $(doc_build_dir)/doctrees -c $(doc_conf_dir) -D latex_paper_size=$(doc_paper_format) .
+doc_opts := -v -d $(doc_build_dir)/doctrees -c $(doc_conf_dir) .
 
 # Dependents for Sphinx documentation build
 doc_dependent_files := \

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,14 +49,19 @@ Released: not yet
 
 * In the mock support, the following resource properties are now auto-set if
   not specified in the input properties:
+
   - Cpc:
+
     - 'dpm-enabled' is auto-set to `False`, if not specified.
     - 'is-ensemble-member' is auto-set to `False`, if not specified.
     - 'status' is auto-set, if not specified, as follows: If the
       'dpm-enabled' property is `True`, it is set to 'active';
       otherwise it is set to 'operating'.
+
   - Partition: 'status' is auto-set to 'stopped', if not specified.
+
   - Lpar: 'status' is auto-set to 'not-activated', if not specified.
+
   - Adapter: 'status' is auto-set to 'active', if not specified.
 
 **Known Issues:**
@@ -150,7 +155,7 @@ Released: 2017-03-16
 * In the CLI, added support for command history. The history is stored in
   the file `~/.zhmc_history`.
 
-* In the CLI, changed the prompt of the interactive mode to `zhmc> `.
+* In the CLI, changed the prompt of the interactive mode to ``zhmc>``.
 
 * Added support for tolerating HTML content in the response, instead of JSON.
   An HTML formatted error message may be in the response for some 4xx and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -287,7 +287,7 @@ htmlhelp_basename = project+'_doc'
 
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+'papersize': 'a4paper',
 
 # The font size ('10pt', '11pt' or '12pt').
 #'pointsize': '10pt',


### PR DESCRIPTION
Please review and merge.

This change has no customer-visible effect, hence no entry in the change log.

Details:
- Fixed indentation errors in docs/changes.rst.
- Fixed "reference start-string without end-string" warnings in docs/changes.rst.
- Migrated from using the deprecated latex_paper_size option in the Makefile, to using the latex_elements['papersize'] definition in the docs/conf.py config file.
- Created an empty docs/_extra directory (with a dummy file in it) in order to get rid of the corresponding warning.