### PR TITLE
Fixes #256: Fixes in unit tests for update_properties() and delete()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -53,6 +53,15 @@ Released: not yet
   creation of manager objects is not part of the external API, this should not
   affect users. See issue #253.
 
+* In the unit testcases for the `update_properties()` and `delete()` methods of
+  resource classes, fixed incorrect assumptions about their method return
+  values. See issue #256.
+
+* In the unit testcases for the `update_properties()` and `delete()` methods of
+  resource classes, fixed incorrectly returned response bodies for mocked
+  DELETE and POST (for update), and replaced that with status 204 (no content).
+  This came up as part of fixing issue #256.
+
 **Enhancements:**
 
 * Added content to the "Concepts" chapter in the documentation.

--- a/tests/unit/test_activation_profile.py
+++ b/tests/unit/test_activation_profile.py
@@ -195,12 +195,9 @@ class ActivationProfileTests(unittest.TestCase):
                   json=result)
             profiles = image_mgr.list(full_properties=False)
             profile = profiles[0]
-            m.post(
-                '/api/cpcs/fake-element-uri-id-1/image-activation-profiles/'
-                'LPAR1',
-                json=result)
-            status = profile.update_properties(properties={})
-            self.assertEqual(status, None)
+            m.post('/api/cpcs/fake-element-uri-id-1/image-activation-profiles/'
+                   'LPAR1', status_code=204)
+            profile.update_properties(properties={})
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -220,11 +220,8 @@ class AdapterTests(unittest.TestCase):
 
             adapters = adapter_mgr.list(full_properties=False)
             adapter = adapters[0]
-            m.delete(
-                "/api/adapters/fake-adapter-id-1",
-                json=result)
-            status = adapter.delete()
-            self.assertEqual(status, None)
+            m.delete("/api/adapters/fake-adapter-id-1", status_code=204)
+            adapter.delete()
 
     def test_update_properties(self):
         """
@@ -256,11 +253,8 @@ class AdapterTests(unittest.TestCase):
 
             adapters = adapter_mgr.list(full_properties=False)
             adapter = adapters[0]
-            m.post(
-                "/api/adapters/fake-adapter-id-1",
-                json=result)
-            status = adapter.update_properties(properties={})
-            self.assertEqual(status, None)
+            m.post("/api/adapters/fake-adapter-id-1", status_code=204)
+            adapter.update_properties(properties={})
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_hba.py
+++ b/tests/unit/test_hba.py
@@ -208,12 +208,9 @@ class HbaTests(unittest.TestCase):
         hbas = hba_mgr.list(full_properties=False)
         hba = hbas[0]
         with requests_mock.mock() as m:
-            result = {}
-            m.delete(
-                '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
-                json=result)
-            status = hba.delete()
-            self.assertEqual(status, None)
+            m.delete('/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                     status_code=204)
+            hba.delete()
 
     def test_update_properties(self):
         """
@@ -223,12 +220,9 @@ class HbaTests(unittest.TestCase):
         hbas = hba_mgr.list(full_properties=False)
         hba = hbas[0]
         with requests_mock.mock() as m:
