### PR TITLE
Added support for listing free crypto domains

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -148,6 +148,11 @@ Released: not yet
 * Added a Python property ``maximum_active_partitions`` to the ``Cpc`` class,
   which returns the maximum number of active LPARs or partitions of a CPC.
 
+* Added ``get_free_crypto_domains()`` method to the ``Cpc`` class,
+  in order to find out free domain index numbers for a given set of
+  crypto adapters. Note: This method is considered experimental in this
+  version.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/examples/example_hmccreds.yaml
+++ b/examples/example_hmccreds.yaml
@@ -75,6 +75,13 @@ examples:
         - adapter
       #loglevel: info
       #timestats: yes
+   list_free_crypto_domains:
+      hmc: "192.168.111.5"
+      cpcname: DPMSE2
+      crypto_adapter_names:
+        - "Crypto 0124 A13B-12"
+      #loglevel: info
+      #timestats: yes
 
 "192.168.111.5":
    userid: ensadmin

--- a/examples/list_free_crypto_domains.py
+++ b/examples/list_free_crypto_domains.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example showing the free crypto domains of a set of crypto adapters in a CPC.
+"""
+
+import sys
+import logging
+import yaml
+import json
+import requests.packages.urllib3
+import operator
+import itertools
+
+import zhmcclient
+
+requests.packages.urllib3.disable_warnings()
+
+if len(sys.argv) != 2:
+    print("Usage: %s hmccreds.yaml" % sys.argv[0])
+    sys.exit(2)
+hmccreds_file = sys.argv[1]
+
+with open(hmccreds_file, 'r') as fp:
+    hmccreds = yaml.load(fp)
+
+examples = hmccreds.get("examples", None)
+if examples is None:
+    print("examples not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+list_free_crypto_domains = examples.get("list_free_crypto_domains", None)
+if list_free_crypto_domains is None:
+    print("list_free_crypto_domains not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+loglevel = list_free_crypto_domains.get("loglevel", None)
+if loglevel is not None:
+    level = getattr(logging, loglevel.upper(), None)
+    if level is None:
+        print("Invalid value for loglevel in credentials file %s: %s" % \
+              (hmccreds_file, loglevel))
+        sys.exit(1)
+    logging.basicConfig(level=level)
+
+hmc = list_free_crypto_domains["hmc"]
+cpcname = list_free_crypto_domains["cpcname"]
+crypto_adapter_names = list_free_crypto_domains["crypto_adapter_names"]
+
+cred = hmccreds.get(hmc, None)
+if cred is None:
+    print("Credentials for HMC %s not found in credentials file %s" % \
+          (hmc, hmccreds_file))
+    sys.exit(1)
+
+userid = cred["userid"]
+password = cred["password"]
+
+print(__doc__)
+
+print("Using HMC %s with userid %s ..." % (hmc, userid))
+session = zhmcclient.Session(hmc, userid, password)
+cl = zhmcclient.Client(session)
+
+timestats = list_free_crypto_domains.get("timestats", False)
+if timestats:
+    session.time_stats_keeper.enable()
+
+cpc = cl.cpcs.find(name=cpcname)
+
+if crypto_adapter_names:
+    crypto_adapters = [cpc.adapters.find(name=ca_name)
+                       for ca_name in crypto_adapter_names]
+else:
+    crypto_adapters = cpc.adapters.findall(type='crypto')
+    crypto_adapter_names = [ca.name for ca in crypto_adapters]
+
+print("Determining crypto configurations of all partitions on CPC %r ..." %
+      cpc.name)
+for partition in cpc.partitions.list(full_properties=True):
+    crypto_config = partition.get_property('crypto-configuration')
+    if crypto_config:
+        print("Partition %r has crypto configuration:" % partition.name)
+        print(json.dumps(crypto_config, indent=4))
+
+print("Determining free crypto domains on all of the crypto adapters %r on "
+      "CPC %r ..." % (crypto_adapter_names, cpc.name))
+free_domains = cpc.get_free_crypto_domains(crypto_adapters)
+
+# Convert this list of numbers into better readable number ranges:
+ranges = []
+for k, g in itertools.groupby(enumerate(free_domains), lambda (i, x): i - x):
+    group = map(operator.itemgetter(1), g)
+    if group[0] == group[-1]:
+        ranges.append("{}".format(group[0]))
+    else:
+        ranges.append("{}-{}".format(group[0], group[-1]))
+free_domains_str = ', '.join(ranges)
+
+print("Free domains: %s" % free_domains_str)
+
+print("Logging off ...")
+session.logoff()
+
+if timestats:
+    print(session.time_stats_keeper)
+
+print("Done.")

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -160,7 +160,7 @@ class AdapterTests(unittest.TestCase):
             'status': 'active',
             'type': 'crypto',
             'adapter-id': '123',
-            'detected-card-type': 'Crypto Express-5S',
+            'detected-card-type': 'crypto-express-5s',
             'card-location': 'vvvv-wwww',
             'state': 'online',
             'physical-channel-status': 'operating',

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -361,7 +361,7 @@ class Adapter(BaseResource):
         if self.get_property('adapter-family') != 'crypto':
             return None
         card_type = self.get_property('detected-card-type')
-        if card_type == 'Crypto Express-5S':
+        if card_type == 'crypto-express-5s':
             max_domains = self.manager.cpc.maximum_active_partitions
         else:
             raise ValueError("Unknown crypto card type: {!r}".


### PR DESCRIPTION
This PR is now ready for being merged - the new functionality has been described as experimental.

Details:
- Added the `get_free_crypto_domains()` method to the `Cpc` class, in order to find out free domain index numbers for a given set of crypto adapters.
- Added an example script `list_free_crypto_domains.py` that demonstrates the new method.