### PR TITLE
Fixes #248: Doc fixes for return value of asynchronous Partition methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,17 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed the documentation of several asynchronous ``Partition`` methods that
+  incorrectly documented returning ``None`` in case of synchronous invocation,
+  to now document returning an empty dictionary:
+
+  - ``Partition.start()``
+  - ``Partition.stop()``
+  - ``Partition.dump_partition()``
+  - ``Partition.psw_restart()``
+
+  All other asynchronous methods did not have this issue. See issue #248.
+
 **Enhancements:**
 
 **Known issues:**

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -331,9 +331,10 @@ class Partition(BaseResource):
 
         Returns:
 
-          `None` or :class:`~zhmcclient.Job`:
+          :class:`py:dict` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns `None`.
+            If `wait_for_completion` is `True`, returns an empty
+            :class:`py:dict` object.
 
             If `wait_for_completion` is `False`, returns a
             :class:`~zhmcclient.Job` object representing the asynchronously
@@ -387,9 +388,10 @@ class Partition(BaseResource):
 
         Returns:
 
-          `None` or :class:`~zhmcclient.Job`:
+          :class:`py:dict` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns `None`.
+            If `wait_for_completion` is `True`, returns an empty
+            :class:`py:dict` object.
 
             If `wait_for_completion` is `False`, returns a
             :class:`~zhmcclient.Job` object representing the asynchronously
@@ -501,9 +503,10 @@ class Partition(BaseResource):
 
         Returns:
 
-          `None` or :class:`~zhmcclient.Job`:
+          :class:`py:dict` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns `None`.
+            If `wait_for_completion` is `True`, returns an empty
+            :class:`py:dict` object.
 
             If `wait_for_completion` is `False`, returns a
             :class:`~zhmcclient.Job` object representing the asynchronously
@@ -558,9 +561,10 @@ class Partition(BaseResource):
 
         Returns:
 
-          `None` or :class:`~zhmcclient.Job`:
+          :class:`py:dict` or :class:`~zhmcclient.Job`:
 
-            If `wait_for_completion` is `True`, returns `None`.
+            If `wait_for_completion` is `True`, returns an empty
+            :class:`py:dict` object.
 
             If `wait_for_completion` is `False`, returns a
             :class:`~zhmcclient.Job` object representing the asynchronously


### PR DESCRIPTION
Details:

- Fixed the documentation of several asynchronous `Partition` methods
  that incorrectly documented a return value `None` in case of synchronous
  invocation, to now document a return value of an empty dictionary.

  This is only a change in the documentation to make it match the existing
  code.

  This was done for these methods:

  - `Partition.start()`
  - `Partition.stop()`
  - `Partition.dump_partition()`
  - `Partition.psw_restart()`

  All other asynchronous methods did not have this issue.