-            result = {}
-            m.post(
-                '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
-                json=result)
-            status = hba.update_properties(properties={})
-            self.assertEqual(status, None)
+            m.post('/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                   status_code=204)
+            hba.update_properties(properties={})
 
     def test_reassign_port(self):
         """

--- a/tests/unit/test_lpar.py
+++ b/tests/unit/test_lpar.py
@@ -182,9 +182,8 @@ class LparTests(unittest.TestCase):
                 "job-status-code": 204,
                 "status": "complete"
             }
-            m.post(
-                "/api/logical-partitions/fake-lpar-id-1/operations/activate",
-                json=result)
+            m.post("/api/logical-partitions/fake-lpar-id-1/operations/"
+                   "activate", json=result)
             status = lpar.activate(wait_for_completion=False)
             self.assertEqual(status, result)
 
@@ -217,9 +216,8 @@ class LparTests(unittest.TestCase):
                 "job-status-code": 204,
                 "status": "complete"
             }
-            m.post(
-                "/api/logical-partitions/fake-lpar-id-1/operations/deactivate",
-                json=result)
+            m.post("/api/logical-partitions/fake-lpar-id-1/operations/"
+                   "deactivate", json=result)
             status = lpar.deactivate(wait_for_completion=False)
             self.assertEqual(status, result)
 

--- a/tests/unit/test_nic.py
+++ b/tests/unit/test_nic.py
@@ -208,12 +208,9 @@ class NicTests(unittest.TestCase):
         nics = nic_mgr.list(full_properties=False)
         nic = nics[0]
         with requests_mock.mock() as m:
-            result = {}
-            m.delete(
-                '/api/partitions/fake-part-id-1/nics/fake-nic-id-1',
-                json=result)
-            status = nic.delete()
-            self.assertEqual(status, None)
+            m.delete('/api/partitions/fake-part-id-1/nics/fake-nic-id-1',
+                     status_code=204)
+            nic.delete()
 
     def test_update_properties(self):
         """
@@ -223,12 +220,9 @@ class NicTests(unittest.TestCase):
         nics = nic_mgr.list(full_properties=False)
         nic = nics[0]
         with requests_mock.mock() as m:
-            result = {}
-            m.post(
-                '/api/partitions/fake-part-id-1/nics/fake-nic-id-1',
-                json=result)
-            status = nic.update_properties(properties={})
-            self.assertEqual(status, None)
+            m.post('/api/partitions/fake-part-id-1/nics/fake-nic-id-1',
+                   status_code=204)
+            nic.update_properties(properties={})
 
     def test_nic_object(self):
         """

--- a/tests/unit/test_partition.py
+++ b/tests/unit/test_partition.py
@@ -257,9 +257,8 @@ class PartitionTests(unittest.TestCase):
                 "job-status-code": 204,
                 "status": "complete"
             }
-            m.post(
-                "/api/partitions/fake-part-id-1/operations/start",
-                json=result)
+            m.post("/api/partitions/fake-part-id-1/operations/start",
+                   json=result)
             status = partition.start(wait_for_completion=False)
             self.assertEqual(status, result)
 
@@ -292,9 +291,8 @@ class PartitionTests(unittest.TestCase):
                 "job-status-code": 204,
                 "status": "complete"
             }
-            m.post(
-                "/api/partitions/fake-part-id-1/operations/stop",
-                json=result)
+            m.post("/api/partitions/fake-part-id-1/operations/stop",
+                   json=result)
             status = partition.stop(wait_for_completion=False)
             self.assertEqual(status, result)
 
@@ -323,9 +321,8 @@ class PartitionTests(unittest.TestCase):
 
             partitions = partition_mgr.list(full_properties=False)
             partition = partitions[0]
-            m.delete("/api/partitions/fake-part-id-1")
-            status = partition.delete()
-            self.assertEqual(status, None)
+            m.delete("/api/partitions/fake-part-id-1", status_code=204)
+            partition.delete()
 
     def test_delete_create_same_name(self):
         """
@@ -451,9 +448,8 @@ class PartitionTests(unittest.TestCase):
             result = {
                 'job-uri': '/api/jobs/fake-job-id-1'
             }
-            m.post(
-                "/api/partitions/fake-part-id-1/operations/scsi-dump",
-                json=result)
+            m.post("/api/partitions/fake-part-id-1/operations/scsi-dump",
+                   json=result)
             status = partition.dump_partition(
                 wait_for_completion=False, parameters={})
             self.assertEqual(status, result)
@@ -485,9 +481,8 @@ class PartitionTests(unittest.TestCase):
             result = {
                 'job-uri': '/api/jobs/fake-job-id-1'
             }
-            m.post(
-                "/api/partitions/fake-part-id-1/operations/psw-restart",
-                json=result)
+            m.post("/api/partitions/fake-part-id-1/operations/psw-restart",
+                   json=result)
             status = partition.psw_restart(wait_for_completion=False)
             self.assertEqual(status, result)
 
@@ -518,9 +513,8 @@ class PartitionTests(unittest.TestCase):
             result = {
                 'job-uri': '/api/jobs/fake-job-id-1'
             }
-            m.post(
-                "/api/partitions/fake-part-id-1/operations/mount-iso-image",
-                json=result)
+            m.post("/api/partitions/fake-part-id-1/operations/mount-iso-image",
+                   json=result)
             status = partition.mount_iso_image(properties={})
             self.assertEqual(status, None)
 
@@ -551,9 +545,8 @@ class PartitionTests(unittest.TestCase):
             result = {
                 'job-uri': '/api/jobs/fake-job-id-1'
             }
-            m.post(
-                "/api/partitions/fake-part-id-1/operations/unmount-iso-image",
-                json=result)
+            m.post("/api/partitions/fake-part-id-1/operations/"
+                   "unmount-iso-image", json=result)
             status = partition.unmount_iso_image()
             self.assertEqual(status, None)
 

--- a/tests/unit/test_port.py
+++ b/tests/unit/test_port.py
@@ -198,12 +198,9 @@ class PortTests(unittest.TestCase):
         ports = port_mgr.list(full_properties=False)
         port = ports[0]
         with requests_mock.mock() as m:
-            result = {}
-            m.post(
-                '/api/adapters/fake-adapter-id-1/storage-ports/0',
-                json=result)
-            status = port.update_properties(properties={})
-            self.assertEqual(status, None)
+            m.post('/api/adapters/fake-adapter-id-1/storage-ports/0',
+                   status_code=204)
+            port.update_properties(properties={})
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -316,7 +316,7 @@ class JobTests(unittest.TestCase):
                 'status': 'running',
             }
             m.get(self.job_uri, json=query_job_status_result)
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             job_status, op_result = job.check_for_completion()
 
