### PR TITLE
Fixes #263, #267: Fixed client-side filter matching

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -65,6 +65,17 @@ Released: not yet
 * Fixed that ``find(name)`` raised ``NotFound`` for existing resources, for
   resource types that are elements (i.e. NICs, HBAs, VFs, Ports) (issue #264).
 
+* Fixed that the filter arguments for ``find()``, ``findall()``, and ``list()``
+  for string properties when matched on the client side are matched using
+  regular expressions instead of exact matching, consistent with the
+  zhmcclient documentation, and with server-side matching on the HMC. See
+  issue #263.
+
+* Fixed that the filter arguments for ``find()``, ``findall()``, and ``list()``
+  when used with lists of match values incorrectly applied ANDing between the
+  list items. They now apply ORing, consistent with the zhmcclient
+  documentation, and with server-side matching on the HMC. See issue #267.
+
 **Enhancements:**
 
 * Added content to the "Concepts" chapter in the documentation.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -62,6 +62,9 @@ Released: not yet
   DELETE and POST (for update), and replaced that with status 204 (no content).
   This came up as part of fixing issue #256.
 
+* Fixed that ``find(name)`` raised ``NotFound`` for existing resources, for
+  resource types that are elements (i.e. NICs, HBAs, VFs, Ports) (issue #264).
+
 **Enhancements:**
 
 * Added content to the "Concepts" chapter in the documentation.

--- a/tests/unit/test_hba.py
+++ b/tests/unit/test_hba.py
@@ -182,6 +182,104 @@ class HbaTests(unittest.TestCase):
                 self.assertTrue(hba.full_properties)
                 self.assertEqual(hba.manager, hba_mgr)
 
+    def test_list_filter_name_ok(self):
+        """
+        Test successful list() with filter arguments using the 'name' property
+        on a HbaManager instance in a partition.
+        """
+        hba_mgr = self.partition.hbas
+
+        with requests_mock.mock() as m:
+
+            mock_result_hba1 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'hba1',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                'class': 'hba',
+                'element-id': 'fake-hba-id-1',
+                'wwpn': 'AABBCCDDEC000082',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                  json=mock_result_hba1)
+            mock_result_hba2 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'hba2',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-2',
+                'class': 'hba',
+                'element-id': 'fake-hba-id-2',
+                'wwpn': 'AABBCCDDEC000083',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/hbas/fake-hba-id-2',
+                  json=mock_result_hba2)
+
+            filter_args = {'name': 'hba2'}
+            hbas = hba_mgr.list(filter_args=filter_args)
+
+            self.assertEqual(len(hbas), 1)
+            hba = hbas[0]
+            self.assertEqual(hba.name, 'hba2')
+            self.assertEqual(
+                hba.uri,
+                '/api/partitions/fake-part-id-1/hbas/fake-hba-id-2')
+            self.assertEqual(hba.properties['name'], 'hba2')
+            self.assertEqual(hba.properties['element-id'], 'fake-hba-id-2')
+            self.assertEqual(hba.manager, hba_mgr)
+
+    def test_list_filter_elementid_ok(self):
+        """
+        Test successful list() with filter arguments using the 'element-id'
+        property on a HbaManager instance in a partition.
+        """
+        hba_mgr = self.partition.hbas
+
+        with requests_mock.mock() as m:
+
+            mock_result_hba1 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'hba1',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                'class': 'hba',
+                'element-id': 'fake-hba-id-1',
+                'wwpn': 'AABBCCDDEC000082',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/hbas/fake-hba-id-1',
+                  json=mock_result_hba1)
+            mock_result_hba2 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'hba2',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/hbas/fake-hba-id-2',
+                'class': 'hba',
+                'element-id': 'fake-hba-id-2',
+                'wwpn': 'AABBCCDDEC000083',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/hbas/fake-hba-id-2',
+                  json=mock_result_hba2)
+
+            filter_args = {'element-id': 'fake-hba-id-2'}
+            hbas = hba_mgr.list(filter_args=filter_args)
+
+            self.assertEqual(len(hbas), 1)
+            hba = hbas[0]
+            self.assertEqual(hba.name, 'hba2')
+            self.assertEqual(
+                hba.uri,
+                '/api/partitions/fake-part-id-1/hbas/fake-hba-id-2')
+            self.assertEqual(hba.properties['name'], 'hba2')
+            self.assertEqual(hba.properties['element-id'], 'fake-hba-id-2')
+            self.assertEqual(hba.manager, hba_mgr)
+
     def test_create(self):
         """
         This tests the 'Create HBA' operation.

--- a/tests/unit/test_nic.py
+++ b/tests/unit/test_nic.py
@@ -182,6 +182,104 @@ class NicTests(unittest.TestCase):
                 self.assertTrue(nic.full_properties)
                 self.assertEqual(nic.manager, nic_mgr)
 
+    def test_list_filter_name_ok(self):
+        """
+        Test successful list() with filter arguments using the 'name' property
+        on a NicManager instance in a partition.
+        """
+        nic_mgr = self.partition.nics
+
+        with requests_mock.mock() as m:
+
+            mock_result_nic1 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'nic1',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/nics/fake-nic-id-1',
+                'class': 'nic',
+                'element-id': 'fake-nic-id-1',
+                'type': 'osd',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/nics/fake-nic-id-1',
+                  json=mock_result_nic1)
+            mock_result_nic2 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'nic2',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/nics/fake-nic-id-2',
+                'class': 'nic',
+                'element-id': 'fake-nic-id-2',
+                'type': 'osd',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/nics/fake-nic-id-2',
+                  json=mock_result_nic2)
+
+            filter_args = {'name': 'nic2'}
+            nics = nic_mgr.list(filter_args=filter_args)
+
+            self.assertEqual(len(nics), 1)
+            nic = nics[0]
+            self.assertEqual(nic.name, 'nic2')
+            self.assertEqual(
+                nic.uri,
+                '/api/partitions/fake-part-id-1/nics/fake-nic-id-2')
+            self.assertEqual(nic.properties['name'], 'nic2')
+            self.assertEqual(nic.properties['element-id'], 'fake-nic-id-2')
+            self.assertEqual(nic.manager, nic_mgr)
+
+    def test_list_filter_elementid_ok(self):
+        """
+        Test successful list() with filter arguments using the 'element-id'
+        property on a NicManager instance in a partition.
+        """
+        nic_mgr = self.partition.nics
+
+        with requests_mock.mock() as m:
+
+            mock_result_nic1 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'nic1',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/nics/fake-nic-id-1',
+                'class': 'nic',
+                'element-id': 'fake-nic-id-1',
+                'type': 'osd',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/nics/fake-nic-id-1',
+                  json=mock_result_nic1)
+            mock_result_nic2 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'nic2',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/nics/fake-nic-id-2',
+                'class': 'nic',
+                'element-id': 'fake-nic-id-2',
+                'type': 'osd',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/nics/fake-nic-id-2',
+                  json=mock_result_nic2)
+
+            filter_args = {'element-id': 'fake-nic-id-2'}
+            nics = nic_mgr.list(filter_args=filter_args)
+
+            self.assertEqual(len(nics), 1)
+            nic = nics[0]
+            self.assertEqual(nic.name, 'nic2')
+            self.assertEqual(
+                nic.uri,
+                '/api/partitions/fake-part-id-1/nics/fake-nic-id-2')
+            self.assertEqual(nic.properties['name'], 'nic2')
+            self.assertEqual(nic.properties['element-id'], 'fake-nic-id-2')
+            self.assertEqual(nic.manager, nic_mgr)
+
     def test_create(self):
         """
         This tests the 'Create NIC' operation.

