### PR TITLE
Fixes #253: Fixed stale name-to-URI cache and other improvements

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,9 +43,34 @@ Released: not yet
   In addition, read retries are now restricted to HTTP GET methods, in case
   the user enabled read retries. See issue #249.
 
+* Fixed that resource creation, deletion, and resource property updating now
+  properly updates the resource name-to-URI cache in the zhmcclient that is
+  maintained in the `*Manager` objects. As part of that, the `BaseManager`
+  init function got an additional required argument `session`, but because
+  creation of manager objects is not part of the external API, this should not
+  affect users. See issue #253.
+
 **Enhancements:**
 
 * Added content to the "Concepts" chapter in the documentation.
+
+* The `update_properties()` method of all Python resource objects now also
+  updates the properties of that Python resource object with the properties
+  provided by the user (in addition to issuing the corresponding Update
+  Properties HMC operation. This was done because that is likely the
+  expectation of users, and we already store user-provided properties in Python
+  resource objects when creating resources so it is now consistent with that.
+  This came up as part of issue #253.
+
+* As part of fixing the name-to-URI cache, a new attribute
+  `name_uri_cache_timetolive` was added to class `RetryTimeoutConfig`, which
+  allows controlling after what time the name-to-URI cache is automatically
+  invalidated. The default for that is set in a new
+  `DEFAULT_NAME_URI_CACHE_TIMETOLIVE` constant. Also, the `*Manager` classes
+  now have a new method `invalidate_name_uri_cache()` which can be used to
+  manually invalidate the name-to-URI cache, for cases where multiple parties
+  (besides the current zhmcclient instance) change resources on the HMC.
+  This came up as part of issue #253.
 
 **Known issues:**
 

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -23,7 +23,7 @@ import unittest
 import time
 from collections import OrderedDict
 
-from zhmcclient import BaseResource, BaseManager
+from zhmcclient import BaseResource, BaseManager, Session
 
 
 class MyResource(BaseResource):
@@ -47,10 +47,11 @@ class MyManager(BaseManager):
 
     # This init method is not part of the external API, so this testcase may
     # need to be updated if the API changes.
-    def __init__(self, parent=None):
+    def __init__(self, session):
         super(MyManager, self).__init__(
             resource_class=MyResource,
-            parent=parent,
+            session=session,
+            parent=None,  # a top-level resource
             uri_prop='fake-uri-prop',
             name_prop='fake-name-prop',
             query_props=['qp1', 'qp2'])
@@ -68,7 +69,8 @@ class ResourceTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-        self.mgr = MyManager()
+        self.session = Session(host='fake-host')
+        self.mgr = MyManager(self.session)
         self.uri = "/api/resource/deadbeef-beef-beef-beef-deadbeefbeef"
         self.name = "fake-name"
         self.uri_prop = 'fake-uri-prop'  # same as in MyManager

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -100,6 +100,7 @@ class ActivationProfileManager(BaseManager):
 
         super(ActivationProfileManager, self).__init__(
             resource_class=ActivationProfile,
+            session=cpc.manager.session,
             parent=cpc,
             uri_prop='element-uri',
             name_prop='name',
@@ -184,6 +185,7 @@ class ActivationProfileManager(BaseManager):
                     if full_properties:
                         resource_obj.pull_full_properties()
 
+        self._name_uri_cache.update_from(resource_obj_list)
         return resource_obj_list
 
 
@@ -244,3 +246,6 @@ class ActivationProfile(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         self.manager.session.post(self.uri, body=properties)
+        self.properties.update(properties.copy())
+        if self.manager._name_prop in properties:
+            self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -30,6 +30,7 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'DEFAULT_MAX_REDIRECTS',
            'DEFAULT_OPERATION_TIMEOUT',
            'DEFAULT_STATUS_TIMEOUT',
+           'DEFAULT_NAME_URI_CACHE_TIMETOLIVE',
            'HMC_LOGGER_NAME',
            'API_LOGGER_NAME']
 
@@ -72,17 +73,34 @@ DEFAULT_READ_RETRIES = 0
 DEFAULT_MAX_REDIRECTS = 30
 
 #: Default timeout in seconds for waiting for completion of an asynchronous
-#: HMC operation. This is used as a default value in asynchronous methods on
+#: HMC operation,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+#:
+#: This is used as a default value in asynchronous methods on
 #: resource objects (e.g. :meth:`zhmcclient.Partition.start`), in the
 #: :meth:`zhmcclient.Job.wait_for_completion` method, and in the
 #: low level method :meth:`zhmcclient.Session.post`.
 DEFAULT_OPERATION_TIMEOUT = 3600
 
 #: Default timeout in seconds for waiting for completion of deferred status
-#: changes for LPARs. This is used as a default value in asynchronous methods
+#: changes for LPARs,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+#:
+#: This is used as a default value in asynchronous methods
 #: of the :class:`~zhmcclient.Lpar` class that change its status (e.g.
 #: :meth:`zhmcclient.Lpar.activate`)).
 DEFAULT_STATUS_TIMEOUT = 60
+
+#: Default time to the next automatic invalidation of the Name-URI cache of
+#: manager objects, in seconds since the last invalidation,
+#: if not specified in the ``retry_timeout_config`` init argument to
+#: :class:`~zhmcclient.Session`.
+#:
+#: The special value 0 means that no Name-URI cache is maintained (i.e. the
+#: caching is disabled).
+DEFAULT_NAME_URI_CACHE_TIMETOLIVE = 300
 
 #: Name of the Python logger that logs HMC operations.
 HMC_LOGGER_NAME = 'zhmcclient.hmc'

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -86,12 +86,11 @@ class CpcManager(BaseManager):
 
         super(CpcManager, self).__init__(
             resource_class=Cpc,
+            session=client.session,
             parent=None,
             uri_prop='object-uri',
             name_prop='name',
             query_props=query_props)
-
-        self._session = client.session
 
     @logged_api_call
     def list(self, full_properties=False, filter_args=None):
@@ -150,6 +149,7 @@ class CpcManager(BaseManager):
                     if full_properties:
                         resource_obj.pull_full_properties()
 
+        self._name_uri_cache.update_from(resource_obj_list)
         return resource_obj_list
 
 

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -70,6 +70,7 @@ class LparManager(BaseManager):
 
         super(LparManager, self).__init__(
             resource_class=Lpar,
+            session=cpc.manager.session,
             parent=cpc,
             uri_prop='object-uri',
             name_prop='name',
@@ -141,6 +142,7 @@ class LparManager(BaseManager):
                     if full_properties:
                         resource_obj.pull_full_properties()
 
+        self._name_uri_cache.update_from(resource_obj_list)
         return resource_obj_list
 
 

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -58,6 +58,7 @@ class NicManager(BaseManager):
 
         super(NicManager, self).__init__(
             resource_class=Nic,
+            session=partition.manager.session,
             parent=partition,
             uri_prop='element-uri',
             name_prop='name',
@@ -121,6 +122,8 @@ class NicManager(BaseManager):
                     resource_obj_list.append(resource_obj)
                     if full_properties:
                         resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
         return resource_obj_list
 
     @logged_api_call
@@ -168,7 +171,11 @@ class NicManager(BaseManager):
         # returned props should overwrite the input props:
         props = properties.copy()
         props.update(result)
-        return Nic(self, props['element-uri'], None, props)
+        name = props.get(self._name_prop, None)
+        uri = props[self._uri_prop]
+        nic = Nic(self, uri, name, props)
+        self._name_uri_cache.update(name, uri)
+        return nic
 
     @logged_api_call
     def nic_object(self, nic_id):
@@ -256,6 +263,8 @@ class Nic(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         self.manager.session.delete(self._uri)
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -283,4 +292,7 @@ class Nic(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        self.manager.session.post(self._uri, body=properties)
+        self.manager.session.post(self.uri, body=properties)
+        self.properties.update(properties.copy())
+        if self.manager._name_prop in properties:
+            self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -52,6 +52,7 @@ class PortManager(BaseManager):
 
         super(PortManager, self).__init__(
             resource_class=Port,
+            session=adapter.manager.session,
             parent=adapter,
             uri_prop='element-uri',
             name_prop='name',
@@ -122,6 +123,8 @@ class PortManager(BaseManager):
                     resource_obj_list.append(resource_obj)
                     if full_properties:
                         resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
         return resource_obj_list
 
 
@@ -183,4 +186,7 @@ class Port(BaseResource):
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        self.manager.session.post(self._uri, body=properties)
+        self.manager.session.post(self.uri, body=properties)
+        self.properties.update(properties.copy())
+        if self.manager._name_prop in properties:
+            self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -35,7 +35,7 @@ from ._logging import get_logger, logged_api_call
 from ._constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_CONNECT_RETRIES, \
     DEFAULT_READ_TIMEOUT, DEFAULT_READ_RETRIES, DEFAULT_MAX_REDIRECTS, \
     DEFAULT_OPERATION_TIMEOUT, DEFAULT_STATUS_TIMEOUT, \
-    HMC_LOGGER_NAME
+    DEFAULT_NAME_URI_CACHE_TIMETOLIVE, HMC_LOGGER_NAME
 
 __all__ = ['Session', 'Job', 'RetryTimeoutConfig', 'get_password_interface']
 
@@ -111,7 +111,8 @@ class RetryTimeoutConfig(object):
 
     def __init__(self, connect_timeout=None, connect_retries=None,
                  read_timeout=None, read_retries=None, max_redirects=None,
-                 operation_timeout=None, status_timeout=None):
+                 operation_timeout=None, status_timeout=None,
+                 name_uri_cache_timetolive=None):
         """
         For all parameters, `None` means that this object does not specify a
         value for the parameter, and that a default value should be used
@@ -155,6 +156,12 @@ class RetryTimeoutConfig(object):
             This timeout applies when waiting for the transition of the status
             of a resource to a desired status. The special value 0 means that
             no timeout is set.
+
+          name_uri_cache_timetolive (:term:`number`): Time to the next
+            automatic invalidation of the Name-URI cache of manager objects, in
+            seconds since the last invalidation. The special value 0 means
+            that no Name-URI cache is maintained (i.e. the caching is
+            disabled).
         """
         self.connect_timeout = connect_timeout
         self.connect_retries = connect_retries
@@ -163,13 +170,15 @@ class RetryTimeoutConfig(object):
         self.max_redirects = max_redirects
         self.operation_timeout = operation_timeout
         self.status_timeout = status_timeout
+        self.name_uri_cache_timetolive = name_uri_cache_timetolive
 
         # Read retries only for these HTTP methods:
         self.method_whitelist = {'GET'}
 
     _attrs = ('connect_timeout', 'connect_retries', 'read_timeout',
               'read_retries', 'max_redirects', 'operation_timeout',
-              'status_timeout', 'method_whitelist')
+              'status_timeout', 'name_uri_cache_timetolive',
+              'method_whitelist')
 
     def override_with(self, override_config):
         """
@@ -234,6 +243,7 @@ class Session(object):
         max_redirects=DEFAULT_MAX_REDIRECTS,
         operation_timeout=DEFAULT_OPERATION_TIMEOUT,
         status_timeout=DEFAULT_STATUS_TIMEOUT,
+        name_uri_cache_timetolive=DEFAULT_NAME_URI_CACHE_TIMETOLIVE,
     )
 
     def __init__(self, host, userid=None, password=None, session_id=None,

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -69,6 +69,7 @@ class VirtualSwitchManager(BaseManager):
 
         super(VirtualSwitchManager, self).__init__(
             resource_class=VirtualSwitch,
+            session=cpc.manager.session,
             parent=cpc,
             uri_prop='object-uri',
             name_prop='name',
@@ -141,6 +142,7 @@ class VirtualSwitchManager(BaseManager):
                     if full_properties:
                         resource_obj.pull_full_properties()
 
+        self._name_uri_cache.update_from(resource_obj_list)
         return resource_obj_list
 
 
@@ -254,3 +256,6 @@ class VirtualSwitch(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         self.manager.session.post(self.uri, body=properties)
+        self.properties.update(properties.copy())
+        if self.manager._name_prop in properties:
+            self.manager._name_uri_cache.update(self.name, self.uri)


### PR DESCRIPTION
Please review and merge.

Details:
* Fixed that resource creation, deletion, and resource property updating now properly updates the resource name-to-URI cache in the zhmcclient that is maintained in the `*Manager` objects. As part of that, the `BaseManager` init function got an additional required argument `session`, but because creation of manager objects is not part of the external API, this should not affect users. See issue #253.
* The `update_properties()` method of all Python resource objects now also updates the properties of that Python resource object with the properties provided by the user (in addition to issuing the corresponding Update Properties HMC operation. This was done because that is likely the expectation of users, and we already store user-provided properties in Python resource objects when creating resources so it is now consistent with that. This came up as part of issue #253.
* As part of fixing the name-to-URI cache, a new attribute `name_uri_cache_timetolive` was added to class `RetryTimeoutConfig`, which allows controlling after what time the name-to-URI cache is automatically invalidated. The default for that is set in a new `DEFAULT_NAME_URI_CACHE_TIMETOLIVE` constant. Also, the `*Manager` classes now have a new method `invalidate_name_uri_cache()` which can be used to manually invalidate the name-to-URI cache, for cases where multiple parties (besides the current zhmcclient instance) change resources on the HMC. This came up as part of issue #253.