### PR TITLE
Fixes #396: CLI: Fixed AttributeError with dict.iteritems() on Python 3.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,10 @@ Released: not yet
 * Minor fixes in the documentation (e.g. fixed name of ``MetricGroupValues``
   class).
 
+* Fixed the zhmc CLI for Python 3 where multiple commands raised
+  AttributeError: "'dict' object has no attribute 'iteritems' in
+  ``zhmccli/_helper.py``. (issue #396).
+
 **Enhancements:**
 
 * Added support for the HMC Metric Service. For details, see section 'Metrics' in the

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -210,7 +210,7 @@ def original_options(options):
       dict: Options with their original names.
     """
     org_options = {}
-    for name, value in options.iteritems():
+    for name, value in six.iteritems(options):
         org_name = name.replace('_', '-')
         org_options[org_name] = value
     return org_options
@@ -244,7 +244,7 @@ def options_to_properties(options, name_map=None):
       dict: Resource properties (key: property name, value: option value)
     """
     properties = {}
-    for name, value in options.iteritems():
+    for name, value in six.iteritems(options):
         if value is None:
             continue
         if name_map:


### PR DESCRIPTION
Verified that the problem can be reproduced and that this change fixes the problem, on RHEL 7.3 with Python 3.6 and with the "zhmc partition update" command.

Please review and merge.