### PR TITLE
Fixes #228: Added support for 'error' field in 'job-results'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,8 @@ Released: not yet
 * Improved robustness of timestats tests by measuring the actual sleep time
   instead of going by the requested sleep time.
   
+* Added support for 'error' field in 'job-results' (fixes issue #228).
+
 **Enhancements:**
 
 * Improved the mock support by adding the typical attributes of its superclass


### PR DESCRIPTION
This improves the `HTTPError` that is raised for a job that completed in error, by also supporting the `error` field in the `job-results` object of the response. So far, only the `message` field was supported. The HMC API book is silent as to what the fields are on the `job-results` object when a job completes in error.

For more details, see the commit message.

Please review and merge.

