### PR TITLE
Fixed package dependencies for minimum pkg level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,12 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+#  - "pypy"        # PyPy 2.5.0, Python 2.7.8
+  - "pypy-5.3.1"  # PyPy 5.3.1, Python 2.7.10
+#  - "pypy3"       # PyPy 2.4.0, Python 3.2.5 -> pip not supported
+# TODO: Find out which pypy3 string will work:
+#  - "pypy3-5.3.1" # PyPy 5.3.1, Python 3.3.?
+#  - "pypy3.3-5.3.1" # PyPy 5.3.1, Python 3.3.?
 os:
   - linux
 env:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
 # Environment variables:
 #   PYTHON_CMD: Python command to use (OS-X needs to distinguish Python 2/3)
 #   PIP_CMD: Pip command to use (OS-X needs to distinguish Python 2/3)
+#   PACKAGE_LEVEL: minimum/latest - Level of Python dependent packages to use
 # Additional prerequisites for running this Makefile are installed by running:
 #   make develop
 # ------------------------------------------------------------------------------
@@ -36,12 +37,10 @@ ifndef PACKAGE_LEVEL
   PACKAGE_LEVEL := latest
 endif
 ifeq ($(PACKAGE_LEVEL),minimum)
-  pip_constraint_opts := -c minimum-constraints.txt
-  pip_upgrade_opts := "pip >=8.0.0"
+  pip_level_opts := -c minimum-constraints.txt
 else
   ifeq ($(PACKAGE_LEVEL),latest)
-    pip_constraint_opts :=
-    pip_upgrade_opts := pip --upgrade
+    pip_level_opts := --upgrade
   else
     $(error Error: Invalid value for PACKAGE_LEVEL variable: $(PACKAGE_LEVEL))
   endif
@@ -168,14 +167,16 @@ help:
 
 .PHONY: _pip
 _pip:
-	@echo 'Installing/upgrading pip and setuptools with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
-	$(PIP_CMD) install $(pip_upgrade_opts)
-	$(PIP_CMD) install $(pip_constraint_opts) setuptools
+	@echo 'Installing/upgrading pip, setuptools and wheel with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
+	$(PIP_CMD) install --upgrade pip
+	$(PIP_CMD) install $(pip_level_opts) pip
+	$(PIP_CMD) install $(pip_level_opts) setuptools
+	$(PIP_CMD) install $(pip_level_opts) wheel
 
 .PHONY: develop
 develop: _pip
 	@echo 'Installing runtime and development requirements with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
-	$(PIP_CMD) install $(pip_constraint_opts) --upgrade -r dev-requirements.txt
+	$(PIP_CMD) install $(pip_level_opts) -r dev-requirements.txt
 	@echo '$@ done.'
 
 .PHONY: build
@@ -250,7 +251,7 @@ check: pylint.log flake8.log
 .PHONY: install
 install: _pip
 	@echo 'Installing runtime requirements with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
-	$(PIP_CMD) install $(pip_constraint_opts) --upgrade .
+	$(PIP_CMD) install $(pip_level_opts) .
 	$(PYTHON_CMD) -c "import zhmcclient; print('Import: ok')"
 	@echo 'Done: Installed $(package_name) into current Python environment.'
 	@echo '$@ done.'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,41 +4,102 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
+# Make sure that the package versions in minimum-constraints.txt are also
+# the minimum versions required in requirements.txt and dev-requirements.txt.
+
+# Runtime dependencies:
 -r requirements.txt
 
 # Unit test:
-pytest>=3.0.0 # MIT
-pytest-cov>=2.0.0 # BSD
+pytest>=3.0.5 # MIT
+pytest-cov>=2.4.0 # BSD
+python-coveralls>=2.9.0 # Apache-2.0
+coverage>=4.0.3 # Apache-2.0
 mock>=2.0.0 # BSD
-requests-mock>=1.0.0 # Apache-2.0
-testfixtures>=4.0.0 # Apache-2.0
+requests-mock>=1.2.0 # Apache-2.0
+testfixtures>=4.13.3 # Apache-2.0
 
 # Sphinx:
