### PR TITLE
Added support for selecting the format of CLI error messages

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -91,6 +91,14 @@ Released: not yet
   of the operating system running in a
   partition (``zhmc partition console``) or LPAR (``zhmc lpar console``).
 
+* Added ``str_def()`` method to all exception classes, which returns a
+  definition-style string for parsing by scripts.
+
+* In the zhmc CLI, added options ``-e``, ``--error-format`` for controlling
+  the format of error messages. The ``-e def`` option selects the format
+  returned by the new ``str_def()`` methods. This format provides for easier
+  parsing of details of error messages by invoking scripts.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -91,6 +91,8 @@ Exceptions
 .. automodule:: zhmcclient._exceptions
 
 .. autoclass:: zhmcclient.Error
+   :members:
+   :special-members: __str__
 
 .. autoclass:: zhmcclient.ConnectionError
    :members:

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -105,6 +105,11 @@ class TestConnectionError(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ConnectionError'), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_msg_named(self):
         """Test exception created with named arguments."""
 
@@ -120,6 +125,11 @@ class TestConnectionError(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ConnectionError'), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestConnectTimeout(unittest.TestCase):
@@ -153,6 +163,15 @@ class TestConnectTimeout(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ConnectTimeout'), str_def)
+        self.assertIn('connect_timeout={!r};'.
+                      format(exc.connect_timeout), str_def)
+        self.assertIn('connect_retries={!r};'.
+                      format(exc.connect_retries), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_msg_named(self):
         """Test exception created with named arguments."""
 
@@ -173,6 +192,15 @@ class TestConnectTimeout(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ConnectTimeout'), str_def)
+        self.assertIn('connect_timeout={!r};'.
+                      format(exc.connect_timeout), str_def)
+        self.assertIn('connect_retries={!r};'.
+                      format(exc.connect_retries), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestReadTimeout(unittest.TestCase):
@@ -206,6 +234,15 @@ class TestReadTimeout(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ReadTimeout'), str_def)
+        self.assertIn('read_timeout={!r};'.
+                      format(exc.read_timeout), str_def)
+        self.assertIn('read_retries={!r};'.
+                      format(exc.read_retries), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_msg_named(self):
         """Test exception created with named arguments."""
 
@@ -226,6 +263,15 @@ class TestReadTimeout(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ReadTimeout'), str_def)
+        self.assertIn('read_timeout={!r};'.
+                      format(exc.read_timeout), str_def)
+        self.assertIn('read_retries={!r};'.
+                      format(exc.read_retries), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestRetriesExceeded(unittest.TestCase):
@@ -257,6 +303,13 @@ class TestRetriesExceeded(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('RetriesExceeded'), str_def)
+        self.assertIn('connect_retries={!r};'.
+                      format(exc.connect_retries), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_msg_named(self):
         """Test exception created with named arguments."""
 
@@ -275,6 +328,13 @@ class TestRetriesExceeded(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('RetriesExceeded'), str_def)
+        self.assertIn('connect_retries={!r};'.
+                      format(exc.connect_retries), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestClientAuthError(unittest.TestCase):
@@ -299,6 +359,11 @@ class TestClientAuthError(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ClientAuthError'), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_msg_named(self):
         """Test exception created with named arguments."""
 
@@ -312,6 +377,11 @@ class TestClientAuthError(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ClientAuthError'), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestServerAuthError(unittest.TestCase):
@@ -356,6 +426,19 @@ class TestServerAuthError(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ServerAuthError'), str_def)
+        self.assertIn('request_method={!r};'.
+                      format(exc.details.request_method), str_def)
+        self.assertIn('request_uri={!r};'.
+                      format(exc.details.request_uri), str_def)
+        self.assertIn('http_status={!r};'.
+                      format(exc.details.http_status), str_def)
+        self.assertIn('reason={!r};'.
+                      format(exc.details.reason), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_msg_named(self):
         """Test exception created with named arguments."""
 
@@ -371,6 +454,19 @@ class TestServerAuthError(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ServerAuthError'), str_def)
+        self.assertIn('request_method={!r};'.
+                      format(exc.details.request_method), str_def)
+        self.assertIn('request_uri={!r};'.
+                      format(exc.details.request_uri), str_def)
+        self.assertIn('http_status={!r};'.
+                      format(exc.details.http_status), str_def)
+        self.assertIn('reason={!r};'.
+                      format(exc.details.reason), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestParseError(unittest.TestCase):
@@ -399,6 +495,13 @@ class TestParseError(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ParseError'), str_def)
+        self.assertIn('line={!r};'.format(exc.line), str_def)
+        self.assertIn('column={!r};'.format(exc.column), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_line_column_2(self):
         """A minimally matching message string."""
         message = ": line 7 column 42 "
@@ -416,6 +519,13 @@ class TestParseError(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ParseError'), str_def)
+        self.assertIn('line={!r};'.format(exc.line), str_def)
+        self.assertIn('column={!r};'.format(exc.column), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
     def test_line_column_3(self):
         """A message string that does not match (because of the 'x' in the
@@ -435,6 +545,13 @@ class TestParseError(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('ParseError'), str_def)
+        self.assertIn('line={!r};'.format(exc.line), str_def)
+        self.assertIn('column={!r};'.format(exc.column), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestVersionError(unittest.TestCase):
@@ -461,6 +578,14 @@ class TestVersionError(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('VersionError'), str_def)
+        self.assertIn('min_api_version={!r};'.
+                      format(exc.min_api_version), str_def)
+        self.assertIn('api_version={!r};'.format(exc.api_version), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestHTTPError(unittest.TestCase):
@@ -525,6 +650,19 @@ class TestHTTPError(unittest.TestCase):
                   "{request-uri}]".format(**resp_body)
         self.assertEqual(str(exc), exp_str)
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('HTTPError'), str_def)
+        self.assertIn('request_method={!r};'.
+                      format(exc.request_method), str_def)
+        self.assertIn('request_uri={!r};'.
+                      format(exc.request_uri), str_def)
+        self.assertIn('http_status={!r};'.
+                      format(exc.http_status), str_def)
+        self.assertIn('reason={!r};'.
+                      format(exc.reason), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
 
 class TestOperationTimeout(unittest.TestCase):
     """
@@ -549,6 +687,13 @@ class TestOperationTimeout(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('OperationTimeout'), str_def)
+        self.assertIn('operation_timeout={!r};'.
+                      format(exc.operation_timeout), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_msg_named(self):
         """Test exception created with named arguments."""
 
@@ -565,6 +710,13 @@ class TestOperationTimeout(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('OperationTimeout'), str_def)
+        self.assertIn('operation_timeout={!r};'.
+                      format(exc.operation_timeout), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestStatusTimeout(unittest.TestCase):
@@ -598,6 +750,17 @@ class TestStatusTimeout(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('StatusTimeout'), str_def)
+        self.assertIn('actual_status={!r};'.
+                      format(exc.actual_status), str_def)
+        self.assertIn('desired_statuses={!r};'.
+                      format(exc.desired_statuses), str_def)
+        self.assertIn('status_timeout={!r};'.
+                      format(exc.status_timeout), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
+
     def test_msg_named(self):
         """Test exception created with named arguments."""
 
@@ -618,6 +781,17 @@ class TestStatusTimeout(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('StatusTimeout'), str_def)
+        self.assertIn('actual_status={!r};'.
+                      format(exc.actual_status), str_def)
+        self.assertIn('desired_statuses={!r};'.
+                      format(exc.desired_statuses), str_def)
+        self.assertIn('status_timeout={!r};'.
+                      format(exc.status_timeout), str_def)
+        self.assertIn('message={!r};'.format(exc.args[0]), str_def)
 
 
 class TestNoUniqueMatch(unittest.TestCase):
@@ -669,6 +843,15 @@ class TestNoUniqueMatch(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('NoUniqueMatch'), str_def)
+        self.assertIn('resource_classname={!r};'.format('Adapter'), str_def)
+        self.assertIn('filter_args={!r};'.
+                      format(exc.filter_args), str_def)
+        self.assertIn('parent_classname={!r};'.format('Cpc'), str_def)
+        self.assertIn('parent_name={!r};'.format(self.cpc.name), str_def)
+
     def test_named(self):
         """Test exception created with named arguments."""
         filter_args = {'type': 'osa', 'status': 'active'}
@@ -686,6 +869,15 @@ class TestNoUniqueMatch(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('NoUniqueMatch'), str_def)
+        self.assertIn('resource_classname={!r};'.format('Adapter'), str_def)
+        self.assertIn('filter_args={!r};'.
+                      format(exc.filter_args), str_def)
+        self.assertIn('parent_classname={!r};'.format('Cpc'), str_def)
+        self.assertIn('parent_name={!r};'.format(self.cpc.name), str_def)
 
 
 class TestNotFound(unittest.TestCase):
@@ -737,6 +929,15 @@ class TestNotFound(unittest.TestCase):
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
 
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('NotFound'), str_def)
+        self.assertIn('resource_classname={!r};'.format('Adapter'), str_def)
+        self.assertIn('filter_args={!r};'.
+                      format(exc.filter_args), str_def)
+        self.assertIn('parent_classname={!r};'.format('Cpc'), str_def)
+        self.assertIn('parent_name={!r};'.format(self.cpc.name), str_def)
+
     def test_named(self):
         """Test exception created with named arguments."""
         filter_args = {'type': 'osa', 'status': 'active'}
@@ -754,6 +955,15 @@ class TestNotFound(unittest.TestCase):
 
         # Check str()
         self.assertEqual(str(exc), exc.args[0])
+
+        # Check str_def()
+        str_def = exc.str_def()
+        self.assertIn('classname={!r};'.format('NotFound'), str_def)
+        self.assertIn('resource_classname={!r};'.format('Adapter'), str_def)
+        self.assertIn('filter_args={!r};'.
+                      format(exc.filter_args), str_def)
+        self.assertIn('parent_classname={!r};'.format('Cpc'), str_def)
+        self.assertIn('parent_name={!r};'.format(self.cpc.name), str_def)
 
 
 if __name__ == '__main__':

--- a/zhmccli/_cmd_info.py
+++ b/zhmccli/_cmd_info.py
@@ -18,7 +18,7 @@ import click
 
 import zhmcclient
 from .zhmccli import cli
-from ._helper import print_properties
+from ._helper import print_properties, raise_click_exception
 
 
 @cli.command('info')
@@ -42,7 +42,7 @@ def cmd_info(cmd_ctx):
     try:
         api_version = client.query_api_version()
     except zhmcclient.Error as exc:
-        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+        raise_click_exception(exc, cmd_ctx.error_format)
 
     cmd_ctx.spinner.stop()
     print_properties(api_version, cmd_ctx.output_format)

--- a/zhmccli/_cmd_session.py
+++ b/zhmccli/_cmd_session.py
@@ -18,6 +18,7 @@ import click
 
 import zhmcclient
 from .zhmccli import cli
+from ._helper import raise_click_exception
 
 
 @cli.group('session')
@@ -63,7 +64,7 @@ def cmd_session_create(cmd_ctx):
     try:
         session.logon(verify=True)
     except zhmcclient.Error as exc:
-        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+        raise_click_exception(exc, cmd_ctx.error_format)
 
     cmd_ctx.spinner.stop()
     click.echo("export ZHMC_HOST=%s" % session.host)
@@ -77,7 +78,7 @@ def cmd_session_delete(cmd_ctx):
     try:
         session.logoff()
     except zhmcclient.Error as exc:
-        raise click.ClickException("%s: %s" % (exc.__class__.__name__, exc))
+        raise_click_exception(exc, cmd_ctx.error_format)
 
     cmd_ctx.spinner.stop()
     click.echo("unset ZHMC_SESSION_ID")

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -44,6 +44,19 @@ class Error(Exception):
         #     ``args`` instance variable of the exception object.
         super(Error, self).__init__(*args)
 
+    def str_def(self):
+        """
+        Interface definition for the corresponding method derived exception
+        classes.
+
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts.
+
+        For the exact format returned by derived exception classes, see the
+        same-named methods there.
+        """
+        raise NotImplementedError
+
 
 class ConnectionError(Error):
     """
@@ -94,6 +107,18 @@ class ConnectionError(Error):
         """
         return "{}(message={!r})". \
                format(self.__class__.__name__, self.args[0])
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; message={};
+        """
+        return "classname={!r}; message={!r};". \
+            format(self.__class__.__name__, self.args[0])
 
 
 class ConnectTimeout(ConnectionError):
@@ -153,6 +178,20 @@ class ConnectTimeout(ConnectionError):
                format(self.__class__.__name__, self.args[0],
                       self.connect_timeout, self.connect_retries)
 
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; connect_timeout={}; connect_retries={}; message={};
+        """  # noqa: E501
+        return "classname={!r}; connect_timeout={!r}; connect_retries={!r}; " \
+            "message={!r};". \
+            format(self.__class__.__name__, self.connect_timeout,
+                   self.connect_retries, self.args[0])
+
 
 class ReadTimeout(ConnectionError):
     """
@@ -210,6 +249,20 @@ class ReadTimeout(ConnectionError):
                format(self.__class__.__name__, self.args[0],
                       self.read_timeout, self.read_retries)
 
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; read_timeout={}; read_retries={}; message={};
+        """
+        return "classname={!r}; read_timeout={!r}; read_retries={!r}; " \
+            "message={!r};". \
+            format(self.__class__.__name__, self.read_timeout,
+                   self.read_retries, self.args[0])
+
 
 class RetriesExceeded(ConnectionError):
     """
@@ -258,6 +311,18 @@ class RetriesExceeded(ConnectionError):
                format(self.__class__.__name__, self.args[0],
                       self.connect_retries)
 
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; connect_retries={}; message={};
+        """
+        return "classname={!r}; connect_retries={!r}; message={!r};". \
+            format(self.__class__.__name__, self.connect_retries, self.args[0])
+
 
 class AuthError(Error):
     """
@@ -304,6 +369,18 @@ class ClientAuthError(AuthError):
         return "{}(message={!r})". \
                format(self.__class__.__name__, self.args[0])
 
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; message={};
+        """
+        return "classname={!r}; message={!r};". \
+            format(self.__class__.__name__, self.args[0])
+
 
 class ServerAuthError(AuthError):
     """
@@ -349,6 +426,21 @@ class ServerAuthError(AuthError):
                format(self.__class__.__name__, self.args[0],
                       self.details.request_method, self.details.request_uri,
                       self.details.http_status, self.details.reason)
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; request_method={}; request_uri={}; http_status={}; reason={}; message={};
+        """  # noqa: E501
+        return "classname={!r}; request_method={!r}; request_uri={!r}; " \
+            "http_status={!r}; reason={!r}; message={!r};". \
+            format(self.__class__.__name__, self.details.request_method,
+                   self.details.request_uri, self.details.http_status,
+                   self.details.reason, self.args[0])
 
 
 class ParseError(Error):
@@ -414,6 +506,19 @@ class ParseError(Error):
                format(self.__class__.__name__, self.args[0], self.line,
                       self.column)
 
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; line={}; column={}; message={};
+        """
+        return "classname={!r}; line={!r}; column={!r}; message={!r};". \
+            format(self.__class__.__name__, self.line, self.column,
+                   self.args[0])
+
 
 class VersionError(Error):
     """
@@ -465,6 +570,20 @@ class VersionError(Error):
         return "{}(message={!r}, min_api_version={!r}, api_version={!r})". \
                format(self.__class__.__name__, self.args[0],
                       self.min_api_version, self.api_version)
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; min_api_version={}; api_version={}; message={};
+        """
+        return "classname={!r}; min_api_version={!r}; api_version={!r}; " \
+            "message={!r};". \
+            format(self.__class__.__name__, self.min_api_version,
+                   self.api_version, self.args[0])
 
 
 class HTTPError(Error):
@@ -652,6 +771,21 @@ class HTTPError(Error):
                format(self.__class__.__name__, self.http_status, self.reason,
                       self.message, self.request_method, self.request_uri)
 
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; request_method={}; request_uri={}; http_status={}; reason={}; message={};
+        """  # noqa: E501
+        return "classname={!r}; request_method={!r}; request_uri={!r}; " \
+            "http_status={!r}; reason={!r}; message={!r};". \
+            format(self.__class__.__name__, self.request_method,
+                   self.request_uri, self.http_status, self.reason,
+                   self.args[0])
+
 
 class OperationTimeout(Error):
     """
@@ -689,6 +823,19 @@ class OperationTimeout(Error):
         return "{}(message={!r}, operation_timeout={!r})". \
                format(self.__class__.__name__, self.args[0],
                       self.operation_timeout)
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; operation_timeout={}; message={};
+        """
+        return "classname={!r}; operation_timeout={!r}; message={!r};". \
+            format(self.__class__.__name__, self.operation_timeout,
+                   self.args[0])
 
 
 class StatusTimeout(Error):
@@ -764,6 +911,20 @@ class StatusTimeout(Error):
             format(self.__class__.__name__, self.args[0], self.actual_status,
                    self.desired_statuses, self.status_timeout)
 
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; actual_status={}; desired_statuses={}; status_timeout={}; message={};
+        """  # noqa: E501
+        return "classname={!r}; actual_status={!r}; desired_statuses={!r}; " \
+            "status_timeout={!r}; message={!r};". \
+            format(self.__class__.__name__, self.actual_status,
+                   self.desired_statuses, self.status_timeout, self.args[0])
+
 
 class NoUniqueMatch(Error):
     """
@@ -831,6 +992,25 @@ class NoUniqueMatch(Error):
                       self.filter_args,
                       parent.__class__.__name__ if parent else None,
                       parent.name if parent else None)
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; resource_classname={}; filter_args={}; parent_classname={}; manager_name={}; message={};
+        """  # noqa: E501
+        parent = self.manager.parent
+        return "classname={!r}; resource_classname={!r}; filter_args={!r}; " \
+               "parent_classname={!r}; parent_name={!r}; message={!r};". \
+               format(self.__class__.__name__,
+                      self.manager.resource_class.__name__,
+                      self.filter_args,
+                      parent.__class__.__name__ if parent else None,
+                      parent.name if parent else None,
+                      self.args[0])
 
 
 class NotFound(Error):
@@ -903,3 +1083,22 @@ class NotFound(Error):
                       self.filter_args,
                       parent.__class__.__name__ if parent else None,
                       parent.name if parent else None)
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; resource_classname={}; filter_args={}; parent_classname={}; parent_name={}; message={};
+        """  # noqa: E501
+        parent = self.manager.parent
+        return "classname={!r}; resource_classname={!r}; filter_args={!r}; " \
+               "parent_classname={!r}; parent_name={!r}; message={!r};". \
+               format(self.__class__.__name__,
+                      self.manager.resource_class.__name__,
+                      self.filter_args,
+                      parent.__class__.__name__ if parent else None,
+                      parent.name if parent else None,
+                      self.args[0])


### PR DESCRIPTION
Details:
- Added `str_def()` methods to all zhmcclient exceptions. These methods return a string that is suited for being processed by scripts that invoke the zhmc CLI.
- Added a command line option `-e` / `-error-format` to the zhmc cli, which controls the format of any error messages. The `-e def` option selects the format returned by the `str_def()` methods.