### PR TITLE
Test: Migrated unit tests to py.test + zhmcclient mock, part 1

### DIFF
--- a/tests/unit/test_activation_profile.py
+++ b/tests/unit/test_activation_profile.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,244 +18,314 @@ Unit tests for _activation_profile module.
 
 from __future__ import absolute_import, print_function
 
-import unittest
+import pytest
 import copy
+import re
 
 from zhmcclient import Client, ActivationProfile
 from zhmcclient_mock import FakedSession
+from .utils import assert_resources
 
 
-class ActivationProfileTests(unittest.TestCase):
-    """All tests for ActivationProfile and ActivationProfileManager classes."""
+class TestActivationProfile(object):
+    """
+    All tests for the ActivationProfile and ActivationProfileManager classes.
+    """
 
-    def assertProfiles(self, profiles, exp_profiles, prop_names):
-        self.assertEqual(set([profile.uri for profile in profiles]),
-                         set([profile.uri for profile in exp_profiles]))
-        for profile in profiles:
-            uri = profile.uri
-            for exp_profile in exp_profiles:
-                if exp_profile.uri == uri:
-                    break
-            for prop_name in prop_names:
-                self.assertEqual(profile.properties[prop_name],
-                                 exp_profile.properties[prop_name])
-
-    def setUp(self):
+    def setup_method(self):
         """
-        Set up a CPC with two of each type of activation profiles.
-
-        Because activation profiles cannot be dynamically added, we work
-        with a CPC that is initially set up and satisfies the need for all
-        tests.
+        Set up a faked session, and add a faked CPC in classic mode,
+        and add two faked activation profiles of each type.
         """
         self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
         self.client = Client(self.session)
 
         self.faked_cpc = self.session.hmc.cpcs.add({
-            'object-id': 'faked-cpc1',
+            'object-id': 'fake-cpc1-oid',
+            # object-uri is set up automatically
             'parent': None,
             'class': 'cpc',
-            'name': 'cpc_1',
-            'description': 'CPC #1',
+            'name': 'fake-cpc1-name',
+            'description': 'CPC #1 (classic mode)',
             'status': 'active',
             'dpm-enabled': False,
             'is-ensemble-member': False,
-            'iml-mode': 'TBD',
+            'iml-mode': 'lpar',
         })
+        self.cpc = self.client.cpcs.find(name='fake-cpc1-name')
+
         self.faked_reset_ap_1 = self.faked_cpc.reset_activation_profiles.add({
+            # element-uri is set up automatically
             'name': 'rap_1',
             'parent': self.faked_cpc.uri,
             'class': 'reset-activation-profile',
             'description': 'RAP #1',
         })
         self.faked_reset_ap_2 = self.faked_cpc.reset_activation_profiles.add({
+            # element-uri is set up automatically
             'name': 'rap_2',
             'parent': self.faked_cpc.uri,
             'class': 'reset-activation-profile',
             'description': 'RAP #2',
         })
         self.faked_image_ap_1 = self.faked_cpc.image_activation_profiles.add({
+            # element-uri is set up automatically
             'name': 'iap_1',
             'parent': self.faked_cpc.uri,
             'class': 'image-activation-profile',
             'description': 'IAP #1',
         })
         self.faked_image_ap_2 = self.faked_cpc.image_activation_profiles.add({
+            # element-uri is set up automatically
             'name': 'iap_2',
             'parent': self.faked_cpc.uri,
             'class': 'image-activation-profile',
             'description': 'IAP #2',
         })
         self.faked_load_ap_1 = self.faked_cpc.load_activation_profiles.add({
+            # element-uri is set up automatically
             'name': 'lap_1',
             'parent': self.faked_cpc.uri,
             'class': 'load-activation-profile',
             'description': 'LAP #1',
         })
         self.faked_load_ap_2 = self.faked_cpc.load_activation_profiles.add({
+            # element-uri is set up automatically
             'name': 'lap_2',
             'parent': self.faked_cpc.uri,
             'class': 'load-activation-profile',
             'description': 'LAP #2',
         })
-        self.cpc = self.client.cpcs.list()[0]
 
