### PR TITLE
Improved robustness of timestats unit tests.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,9 @@ Released: not yet
 
 * Fixed in the CLI that the spinner character was part of the output.
 
+* Improved robustness of timestats tests by measuring the actual sleep time
+  instead of going by the requested sleep time.
+  
 **Enhancements:**
 
 * Improved the mock support by adding the typical attributes of its superclass


### PR DESCRIPTION
This fixes some recent errors in Travis, e.g.:
* In PR #230 for Python 2 on OS-X: https://travis-ci.org/zhmcclient/python-zhmcclient/jobs/217215232
* In PR #227 for Python 3 on OS-X: https://travis-ci.org/zhmcclient/python-zhmcclient/jobs/217216057

Please review and merge.

Details:
- Measured the actual sleep time instead of using the requested sleep time.
- Added unit tests for average, min and max time.