### PR TITLE
Added update_properties() to Cpc and Lpar.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -153,6 +153,9 @@ Released: not yet
   crypto adapters. Note: This method is considered experimental in this
   version.
 
+* Added an ``update_properties()`` method to the ``Lpar`` and ``Cpc``
+  resource classes.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
Please review and merge.
The testcase migration changes will depend on this change.
For details, see commit message.

**Note:** Unit test code will be added when migrating these resource types to py.test and zhmcclient mock support.