### PR TITLE
Fixes #113: CLI: Added logging support

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -81,6 +81,8 @@ Released: not yet
 * In the CLI, added a ``-p`` / ``--password`` option for specifying the HMC
   password (issue #225).
 
+* Added logging support to the zhmc CLI (issue #113).
+
 **Known Issues:**
 
 * See `list of open issues`_.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -125,6 +125,17 @@ commands::
                           json]]
                                       Output format (Default: table).
       -t, --timestats                 Show time statistics of HMC operations.
+      --log-dest [stderr|syslog|none]
+                                      Log destination for this command (Default:
+                                      none).
+      --log-level [error|warning|info|debug]
+                                      Log level for this command (Default:
+                                      warning).
+      --log-comp [api|hmc|all]        Logged components for this command. May be
+                                      specified multiple times (Default: all).
+      --syslog-facility [user|local0|local1|local2|local3|local4|local5|local6|local7]
+                                      Syslog facility when logging to the syslog
+                                      (Default: user).
       --version                       Show the version of this command and exit.
       --help                          Show this message and exit.
 
@@ -160,12 +171,16 @@ list can be picked with <TAB> or with the cursor keys. In the following
 examples, an underscore ``_`` is shown as the cursor::
 
     > --_
-        --host           Hostname or IP address of the HMC (Default: ZHMC_HOST environment variable).
-        --userid         Username for the HMC (Default: ZHMC_USERID environment variable).
-        --password       Password for the HMC (Default: ZHMC_PASSWORD environment variable).
-        --output-format  Output format (Default: table).
-        --timestats      Show time statistics of HMC operations.
-        --version        Show the version of this command and exit.
+        --host            Hostname or IP address of the HMC (Default: ZHMC_HOST environment variable).
+        --userid          Username for the HMC (Default: ZHMC_USERID environment variable).
+        --password        Password for the HMC (Default: ZHMC_PASSWORD environment variable).
+        --output-format   Output format (Default: table).
+        --timestats       Show time statistics of HMC operations.
+        --log-dest        Log destination for this command (Default: none).
+        --log-level       Log level for this command (Default: warning).
+        --log-comp        Logged components for this command. May be specified multiple times (Default: all).
+        --syslog-facility Syslog facility when logging to the syslog (Default: user).
+        --version         Show the version of this command and exit.
 
     > c_
        cpc    Command group for managing CPCs.
@@ -338,3 +353,79 @@ This output format can be selected by the ``-o`` or
 .. _`Wikipedia`: http://www.mediawiki.org/wiki/Help:Tables
 .. _`JSON`: http://json.org/example.html
 
+
+.. _`CLI logging`:
+
+CLI logging
+-----------
+
+The zhmc CLI supports logging to the standard error stream, and to the
+system log.
+
+By default, logging is turned off. It can be turned on via the global option
+``--log-dest`` which specifies the log destination:
+
+* ``stderr`` - Standard error stream of the zhmc command.
+* ``syslog`` - System log of the local system.
+
+The global option ``--log-level`` allows specifying the log level, which can be
+one of: ``error``, ``warning``, ``info``, ``debug``. This sets the
+corresponding log level for all Python loggers, and in case of logging to the
+system log will also set the syslog priorities accordingly.
+
+The Python loggers are selected via the global option ``--log-comp``, which can
+be specified multiple times and specifies a component (= Python logger) to be
+enabled for logging:
+
+* ``api`` - Enable the ``zhmcclient.api`` Python logger, which logs any API
+  calls into the zhmcclient library that are made from the zhmc CLI.
+* ``hmc`` - Enable the ``zhmcclient.hmc`` Python logger, which logs the
+  interactions with the HMC.
+* ``all`` - Enable the root Python logger, which logs anything that is
+  propagated up to it. In case of the zhmc CLI, this will mostly be the
+  ``requests`` package.
+
+Logging to the system log
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When specifying the ``syslog`` log destination, the enabled Python loggers
+log to the system log of the local system.
+
+In order to see something in the system log, one has to understand how the
+log records are marked in terms of `facility` and `priority` and the
+corresponding matching of these markers in the syslog demon, and the
+mechanism that is used to write a record to the syslog needs to be enabled.
+
+The write mechanism used by the zhmc CLI depends on the platform, as follows:
+
+* On Linux: Via a Unix socket to ``/dev/log``
+* On OS-X: Via a Unix socket to ``/var/run/syslog``
+* On Windows: Via a UDP socket to ``localhost`` port 514
+
+The respective mechanism must be enabled on the platform for logging to work.
+If the required mechanism is not enabled on a system, the log record will
+simply be dropped silently.
+
+The `facility` used for each log record can be specified with the global option
+``--syslog-facility``, to be one of: ``user`` (default), ``local<N>`` with
+N=[0..7].
+
+This facility marker can be used in the configuration of the syslog demon on
+the local system to direct log records into different files.
+
+For example, on RHEL 7 and CentOS 7, the syslog demon's config file is
+``/etc/rsyslog.conf`` and may contain this::
+
+    #### RULES ####
+    *.info;mail.none;authpriv.none;cron.none                /var/log/messages
+
+The first string is a semicolon-separated list of ``<facility>.<priority>``
+markers, where ``*`` can be used for wildcarding. The first list item
+``*.info`` means that any facility with priority ``info`` or higher will match
+this line and will thus go into the ``/var/log/messages`` file.
+
+Because the zhmc CLI uses the ``debug`` log level, one can see that only
+if its corresponding priority is enabled in the syslog configuration::
+
+    #### RULES ####
+    *.debug;mail.none;authpriv.none;cron.none                /var/log/messages

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -125,14 +125,13 @@ commands::
                           json]]
                                       Output format (Default: table).
       -t, --timestats                 Show time statistics of HMC operations.
