### PR TITLE
Fixes #203: CLI: Added support for an OS console into partition/LPAR.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -88,6 +88,10 @@ Released: not yet
 
 * Improved unit test cases for ``zhmcclient._exceptions`` module.
 
+* Added support to the zhmc CLI for an interactive session to the console
+  of the operating system running in a
+  partition (``zhmc partition console``) or LPAR (``zhmc lpar console``).
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -126,7 +126,7 @@ commands::
                                       Output format (Default: table).
       -t, --timestats                 Show time statistics of HMC operations.
       --log COMP=LEVEL,...            Set a component to a log level
-                                      (COMP: [api|hmc|all],
+                                      (COMP: [api|hmc|console|all],
                                        LEVEL: [error|warning|info|debug],
                                        Default: all=warning).
       --log-dest [stderr|syslog|none]
@@ -182,7 +182,7 @@ examples, an underscore ``_`` is shown as the cursor::
         --password        Password for the HMC (Default: ZHMC_PASSWORD environment variable).
         --output-format   Output format (Default: table).
         --timestats       Show time statistics of HMC operations.
-        --log             Set a component to a log level (COMP: [api|hmc|all], LEVEL: [error|warning|info|debug], Default: all=warning).
+        --log             Set a component to a log level (COMP: [api|hmc|console|all], LEVEL: [error|warning|info|debug], Default: all=warning).
         --log-dest        Log destination for this command (Default: stderr).
         --syslog-facility Syslog facility when logging to the syslog (Default: user).
         --version         Show the version of this command and exit.
@@ -452,6 +452,9 @@ Valid log components are:
   calls into the zhmcclient library that are made from the zhmc CLI.
 * ``hmc`` - Enable the ``zhmcclient.hmc`` Python logger, which logs the
   interactions with the HMC.
+* ``console`` - Enable the ``zhmccli.console`` Python logger, which logs the
+  interactions with the console of the operating system running in a partition
+  or LPAR.
 * ``all`` - Enable the root Python logger, which logs anything that is
   propagated up to it. In case of the zhmc CLI, this will mostly be the
   ``requests`` package, plus the ``api`` and ``hmc`` components.

--- a/examples/show_os_messages.py
+++ b/examples/show_os_messages.py
@@ -114,12 +114,17 @@ print("Showing OS messages (including refresh messages) ...")
 
 try:
     for headers, message in receiver.notifications():
-        print("HMC notification #%s:" % headers['session-sequence-nr'])
+        print("# HMC notification #%s:" % headers['session-sequence-nr'])
         os_msg_list = message['os-messages']
         for os_msg in os_msg_list:
-            msg_txt = os_msg['message-text'].strip('\n')
             msg_id = os_msg['message-id']
-            print("OS message #%s:\n%s" % (msg_id, msg_txt))
+            held = os_msg['is-held']
+            priority = os_msg['is-priority']
+            prompt = os_msg.get('prompt-text', None)
+            print("# OS message %s (held: %s, priority: %s, prompt: %r):" %
+                  (msg_id, held, priority, prompt))
+            msg_txt = os_msg['message-text'].strip('\n')
+            print(msg_txt)
 except KeyboardInterrupt:
     print("Keyboard interrupt: Closing OS message channel...")
     receiver.close()

--- a/zhmccli/zhmccli.py
+++ b/zhmccli/zhmccli.py
@@ -24,6 +24,7 @@ from logging.handlers import SysLogHandler
 from logging import StreamHandler
 import platform
 
+import zhmcclient
 from ._helper import CmdContext, GENERAL_OPTIONS_METAVAR, REPL_HISTORY_FILE, \
     REPL_PROMPT, TABLE_FORMATS, LOG_LEVELS, LOG_COMPONENTS, LOG_DESTINATIONS, \
     SYSLOG_FACILITIES
@@ -185,11 +186,15 @@ def cli(ctx, host, userid, password, output_format, timestats, log, log_dest,
                 logger.setLevel(level)
             else:
                 if log_comp == 'api':
-                    logger = logging.getLogger('zhmcclient.api')
+                    logger = logging.getLogger(zhmcclient.API_LOGGER_NAME)
                     logger.addHandler(handler)
                     logger.setLevel(level)
                 if log_comp == 'hmc':
-                    logger = logging.getLogger('zhmcclient.hmc')
+                    logger = logging.getLogger(zhmcclient.HMC_LOGGER_NAME)
+                    logger.addHandler(handler)
+                    logger.setLevel(level)
+                if log_comp == 'console':
+                    logger = logging.getLogger(zhmcclient.CONSOLE_LOGGER_NAME)
                     logger.addHandler(handler)
                     logger.setLevel(level)
 

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -32,7 +32,8 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'DEFAULT_STATUS_TIMEOUT',
            'DEFAULT_NAME_URI_CACHE_TIMETOLIVE',
            'HMC_LOGGER_NAME',
-           'API_LOGGER_NAME']
+           'API_LOGGER_NAME',
+           'CONSOLE_LOGGER_NAME']
 
 
 #: Default HTTP connect timeout in seconds,
@@ -107,3 +108,6 @@ HMC_LOGGER_NAME = 'zhmcclient.hmc'
 
 #: Name of the Python logger that logs zhmcclient API calls made by the user.
 API_LOGGER_NAME = 'zhmcclient.api'
+
+#: Name of the Python logger that logs zhmccli console calls made by the user.
+CONSOLE_LOGGER_NAME = 'zhmccli.console'


### PR DESCRIPTION
Please review and merge.

This change adds support to the zhmc CLI for an interactive shell to the console of the operating system running in a partition or LPAR. The new commands are `zhmc partition console` and `zhmc lpar console`.