### PR TITLE
Fixes #316: Mock: Added support for remaining partition ops in URI handler.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -162,6 +162,10 @@ Released: not yet
 * Improved the description of the ``Hba.create()`` and ``Nic.create()``
   methods to describe how the backing adapter port is specified.
 
+* Extended the zhmcclient mock support by adding support for all operations
+  thet are supported at the zhmcclient API but were not yet supported for
+  mocking, so far.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
**Note:** This PR is on top of PRs #359 and #360.
Affects only mock support.
Ready for review and merge.
Details in commit message.