### PR TITLE
Mitigated issue with read retries and DELETE

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,12 @@ Released: not yet
 * Fixed that the defaults for memory for the ``zhmc partition create`` command
   were ignored (issue #246).
 
+* The default values for the retra / timeout configuration for a session has
+  been changed to disable read retries and to set the read timeout to 1 hour.
+  This has been done in order to mitigate the behavior of the 'requests' module
+  to retry HTTP methods even if they are not idempotent (e.g. DELETE).
+  This is a short term mitigation for issue #249.
+
 **Enhancements:**
 
 * Added content to the "Concepts" chapter in the documentation.

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -47,12 +47,24 @@ DEFAULT_CONNECT_RETRIES = 3
 #: Default HTTP read timeout in seconds,
 #: if not specified in the ``retry_timeout_config`` init argument to
 #: :class:`~zhmcclient.Session`.
-DEFAULT_READ_TIMEOUT = 300
+#:
+#: Note: The default value for this parameter has been increased to a large
+#: value in order to mitigate the behavior of the 'requests' module to
+#: retry HTTP methods even if they are not idempotent (e.g. DELETE).
+#: See zhmcclient `issue #249
+#: <https://github.com/zhmcclient/python-zhmcclient/issues/249>`_.
+DEFAULT_READ_TIMEOUT = 3600
 
 #: Default number of HTTP read retries,
 #: if not specified in the ``retry_timeout_config`` init argument to
 #: :class:`~zhmcclient.Session`.
-DEFAULT_READ_RETRIES = 3
+#:
+#: Note: The default value for this parameter has been set to 0 in order to
+#: mitigate the behavior of the 'requests' module to retry HTTP methods even if
+#: they are not idempotent (e.g. DELETE).
+#: See zhmcclient `issue #249
+#: <https://github.com/zhmcclient/python-zhmcclient/issues/249>`_.
+DEFAULT_READ_RETRIES = 0
 
 #: Default max. number of HTTP redirects,
 #: if not specified in the ``retry_timeout_config`` init argument to


### PR DESCRIPTION
This PR mitigates issue #249. A final fix may or may not come, so this PR should be integrated in any case.

Please review and merge.

Details:
- This change sets the default values for the retry / timeout  configuration to read_timeout=3600 and read_retries=0. This  was needed in order to help with the issue that the 'requests' module re-requests a DELETE request another time if the first request is being processed but times out on the read timeout because it takes longer. The Delete Partition operation is such a candidate, at least when the partition got many NICs added and was started and stopped.