### PR TITLE
Fixes #271: Fixed filter args for properties that are not on every resource

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -84,6 +84,13 @@ Released: not yet
 
 * Fixed errors in zhmcclient mock support related to DPM mode checking.
 
+* Fixed that filter arguments specifying properties that are not on each
+  resource, resulted in raising KeyError. An example was when the
+  "card-location" property was specified when finding adapters; that property
+  does not exist for Hipersocket adapters, but for all other types. This
+  situation is now handled by treating such resources as non-matching.
+  See issue #271.
+
 **Enhancements:**
 
 * Added content to the "Concepts" chapter in the documentation.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -271,6 +271,12 @@ The match value specifies how the corresponding resource property matches:
 * If the match value is a list or a tuple, a resource matches if any item in
   the list or tuple matches (i.e. this is a logical OR between the list items).
 
+If a property that is specified in filter arguments does not exist on all
+resources that are subject to be searched, those resources that do not have the
+property are treated as non-matching. An example for this situation is the
+"card-location" property of the Adapter resource which does not exist for
+Hipersocket adapters.
+
 Examples:
 
 * This example uses the :meth:`~zhmcclient.BaseManager.findall` method to


### PR DESCRIPTION
Please review and merge.

Details from the commit message:
* Fixed that filter arguments specifying properties that are not on each resource, resulted in raising KeyError. An example was when the card-location property was specified when finding adapters; that property does not exist for Hipersocket adapters, ubt for all other types. This situation is now handled by treating such resources as non-matching. See issue #271.
* Added a docstring to the internal method _matches_prop().