### PR TITLE
Increased default status timeout from 60s to 15min.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,11 @@ Released: not yet
 
 **Enhancements:**
 
+* Increased the default status timeout from 60 sec to 15 min, in order to
+  accomodate for some large environments. The status timeout applies to
+  waiting for reaching the desired LPAR status after the HMC operation
+  'Activate LPAR' or 'Deactivate LPAR' has completed.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -91,7 +91,7 @@ DEFAULT_OPERATION_TIMEOUT = 3600
 #: This is used as a default value in asynchronous methods
 #: of the :class:`~zhmcclient.Lpar` class that change its status (e.g.
 #: :meth:`zhmcclient.Lpar.activate`)).
-DEFAULT_STATUS_TIMEOUT = 60
+DEFAULT_STATUS_TIMEOUT = 900
 
 #: Default time to the next automatic invalidation of the Name-URI cache of
 #: manager objects, in seconds since the last invalidation,


### PR DESCRIPTION
Increased the default status timeout from 60 sec to 15 min, in order to accomodate for some large environments. The status timeout applies to waiting for reaching the desired LPAR status after the HMC operation 'Activate LPAR' or 'Deactivate LPAR' has completed.

As long as this PR is not yet merged, it can be installed via:

    pip install git+https://github.com/zhmcclient/python-zhmcclient.git@andy/increase-status-timeout