### PR TITLE
Rename z Systems family to IBM Z

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@
 .. limitations under the License.
 ..
 
-zhmcclient - A pure Python client library for the z Systems HMC Web Services API
-================================================================================
+zhmcclient - A pure Python client library for the IBM Z HMC Web Services API
+============================================================================
 
 .. PyPI download statistics are broken, but the new PyPI warehouse makes PyPI
 .. download statistics available through Google BigQuery
@@ -73,15 +73,15 @@ Overview
 
 The zhmcclient package is a client library
 written in pure Python that interacts with the Web Services API of the Hardware
-Management Console (HMC) of `z Systems`_ or `LinuxONE`_ machines. The goal of
+Management Console (HMC) of `IBM Z`_ or `LinuxONE`_ machines. The goal of
 this package is to make the HMC Web Services API easily consumable for Python
 programmers.
 
-.. _z Systems: http://www.ibm.com/systems/z/
+.. _IBM Z: http://www.ibm.com/systems/z/
 .. _LinuxONE: http://www.ibm.com/systems/linuxone/
 
 The HMC Web Services API is the access point for any external tools to
-manage the z Systems or LinuxONE platform. It supports management of the
+manage the IBM Z  or LinuxONE platform. It supports management of the
 lifecycle and configuration of various platform resources, such as partitions,
 CPU, memory, virtual switches, I/O adapters, and more.
 

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -194,7 +194,7 @@ Resources scoped to CPCs in any mode
      TBD - Not yet supported.
 
   CPC
-     Central Processor Complex, a physical z Systems or LinuxONE computer.
+     Central Processor Complex, a physical IBM Z or LinuxONE computer.
 
      For details, see section :ref:`CPCs`.
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -125,7 +125,7 @@ commands:
     > --help
     Usage: zhmc  [OPTIONS] COMMAND [ARGS]...
 
-      Command line interface for the z Systems HMC.
+      Command line interface for the IBM Z HMC.
       . . .
 
     Options:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,10 +63,10 @@ else:
 # General information about the project.
 project = u'zhmcclient'
 copyright = u'IBM'
-author = u'z Systems KVM OpenStack Team'
+author = u'IBM Z KVM OpenStack Team'
 
 # The short description of the package.
-_short_description = u'Client library for z Systems Hardware Management Console Web Services API'
+_short_description = u'Client library for IBM Z Hardware Management Console Web Services API'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,8 +13,8 @@
 .. limitations under the License.
 ..
 
-zhmcclient - A pure Python client library for the z Systems HMC Web Services API
-********************************************************************************
+zhmcclient - A pure Python client library for the IBM Z HMC Web Services API
+****************************************************************************
 
 .. _GitHub project page: https://github.com/zhmcclient/python-zhmcclient
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -26,15 +26,15 @@ What this package provides
 
 The zhmcclient package (also known as python-zhmcclient) is a client library
 written in pure Python that interacts with the Web Services API of the Hardware
-Management Console (HMC) of `z Systems`_ or `LinuxONE`_ machines. The goal of
+Management Console (HMC) of `IBM Z`_ or `LinuxONE`_ machines. The goal of
 this package is to make the HMC Web Services API easily consumable for Python
 programmers.
 
-.. _z Systems: http://www.ibm.com/systems/z/
+.. _IBM Z: http://www.ibm.com/systems/z/
 .. _LinuxONE: http://www.ibm.com/systems/linuxone/
 
 The HMC Web Services API is the access point for any external tools to
-manage the z Systems or LinuxONE platform. It supports management of the
+manage the IBM Z or LinuxONE platform. It supports management of the
 lifecycle and configuration of various platform resources, such as partitions,
 CPU, memory, virtual switches, I/O adapters, and more.
 
@@ -64,7 +64,7 @@ The zhmcclient package is supported in these environments:
 * HMC versions: 2.11.1 and higher
 
 The following table shows for each HMC version the supported HMC API version
-and the supported z Systems and LinuxONE machine generations:
+and the supported IBM Z and LinuxONE machine generations:
 
 ===========  ===============  ======================  ===============================================
 HMC version  HMC API version  HMC API book            Machine generations

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 
 [metadata]
 name = zhmcclient
-summary = A pure Python client library for the z Systems HMC Web Services API.
+summary = A pure Python client library for the IBM Z HMC Web Services API.
 description-file =
     README.rst
 license = Apache License, Version 2.0

--- a/zhmccli/zhmccli.py
+++ b/zhmccli/zhmccli.py
@@ -89,7 +89,7 @@ SYSLOG_ADDRESSES = {
 def cli(ctx, host, userid, password, output_format, transpose, error_format,
         timestats, log, log_dest, syslog_facility):
     """
-    Command line interface for the z Systems HMC.
+    Command line interface for the IBM Z HMC.
 
     The options shown in this help text are general options that can also
     be specified on any of the (sub-)commands.

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-zhmcclient - A pure Python client library for the z Systems HMC Web Services
+zhmcclient - A pure Python client library for the IBM Z HMC Web Services
 API.
 
 For documentation, see TODO: Add link to RTD once available.

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-A :term:`CPC` (Central Processor Complex) is a physical z Systems or LinuxONE
+A :term:`CPC` (Central Processor Complex) is a physical IBM Z or LinuxONE
 computer.
 
 A particular HMC can manage multiple CPCs.

--- a/zhmcclient/_metrics.py
+++ b/zhmcclient/_metrics.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-The HMC supports the retrieval of metrics values for resources of a z Systems
+The HMC supports the retrieval of metrics values for resources of a IBM Z
 or LinuxONE computer. This section describes the zhmcclient API for retrieving
 such metrics from the HMC.
 


### PR DESCRIPTION
The z Systems family was rebranded to IBM Z.
This change renames documentation and code
in the project.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>