### PR TITLE
Fixes #225: CLI: Added -p/--password option

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,10 @@ Released: not yet
 
 **Incompatible changes:**
 
+* The password retrieval function that can optionally be passed to
+  ``Session()`` has changed its interface; it is now being called with host and
+  userid. Related to issue #225.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -73,6 +77,9 @@ Released: not yet
   options, that allow skipping confirmation prompts.
 
 * Added OS-X as a test environment to the Travis CI setup.
+
+* In the CLI, added a ``-p`` / ``--password`` option for specifying the HMC
+  password (issue #225).
 
 **Known Issues:**
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,9 @@ Released: not yet
 
 * Fixed in the CLI that the spinner character was part of the output.
 
+* Improved robustness of timestats tests by measuring the actual sleep time
+  instead of going by the requested sleep time.
+  
 **Enhancements:**
 
 * Improved the mock support by adding the typical attributes of its superclass

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -119,6 +119,8 @@ commands::
                                       ZHMC_HOST environment variable).
       -u, --userid TEXT               Username for the HMC (Default: ZHMC_USERID
                                       environment variable).
+      -p, --password TEXT             Password for the HMC (Default: ZHMC_PASSWORD
+                                      environment variable).
       -o, --output-format [[table|plain|simple|psql|rst|mediawiki|html|latex|
                           json]]
                                       Output format (Default: table).
@@ -160,6 +162,7 @@ examples, an underscore ``_`` is shown as the cursor::
     > --_
         --host           Hostname or IP address of the HMC (Default: ZHMC_HOST environment variable).
         --userid         Username for the HMC (Default: ZHMC_USERID environment variable).
+        --password       Password for the HMC (Default: ZHMC_PASSWORD environment variable).
         --output-format  Output format (Default: table).
         --timestats      Show time statistics of HMC operations.
         --version        Show the version of this command and exit.
@@ -213,12 +216,12 @@ Bash tab completion for zhmc is used like any other bash tab completion::
 Environment variables and avoiding password prompts
 ---------------------------------------------------
 
-The zhmc CLI has command line options for specifying the HMC host and the HMC
-userid to be used. For security reasons, it does not have a command line option
-for specifying the password of the HMC userid.
+The zhmc CLI has command line options for specifying the HMC host, userid and
+password to be used.
 
 If the HMC operations performed by a particular zhmc command require a
-password, the password is prompted for (in both modes of operation)::
+password, and the password is not specified otherwise, the password is prompted
+for (in both modes of operation)::
 
       $ zhmc -h zhmc.example.com -u hmcuser cpc list
       Enter password: <password>
@@ -231,11 +234,14 @@ password, no password is prompted for::
       . . . <information about this HMC>
 
 For script integration, it is important to have a way to avoid the interactive
-password prompt. This can be done by storing the session-id string returned by
-the HMC when logging on, in an environment variable.
+password prompt, and still not being forced to specify the password on the
+command line. This can be done in either of two ways:
 
-The ``zhmc`` command supports a ``session create`` (sub-)command that outputs
-the (bash) shell commands to set all needed environment variables::
+* by storing the session-id string returned by the HMC when logging on, in an
+  environment variable.
+
+  The ``zhmc`` command supports a ``session create`` (sub-)command that outputs
+  the (bash) shell commands to set all needed environment variables::
 
       $ zhmc -h zhmc.example.com -u hmcuser session create
       Enter password: <password>
@@ -243,9 +249,9 @@ the (bash) shell commands to set all needed environment variables::
       export ZHMC_USERID=hmcuser
       export ZHMC_SESSION_ID=<session-id>
 
-This ability can be used to set those environment variables and thus to persist
-the session-id in the shell environment, from where it will be used in
-any subsequent zhmc commands::
+  This ability can be used to set those environment variables and thus to
+  persist the session-id in the shell environment, from where it will be used
+  in any subsequent zhmc commands::
 
       $ eval $(zhmc -h zhmc.example.com -u hmcuser session create)
       Enter password: <password>
