### PR TITLE
vlan-id must be an integer

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -57,6 +57,9 @@ Released: not yet
 * Fixed the incorrect parameters of ``Partition.mount_iso_image()``. See
   issue #57.
 
+* Reads the vlan-id as a integer instead as a string for
+  the 'zhmc nic create/update' cli command. See issue #337.
+
 **Enhancements:**
 
 * Improved content of ``zhmcclient.ParseError`` message for better problem

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -126,7 +126,7 @@ def nic_show(cmd_ctx, cpc, partition, nic):
               help='Network Mask of the SSC management NIC. '
               'Only applicable to and required for NICs of ssc type '
               'partitions when ssc-ip-address-type is ipv4 or ipv6.')
-@click.option('--vlan-id', type=str, required=False,
+@click.option('--vlan-id', type=int, required=False,
               help='VLAN ID of the SSC management NIC '
               'Only applicable to NICs of ssc type partitions. '
               'Default: No VLAN is used.')
@@ -185,7 +185,7 @@ def nic_create(cmd_ctx, cpc, partition, **options):
 @click.option('--ssc-mask-prefix', type=str, required=False,
               help='Network Mask of the SSC management NIC. '
               'Only applicable to NICs of ssc type partitions.')
-@click.option('--vlan-id', type=str, required=False,
+@click.option('--vlan-id', type=int, required=False,
               help='VLAN ID of the SSC management NIC '
               'Only applicable to NICs of ssc type partitions.')
 @click.pass_obj


### PR DESCRIPTION
Today,  the vlan-id is passed as a string to
the HMC WS API by the CLI. The HMC returns a
HTTPError: 400,7 because it expects that the
vlan-id is an integer. This change reads the
vlan-id as a integer instead as a string.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>