### PR TITLE
Added properties for max partitions to Cpc and for max crypto domains to Adapter

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -136,6 +136,15 @@ Released: not yet
   as a JSON string, a binary string which is used directly, or a unicode
   string which is encoded using UTF-8. This was necessary to fix issue #57.
 
+* In the zhmcclient mock support, added a Python property ``name`` to all
+  faked resources, which returns the value of the 'name' resource property.
+
+* Added a Python property ``maximum_crypto_domains`` to the ``Adapter`` class,
+  which returns the maximum number of crypto domains of a crypto adapter.
+
+* Added a Python property ``maximum_active_partitions`` to the ``Cpc`` class,
+  which returns the maximum number of active LPARs or partitions of a CPC.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -329,6 +329,45 @@ class Adapter(BaseResource):
                 self._port_uri_segment = ''
         return self._port_uri_segment
 
+    @property
+    @logged_api_call
+    def maximum_crypto_domains(self):
+        """
+        Integer: The maximum number of crypto domains on this crypto adapter.
+
+        The following table shows the maximum number of crypto domains for
+        crypto adapters supported on machines in DPM mode:
+
+        =================  ==================  ===============
+        Adapter type       Machine generation  Maximum domains
+        =================  ==================  ===============
+        Crypto Express 5S  z13 / Emperor                    85
+        Crypto Express 5S  z13s / Rockhopper                40
+        =================  ==================  ===============
+
+        If this adapter is not a crypto adapter, `None` is returned.
+
+        If the crypto adapter card type is not known, :exc:`ValueError` is
+        raised.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+          :exc:`ValueError`: Unknown crypto card type
+        """
+        if self.get_property('adapter-family') != 'crypto':
+            return None
+        card_type = self.get_property('detected-card-type')
+        if card_type == 'Crypto Express-5S':
+            max_domains = self.manager.cpc.maximum_active_partitions
+        else:
+            raise ValueError("Unknown crypto card type: {!r}".
+                             format(card_type))
+        return max_domains
+
     @logged_api_call
     def delete(self):
         """

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -320,6 +320,52 @@ class Cpc(BaseResource):
         """
         return self.prop('dpm-enabled', False)
 
+    _MAX_PARTITIONS_BY_MACHINE_TYPE = {
+        '2817': 60,  # z196
+        '2818': 30,  # z114
+        '2827': 60,  # zEC12
+        '2828': 30,  # zBC12
+        '2964': 85,  # z13 / Emperor
+        '2965': 40,  # z13s / Rockhopper
+    }
+
+    @property
+    @logged_api_call
+    def maximum_active_partitions(self):
+        """
+        Integer: The maximum number of active logical partitions or partitions
+        of this CPC.
+
+        The following table shows the maximum number of active logical
+        partitions or partitions by machine generations supported at the HMC
+        API:
+
+        ==================  ==================
+        Machine generation  Maximum partitions
+        ==================  ==================
+        z196                                60
+        z114                                30
+        zEC12                               60
+        zBC12                               30
+        z13 / Emperor                       85
+        z13s / Rockhopper                   40
+        ==================  ==================
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+          :exc:`ValueError`: Unknown machine type
+        """
+        machine_type = self.get_property('machine-type')
+        try:
+            max_parts = self._MAX_PARTITIONS_BY_MACHINE_TYPE[machine_type]
+        except KeyError:
+            raise ValueError("Unknown machine type: {!r}".format(machine_type))
+        return max_parts
+
     @logged_api_call
     def start(self, wait_for_completion=True, operation_timeout=None):
         """

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -127,6 +127,17 @@ class FakedBaseResource(object):
         """
         return self._uri
 
+    @property
+    def name(self):
+        """
+        The name (property 'name') of this resource.
+
+        Raises:
+
+          :exc:`KeyError`: Resource does not have a 'name' property.
+        """
+        return self._properties['name']
+
     def update(self, properties):
         """
         update the properties of this resource.


### PR DESCRIPTION
For details, see commit message.

The max domains property in the Adapter class has unit test code.
The max partitions property in the Cpc class does not have unit test code because it has not yet been converted to use the zhmcclient mock support. It will be added once that happens.