### PR TITLE
Add config file for Code Climate tool

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,15 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - python
+  radon:
+    enabled: true
+ratings:
+  paths:
+  - "**.py"
+exclude_paths:
+- tests/
+- examples/


### PR DESCRIPTION
Code Climate is a fully-configurable static analysis
tool. This change will provide a .codeclimate.yml
configuration file which enables the two Code Climate
engines Radon (https://github.com/rubik/radon) and Duplication
(https://github.com/codeclimate/codeclimate-duplication).
Radon is a Python tool that computes various metrics like
cyclomatic complexity from the source code.
Duplication analyzes code for structural similarities.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>