### PR TITLE
Fix ssc-dns-servers option handling in CLI

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,9 @@ Released: not yet
 * Clarified in the documentation of all exceptions that have a ``details``
   instance variable, that it is never ``None``.
 
+* Fixed using '--ssc-dns-servers' option for the CLI commands
+  'zhmc partition create/update'. See issue #310.
+
 **Enhancements:**
 
 * Improved content of ``zhmcclient.ParseError`` message for better problem

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -430,6 +430,9 @@ def cmd_partition_create(cmd_ctx, cpc_name, options):
             'cp-processors' not in properties:
         properties['ifl-processors'] = DEFAULT_IFL_PROCESSORS
 
+    if options['ssc-dns-servers'] is not None:
+        properties['ssc-dns-servers'] = options['ssc-dns-servers'].split(',')
+
     try:
         new_partition = cpc.partitions.create(properties)
     except zhmcclient.Error as exc:
@@ -522,6 +525,9 @@ def cmd_partition_update(cmd_ctx, cpc_name, partition_name, options):
     else:
         # boot-device="none" is the default
         pass
+
+    if options['ssc-dns-servers'] is not None:
+        properties['ssc-dns-servers'] = options['ssc-dns-servers'].split(',')
 
     if not properties:
         cmd_ctx.spinner.stop()


### PR DESCRIPTION
Details:
When we try to set the --ssc-dns-servers in the
zhmc partition create or update command we get
an HTTPError: 400,7 because the HMC expects
an array for this option. This change fills
the passed ssc-dns-servers separated by a comma
into an array. A maximum of two ssc-dns-servers
are accepted by the HMC.
Resolves #310

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>