-    def test_resource_repr(self):
+    @pytest.mark.parametrize(
+        "profile_type", ['reset', 'image', 'load']
+    )
+    def test_profilemanager_initial_attrs(self, profile_type):
+        """Test initial attributes of ActivationProfileManager."""
+
+        mgr_attr = profile_type + '_activation_profiles'
+        profile_mgr = getattr(self.cpc, mgr_attr)
+
+        # Verify all public properties of the manager object
+        assert profile_mgr.resource_class == ActivationProfile
+        assert profile_mgr.session == self.session
+        assert profile_mgr.parent == self.cpc
+        assert profile_mgr.cpc == self.cpc
+        assert profile_mgr.profile_type == profile_type
+
+    # TODO: Test for ActivationProfileManager.__repr__()
+
+    @pytest.mark.parametrize(
+        "profile_type", ['reset', 'image', 'load']
+    )
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(),
+             ['name', 'element-uri']),
+            (dict(full_properties=False),
+             ['name', 'element-uri']),
+            (dict(full_properties=True),
+             None),
+        ]
+    )
+    def test_profilemanager_list_full_properties(
+            self, full_properties_kwargs, prop_names, profile_type):
+        """Test ActivationProfileManager.list() with full_properties."""
+
+        mgr_attr = profile_type + '_activation_profiles'
+        faked_profile_mgr = getattr(self.faked_cpc, mgr_attr)
+        exp_faked_profiles = faked_profile_mgr.list()
+        profile_mgr = getattr(self.cpc, mgr_attr)
+
+        # Execute the code to be tested
+        profiles = profile_mgr.list(**full_properties_kwargs)
+
+        assert_resources(profiles, exp_faked_profiles, prop_names)
+
+    @pytest.mark.parametrize(
+        "profile_type, filter_args, exp_names", [
+            ('reset',
+             {'name': 'rap_2'},
+             ['rap_2']),
+            ('reset',
+             {'name': '.*rap_1'},
+             ['rap_1']),
+            ('reset',
+             {'name': 'rap_1.*'},
+             ['rap_1']),
+            ('reset',
+             {'name': 'rap_.'},
+             ['rap_1', 'rap_2']),
+            ('reset',
+             {'name': '.ap_1'},
+             ['rap_1']),
+            ('reset',
+             {'name': '.+'},
+             ['rap_1', 'rap_2']),
+            ('reset',
+             {'name': 'rap_1.+'},
+             []),
+            ('reset',
+             {'name': '.+rap_1'},
+             []),
+            ('image',
+             {'name': 'iap_1'},
+             ['iap_1']),
+            ('image',
+             {'name': '.*iap_1'},
+             ['iap_1']),
+            ('image',
+             {'name': 'iap_1.*'},
+             ['iap_1']),
+            ('image',
+             {'name': 'iap_.'},
+             ['iap_1', 'iap_2']),
+            ('image',
+             {'name': '.ap_1'},
+             ['iap_1']),
+            ('image',
+             {'name': '.+'},
+             ['iap_1', 'iap_2']),
+            ('image',
+             {'name': 'iap_1.+'},
+             []),
+            ('image',
+             {'name': '.+iap_1'},
+             []),
+            ('load',
+             {'name': 'lap_2'},
+             ['lap_2']),
+            ('load',
+             {'name': '.*lap_1'},
+             ['lap_1']),
+            ('load',
+             {'name': 'lap_1.*'},
+             ['lap_1']),
+            ('load',
+             {'name': 'lap_.'},
+             ['lap_1', 'lap_2']),
+            ('load',
+             {'name': '.ap_1'},
+             ['lap_1']),
+            ('load',
+             {'name': '.+'},
+             ['lap_1', 'lap_2']),
+            ('load',
+             {'name': 'lap_1.+'},
+             []),
+            ('load',
+             {'name': '.+lap_1'},
+             []),
+            ('reset',
+             {'class': 'reset-activation-profile'},
+             ['rap_1', 'rap_2']),
+            ('image',
+             {'class': 'image-activation-profile'},
+             ['iap_1', 'iap_2']),
+            ('load',
+             {'class': 'load-activation-profile'},
+             ['lap_1', 'lap_2']),
+            ('reset',
+             {'class': 'reset-activation-profile',
+              'description': 'RAP #2'},
+             ['rap_2']),
+            ('image',
+             {'class': 'image-activation-profile',
+              'description': 'IAP #1'},
+             ['iap_1']),
+            ('load',
+             {'class': 'load-activation-profile',
+              'description': 'LAP #2'},
+             ['lap_2']),
+            ('reset',
+             {'description': 'RAP #1'},
+             ['rap_1']),
+            ('image',
+             {'description': 'IAP #2'},
+             ['iap_2']),
+            ('load',
+             {'description': 'LAP #1'},
+             ['lap_1']),
+        ]
+    )
+    def test_profilemanager_list_filter_args(
+            self, profile_type, filter_args, exp_names):
+        """Test ActivationProfileManager.list() with filter_args."""
+
+        mgr_attr = profile_type + '_activation_profiles'
+        profile_mgr = getattr(self.cpc, mgr_attr)
+
+        # Execute the code to be tested
+        profiles = profile_mgr.list(filter_args=filter_args)
+
+        assert len(profiles) == len(exp_names)
+        if exp_names:
+            names = [ap.properties['name'] for ap in profiles]
+            assert set(names) == set(exp_names)
+
+    # TODO: Test for initial ActivationProfile attributes
+
+    def test_profile_repr(self):
         """Test ActivationProfile.__repr__()."""