-# Note: The ordereddict package is a backport of collections.OrderedDict
-#       to Python 2.6 and earlier. OrderedDict is needed by GitPython, which
-#       is needed by sphinx-git.
 Sphinx>=1.5.1 # BSD
-ordereddict>=1.0 ; python_version < '2.7' # MIT
-GitPython>=2.0.6 # BSD
 sphinx-git>=10.0.0 # GPL
+GitPython>=2.1.1 # BSD
 
 # PyLint:
-# Astroid is used by Pylint. Astroid 1.3 and above, and Pylint 1.4
-# and above no longer work with Python 2.6, and have been removed
-# from Pypi in 2/2016 after being available for some time.
-# Therefore, we cannot use Pylint under Python 2.6.
-# Also, Pylint does not support Python 3.
-astroid>=1.0.0 ; python_version == '2.7'
-pylint>=1.0.0 ; python_version == '2.7'
+pylint>=1.6.4 ; python_version == '2.7'
+astroid>=1.4.9 ; python_version == '2.7' # from pylint
 
 # Flake8:
-flake8>=2.0 # MIT
+flake8>=3.2.1 # MIT
 
 # Twine: Needed for uploading to Pypi
-twine>=1.0.1 # Apache-2.0
+twine>=1.8.1 # Apache-2.0
 
-# Jupyter Notebook
+# Jupyter Notebook:
 jupyter>=1.0.0 # BSD
 
 # Examples:
