### PR TITLE
CLI: Improvements for dealing with LPAR status 'exceptions'.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -56,6 +56,18 @@ Released: not yet
   waiting for reaching the desired LPAR status after the HMC operation
   'Activate LPAR' or 'Deactivate LPAR' has completed.
 
+* Allow ``None`` as a value for the ``load_parameter`` argument of
+  ``Lpar.load()``, and changed the default to be ``None`` (the latter change
+  does not change the behavior).
+
+* Added actual status, desired statuses and status timeout as attributes to
+  the ``StatusTimeout`` exception, for programmatic processing by callers.
+
+* In the zhmc CLI, added a ``--allow-status-exceptions`` option for the
+  ``lpar activate/deactivate/load`` commands. Setting this option causes the
+  LPAR status "exceptions" to be considered an additional valid end status when
+  waiting for completion of the operation.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -149,8 +149,10 @@ def lpar_update(cmd_ctx, cpc, lpar, **options):
 @lpar_group.command('activate', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('LPAR', type=str, metavar='LPAR')
+@click.option('--allow-status-exceptions', is_flag=True, required=False,
+              help='Allow status "exceptions" as a valid end status.')
 @click.pass_obj
-def lpar_activate(cmd_ctx, cpc, lpar):
+def lpar_activate(cmd_ctx, cpc, lpar, **options):
     """
     Activate an LPAR.
 
@@ -158,7 +160,7 @@ def lpar_activate(cmd_ctx, cpc, lpar):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_activate(cmd_ctx, cpc, lpar))
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_activate(cmd_ctx, cpc, lpar, options))
 
 
 @lpar_group.command('deactivate', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -168,8 +170,10 @@ def lpar_activate(cmd_ctx, cpc, lpar):
               expose_value=False,
               help='Skip prompt to confirm deactivation of the LPAR.',
               prompt='Are you sure you want to deactivate the LPAR ?')
+@click.option('--allow-status-exceptions', is_flag=True, required=False,
+              help='Allow status "exceptions" as a valid end status.')
 @click.pass_obj
-def lpar_deactivate(cmd_ctx, cpc, lpar):
+def lpar_deactivate(cmd_ctx, cpc, lpar, **options):
     """
     Deactivate an LPAR.
 
@@ -177,7 +181,8 @@ def lpar_deactivate(cmd_ctx, cpc, lpar):
     general options (see 'zhmc --help') can also be specified right after the
     'zhmc' command name.
     """
-    cmd_ctx.execute_cmd(lambda: cmd_lpar_deactivate(cmd_ctx, cpc, lpar))
+    cmd_ctx.execute_cmd(lambda: cmd_lpar_deactivate(cmd_ctx, cpc, lpar,
+                                                    options))
 
 
 @lpar_group.command('load', options_metavar=COMMAND_OPTIONS_METAVAR)
@@ -187,6 +192,8 @@ def lpar_deactivate(cmd_ctx, cpc, lpar):
 @click.option('--load-parameter', type=str, required=False,
               help='Provides additional control over the outcome of a '
               'Load operation.')
+@click.option('--allow-status-exceptions', is_flag=True, required=False,
+              help='Allow status "exceptions" as a valid end status.')
 @click.pass_obj
 def lpar_load(cmd_ctx, cpc, lpar, load_address, **options):
     """
@@ -273,13 +280,13 @@ def cmd_lpar_update(cmd_ctx, cpc_name, lpar_name, options):
     click.echo("LPAR %s has been updated." % lpar_name)
 
 
-def cmd_lpar_activate(cmd_ctx, cpc_name, lpar_name):
+def cmd_lpar_activate(cmd_ctx, cpc_name, lpar_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     lpar = find_lpar(client, cpc_name, lpar_name)
 
     try:
-        lpar.activate(wait_for_completion=True)
+        lpar.activate(wait_for_completion=True, **options)
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
@@ -287,13 +294,13 @@ def cmd_lpar_activate(cmd_ctx, cpc_name, lpar_name):
     click.echo('Activation of LPAR %s is complete.' % lpar_name)
 
 
-def cmd_lpar_deactivate(cmd_ctx, cpc_name, lpar_name):
+def cmd_lpar_deactivate(cmd_ctx, cpc_name, lpar_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
     lpar = find_lpar(client, cpc_name, lpar_name)
 
     try:
-        lpar.deactivate(wait_for_completion=True)
+        lpar.deactivate(wait_for_completion=True, **options)
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 
@@ -306,13 +313,8 @@ def cmd_lpar_load(cmd_ctx, cpc_name, lpar_name, load_address, options):
     client = zhmcclient.Client(cmd_ctx.session)
     lpar = find_lpar(client, cpc_name, lpar_name)
 
-    load_parameter = ""
-    if options['load_parameter']:
-        load_parameter = options['load_parameter']
-
     try:
-        lpar.load(load_address, load_parameter=load_parameter,
-                  wait_for_completion=True)
+        lpar.load(load_address, wait_for_completion=True, **options)
     except zhmcclient.Error as exc:
         raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
 

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -460,12 +460,66 @@ class OperationTimeout(Error):
 
 class StatusTimeout(Error):
     """
-    This exception indicates that the waiting for reaching a desired resource
+    This exception indicates that the waiting for reaching a desired LPAR
     status has timed out.
+
+    The possible status values for an LPAR are:
+
+    * ``"not-activated"`` - The LPAR is not active.
+    * ``"not-operating" - The LPAR is active but no operating system is
+      running in the LPAR.
+    * ``"operating"`` - The LPAR is active and an operating system is
+      running in the LPAR.
+    * ``"exceptions"`` - The LPAR or its CPC has one or more unusual
+      conditions.
 
     Derived from :exc:`~zhmcclient.Error`.
     """
-    pass
+
+    def __init__(self, msg, actual_status, desired_statuses, status_timeout):
+        """
+        Parameters:
+
+          msg (:term:`string`):
+            A human readable message describing the problem.
+
+          actual_status (:term:`string`):
+            The actual status (at the point in time when the status timeout
+            expired).
+
+          desired_statuses (iterable of :term:`string`):
+            The desired status values that were supposed to be reached.
+
+          status_timeout (:term:`number`):
+            The status timeout (in seconds) that has expired.
+        """
+        super(StatusTimeout, self).__init__(msg)
+        self._actual_status = actual_status
+        self._desired_statuses = desired_statuses
+        self._status_timeout = status_timeout
+
+    @property
+    def actual_status(self):
+        """
+        :term:`string`: The actual status (at the point in time when the
+        status timeout expired).
+        """
+        return self._actual_status
+
+    @property
+    def desired_statuses(self):
+        """
+        iterable of :term:`string`: The desired status values that were
+        supposed to be reached.
+        """
+        return self._desired_statuses
+
+    @property
+    def status_timeout(self):
+        """
+        :term:`number`: The status timeout (in seconds) that has expired.
+        """
+        return self._status_timeout
 
 
 class NoUniqueMatch(Error):


### PR DESCRIPTION
As long as this PR is not yet merged, it can be installed via:

    pip install git+https://github.com/zhmcclient/python-zhmcclient.git@andy/fix-status-timeout

This change provides some improvement for the zhmc CLI when dealing with the LPAR status "exceptions" when activating, deactivating or loading the LPAR.

The main change is to add a command line option `--allow-status-exceptions` for the `lpar activate/deactivate/load` commands. Setting this option causes the LPAR status "exceptions" to be considered an additional valid end status.

Some other changes were needed as part of that:
* Allowed `None` as a value for the `load_parameter` argument of `Lpar.load(), and changed the default to be `None` (which does not change the behavior).
* Added actual status, desired statuses and status timeout as attributes to the `StatusTimeout` exception, for programmatic processing by callers. This is not yet exploited in the zhmc CLI, but it can already be exploited by users of the zhmcclient API.