-        # We test just for reset activation profiles, because the class is the
-        # same for all profile types and we know that the __repr__() method
-        # does not depend on the profile type either.
 
-        reset_ap = ActivationProfile(
-            self.cpc.reset_activation_profiles,
-            uri=self.cpc.uri + '/reset-activation-profiles/rap-1',
-            name='rap #1')
+        # We test __repr__() just for reset activation profiles, because the
+        # ActivationProfile class is the same for all profile types and we know
+        # that __repr__() does not depend on the profile type.
+        profile_mgr = self.cpc.reset_activation_profiles
+        reset_ap = profile_mgr.find(name='rap_1')
 
+        # Execute the code to be tested
         repr_str = repr(reset_ap)
 
         repr_str = repr_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            repr_str,
-            r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.format(
-                classname=reset_ap.__class__.__name__,
-                id=id(reset_ap)))
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=reset_ap.__class__.__name__,
+                               id=id(reset_ap)),
+                        repr_str)
 
-    def test_manager_initial_attrs(self):
-        """Test initial attributes of ActivationProfileManager."""
+    @pytest.mark.parametrize(
+        "profile_type", ['reset', 'image', 'load']
+    )
+    @pytest.mark.parametrize(
+        "input_props", [
+            {},
+            {'description': 'New profile description'},
+        ]
+    )
+    def test_profile_update_properties(self, input_props, profile_type):
+        """Test ActivationProfile.update_properties()."""
 
-        reset_ap_mgr = self.cpc.reset_activation_profiles
-        self.assertEqual(reset_ap_mgr.cpc, self.cpc)
-        self.assertEqual(reset_ap_mgr.profile_type, "reset")
+        mgr_attr = profile_type + '_activation_profiles'
+        profile_mgr = getattr(self.cpc, mgr_attr)
 
-        image_ap_mgr = self.cpc.image_activation_profiles
-        self.assertEqual(image_ap_mgr.cpc, self.cpc)
-        self.assertEqual(image_ap_mgr.profile_type, "image")
+        profile = profile_mgr.list()[0]
 
-        load_ap_mgr = self.cpc.load_activation_profiles
-        self.assertEqual(load_ap_mgr.cpc, self.cpc)
-        self.assertEqual(load_ap_mgr.profile_type, "load")
-
-    def test_manager_list_short(self):
-        """
-        Test ActivationProfileManager.list() with short set of properties.
-        """
-        # The faked resources are used to define the expected resources and
-        # their properties.
-        exp_profiles = [self.faked_image_ap_1, self.faked_image_ap_2]
-        profile_mgr = self.cpc.image_activation_profiles
-
-        profiles = profile_mgr.list(full_properties=False)
-
-        self.assertProfiles(profiles, exp_profiles,
-                            ['name', 'element-uri'])
-
-    def test_manager_list_full(self):
-        """
-        Test ActivationProfileManager.list() with full set of properties.
-        """
-        # The faked resources are used to define the expected resources and
-        # their properties.
-        exp_profiles = [self.faked_reset_ap_1, self.faked_reset_ap_2]
-        profile_mgr = self.cpc.reset_activation_profiles
-
-        profiles = profile_mgr.list(full_properties=True)
-
-        self.assertProfiles(profiles, exp_profiles,
-                            ['name', 'element-uri', 'class', 'description'])
-
-    def test_manager_list_filter_name(self):
-        """
-        Test ActivationProfileManager.list() with filtering by name.
-        """
-        # The faked resources are used to define the expected resources and
-        # their properties.
-        exp_profiles = [self.faked_reset_ap_2]
-        profile_mgr = self.cpc.reset_activation_profiles
-
-        profiles = profile_mgr.list(filter_args={'name': 'rap_2'})
-
-        self.assertProfiles(profiles, exp_profiles,
-                            ['name', 'element-uri'])
-
-    def test_manager_list_filter_same(self):
-        """
-        Test ActivationProfileManager.list() with filtering by a property
-        where more than one resource has the same value.
-        """
-        # The faked resources are used to define the expected resources and
-        # their properties.
-        exp_profiles = [self.faked_reset_ap_1, self.faked_reset_ap_2]
-        profile_mgr = self.cpc.reset_activation_profiles
-
-        profiles = profile_mgr.list(
-            filter_args={'class': 'reset-activation-profile'})
-
-        self.assertProfiles(profiles, exp_profiles,
-                            ['name', 'element-uri'])
-
-    def test_manager_list_filter_two(self):
-        """
-        Test ActivationProfileManager.list() with filtering by two properties.
-        """
-        # The faked resources are used to define the expected resources and
-        # their properties.
-        exp_profiles = [self.faked_reset_ap_2]
-        profile_mgr = self.cpc.reset_activation_profiles
-
-        profiles = profile_mgr.list(
-            filter_args={'class': 'reset-activation-profile',
-                         'description': 'RAP #2'})
-
-        self.assertProfiles(profiles, exp_profiles,
-                            ['name', 'element-uri'])
-
-    def test_resource_update_nothing(self):
-        """
-        Test ActivationProfile.update_properties() with no properties.
-        """
-        profile_mgr = self.cpc.load_activation_profiles
-        profiles = profile_mgr.list(filter_args={'name': 'lap_1'})
-        self.assertEqual(len(profiles), 1)
-        profile = profiles[0]
-
+        profile.pull_full_properties()
         saved_properties = copy.deepcopy(profile.properties)
 
