### PR TITLE
Reduced Travis CI further.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,20 +58,20 @@ matrix:
       env:
         - PACKAGE_LEVEL=minimum
         - PYTHON=2
-    - os: osx
-      sudo: required
-      language: generic
-      python:
-      env:
-        - PACKAGE_LEVEL=latest
-        - PYTHON=2
-    - os: osx
-      sudo: required
-      language: generic
-      python:
-      env:
-        - PACKAGE_LEVEL=minimum
-        - PYTHON=3
+#    - os: osx
+#      sudo: required
+#      language: generic
+#      python:
+#      env:
+#        - PACKAGE_LEVEL=latest
+#        - PYTHON=2
+#    - os: osx
+#      sudo: required
+#      language: generic
+#      python:
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#        - PYTHON=3
     - os: osx
       sudo: required
       language: generic
@@ -104,14 +104,17 @@ install:
   - make develop
   - $PIP_CMD install python-coveralls
   - $PIP_CMD list
+  - make pyshow
+  - bash -c "echo $TRAVIS_EVENT_TYPE"
 
 # commands to run builds & tests
 script:
   - make check
-  - make build
-  - make builddoc
   - make test
-  - make pyshow
+  - if [[ $TRAVIS_EVENT_TYPE == 'cron' ]]; then
+      make build;
+      make builddoc;
+    fi
 
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 && $PACKAGE_LEVEL == latest ]]; then coveralls; fi


### PR DESCRIPTION
Please review and merge.

A Travis cron job has been defined that currently runs daily. The cron job is expected to run the full job (including the build abd builddoc make targets). Travis runs triggered by GitHub (e.g. on this PR) are expected to not run these steps.

Details:
- The 'make build' and 'make builddoc' steps are now run only if the travis run is triggered by Travis cron. The runs triggered by GitHub no longer run these steps.
- Removed the multiple package levels from the OS-X runs - it is sufficient if they are run on Linux.