+      --log COMP=LEVEL,...            Set a component to a log level
+                                      (COMP: [api|hmc|all],
+                                       LEVEL: [error|warning|info|debug],
+                                       Default: all=warning).
       --log-dest [stderr|syslog|none]
                                       Log destination for this command (Default:
-                                      none).
-      --log-level [error|warning|info|debug]
-                                      Log level for this command (Default:
-                                      warning).
-      --log-comp [api|hmc|all]        Logged components for this command. May be
-                                      specified multiple times (Default: all).
+                                      stderr).
       --syslog-facility [user|local0|local1|local2|local3|local4|local5|local6|local7]
                                       Syslog facility when logging to the syslog
                                       (Default: user).
@@ -176,9 +175,8 @@ examples, an underscore ``_`` is shown as the cursor::
         --password        Password for the HMC (Default: ZHMC_PASSWORD environment variable).
         --output-format   Output format (Default: table).
         --timestats       Show time statistics of HMC operations.
-        --log-dest        Log destination for this command (Default: none).
-        --log-level       Log level for this command (Default: warning).
-        --log-comp        Logged components for this command. May be specified multiple times (Default: all).
+        --log             Set a component to a log level (COMP: [api|hmc|all], LEVEL: [error|warning|info|debug], Default: all=warning).
+        --log-dest        Log destination for this command (Default: stderr).
         --syslog-facility Syslog facility when logging to the syslog (Default: user).
         --version         Show the version of this command and exit.
 
@@ -362,20 +360,25 @@ CLI logging
 The zhmc CLI supports logging to the standard error stream, and to the
 system log.
 
-By default, logging is turned off. It can be turned on via the global option
-``--log-dest`` which specifies the log destination:
+By default, the zhmc CLI logs to the standard error stream. This can be changed
+via the global option ``--log-dest`` which specifies the log destination:
 
 * ``stderr`` - Standard error stream of the zhmc command.
 * ``syslog`` - System log of the local system.
+* ``none`` - No logging.
 
-The global option ``--log-level`` allows specifying the log level, which can be
-one of: ``error``, ``warning``, ``info``, ``debug``. This sets the
-corresponding log level for all Python loggers, and in case of logging to the
-system log will also set the syslog priorities accordingly.
+The global option ``--log`` allows specifying one or more combinations of log
+component and log level. For example, the command::
 
-The Python loggers are selected via the global option ``--log-comp``, which can
-be specified multiple times and specifies a component (= Python logger) to be
-enabled for logging:
+    $ zhmc --log hmc=debug,api=info ...
+
+sets log level ``debug`` for the ``hmc`` component, and log level ``info`` for
+the ``api`` component.
+
+Valid log levels are: ``error``, ``warning``, ``info``, ``debug``. In case of
+logging to the system log, this will also set the syslog priority accordingly.
+
+Valid log components are:
 
 * ``api`` - Enable the ``zhmcclient.api`` Python logger, which logs any API
   calls into the zhmcclient library that are made from the zhmc CLI.
@@ -383,7 +386,7 @@ enabled for logging:
   interactions with the HMC.
 * ``all`` - Enable the root Python logger, which logs anything that is
   propagated up to it. In case of the zhmc CLI, this will mostly be the
-  ``requests`` package.
+  ``requests`` package, plus the ``api`` and ``hmc`` components.
 
 Logging to the system log
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -36,6 +36,15 @@ REPL_PROMPT = u'zhmc> '  # Must be Unicode
 TABLE_FORMATS = ['table', 'plain', 'simple', 'psql', 'rst', 'mediawiki',
                  'html', 'latex']
 
+LOG_DESTINATIONS = ['stderr', 'syslog', 'none']
+
+LOG_LEVELS = ['error', 'warning', 'info', 'debug']
+
+LOG_COMPONENTS = ['api', 'hmc', 'all']
+
+SYSLOG_FACILITIES = ['user', 'local0', 'local1', 'local2', 'local3', 'local4',
+                     'local5', 'local6', 'local7']
+
 
 def abort_if_false(ctx, param, value):
     # pylint: disable=unused-argument


### PR DESCRIPTION
Please review and test.

So far, tested on RHEL 7.2 with stderr and syslog.

Further tests would be useful with the syslog destination on OS-X, Windows, and AIX.
The syslog must be enabled for the "debug" priority.

Example commands for testing:
```
zhmc -h 10.... -u .... --log-dest syslog --log all=debug session create
sudo tail -n 50 <your-syslog-file>
```
Verify that you got some zhmcclient debug log records in the syslog file.
Make sure your syslog configuration has the "debug" priority enabled, and use the correct syslog file for that.