### PR TITLE
Circumvented urllib3 issue with requests 2.17.1 and 2.17.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pbr>=1.10.0 # Apache-2.0
 progressbar2>=3.12.0 # BSD
 prompt_toolkit>=1.0.9 # BSD, from click-repl
 python-utils>=2.0.1 # BSD, from progressbar2
-requests>=2.12.4 # Apache-2.0
+requests>=2.12.4,!=2.17.1,!=2.17.2 # Apache-2.0
 six>=1.10.0 # MIT
 stomp.py>=4.1.15 # Apache
 tabulate>=0.7.7 # MIT


### PR DESCRIPTION
The `requests` 2.17.1 package introduced an issue, in that urllib3 is no longer in requests.packages:

```
python -c "import zhmcclient; print('Import: ok')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "zhmcclient/__init__.py", line 30, in <module>
    from ._session import *       # noqa: F401
  File "zhmcclient/_session.py", line 29, in <module>
    from requests.packages import urllib3
ImportError: cannot import name urllib3
```

The `requests` 2.17.0 package still worked fine.

This PR excludes 2.17.1 and 2.17.2 in the `requirements.txt` file.

Update: requests 2.17.3 provides a final fix.