### PR TITLE
[WIP] Fixes #176: CLI: Avoid extra password prompts and changed options to be one set

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,26 @@
 Change log
 ----------
 
+
+Version 0.19.0
+^^^^^^^^^^^^^^
+
+**Incompatible changes:**
+
+* Changed the way the CLI deals with global options when invoked in interactive
+  mode: Previously, each subcommand had its own set of options that were
+  defaulted from the options specified in the zhmc command line. Now, there is
+  only one set of options that is initially set from the zhmc command line,
+  and subsequently modified with the options specified for each subcommand.
+  This means options on subcommands are "remembered" for subsequent
+  subcommands. Related to issues #176 and #225.
+
+**Enhancements:**
+
+* In the interactive mode of the CLI, the password is now reused between
+  subcommands (issue #176).
+
+
 Version 0.18.0
 ^^^^^^^^^^^^^^
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -93,6 +93,12 @@ However, the zhmc shell will prompt for a password only once during its
 invocation, while the standalone command will prompt for a password every time.
 See also `Environment variables and avoiding password prompts`_.
 
+In interactive mode, there is only one set of general options. Therefore,
+any general options specified on an interactively typed subcommand modify
+that one set of options, and they are available as defaults to the next
+subcommand. Changing host, userid or password on a subcommand resets the
+session with the HMC and drives a new session creation.
+
 The internal commands ``:?``, ``:h``, or ``:help`` display general help
 information for external and internal commands:
 
@@ -336,7 +342,6 @@ command line. This can be done in either of two ways:
 
 The ZHMC_HOST, ZHMC_USERID, and ZHMC_PASSWORD environment variables act as
 defaults for the corresponding command line options.
-
 
 .. _`CLI commands`:
 

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -198,6 +198,7 @@ class CmdContext(object):
         return self._spinner
 
     def execute_cmd(self, cmd):
+
         if self._session is None:
             if self._host is None:
                 raise_click_exception("No HMC host provided",


### PR DESCRIPTION
Please review and merge.

Please pay particular attention to the fact that we now have only one set of options in interactive mode, so the options used by a subcommand are still in place for the next subcommand.