@@ -258,21 +264,18 @@ any subsequent zhmc commands::
       $ zhmc cpc list
       . . . <list of CPCs managed by this HMC>
 
-As you can see from this example, the password is only prompted for when
-creating the session, and the session-id stored in the shell environment is
-utilized in the ``zhmc cpc list`` command, avoiding another password prompt.
+  As you can see from this example, the password is only prompted for when
+  creating the session, and the session-id stored in the shell environment is
+  utilized in the ``zhmc cpc list`` command, avoiding another password prompt.
 
-Using the session-id from the environment is also a performance improvement,
-because it avoids the HMC Logon operation that otherwise would take place.
+  Using the session-id from the environment is also a performance improvement,
+  because it avoids the HMC Logon operation that otherwise would take place.
 
-We believe that storing passwords in shell scripting environments should be
-avoided for security reasons, and using the session-id from the ZHMC_SESSION_ID
-environment variable should be a reasonable compromise between security
-and convenience.
+* by storing the HMC password in the ZHMC_PASSWORD environment variable.
 
-The ZHMC_HOST and ZHMC_USERID environment variables act as defaults for the
-corresponding command line options.
-
+The ZHMC_HOST, ZHMC_USERID, and ZHMC_PASSWORD environment variables act as
+defaults for the corresponding command line options.
+ 
 .. _`CLI commands`:
 
 CLI commands

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -34,6 +34,8 @@ Session
    :members:
    :special-members: __str__
 
+.. autofunction:: zhmcclient.get_password_interface
+
 
 .. _`Retry-timeout configuration`:
 

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -55,16 +55,25 @@ class InvalidOutputFormatError(click.ClickException):
 
 class CmdContext(object):
 
-    def __init__(self, host, userid, output_format, timestats, session_id,
-                 get_password):
+    def __init__(self, host, userid, password, output_format, timestats,
+                 session_id, get_password):
         self._host = host
         self._userid = userid
+        self._password = password
         self._output_format = output_format
         self._timestats = timestats
         self._session_id = session_id
         self._get_password = get_password
         self._session = None
         self._spinner = click_spinner.Spinner()
+
+    def __repr__(self):
+        ret = "CmdContext(at 0x%08x, host=%r, userid=%r, password=%r, " \
+            "output_format=%r, session_id=%r, session=%r, ...)" % \
+            (id(self), self._host, self._userid,
+             '...' if self._password else None, self._output_format,
+             self._session_id, self._session)
+        return ret
 
     @property
     def host(self):
@@ -130,13 +139,9 @@ class CmdContext(object):
         if self._session is None:
             if self._host is None:
                 raise click.ClickException("No HMC host provided")
-            if self._session_id is not None:
-                self._session = zhmcclient.Session(
-                    self._host, self._userid, session_id=self._session_id,
-                    get_password=self._get_password)
-            else:
-                self._session = zhmcclient.Session(
-                    self._host, self._userid, get_password=self._get_password)
+            self._session = zhmcclient.Session(
+                self._host, self._userid, self._password,
+                session_id=self._session_id, get_password=self._get_password)
         if self.timestats:
             self._session.time_stats_keeper.enable()
         self.spinner.start()


### PR DESCRIPTION
Please review and merge.

Note that we now have both ZHMC_PASSWORD and ZHMC_SESSION_ID as environment variables, and either can be used to avoid the password prompt and use of the new password option. Maybe we need to clean that up a bit.

Details:
- Added a `-p` / `--password` option to specify the HMC password.
- Changed interface to password retrieval function invoked by 'Session'; it now has host and userid as arguments. This needed to be done because host and userid were passed by closure, while now they are passed explicitly. This also helps when users start using this feature.
- Added a `__repr__()` function for `CmdContext`, for better debugging.