### PR TITLE
Deprecated flush() and renamed invalidate_name_uri_cache()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,9 @@ Released: not yet
 
 **Deprecations:**
 
+* Deprecated the ``BaseManager.flush()`` method in favor of the new
+  ``BaseManager.invalidate_cache()`` method.
+
 **Bug fixes:**
 
 * Fixed that the defaults for memory for the ``zhmc partition create`` command
@@ -93,7 +96,7 @@ Released: not yet
   allows controlling after what time the name-to-URI cache is automatically
   invalidated. The default for that is set in a new
   `DEFAULT_NAME_URI_CACHE_TIMETOLIVE` constant. Also, the `*Manager` classes
-  now have a new method `invalidate_name_uri_cache()` which can be used to
+  now have a new method `invalidate_cache()` which can be used to
   manually invalidate the name-to-URI cache, for cases where multiple parties
   (besides the current zhmcclient instance) change resources on the HMC.
   This came up as part of issue #253.

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -42,6 +42,8 @@ indicated in the description of the functionality.
 
 from __future__ import absolute_import
 
+import warnings
+
 from ._manager import BaseManager
 from ._resource import BaseResource
 from ._lpar import LparManager
@@ -237,9 +239,17 @@ class Cpc(BaseResource):
     @property
     def vswitches(self):
         """
-        Deprecated: Use :attr:`~zhmcclient.Cpc.virtual_switches` instead.
+        :class:`~zhmcclient.VirtualSwitchManager`: Access to the
+        :term:`Virtual Switches <Virtual Switch>` in this CPC.
+
+        **Deprecated:** This attribute is deprecated and using it will cause a
+        :exc:`~py:exceptions.DeprecationWarning` to be issued. Use
+        :attr:`~zhmcclient.Cpc.virtual_switches` instead.
         """
-        # TODO: Issue a deprecation warning
+        warnings.warn(
+            "Use of the vswitches attribute on zhmcclient.Cpc objects is "
+            "deprecated; use the virtual_switches attribute instead",
+            DeprecationWarning)
         return self.virtual_switches
 
     @property

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 import six
 import re
 from datetime import datetime, timedelta
+import warnings
 from requests.utils import quote
 
 from ._logging import get_logger, logged_api_call
@@ -235,7 +236,7 @@ class BaseManager(object):
         self._name_uri_cache = _NameUriCache(
             self, session.retry_timeout_config.name_uri_cache_timetolive)
 
-    def invalidate_name_uri_cache(self):
+    def invalidate_cache(self):
         """
         Invalidate the Name-URI cache of this manager.
 
@@ -244,9 +245,9 @@ class BaseManager(object):
         up certain zhmcclient methods.
 
         The Name-URI cache is properly updated during changes on the resource
-        name (e.g. via ``update_properties()``) or changes on the resource URI
-        (e.g. via resource creation or deletion), if these changes are
-        performed through the same manager object.
+        name (e.g. via :meth:`~zhmcclient.Partition.update_properties`) or
+        changes on the resource URI (e.g. via resource creation or deletion),
+        if these changes are performed through the same Python manager object.
 
         However, changes performed through a different manager object (e.g.
         because a different session, client or parent resource object was
@@ -262,7 +263,7 @@ class BaseManager(object):
         Note that the Name-URI cache automatically invalidates itself after a
         certain time since the last invalidation. That auto invalidation time
         can be configured using the
-        :attr:`~zhmcclient.RetryTimeoutConfig.name_uri_cache_timetolive``
+        :attr:`~zhmcclient.RetryTimeoutConfig.name_uri_cache_timetolive`
         attribute of the :class:`~zhmcclient.RetryTimeoutConfig` class.
         """
         self._name_uri_cache.invalidate()
@@ -680,8 +681,13 @@ class BaseManager(object):
     @logged_api_call
     def flush(self):
         """
-        Flush the cached name-to-URI mapping.
+        Invalidate the Name-URI cache of this manager.
 
-        This only needs to be done after renaming a resource.
+        **Deprecated:** This method is deprecated and using it will cause a
+        :exc:`~py:exceptions.DeprecationWarning` to be issued. Use
+        :meth:`~zhmcclient.BaseManager.invalidate_cache` instead.
         """
-        self._uris.clear()
+        warnings.warn(
+            "Use of flush() on zhmcclient manager objects is deprecated; "
+            "use invalidate_cache() instead", DeprecationWarning)
+        self.invalidate_cache()


### PR DESCRIPTION
Please review and merge.

Details from the commit message:
- In `BaseManager`, renamed `invalidate_name_uri_cache()` to `invalidate_cache()`. This is an incompatible change, but it was not yet released.
- In `BaseManager`, deprecated `flush()` by updating its documentation and by issuing a `DeprecationWarning`, if used.
- In `Cpc`, added issuing a `DeprecationWarning` in the already deprecated `vswitches` attribute.