-PyYAML>=3.10 # MIT
+PyYAML>=3.12 # MIT
+
+# Indirect dependencies:
+alabaster>=0.7.9
+appnope>=0.1.0 ; sys_platform == "darwin" # from ipython
+args>=0.1.0
+Babel>=2.3.4
+backports-abc>=0.5
+backports.functools-lru-cache>=1.3
+backports.shutil-get-terminal-size>=1.0.0
+bleach>=1.5.0
+certifi>=2016.9.26
+clint>=0.5.1
+configparser>=3.5.0
+docutils>=0.13.1
+entrypoints>=0.2.2
+enum34>=1.1.6
+funcsigs>=1.0.2 ; python_version < '3.3' # from mock
+functools32>=3.2.3.post2 ; python_version == '2.7'
+gitdb2>=2.0.0
+html5lib>=0.9999999
+imagesize>=0.7.1
+ipykernel>=4.5.2
+ipython>=5.1.0
+ipython-genutils>=0.1.0
+ipywidgets>=5.2.2
+isort>=4.2.5
+Jinja2>=2.8
+jsonschema>=2.5.1
+jupyter-client>=4.4.0
+jupyter-console>=5.0.0
+jupyter-core>=4.2.1
+lazy-object-proxy>=1.2.2
+MarkupSafe>=0.23
+mccabe>=0.5.3
+mistune>=0.7.3
+nbconvert>=5.0.0
+nbformat>=4.2.0
+nose>=1.3.7
+notebook>=4.3.1
+numpy>=1.11.3
+pandocfilters>=1.4.1
+pathlib2>=2.1.0
+pexpect>=4.2.1
+pickleshare>=0.7.4
+pkginfo>=1.4.1
+ptyprocess>=0.5.1
+py>=1.4.32
+pycodestyle>=2.2.0
+pyflakes>=1.3.0
+Pygments>=2.1.3
+pytz>=2016.10
+pyzmq>=16.0.2
+qtconsole>=4.2.1
+requests-toolbelt>=0.7.0
+simplegeneric>=0.8.1
+singledispatch>=3.4.0.3
+smmap2>=2.0.1
+snowballstemmer>=1.2.1
+terminado>=0.6
+testpath>=0.3
+tornado>=4.4.2
+traitlets>=4.3.1
+widgetsnbextension>=1.2.6
+wrapt>=1.10.8

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -50,6 +50,11 @@ Released: not yet
   
 * Added support for 'error' field in 'job-results' (fixes issue #228).
 
+* Fixed version mismatches in CI test environment when testing with
+  the minimum package level by consistently using the latest released
+  packages as of zhmcclient v0.9.0 (2016-12-27). This caused an increase
+  in versions of packages needed for the runtime.
+
 **Enhancements:**
 
 * Improved the mock support by adding the typical attributes of its superclass

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -7,48 +7,134 @@
 # (see zhmcclient issue #199 as one example where a minimum version was
 # missing).
 
-# Direct dependencies for runtime:
+# The versions specified in this file were the latest versions released on Pypi
+# as of zhmcclient v0.9.0 (2016-12-27, see Travis CI run #576
+# https://travis-ci.org/zhmcclient/python-zhmcclient/builds/186986898).
 
-setuptools===17.0
-six===1.9.0
-pbr===1.8.0
-requests===2.10.0
-decorator===4.0.0
-tabulate===0.7.1
-progressbar2===3.5.0
-click===6.0
-click-spinner===0.1.7
+# Make sure that the package versions in minimum-constraints.txt are also
+# the minimum versions required in requirements.txt and dev-requirements.txt.
+
+# Note: New dependent packages for current version of setuptools that are not
+# in the specified version fo setuptools. They are installed into virtual
+# environments default (due to using the latest setuptools version).
+# Ideally, these packages would be removed when testing the minimum package
+# level, but probably they don't hurt:
+#   appdirs (1.4.3) # from setuptools
+#   packaging (16.8) # from setuptools
+#   pyparsing (2.2.0) # from packaging
+
+# Note: New dependent packages that came in after the original definition of
+# the dependents (as of 2017-04-11). They should not be installed when
+# testing with the minimum package level (and they will be pulled in with their
+# latest versions automatically when testing with the latest package level):
+#   python-dateutil (2.6.0)
+#   scandir (1.5)
+#   webencodings (0.5.1)
+
+
+# Dependencies for installation with Pip:
+
+pip===9.0.1
+setuptools===30.0.0
+wheel===0.29.0
+
+
+# Dependencies for runtime (must be consistent with requirements.txt)
+
+click===6.6
 click-repl===0.1.0
-stomp.py===4.0.0
+click-spinner===0.1.6
+decorator===4.0.10
+pbr===1.10.0
+progressbar2===3.12.0
+prompt_toolkit===1.0.9 # from click-repl
+python-utils===2.0.1 # from progressbar2
+requests===2.12.4
+six===1.10.0
+stomp.py===4.1.15
+tabulate===0.7.7
+wcwidth===0.1.7 # from prompt_toolkit
 
-# Indirect dependencies for runtime:
 
-# From click-repl
-prompt_toolkit===1.0.0
+# Dependencies for development (must be consistent with dev-requirements.txt)
 
-# From prompt_toolkit
-wcwidth===0.1.6
-
-# Direct dependencies for development:
-
-pytest===3.0.0
-pytest-cov===2.0.0
-mock===2.0.0
-requests-mock===1.0.0
-testfixtures===4.0.0
-
-Sphinx===1.5.1
-ordereddict===1.0 ; python_version < '2.7'
-GitPython===2.0.6
-sphinx-git===10.0.0
-
-astroid===1.0.0 ; python_version == '2.7'
-pylint===1.0.0 ; python_version == '2.7'
-
-flake8===2.0
-
-twine===1.0.1
-
+alabaster===0.7.9
+appnope===0.1.0 ; sys_platform == "darwin" # from ipython
+args===0.1.0
+astroid===1.4.9 ; python_version == '2.7' # from pylint
+Babel===2.3.4
+backports-abc===0.5
+backports.functools-lru-cache===1.3
+backports.shutil-get-terminal-size===1.0.0
+bleach===1.5.0
+certifi===2016.9.26
+click-repl===0.1.0
+clint===0.5.1
+configparser===3.5.0
+coverage===4.0.3
+docutils===0.13.1
+entrypoints===0.2.2
+enum34===1.1.6
+flake8===3.2.1
+funcsigs===1.0.2 ; python_version < '3.3' # from mock
+functools32===3.2.3.post2 ; python_version == '2.7'
+gitdb2===2.0.0
+GitPython===2.1.1
+html5lib===0.9999999
+imagesize===0.7.1
+ipykernel===4.5.2
+ipython===5.1.0
+ipython-genutils===0.1.0
+ipywidgets===5.2.2
+isort===4.2.5
+Jinja2===2.8
+jsonschema===2.5.1
 jupyter===1.0.0
-
-PyYAML===3.10
+jupyter-client===4.4.0
+jupyter-console===5.0.0
+jupyter-core===4.2.1
+lazy-object-proxy===1.2.2
+MarkupSafe===0.23
+mccabe===0.5.3
+mistune===0.7.3
+mock===2.0.0
+nbconvert===5.0.0
+nbformat===4.2.0
+nose===1.3.7
+notebook===4.3.1
+numpy===1.11.3
+pandocfilters===1.4.1
+pathlib2===2.1.0
+pexpect===4.2.1
+pickleshare===0.7.4
+pkginfo===1.4.1
+progressbar2===3.12.0
+ptyprocess===0.5.1
+py===1.4.32
+pycodestyle===2.2.0
+pyflakes===1.3.0
+Pygments===2.1.3
+pylint===1.6.4 ; python_version == '2.7'
+pytest===3.0.5
+pytest-cov===2.4.0
+python-coveralls===2.9.0
+pytz===2016.10
+PyYAML===3.12
+pyzmq===16.0.2
+qtconsole===4.2.1
+requests-mock===1.2.0
+requests-toolbelt===0.7.0
+simplegeneric===0.8.1
+singledispatch===3.4.0.3
+smmap2===2.0.1
+snowballstemmer===1.2.1
+Sphinx===1.5.1
+sphinx-git===10.0.0
+terminado===0.6
+testfixtures===4.13.3
+testpath===0.3
+tornado===4.4.2
+traitlets===4.3.1
+twine===1.8.1
+widgetsnbextension===1.2.6
+wrapt===1.10.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,24 +4,20 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-# Direct dependencies:
+# Make sure that the package versions in minimum-constraints.txt are also
+# the minimum versions required in requirements.txt and dev-requirements.txt.
 
-setuptools>=17.0 # Python Software Foundation
-six>=1.9.0 # MIT
-pbr>=1.8.0 # Apache-2.0
-requests>=2.10.0 # Apache-2.0
-decorator>=4.0.0 # new BSD
-tabulate>=0.7.1 # MIT
-progressbar2>=3.5.0 # BSD
-click>=6.0 # BSD
-click-spinner>=0.1.7 # MIT
+# Direct and indirect dependencies (except pip, setuptools, wheel):
+click>=6.6 # BSD
 click-repl>=0.1.0 # MIT
-stomp.py>=4.0.0 # Apache
-
-# Indirect dependencies:
-
-# From click-repl
-prompt_toolkit>=1.0.0 # BSD
-
-# From prompt_toolkit
-wcwidth>=0.1.6 # MIT
+click-spinner>=0.1.6 # MIT
+decorator>=4.0.10 # new BSD
+pbr>=1.10.0 # Apache-2.0
+progressbar2>=3.12.0 # BSD
+prompt_toolkit>=1.0.9 # BSD, from click-repl
+python-utils>=2.0.1 # BSD, from progressbar2
+requests>=2.12.4 # Apache-2.0
+six>=1.10.0 # MIT
+stomp.py>=4.1.15 # Apache
+tabulate>=0.7.7 # MIT
+wcwidth>=0.1.7 # MIT, from prompt_toolkit


### PR DESCRIPTION
Please review and merge if the test runs succeed.

Background:

  There were many indirect package dependencies that were not
  listed in the requirements and version constraint files.
  This resulted in an install failure when testing with
  PACKAGE_LEVEL=minimum, because the specified old versions of
  the packages that were listed, were mixed with the latest
  versions of the packages that were not listed.

Details of changes:

- Added all missing package dependencies as of 2016-12-08, with
  their versions as of that date as a minimum.
- Changed the minimum versions of already existing package
  dependencies to the versions as of 2016-12-08. This resulted
  sometimes in increasing the minimum version, and sometimes in
  decreasing it.

Signed-off-by: Andreas Maier <maiera@de.ibm.com>