@@ -339,7 +339,7 @@ class JobTests(unittest.TestCase):
                 # 'job-results' is optional and is omitted
             }
             m.get(self.job_uri, json=query_job_status_result)
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             job_status, op_result = job.check_for_completion()
 
@@ -365,7 +365,7 @@ class JobTests(unittest.TestCase):
                 'job-results': exp_op_result,
             }
             m.get(self.job_uri, json=query_job_status_result)
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             job_status, op_result = job.check_for_completion()
 
@@ -388,7 +388,7 @@ class JobTests(unittest.TestCase):
             }
 
             m.get(self.job_uri, json=query_job_status_result)
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             with self.assertRaises(HTTPError) as cm:
                 job_status, op_result = job.check_for_completion()
@@ -413,7 +413,7 @@ class JobTests(unittest.TestCase):
             }
 
             m.get(self.job_uri, json=query_job_status_result)
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             with self.assertRaises(HTTPError) as cm:
                 job_status, op_result = job.check_for_completion()
@@ -442,7 +442,7 @@ class JobTests(unittest.TestCase):
             }
 
             m.get(self.job_uri, json=query_job_status_result)
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             with self.assertRaises(HTTPError) as cm:
                 job_status, op_result = job.check_for_completion()
@@ -471,7 +471,7 @@ class JobTests(unittest.TestCase):
             }
 
             m.get(self.job_uri, json=query_job_status_result)
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             with self.assertRaises(HTTPError) as cm:
                 job_status, op_result = job.check_for_completion()
@@ -499,7 +499,7 @@ class JobTests(unittest.TestCase):
                 'job-results': exp_op_result,
             }
             m.get(self.job_uri, json=query_job_status_result)
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             op_result = job.wait_for_completion()
 
@@ -522,7 +522,7 @@ class JobTests(unittest.TestCase):
                       {'text': result_running_callback},
                       {'text': result_complete_callback},
                   ])
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             op_result = job.wait_for_completion()
 
@@ -542,7 +542,7 @@ class JobTests(unittest.TestCase):
                       {'text': result_running_callback},
                       {'text': result_complete_callback},
                   ])
-            m.delete(self.job_uri)
+            m.delete(self.job_uri, status_code=204)
 
             # Here we provoke a timeout, by setting the timeout to less than
             # the time it would take to return the completed job status.

--- a/tests/unit/test_virtual_function.py
+++ b/tests/unit/test_virtual_function.py
@@ -220,13 +220,9 @@ class VirtualFunctionTests(unittest.TestCase):
         vfs = vf_mgr.list(full_properties=False)
         vf = vfs[0]
         with requests_mock.mock() as m:
-            result = {}
-            m.delete(
-                '/api/partitions/fake-part-id-1/virtual-functions/'
-                'fake-vf-id-1',
-                json=result)
-            status = vf.delete()
-            self.assertEqual(status, None)
+            m.delete('/api/partitions/fake-part-id-1/virtual-functions/'
+                     'fake-vf-id-1', status_code=204)
+            vf.delete()
 
     def test_update_properties(self):
         """
@@ -236,13 +232,9 @@ class VirtualFunctionTests(unittest.TestCase):
         vfs = vf_mgr.list(full_properties=False)
         vf = vfs[0]
         with requests_mock.mock() as m:
-            result = {}
-            m.post(
-                '/api/partitions/fake-part-id-1/virtual-functions/'
-                'fake-vf-id-1',
-                json=result)
-            status = vf.update_properties(properties={})
-            self.assertEqual(status, None)
+            m.post('/api/partitions/fake-part-id-1/virtual-functions/'
+                   'fake-vf-id-1', status_code=204)
+            vf.update_properties(properties={})
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_virtual_switch.py
+++ b/tests/unit/test_virtual_switch.py
@@ -183,11 +183,8 @@ class VirtualSwitchTests(unittest.TestCase):
 
             vswitches = vswitch_mgr.list(full_properties=False)
             vswitch = vswitches[0]
-            m.post(
-                "/api/virtual-switches/fake-vswitch-id1",
-                json=result)
-            status = vswitch.update_properties(properties={})
-            self.assertEqual(status, None)
+            m.post("/api/virtual-switches/fake-vswitch-id1", status_code=204)
+            vswitch.update_properties(properties={})
 
     def test_get_connected_nics(self):
         """


### PR DESCRIPTION
Please review and merge.

Details:
- Fixed incorrect assumptions about their method return values. See issue #256.
- Fixed incorrectly returned response bodies for mocked DELETE and POST (for update), and replaced that with status 204 (no content). This came up as part of fixing issue #256.