### PR TITLE
Fixes #258: Fixed unconditional addition of ifl-processors in CLI

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,9 +27,12 @@ Released: not yet
 
 **Incompatible changes:**
 
-* Changed the default for number of IFL processors for the
-  ``zhmc partition create`` command from 0 to 1, so that now a partition can
-  be created with the defaults for any partition property options.
+* In the CLI, changed the default for number of processors for the
+  ``zhmc partition create`` command to create 1 IFL by default, if neither
+  IFLs nor CPs had been specified. Also, a specified number of 0 processors
+  is now passed on to the HMC (and rejected there) instead of being removed
+  by the CLI. This keeps the logic simpler and more understandable. See
+  also issue #258.
 
 **Deprecations:**
 

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -25,7 +25,6 @@ from ._cmd_cpc import find_cpc
 
 # Defaults for partition creation
 DEFAULT_IFL_PROCESSORS = 1
-DEFAULT_CP_PROCESSORS = 0
 DEFAULT_INITIAL_MEMORY_MB = 1024
 DEFAULT_MAXIMUM_MEMORY_MB = 1024
 DEFAULT_PROCESSOR_MODE = 'shared'
@@ -130,13 +129,12 @@ def partition_stop(cmd_ctx, cpc, partition):
 @click.option('--description', type=str, required=False,
               help='The description of the new partition.')
 @click.option('--cp-processors', type=int, required=False,
-              default=DEFAULT_CP_PROCESSORS,
               help='The number of general purpose (CP) processors. '
-              'Default: {}'.format(DEFAULT_CP_PROCESSORS))
+              'Default: No CP processors')
 @click.option('--ifl-processors', type=int, required=False,
-              default=DEFAULT_IFL_PROCESSORS,
               help='The number of IFL processors. '
-              'Default: {}'.format(DEFAULT_IFL_PROCESSORS))
+              'Default: {}, if no CP processors have been specified'.
+              format(DEFAULT_IFL_PROCESSORS))
 @click.option('--processor-mode', type=click.Choice(['dedicated', 'shared']),
               required=False, default=DEFAULT_PROCESSOR_MODE,
               help='The sharing mode for processors. '
@@ -365,11 +363,10 @@ def cmd_partition_create(cmd_ctx, cpc_name, options):
         # boot-device="none" is the default
         pass
 
-    # Handle that the HMC rejects CPs=0 if IFLs>0 and vice versa
-    if properties['ifl-processors'] == 0:
-        del properties['ifl-processors']
-    if properties['cp-processors'] == 0:
-        del properties['cp-processors']
+    # Default for the number of processors
+    if 'ifl-processors' not in properties and \
+            'cp-processors' not in properties:
+        properties['ifl-processors'] = DEFAULT_IFL_PROCESSORS
 
     try:
         new_partition = cpc.partitions.create(properties)


### PR DESCRIPTION
Please review and merge.

From the commit message:

This fixes issue #258, where a previous addition to the development version of v0.13.0 has caused the ifl-processors property to always be added to the Create Partition request, if the corresponding option had not been specified in the zhmc command line. Now, a default is only added if neither CPs nor IFLs are specified on the command line.

Also, in order to simplify the logic, if the IFL or CP option is specified with 0, that is no longer handled by removing the option from the properties sent to the HMC. Instead, the HMC is now going to reject that. This is more in line with having easy to understand logic on the client side.