### PR TITLE
Added wait_for_status() methods to Lpar and Partition.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -99,6 +99,10 @@ Released: not yet
   returned by the new ``str_def()`` methods. This format provides for easier
   parsing of details of error messages by invoking scripts.
 
+* Added ``wait_for_status()`` methods to the ``Lpar`` and ``Partition``
+  classes, in order to ease the work for users that need to ensure that a
+  particular LPAR or partition status is reached.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -841,7 +841,7 @@ class OperationTimeout(Error):
 class StatusTimeout(Error):
     """
     This exception indicates that the waiting for reaching a desired LPAR
-    status has timed out.
+    or Partition status has timed out.
 
     The possible status values for an LPAR are:
 
@@ -852,6 +852,10 @@ class StatusTimeout(Error):
       running in the LPAR.
     * ``"exceptions"`` - The LPAR or its CPC has one or more unusual
       conditions.
+
+    The possible status values for a Partition are described in the
+    'status' property of the data model for the partition resource in the
+    :term:`HMC API` book.
 
     Derived from :exc:`~zhmcclient.Error`.
     """

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -263,7 +263,7 @@ class Lpar(BaseResource):
             statuses = ["not-operating"]
             if allow_status_exceptions:
                 statuses.append("exceptions")
-            self._wait_for_status(statuses, status_timeout)
+            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call
@@ -354,7 +354,7 @@ class Lpar(BaseResource):
             statuses = ["not-activated"]
             if allow_status_exceptions:
                 statuses.append("exceptions")
-            self._wait_for_status(statuses, status_timeout)
+            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call
@@ -452,7 +452,7 @@ class Lpar(BaseResource):
             statuses = ["operating"]
             if allow_status_exceptions:
                 statuses.append("exceptions")
-            self._wait_for_status(statuses, status_timeout)
+            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call
@@ -528,7 +528,8 @@ class Lpar(BaseResource):
         self.manager.session.post(
             self.uri + '/operations/send-os-cmd', body)
 
-    def _wait_for_status(self, status, status_timeout=None):
+    @logged_api_call
+    def wait_for_status(self, status, status_timeout=None):
         """
         Wait until the status of this LPAR has a desired value.
 
@@ -553,8 +554,9 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached one of the desired status values. The special value 0 means
             that no timeout is set.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.StatusTimeout` is raised.
+            `None` means that the default status timeout will be used.
+            If the timeout expires , a :exc:`~zhmcclient.StatusTimeout` is
+            raised.
 
         Raises:
 


### PR DESCRIPTION
Details:
- The `wait_for_status()` method for the `Lpar` class was already available
  as an internal method, which was simply externalized.
- For the `Partition` class, a similar method has been added.
- The reason for these methods is that they make it much easier to ensure
  a particular operational status.