-        # Method to be tested
-        profile.update_properties(properties={})
+        # Execute the code to be tested
+        profile.update_properties(properties=input_props)
 
-        # Verify that the properties of the local resource object have not
-        # changed
-        self.assertEqual(profile.properties, saved_properties)
+        # Verify that the resource object already reflects the property
+        # updates.
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in profile.properties
+            prop_value = profile.properties[prop_name]
+            assert prop_value == exp_prop_value
 
-    def test_resource_update_not_fetched(self):
-        """
-        Test ActivationProfile.update_properties() with an existing
-        property that has not been fetched into the local resource object.
-        """
-        profile_mgr = self.cpc.load_activation_profiles
-        profiles = profile_mgr.list(filter_args={'name': 'lap_1'})
-        self.assertEqual(len(profiles), 1)
-        profile = profiles[0]
-
-        # A property that is not in the result of list():
-        update_prop_name = 'description'
-        update_prop_value = "new description for lap_1"
-
-        # Method to be tested
-        profile.update_properties(
-            properties={update_prop_name: update_prop_value})
-
-        # Verify that the local resource object reflects the update
-        self.assertEqual(profile.properties[update_prop_name],
-                         update_prop_value)
-
-        # Update the properties of the resource object and verify that the
-        # resource object reflects the update
+        # Refresh the resource object and verify that the resource object
+        # still reflects the property updates.
         profile.pull_full_properties()
-        self.assertEqual(profile.properties[update_prop_name],
-                         update_prop_value)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in profile.properties
+            prop_value = profile.properties[prop_name]
+            assert prop_value == exp_prop_value

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -1208,19 +1208,30 @@ class PartitionStartStopHandlerTests(unittest.TestCase):
         partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
         self.assertEqual(partition1['status'], 'stopped')
 
-        # the function to be tested:
+        # the start() function to be tested, with a valid initial status:
         self.urihandler.post(self.hmc, '/api/partitions/1/operations/start',
                              None, True, True)
-
         partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
         self.assertEqual(partition1['status'], 'active')
 
-        # the function to be tested:
+        # the start() function to be tested, with an invalid initial status:
+        with self.assertRaises(HTTPError):
+            self.urihandler.post(self.hmc,
+                                 '/api/partitions/1/operations/start',
+                                 None, True, True)
+
+        # the stop() function to be tested, with a valid initial status:
+        self.assertEqual(partition1['status'], 'active')
         self.urihandler.post(self.hmc, '/api/partitions/1/operations/stop',
                              None, True, True)
-
         partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
         self.assertEqual(partition1['status'], 'stopped')
+
+        # the stop() function to be tested, with an invalid initial status:
+        with self.assertRaises(HTTPError):
+            self.urihandler.post(self.hmc,
+                                 '/api/partitions/1/operations/stop',
+                                 None, True, True)
 
 
 class HbaHandlerTests(unittest.TestCase):

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -572,6 +572,7 @@ class PartitionStartHandler(object):
                 format(partition.name, status))
         # Reflect the result of starting the partition
         partition.properties['status'] = 'active'
+        return {}
 
 
 class PartitionStopHandler(object):
@@ -597,6 +598,7 @@ class PartitionStopHandler(object):
                 format(partition.name, status))
         # Reflect the result of stopping the partition
         partition.properties['status'] = 'stopped'
+        return {}
 
 
 def ensure_crypto_config(partition):


### PR DESCRIPTION
This PR is on top of PRs #350 and #351 and #354.
Ready for review and merge.
Part1 is for the zhmcclient resources: ActivationProfile, Adapter, Cpc, Partition.
The unit tests contains some TODOs for stuff that was missing already before the migration.