--- a/tests/unit/test_port.py
+++ b/tests/unit/test_port.py
@@ -156,6 +156,8 @@ class PortTests(unittest.TestCase):
         """
         adapters = self.adapters
         adapter = adapters[0]
+        port_mgr = adapter.ports
+
         with requests_mock.mock() as m:
 
             mock_result_port1 = {
@@ -169,11 +171,9 @@ class PortTests(unittest.TestCase):
                 'class': 'storage-port',
                 'name': 'Port 0'
             }
-
             m.get('/api/adapters/fake-adapter-id-1/storage-ports/0',
                   json=mock_result_port1)
 
-            port_mgr = adapter.ports
             ports = port_mgr.list(full_properties=True)
             if len(ports) != 0:
                 storage_uris = self.result['adapters'][0]['storage-port-uris']
@@ -189,6 +189,82 @@ class PortTests(unittest.TestCase):
                     storage_uris[idx])
                 self.assertTrue(port.full_properties)
                 self.assertEqual(port.manager, port_mgr)
+
+    def test_list_filter_name_ok(self):
+        """
+        Test successful list() with filter arguments using the 'name' property
+        on a PortManager instance in a partition.
+        """
+        adapters = self.adapters
+        adapter = adapters[0]
+        port_mgr = adapter.ports
+
+        with requests_mock.mock() as m:
+
+            mock_result_port1 = {
+                'parent': '/api/adapters/fake-adapter-id-1',
+                'index': 0,
+                'fabric-id': '',
+                'description': '',
+                'element-uri':
+                    '/api/adapters/fake-adapter-id-1/storage-ports/0',
+                'element-id': '0',
+                'class': 'storage-port',
+                'name': 'Port 0'
+            }
+            m.get('/api/adapters/fake-adapter-id-1/storage-ports/0',
+                  json=mock_result_port1)
+
+            filter_args = {'name': 'Port 0'}
+            ports = port_mgr.list(filter_args=filter_args)
+
+            self.assertEqual(len(ports), 1)
+            port = ports[0]
+            self.assertEqual(port.name, 'Port 0')
+            self.assertEqual(
+                port.uri,
+                '/api/adapters/fake-adapter-id-1/storage-ports/0')
+            self.assertEqual(port.properties['name'], 'Port 0')
+            self.assertEqual(port.properties['element-id'], '0')
+            self.assertEqual(port.manager, port_mgr)
+
+    def test_list_filter_elementid_ok(self):
+        """
+        Test successful list() with filter arguments using the 'element-id'
+        property on a PortManager instance in a partition.
+        """
+        adapters = self.adapters
+        adapter = adapters[0]
+        port_mgr = adapter.ports
+
+        with requests_mock.mock() as m:
+
+            mock_result_port1 = {
+                'parent': '/api/adapters/fake-adapter-id-1',
+                'index': 0,
+                'fabric-id': '',
+                'description': '',
+                'element-uri':
+                    '/api/adapters/fake-adapter-id-1/storage-ports/0',
+                'element-id': '0',
+                'class': 'storage-port',
+                'name': 'Port 0'
+            }
+            m.get('/api/adapters/fake-adapter-id-1/storage-ports/0',
+                  json=mock_result_port1)
+
+            filter_args = {'element-id': '0'}
+            ports = port_mgr.list(filter_args=filter_args)
+
+            self.assertEqual(len(ports), 1)
+            port = ports[0]
+            self.assertEqual(port.name, 'Port 0')
+            self.assertEqual(
+                port.uri,
+                '/api/adapters/fake-adapter-id-1/storage-ports/0')
+            self.assertEqual(port.properties['name'], 'Port 0')
+            self.assertEqual(port.properties['element-id'], '0')
+            self.assertEqual(port.manager, port_mgr)
 
     def test_update_properties(self):
         """

--- a/tests/unit/test_virtual_function.py
+++ b/tests/unit/test_virtual_function.py
@@ -192,6 +192,110 @@ class VirtualFunctionTests(unittest.TestCase):
                 self.assertTrue(vf.full_properties)
                 self.assertEqual(vf.manager, vf_mgr)
 
+    def test_list_filter_name_ok(self):
+        """
+        Test successful list() with filter arguments using the 'name' property
+        on a VirtualFunctionManager instance in a partition.
+        """
+        vf_mgr = self.partition.virtual_functions
+
+        with requests_mock.mock() as m:
+
+            mock_result_vf1 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'vf1',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-1',
+                'class': 'virtual-function',
+                'element-id': 'fake-vf-id-1',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/virtual-functions/'
+                  'fake-vf-id-1',
+                  json=mock_result_vf1)
+            mock_result_vf2 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'vf2',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-2',
+                'class': 'virtual-function',
+                'element-id': 'fake-vf-id-2',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/virtual-functions/'
+                  'fake-vf-id-2',
+                  json=mock_result_vf2)
+
+            filter_args = {'name': 'vf2'}
+            vfs = vf_mgr.list(filter_args=filter_args)
+
+            self.assertEqual(len(vfs), 1)
+            vf = vfs[0]
+            self.assertEqual(vf.name, 'vf2')
+            self.assertEqual(
+                vf.uri,
+                '/api/partitions/fake-part-id-1/virtual-functions/'
+                'fake-vf-id-2')
+            self.assertEqual(vf.properties['name'], 'vf2')
+            self.assertEqual(vf.properties['element-id'], 'fake-vf-id-2')
+            self.assertEqual(vf.manager, vf_mgr)
+
+    def test_list_filter_elementid_ok(self):
+        """
+        Test successful list() with filter arguments using the 'element-id'
+        property on a VirtualFunctionManager instance in a partition.
+        """
+        vf_mgr = self.partition.virtual_functions
+
+        with requests_mock.mock() as m:
+
+            mock_result_vf1 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'vf1',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-1',
+                'class': 'virtual-function',
+                'element-id': 'fake-vf-id-1',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/virtual-functions/'
+                  'fake-vf-id-1',
+                  json=mock_result_vf1)
+            mock_result_vf2 = {
+                'parent': '/api/partitions/fake-part-id-1',
+                'name': 'vf2',
+                'element-uri':
+                    '/api/partitions/fake-part-id-1/virtual-functions/'
+                    'fake-vf-id-2',
+                'class': 'virtual-function',
+                'element-id': 'fake-vf-id-2',
+                'description': '',
+                'more_properties': 'bliblablub'
+            }
+            m.get('/api/partitions/fake-part-id-1/virtual-functions/'
+                  'fake-vf-id-2',
+                  json=mock_result_vf2)
+
+            filter_args = {'element-id': 'fake-vf-id-2'}
+            vfs = vf_mgr.list(filter_args=filter_args)
+
+            self.assertEqual(len(vfs), 1)
+            vf = vfs[0]
+            self.assertEqual(vf.name, 'vf2')
+            self.assertEqual(
+                vf.uri,
+                '/api/partitions/fake-part-id-1/virtual-functions/'
+                'fake-vf-id-2')
+            self.assertEqual(vf.properties['name'], 'vf2')
+            self.assertEqual(vf.properties['element-id'], 'fake-vf-id-2')
+            self.assertEqual(vf.manager, vf_mgr)
+
     def test_create(self):
         """
         This tests the 'Create Virtual Function' operation.

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -61,7 +61,8 @@ class HbaManager(BaseManager):
             parent=partition,
             uri_prop='element-uri',
             name_prop='name',
-            query_props=[])
+            query_props=[],
+            list_has_name=False)
 
     @property
     def partition(self):

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -117,7 +117,8 @@ class _NameUriCache(object):
         manager from the HMC, and populating the cache with that information.
         """
         self.invalidate()
-        res_list = self._manager.list()
+        full = not self._manager._list_has_name
+        res_list = self._manager.list(full_properties=full)
         self.update_from(res_list)
 
     def update_from(self, res_list):
@@ -178,7 +179,7 @@ class BaseManager(object):
     """
 
     def __init__(self, resource_class, session, parent, uri_prop, name_prop,
-                 query_props):
+                 query_props, list_has_name=True):
         # This method intentionally has no docstring, because it is internal.
         #
         # Parameters:
@@ -208,6 +209,10 @@ class BaseManager(object):
         #     If the support for a resource property changes within the set of
         #     HMC versions that support this type of resource, this list must
         #     represent the version of the HMC this session is connected to.
+        #   list_has_name (bool):
+        #     Indicates whether the list() method for the resource populates
+        #     the name property (i.e. name_prop). For example, for NICs the
+        #     list() method returns minimalistic Nic objects without name.
 
         # We want to surface precondition violations as early as possible,
         # so we test those that are not surfaced through the init code:
@@ -223,6 +228,7 @@ class BaseManager(object):
         self._uri_prop = uri_prop
         self._name_prop = name_prop
         self._query_props = query_props
+        self._list_has_name = list_has_name
 
         self._name_uri_cache = _NameUriCache(
             self, session.retry_timeout_config.name_uri_cache_timetolive)

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -62,7 +62,8 @@ class NicManager(BaseManager):
             parent=partition,
             uri_prop='element-uri',
             name_prop='name',
-            query_props=[])
+            query_props=[],
+            list_has_name=False)
 
     @property
     def partition(self):

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -56,7 +56,8 @@ class PortManager(BaseManager):
             parent=adapter,
             uri_prop='element-uri',
             name_prop='name',
-            query_props=[])
+            query_props=[],
+            list_has_name=False)
 
     @property
     def adapter(self):

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -60,7 +60,8 @@ class VirtualFunctionManager(BaseManager):
             parent=partition,
             uri_prop='element-uri',
             name_prop='name',
-            query_props=[])
+            query_props=[],
+            list_has_name=False)
 
     @property
     def partition(self):


### PR DESCRIPTION
Please review and merge. Note that there is a discussion point in issue #263 that should be considered in your review.

Details from the commit message:
* Fixed that the filter arguments for find(), findall(), and list() for string properties when matched on the client side are matched using regular expressions instead of exact matching, consistent with the zhmcclient documentation, and with server-side matching on the HMC. See issue #263.
* Fixed that the filter arguments for find(), findall(), and list() when used with lists of match values incorrectly applied ANDing between the list items. They now apply ORing, consistent with the zhmcclient documentation, and with server-side matching on the HMC. See issue #267.