### PR TITLE
Add support for Console resource and its children

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -154,7 +154,7 @@ Resources scoped to the HMC
 .. glossary::
 
   Console
-     TBD - Not yet supported.
+     The HMC itself.
 
   Group
      TBD - Not yet supported.
@@ -168,28 +168,30 @@ Resources scoped to the HMC
      The execution of an asynchronous HMC operation.
 
   LDAP Server Definition
-     TBD - Not yet supported.
+     The information in an HMC about an LDAP server that may be used for
+     HMC user authorization purposes.
 
   Metrics Context
      A user-created definition of metrics that can be retrieved.
 
   Password Rule
-     TBD - Not yet supported.
+     A rule which HMC users need to follow when creating a HMC logon password.
 
   Session
      A session between a client of the HMC API and the HMC.
 
   Task
-     TBD - Not yet supported.
+     An action that an HMC user with appropriate authority can perform.
 
   User
-     TBD - Not yet supported.
+     An HMC user.
 
   User Pattern
-     TBD - Not yet supported.
+     A pattern for HMC user IDs that are not defined on the HMC as users but
+     can be verified by an LDAP server for user authentication.
 
   User Role
-     TBD - Not yet supported.
+     An authority role which can be assigned to one or more HMC users.
 
 Resources scoped to CPCs in any mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -116,6 +116,30 @@ Released: not yet
 * Improved the way the named tuples ``MetricGroupDefinition`` and
   ``MetricDefinition`` are documented.
 
+* Added support for ``Console`` resource and its child resources ``User``,
+  ``User Role``, ``User Pattern``, ``Password Rule``, ``Task``, and
+  ``LDAP Server Definition``, both for the zhmcclient API and for the
+  zhmcclient mock support.
+
+* As part of support for the ``Console`` resource, added a new resource class
+  ``UnmanagedCpc`` which representd unmanaged CPCs that have been discovered by
+  the HMC. The existing ``Cpc`` class continues to represent only managed CPCs;
+  this has been clarified in the documentation.
+
+* As part of support for the ``Console`` resource, added a method
+  ``wait_for_available()`` to the ``Client`` class, which waits until the HMC
+  is available again after a restart. This method is used by
+  ``Console.restart()``, but it can also be used by zhmcclient users.
+
+* As part of support for the ``Console`` resource, improved ``Session.post()``
+  to allow for an empty response body when the operation returns with HTTP
+  status 202 (Accepted). This status code so far was always assumed to indicate
+  that an asynchronous job had been started, but it can happen in some
+  ``Console`` operations as well.
+
+* Improved the error information in the ``ParseError`` exception, by adding
+  the "Content-Type" header in cases where that is interesting.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -209,14 +209,22 @@ silently handled by the zhmcclient package:
   that the HMC session token has expired. It is handled by re-logon, creating a
   new session token, and retrying the original HMC operation.
 
-* POST with status 202: This means that an asynchronous job has been started
-  that performs the actual operation. If ``wait_for_completion=True`` in the
-  method that performs the HMC operation, this combination is handled by
-  waiting for completion of the job (via polling with GET on the job URI),
-  gathering success or failure from the job results. In case of success, the
-  job results are returned in an appropriate form. In case of failure, an
-  :class:`~zhmcclient.HTTPError` is raised based upon the error information in
-  the job results.
+* POST with status 202: This status code means that the operation is being
+  performed asynchronously. There are two cases for that:
+
+  * If there is a response body, an asynchronous job has been started on the
+    HMC that performs the actual operation. If ``wait_for_completion`` is
+    ``True`` in the method that invoked the HMC operation, the method waits for
+    completion of the job (via polling with GET on the job URI), gathering
+    success or failure from the job results. In case of success, the job
+    results are returned from the method. In case of failure, an
+    :class:`~zhmcclient.HTTPError` is raised based upon the error information
+    in the job results.
+
+  * If there is no response body, the operation is performed asynchronously
+    on the HMC, but there is no job resource that can be used to poll for
+    completion status. This is used only for operations such as restarting the
+    HMC.
 
 The other HTTP status / reason code combinations are forwarded to the user by
 means of raising :class:`~zhmcclient.HTTPError`. That exception class is

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -175,10 +175,24 @@ accordingly:
 
 1. The Web Services API must be enabled on the HMC.
 
-2. The HMC user ID that will be used by the zhmcclient must be authorized for
-   the following tasks:
+2. To use all functionality provided in the zhmcclient package, the HMC user ID
+   that will be used by the zhmcclient must be authorized for the following
+   tasks. The description of each method of the zhmcclient package will mention
+   its specific authorization requirements.
 
-   * Use of the Web Services API.
+   * "Remote Restart" must be enabled on the HMC
+
+   * Use of the Web Services API
+   * Shutdown/Restart
+   * Manage Alternate HMC
+   * Audit and Log Management
+   * View Security Logs
+   * Manage LDAP Server Definitions
+   * Manage Password Rules
+   * Manage Users
+   * Manage User Patterns
+   * Manage User Roles
+   * Manage User Templates
 
    When using CPCs in DPM mode:
 

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -181,6 +181,12 @@ Faked HMC
 .. autoclass:: zhmcclient_mock.FakedAdapter
    :members:
 
+.. autoclass:: zhmcclient_mock.FakedConsoleManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedConsole
+   :members:
+
 .. autoclass:: zhmcclient_mock.FakedCpcManager
    :members:
 
@@ -191,6 +197,12 @@ Faked HMC
    :members:
 
 .. autoclass:: zhmcclient_mock.FakedHba
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedLdapServerDefinitionManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedLdapServerDefinition
    :members:
 
 .. autoclass:: zhmcclient_mock.FakedLparManager
@@ -211,10 +223,46 @@ Faked HMC
 .. autoclass:: zhmcclient_mock.FakedPartition
    :members:
 
+.. autoclass:: zhmcclient_mock.FakedPasswordRuleManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedPasswordRule
+   :members:
+
 .. autoclass:: zhmcclient_mock.FakedPortManager
    :members:
 
 .. autoclass:: zhmcclient_mock.FakedPort
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedTaskManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedTask
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedUnmanagedCpcManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedUnmanagedCpc
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedUserManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedUser
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedUserPatternManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedUserPattern
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedUserRoleManager
+   :members:
+
+.. autoclass:: zhmcclient_mock.FakedUserRole
    :members:
 
 .. autoclass:: zhmcclient_mock.FakedVirtualFunctionManager

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -45,7 +45,7 @@ Boolean                      :class:`py:bool`
 Byte, Integer, Long, Short   :term:`integer`
 Float                        :class:`py:float`
 String, String Enum          :term:`unicode string`
-Timestamp                    :term:`integer`
+:term:`timestamp`            :term:`integer`
 Array                        :class:`py:list`
 Object                       :class:`py:dict`
 ===========================  =====================
@@ -63,6 +63,22 @@ CPCs
    :special-members: __str__
 
 .. autoclass:: zhmcclient.Cpc
+   :members:
+   :special-members: __str__
+
+
+.. _`Unmanaged CPCs`:
+
+Unmanaged CPCs
+--------------
+
+.. automodule:: zhmcclient._unmanaged_cpc
+
+.. autoclass:: zhmcclient.UnmanagedCpcManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.UnmanagedCpc
    :members:
    :special-members: __str__
 
@@ -207,5 +223,117 @@ Virtual Switches
    :special-members: __str__
 
 .. autoclass:: zhmcclient.VirtualSwitch
+   :members:
+   :special-members: __str__
+
+
+.. _`Console`:
+
+Console
+-------
+
+.. automodule:: zhmcclient._console
+
+.. autoclass:: zhmcclient.ConsoleManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.Console
+   :members:
+   :special-members: __str__
+
+
+.. _`User`:
+
+User
+----
+
+.. automodule:: zhmcclient._user
+
+.. autoclass:: zhmcclient.UserManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.User
+   :members:
+   :special-members: __str__
+
+
+.. _`User Role`:
+
+User Role
+---------
+
+.. automodule:: zhmcclient._user_role
+
+.. autoclass:: zhmcclient.UserRoleManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.UserRole
+   :members:
+   :special-members: __str__
+
+
+.. _`User Pattern`:
+
+User Pattern
+------------
+
+.. automodule:: zhmcclient._user_pattern
+
+.. autoclass:: zhmcclient.UserPatternManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.UserPattern
+   :members:
+   :special-members: __str__
+
+
+.. _`Password Rule`:
+
+Password Rule
+-------------
+
+.. automodule:: zhmcclient._password_rule
+
+.. autoclass:: zhmcclient.PasswordRuleManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.PasswordRule
+   :members:
+   :special-members: __str__
+
+
+.. _`Task`:
+
+Task
+----
+
+.. automodule:: zhmcclient._task
+
+.. autoclass:: zhmcclient.TaskManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.Task
+   :members:
+   :special-members: __str__
+
+
+.. _`LDAP Server Definition`:
+
+LDAP Server Definition
+----------------------
+
+.. automodule:: zhmcclient._ldap_server_definition
+
+.. autoclass:: zhmcclient.LdapServerDefinitionManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.LdapServerDefinition
    :members:
    :special-members: __str__

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -1,0 +1,304 @@
+# Copyright 2016-2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _console module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+
+from zhmcclient import Client, Error, Console, UserManager, UserRoleManager, \
+    UserPatternManager, PasswordRuleManager, TaskManager, \
+    LdapServerDefinitionManager
+from zhmcclient_mock import FakedSession
+from .utils import assert_resources
+
+
+class TestConsole(object):
+    """All tests for the Console and ConsoleManager classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+
+    def test_consolemanager_initial_attrs(self):
+        """Test initial attributes of ConsoleManager."""
+
+        console_mgr = self.client.consoles
+
+        # Verify all public properties of the manager object
+        assert console_mgr.resource_class == Console
+        assert console_mgr.class_name == 'console'
+        assert console_mgr.session == self.session
+        assert console_mgr.parent is None
+        assert console_mgr.client == self.client
+
+    # TODO: Test for ConsoleManager.__repr__()
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(full_properties=False),
+             ['object-uri']),
+            (dict(full_properties=True),
+             ['object-uri', 'name']),
+            (dict(),  # test default for full_properties (True)
+             ['object-uri', 'name']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args", [  # will be ignored
+            None,
+            {},
+            {'name': 'foo'},
+        ]
+    )
+    def test_consolemanager_list(
+            self, filter_args, full_properties_kwargs, prop_names):
+        """Test ConsoleManager.list()."""
+
+        exp_faked_consoles = [self.faked_console]
+        console_mgr = self.client.consoles
+
+        # Execute the code to be tested
+        consoles = console_mgr.list(
+            filter_args=filter_args,
+            **full_properties_kwargs)
+
+        assert_resources(consoles, exp_faked_consoles, prop_names)
+
+    def test_console_initial_attrs(self):
+        """Test initial attributes of Console."""
+
+        console_mgr = self.client.consoles
+        console = console_mgr.find(name=self.faked_console.name)
+
+        # Verify all public properties of the resource object (except those
+        # of its BaseResource superclass which are tested at that level).
+        assert isinstance(console.users, UserManager)
+        assert isinstance(console.user_roles, UserRoleManager)
+        assert isinstance(console.user_patterns, UserPatternManager)
+        assert isinstance(console.password_rules, PasswordRuleManager)
+        assert isinstance(console.tasks, TaskManager)
+        assert isinstance(console.ldap_server_definitions,
+                          LdapServerDefinitionManager)
+
+    def test_console_repr(self):
+        """Test Console.__repr__()."""
+
+        console_mgr = self.client.consoles
+        console = console_mgr.find(name=self.faked_console.name)
+
+        # Execute the code to be tested
+        repr_str = repr(console)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=console.__class__.__name__,
+                               id=id(console)),
+                        repr_str)
+
+    @pytest.mark.parametrize(
+        "wait", [
+            True,
+            # False,  # TODO: Re-enable once implemented
+        ]
+    )
+    @pytest.mark.parametrize(
+        "force", [
+            True,
+            False,
+        ]
+    )
+    def test_console_restart(self, force, wait):
+        """Test Console.restart()."""
+
+        console_mgr = self.client.consoles
+        console = console_mgr.find(name=self.faked_console.name)
+
+        # Note: The force parameter is passed in, but we expect the restart
+        # to always succeed. This means we are not testing cases with other
+        # HMC users being logged on, that would either cause a non-forced
+        # restart to be rejected, or a forced restart to succeed despite them.
+
+        # Execute the code to be tested.
+        ret = console.restart(
+            force=force,
+            wait_for_available=wait,
+            operation_timeout=600)
+
+        assert ret is None
+
+        if wait:
+            # The HMC is expected to be up again, and therefore a simple
+            # operation is expected to succeed:
+            try:
+                self.client.query_api_version()
+            except Error as exc:
+                pytest.fail(
+                    "Unexpected zhmcclient exception during "
+                    "query_api_version() after HMC restart: %s" % exc)
+        else:
+            # The HMC is expected to still be in the restart process, and
+            # therefore a simple operation is expected to fail. This test
+            # may end up to be timing dependent.
+            try:
+                self.client.query_api_version()
+            except Error as exc:
+                pass
+            except Exception as exc:
+                pytest.fail(
+                    "Unexpected non-zhmcclient exception during "
+                    "query_api_version() after HMC restart: %s" % exc)
+            else:
+                pytest.fail(
+                    "Unexpected success of query_api_version() after HMC "
+                    "restart.")
+
+    @pytest.mark.parametrize(
+        "force", [
+            True,
+            False,
+        ]
+    )
+    def test_console_shutdown(self, force):
+        """Test Console.shutdown()."""
+
+        console_mgr = self.client.consoles
+        console = console_mgr.find(name=self.faked_console.name)
+
+        # Note: The force parameter is passed in, but we expect the shutdown
+        # to always succeed. This means we are not testing cases with other
+        # HMC users being logged on, that would either cause a non-forced
+        # shutdown to be rejected, or a forced shutdown to succeed despite
+        # them.
+
+        # Execute the code to be tested.
+        ret = console.shutdown(force=force)
+
+        assert ret is None
+
+        # The HMC is expected to be offline, and therefore a simple operation
+        # is expected to fail.
+        try:
+            self.client.query_api_version()
+        except Error as exc:
+            pass
+        except Exception as exc:
+            pytest.fail(
+                "Unexpected non-zhmcclient exception during "
+                "query_api_version() after HMC shutdown: %s" % exc)
+        else:
+            pytest.fail(
+                "Unexpected success of query_api_version() after HMC "
+                "shutdown.")
+
+    def test_console_audit_log(self):
+        """Test Console.get_audit_log()."""
+
+        # TODO: Add begin/end_time once mocked audit log is supported
+
+        console_mgr = self.client.consoles
+        console = console_mgr.find(name=self.faked_console.name)
+
+        # Execute the code to be tested.
+        log_items = console.get_audit_log()
+
+        assert isinstance(log_items, list)
+
+        # TODO: Verify log items once mocked audit log is supported
+
+    def test_console_security_log(self):
+        """Test Console.get_security_log()."""
+
+        # TODO: Add begin/end_time once mocked security log is supported
+
+        console_mgr = self.client.consoles
+        console = console_mgr.find(name=self.faked_console.name)
+
+        # Execute the code to be tested.
+        log_items = console.get_security_log()
+
+        assert isinstance(log_items, list)
+
+        # TODO: Verify log items once mocked security log is supported
+
+    @pytest.mark.parametrize(
+        "name, exp_cpc_names, prop_names", [
+            (None,
+             ['ucpc_name_1', 'ucpc_name_2'],
+             ['object-uri', 'name']),
+            ('.*',
+             ['ucpc_name_1', 'ucpc_name_2'],
+             ['object-uri', 'name']),
+            ('ucpc_name_.*',
+             ['ucpc_name_1', 'ucpc_name_2'],
+             ['object-uri', 'name']),
+            ('ucpc_name_1',
+             ['ucpc_name_1'],
+             ['object-uri', 'name']),
+            ('ucpc_name_1.*',
+             ['ucpc_name_1'],
+             ['object-uri', 'name']),
+            ('ucpc_name_1.+',
+             [],
+             ['object-uri', 'name']),
+        ]
+    )
+    def test_console_list_unmanaged_cpcs(
+            self, name, exp_cpc_names, prop_names):
+        """Test Console.list_unmanaged_cpcs() and
+        UnmanagedCpcManager.list()."""
+
+        console_mgr = self.client.consoles
+        console = console_mgr.find(name=self.faked_console.name)
+
+        # Add two unmanaged faked CPCs
+        faked_ucpc1 = self.faked_console.unmanaged_cpcs.add({
+            'object-id': 'ucpc-oid-1',
+            # object-uri is set up automatically
+            'name': 'ucpc_name_1',
+        })
+        faked_ucpc2 = self.faked_console.unmanaged_cpcs.add({
+            'object-id': 'ucpc-oid-2',
+            # object-uri is set up automatically
+            'name': 'ucpc_name_2',
+        })
+        faked_ucpcs = [faked_ucpc1, faked_ucpc2]
+
+        exp_faked_ucpcs = [cpc for cpc in faked_ucpcs
+                           if cpc.name in exp_cpc_names]
+
+        # Execute the code to be tested.
+        # This indirectly tests UnmanagedCpcManager.list().
+        ucpcs = console.list_unmanaged_cpcs(name)
+
+        assert_resources(ucpcs, exp_faked_ucpcs, prop_names)

--- a/tests/unit/test_ldap_server_definition.py
+++ b/tests/unit/test_ldap_server_definition.py
@@ -1,0 +1,319 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _ldap_srv_def module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+import copy
+
+from zhmcclient import Client, HTTPError, NotFound, LdapServerDefinition
+from zhmcclient_mock import FakedSession
+from .utils import assert_resources
+
+
+class TestLdapServerDefinition(object):
+    """All tests for the LdapServerDefinition and LdapServerDefinitionManager
+    classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        self.console = self.client.consoles.find(name=self.faked_console.name)
+
+    def add_ldap_srv_def(self, name):
+        faked_ldap_srv_def = self.faked_console.ldap_server_definitions.add({
+            'element-id': 'oid-{}'.format(name),
+            # element-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'ldap-server-definition',
+            'name': name,
+            'description': 'LDAP Server Definition {}'.format(name),
+            'primary-hostname-ipaddr': 'host-{}'.format(name),
+        })
+        return faked_ldap_srv_def
+
+    def test_ldap_srv_def_manager_repr(self):
+        """Test LdapServerDefinitionManager.__repr__()."""
+
+        ldap_srv_def_mgr = self.console.ldap_server_definitions
+
+        # Execute the code to be tested
+        repr_str = repr(ldap_srv_def_mgr)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=ldap_srv_def_mgr.__class__.__name__,
+                               id=id(ldap_srv_def_mgr)),
+                        repr_str)
+
+    def test_ldap_srv_def_manager_initial_attrs(self):
+        """Test initial attributes of LdapServerDefinitionManager."""
+
+        ldap_srv_def_mgr = self.console.ldap_server_definitions
+
+        # Verify all public properties of the manager object
+        assert ldap_srv_def_mgr.resource_class == LdapServerDefinition
+        assert ldap_srv_def_mgr.class_name == 'ldap-server-definition'
+        assert ldap_srv_def_mgr.session is self.session
+        assert ldap_srv_def_mgr.parent is self.console
+        assert ldap_srv_def_mgr.console is self.console
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(full_properties=False),
+             ['element-uri']),
+            (dict(full_properties=True),
+             ['element-uri', 'name']),
+            (dict(),  # test default for full_properties (True)
+             ['element-uri', 'name']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args, exp_names", [
+            (None,
+             ['a', 'b']),
+            ({},
+             ['a', 'b']),
+            ({'name': 'a'},
+             ['a']),
+        ]
+    )
+    def test_ldap_srv_def_manager_list(
+            self, filter_args, exp_names, full_properties_kwargs, prop_names):
+        """Test LdapServerDefinitionManager.list()."""
+
+        faked_ldap_srv_def1 = self.add_ldap_srv_def(name='a')
+        faked_ldap_srv_def2 = self.add_ldap_srv_def(name='b')
+        faked_ldap_srv_defs = [faked_ldap_srv_def1, faked_ldap_srv_def2]
+        exp_faked_ldap_srv_defs = [u for u in faked_ldap_srv_defs
+                                   if u.name in exp_names]
+        ldap_srv_def_mgr = self.console.ldap_server_definitions
+
+        # Execute the code to be tested
+        ldap_srv_defs = ldap_srv_def_mgr.list(filter_args=filter_args,
+                                              **full_properties_kwargs)
+
+        assert_resources(ldap_srv_defs, exp_faked_ldap_srv_defs, prop_names)
+
+    @pytest.mark.parametrize(
+        "input_props, exp_prop_names, exp_exc", [
+            ({},  # props missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X'},  # props missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X',
+              'name': 'a'},
+             ['element-uri', 'name', 'description'],
+             None),
+        ]
+    )
+    def test_ldap_srv_def_manager_create(
+            self, input_props, exp_prop_names, exp_exc):
+        """Test LdapServerDefinitionManager.create()."""
+
+        ldap_srv_def_mgr = self.console.ldap_server_definitions
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                ldap_srv_def_mgr.create(properties=input_props)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+        else:
+
+            # Execute the code to be tested.
+            ldap_srv_def = ldap_srv_def_mgr.create(properties=input_props)
+
+            # Check the resource for consistency within itself
+            assert isinstance(ldap_srv_def, LdapServerDefinition)
+            ldap_srv_def_name = ldap_srv_def.name
+            exp_ldap_srv_def_name = ldap_srv_def.properties['name']
+            assert ldap_srv_def_name == exp_ldap_srv_def_name
+            ldap_srv_def_uri = ldap_srv_def.uri
+            exp_ldap_srv_def_uri = ldap_srv_def.properties['element-uri']
+            assert ldap_srv_def_uri == exp_ldap_srv_def_uri
+
+            # Check the properties against the expected names and values
+            for prop_name in exp_prop_names:
+                assert prop_name in ldap_srv_def.properties
+                if prop_name in input_props:
+                    value = ldap_srv_def.properties[prop_name]
+                    exp_value = input_props[prop_name]
+                    assert value == exp_value
+
+    def test_ldap_srv_def_repr(self):
+        """Test LdapServerDefinition.__repr__()."""
+
+        faked_ldap_srv_def1 = self.add_ldap_srv_def(name='a')
+        ldap_srv_def1 = self.console.ldap_server_definitions.find(
+            name=faked_ldap_srv_def1.name)
+
+        # Execute the code to be tested
+        repr_str = repr(ldap_srv_def1)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=ldap_srv_def1.__class__.__name__,
+                               id=id(ldap_srv_def1)),
+                        repr_str)
+
+    @pytest.mark.parametrize(
+        "input_props, exp_exc", [
+            ({'name': 'a'},
+             None),
+            ({'name': 'b'},
+             None),
+        ]
+    )
+    def test_ldap_srv_def_delete(self, input_props, exp_exc):
+        """Test LdapServerDefinition.delete()."""
+
+        faked_ldap_srv_def = self.add_ldap_srv_def(name=input_props['name'])
+
+        ldap_srv_def_mgr = self.console.ldap_server_definitions
+        ldap_srv_def = ldap_srv_def_mgr.find(name=faked_ldap_srv_def.name)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                ldap_srv_def.delete()
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the LDAP Server Definition still exists
+            ldap_srv_def_mgr.find(name=faked_ldap_srv_def.name)
+
+        else:
+
+            # Execute the code to be tested.
+            ldap_srv_def.delete()
+
+            # Check that the LDAP Server Definition no longer exists
+            with pytest.raises(NotFound) as exc_info:
+                ldap_srv_def_mgr.find(name=faked_ldap_srv_def.name)
+
+    def test_ldap_srv_def_delete_create_same_name(self):
+        """Test LdapServerDefinition.delete() followed by create() with same
+        name."""
+
+        ldap_srv_def_name = 'faked_a'
+
+        # Add the LDAP Server Definition to be tested
+        self.add_ldap_srv_def(name=ldap_srv_def_name)
+
+        # Input properties for a LDAP Server Definition with the same name
+        sn_ldap_srv_def_props = {
+            'name': ldap_srv_def_name,
+            'description': 'LDAP Server Definition with same name',
+            'type': 'user-defined',
+        }
+
+        ldap_srv_def_mgr = self.console.ldap_server_definitions
+        ldap_srv_def = ldap_srv_def_mgr.find(name=ldap_srv_def_name)
+
+        # Execute the deletion code to be tested
+        ldap_srv_def.delete()
+
+        # Check that the LDAP Server Definition no longer exists
+        with pytest.raises(NotFound):
+            ldap_srv_def_mgr.find(name=ldap_srv_def_name)
+
+        # Execute the creation code to be tested.
+        ldap_srv_def_mgr.create(sn_ldap_srv_def_props)
+
+        # Check that the LDAP Server Definition exists again under that name
+        sn_ldap_srv_def = ldap_srv_def_mgr.find(name=ldap_srv_def_name)
+        description = sn_ldap_srv_def.get_property('description')
+        assert description == sn_ldap_srv_def_props['description']
+
+    @pytest.mark.parametrize(
+        "input_props", [
+            {},
+            {'description': 'New LDAP Server Definition description'},
+        ]
+    )
+    def test_ldap_srv_def_update_properties(self, input_props):
+        """Test LdapServerDefinition.update_properties()."""
+
+        ldap_srv_def_name = 'faked_a'
+
+        # Add the LDAP Server Definition to be tested
+        self.add_ldap_srv_def(name=ldap_srv_def_name)
+
+        ldap_srv_def_mgr = self.console.ldap_server_definitions
+        ldap_srv_def = ldap_srv_def_mgr.find(name=ldap_srv_def_name)
+
+        ldap_srv_def.pull_full_properties()
+        saved_properties = copy.deepcopy(ldap_srv_def.properties)
+
+        # Execute the code to be tested
+        ldap_srv_def.update_properties(properties=input_props)
+
+        # Verify that the resource object already reflects the property
+        # updates.
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in ldap_srv_def.properties
+            prop_value = ldap_srv_def.properties[prop_name]
+            assert prop_value == exp_prop_value, \
+                "Unexpected value for property {!r}".format(prop_name)
+
+        # Refresh the resource object and verify that the resource object
+        # still reflects the property updates.
+        ldap_srv_def.pull_full_properties()
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in ldap_srv_def.properties
+            prop_value = ldap_srv_def.properties[prop_name]
+            assert prop_value == exp_prop_value

--- a/tests/unit/test_password_rule.py
+++ b/tests/unit/test_password_rule.py
@@ -1,0 +1,337 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _password_rule module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+import copy
+
+from zhmcclient import Client, HTTPError, NotFound, PasswordRule
+from zhmcclient_mock import FakedSession
+from .utils import assert_resources
+
+
+class TestPasswordRule(object):
+    """All tests for the PasswordRule and PasswordRuleManager classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        self.console = self.client.consoles.find(name=self.faked_console.name)
+
+    def add_password_rule(self, name, type_):
+        faked_password_rule = self.faked_console.password_rules.add({
+            'element-id': 'oid-{}'.format(name),
+            # element-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'password-rule',
+            'name': name,
+            'description': 'Password Rule {}'.format(name),
+            'type': type_,
+        })
+        return faked_password_rule
+
+    def add_user(self, name, type_):
+        faked_user = self.faked_console.users.add({
+            'object-id': 'oid-{}'.format(name),
+            # object-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'user',
+            'name': name,
+            'description': 'User {}'.format(name),
+            'type': type_,
+            'authentication-type': 'local',
+        })
+        return faked_user
+
+    def test_password_rule_manager_repr(self):
+        """Test PasswordRuleManager.__repr__()."""
+
+        password_rule_mgr = self.console.password_rules
+
+        # Execute the code to be tested
+        repr_str = repr(password_rule_mgr)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=password_rule_mgr.__class__.__name__,
+                               id=id(password_rule_mgr)),
+                        repr_str)
+
+    def test_password_rule_manager_initial_attrs(self):
+        """Test initial attributes of PasswordRuleManager."""
+
+        password_rule_mgr = self.console.password_rules
+
+        # Verify all public properties of the manager object
+        assert password_rule_mgr.resource_class == PasswordRule
+        assert password_rule_mgr.class_name == 'password-rule'
+        assert password_rule_mgr.session is self.session
+        assert password_rule_mgr.parent is self.console
+        assert password_rule_mgr.console is self.console
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(full_properties=False),
+             ['element-uri']),
+            (dict(full_properties=True),
+             ['element-uri', 'name']),
+            (dict(),  # test default for full_properties (True)
+             ['element-uri', 'name']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args, exp_names", [
+            (None,
+             ['a', 'b']),
+            ({},
+             ['a', 'b']),
+            ({'name': 'a'},
+             ['a']),
+        ]
+    )
+    def test_password_rule_manager_list(
+            self, filter_args, exp_names, full_properties_kwargs, prop_names):
+        """Test PasswordRuleManager.list()."""
+
+        faked_password_rule1 = self.add_password_rule(
+            name='a', type_='user-defined')
+        faked_password_rule2 = self.add_password_rule(
+            name='b', type_='system-defined')
+        faked_password_rules = [faked_password_rule1, faked_password_rule2]
+        exp_faked_password_rules = [u for u in faked_password_rules
+                                    if u.name in exp_names]
+        password_rule_mgr = self.console.password_rules
+
+        # Execute the code to be tested
+        password_rules = password_rule_mgr.list(filter_args=filter_args,
+                                                **full_properties_kwargs)
+
+        assert_resources(password_rules, exp_faked_password_rules, prop_names)
+
+    @pytest.mark.parametrize(
+        "input_props, exp_prop_names, exp_exc", [
+            ({},  # props missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X'},  # props missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X',
+              'name': 'a'},
+             ['element-uri', 'name', 'description'],
+             None),
+        ]
+    )
+    def test_password_rule_manager_create(self, input_props, exp_prop_names,
+                                          exp_exc):
+        """Test PasswordRuleManager.create()."""
+
+        password_rule_mgr = self.console.password_rules
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                password_rule_mgr.create(properties=input_props)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+        else:
+
+            # Execute the code to be tested.
+            password_rule = password_rule_mgr.create(properties=input_props)
+
+            # Check the resource for consistency within itself
+            assert isinstance(password_rule, PasswordRule)
+            password_rule_name = password_rule.name
+            exp_password_rule_name = password_rule.properties['name']
+            assert password_rule_name == exp_password_rule_name
+            password_rule_uri = password_rule.uri
+            exp_password_rule_uri = password_rule.properties['element-uri']
+            assert password_rule_uri == exp_password_rule_uri
+
+            # Check the properties against the expected names and values
+            for prop_name in exp_prop_names:
+                assert prop_name in password_rule.properties
+                if prop_name in input_props:
+                    value = password_rule.properties[prop_name]
+                    exp_value = input_props[prop_name]
+                    assert value == exp_value
+
+    def test_password_rule_repr(self):
+        """Test PasswordRule.__repr__()."""
+
+        faked_password_rule1 = self.add_password_rule(
+            name='a', type_='user-defined')
+        password_rule1 = self.console.password_rules.find(
+            name=faked_password_rule1.name)
+
+        # Execute the code to be tested
+        repr_str = repr(password_rule1)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=password_rule1.__class__.__name__,
+                               id=id(password_rule1)),
+                        repr_str)
+
+    @pytest.mark.parametrize(
+        "input_props, exp_exc", [
+            ({'name': 'a',
+              'type': 'user-defined'},
+             None),
+            ({'name': 'b',
+              'type': 'system-defined'},
+             None),
+        ]
+    )
+    def test_password_rule_delete(self, input_props, exp_exc):
+        """Test PasswordRule.delete()."""
+
+        faked_password_rule = self.add_password_rule(
+            name=input_props['name'],
+            type_=input_props['type'])
+
+        password_rule_mgr = self.console.password_rules
+        password_rule = password_rule_mgr.find(name=faked_password_rule.name)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                password_rule.delete()
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the Password Rule still exists
+            password_rule_mgr.find(name=faked_password_rule.name)
+
+        else:
+
+            # Execute the code to be tested.
+            password_rule.delete()
+
+            # Check that the Password Rule no longer exists
+            with pytest.raises(NotFound) as exc_info:
+                password_rule_mgr.find(name=faked_password_rule.name)
+
+    def test_password_rule_delete_create_same_name(self):
+        """Test PasswordRule.delete() followed by create() with same name."""
+
+        password_rule_name = 'faked_a'
+
+        # Add the Password Rule to be tested
+        self.add_password_rule(name=password_rule_name, type_='user-defined')
+
+        # Input properties for a Password Rule with the same name
+        sn_password_rule_props = {
+            'name': password_rule_name,
+            'description': 'Password Rule with same name',
+            'type': 'user-defined',
+        }
+
+        password_rule_mgr = self.console.password_rules
+        password_rule = password_rule_mgr.find(name=password_rule_name)
+
+        # Execute the deletion code to be tested
+        password_rule.delete()
+
+        # Check that the Password Rule no longer exists
+        with pytest.raises(NotFound):
+            password_rule_mgr.find(name=password_rule_name)
+
+        # Execute the creation code to be tested.
+        password_rule_mgr.create(sn_password_rule_props)
+
+        # Check that the Password Rule exists again under that name
+        sn_password_rule = password_rule_mgr.find(name=password_rule_name)
+        description = sn_password_rule.get_property('description')
+        assert description == sn_password_rule_props['description']
+
+    @pytest.mark.parametrize(
+        "input_props", [
+            {},
+            {'description': 'New Password Rule description'},
+        ]
+    )
+    def test_password_rule_update_properties(self, input_props):
+        """Test PasswordRule.update_properties()."""
+
+        password_rule_name = 'faked_a'
+
+        # Add the Password Rule to be tested
+        self.add_password_rule(name=password_rule_name, type_='user-defined')
+
+        password_rule_mgr = self.console.password_rules
+        password_rule = password_rule_mgr.find(name=password_rule_name)
+
+        password_rule.pull_full_properties()
+        saved_properties = copy.deepcopy(password_rule.properties)
+
+        # Execute the code to be tested
+        password_rule.update_properties(properties=input_props)
+
+        # Verify that the resource object already reflects the property
+        # updates.
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in password_rule.properties
+            prop_value = password_rule.properties[prop_name]
+            assert prop_value == exp_prop_value, \
+                "Unexpected value for property {!r}".format(prop_name)
+
+        # Refresh the resource object and verify that the resource object
+        # still reflects the property updates.
+        password_rule.pull_full_properties()
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in password_rule.properties
+            prop_value = password_rule.properties[prop_name]
+            assert prop_value == exp_prop_value

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,0 +1,140 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _task module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+
+from zhmcclient import Client, Task
+from zhmcclient_mock import FakedSession
+from .utils import assert_resources
+
+
+class TestTask(object):
+    """All tests for the Task and TaskManager classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        self.console = self.client.consoles.find(name=self.faked_console.name)
+
+    def add_task(self, name, view_only=True):
+        faked_task = self.faked_console.tasks.add({
+            'element-id': 'oid-{}'.format(name),
+            # element-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'task',
+            'name': name,
+            'description': 'Task {}'.format(name),
+            'view-only-mode-supported': view_only,
+        })
+        return faked_task
+
+    def test_task_manager_repr(self):
+        """Test TaskManager.__repr__()."""
+
+        task_mgr = self.console.tasks
+
+        # Execute the code to be tested
+        repr_str = repr(task_mgr)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=task_mgr.__class__.__name__,
+                               id=id(task_mgr)),
+                        repr_str)
+
+    def test_task_manager_initial_attrs(self):
+        """Test initial attributes of TaskManager."""
+
+        task_mgr = self.console.tasks
+
+        # Verify all public properties of the manager object
+        assert task_mgr.resource_class == Task
+        assert task_mgr.class_name == 'task'
+        assert task_mgr.session is self.session
+        assert task_mgr.parent is self.console
+        assert task_mgr.console is self.console
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(full_properties=False),
+             ['element-uri']),
+            (dict(full_properties=True),
+             ['element-uri', 'name']),
+            (dict(),  # test default for full_properties (True)
+             ['element-uri', 'name']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args, exp_names", [
+            (None,
+             ['a', 'b']),
+            ({},
+             ['a', 'b']),
+            ({'name': 'a'},
+             ['a']),
+        ]
+    )
+    def test_task_manager_list(
+            self, filter_args, exp_names, full_properties_kwargs, prop_names):
+        """Test TaskManager.list()."""
+
+        faked_task1 = self.add_task(name='a')
+        faked_task2 = self.add_task(name='b')
+        faked_tasks = [faked_task1, faked_task2]
+        exp_faked_tasks = [u for u in faked_tasks if u.name in exp_names]
+        task_mgr = self.console.tasks
+
+        # Execute the code to be tested
+        tasks = task_mgr.list(filter_args=filter_args,
+                              **full_properties_kwargs)
+
+        assert_resources(tasks, exp_faked_tasks, prop_names)
+
+    def test_task_repr(self):
+        """Test Task.__repr__()."""
+
+        faked_task1 = self.add_task(name='a')
+        task1 = self.console.tasks.find(name=faked_task1.name)
+
+        # Execute the code to be tested
+        repr_str = repr(task1)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=task1.__class__.__name__,
+                               id=id(task1)),
+                        repr_str)

--- a/tests/unit/test_unmanaged_cpc.py
+++ b/tests/unit/test_unmanaged_cpc.py
@@ -1,0 +1,139 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _unmanaged_cpc module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+
+from zhmcclient import Client, UnmanagedCpc
+from zhmcclient_mock import FakedSession
+from .utils import assert_resources
+
+
+class TestUnmanagedCpc(object):
+    """All tests for the UnmanagedCpc and UnmanagedCpcManager classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        self.console = self.client.consoles.find(name=self.faked_console.name)
+
+    def add_unmanaged_cpc(self, name):
+        faked_unmanaged_cpc = self.faked_console.unmanaged_cpcs.add({
+            'object-id': 'oid-{}'.format(name),
+            # object-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'cpc',
+            'name': name,
+            'description': 'Unmanaged CPC {}'.format(name),
+        })
+        return faked_unmanaged_cpc
+
+    def test_ucpc_manager_repr(self):
+        """Test UnmanagedCpcManager.__repr__()."""
+
+        ucpc_mgr = self.console.unmanaged_cpcs
+
+        # Execute the code to be tested
+        repr_str = repr(ucpc_mgr)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=ucpc_mgr.__class__.__name__,
+                               id=id(ucpc_mgr)),
+                        repr_str)
+
+    def test_ucpc_manager_initial_attrs(self):
+        """Test initial attributes of UnmanagedCpcManager."""
+
+        ucpc_mgr = self.console.unmanaged_cpcs
+
+        # Verify all public properties of the manager object
+        assert ucpc_mgr.resource_class == UnmanagedCpc
+        assert ucpc_mgr.class_name == 'cpc'
+        assert ucpc_mgr.session is self.session
+        assert ucpc_mgr.parent is self.console
+        assert ucpc_mgr.console is self.console
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(full_properties=False),
+             ['object-uri']),
+            (dict(full_properties=True),
+             ['object-uri', 'name']),
+            (dict(),  # test default for full_properties (True)
+             ['object-uri', 'name']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args, exp_names", [
+            (None,
+             ['a', 'b']),
+            ({},
+             ['a', 'b']),
+            ({'name': 'a'},
+             ['a']),
+        ]
+    )
+    def test_ucpc_manager_list(
+            self, filter_args, exp_names, full_properties_kwargs, prop_names):
+        """Test UnmanagedCpcManager.list()."""
+
+        faked_ucpc1 = self.add_unmanaged_cpc(name='a')
+        faked_ucpc2 = self.add_unmanaged_cpc(name='b')
+        faked_ucpcs = [faked_ucpc1, faked_ucpc2]
+        exp_faked_ucpcs = [u for u in faked_ucpcs if u.name in exp_names]
+        ucpc_mgr = self.console.unmanaged_cpcs
+
+        # Execute the code to be tested
+        ucpcs = ucpc_mgr.list(filter_args=filter_args,
+                              **full_properties_kwargs)
+
+        assert_resources(ucpcs, exp_faked_ucpcs, prop_names)
+
+    def test_ucpc_repr(self):
+        """Test UnmanagedCpc.__repr__()."""
+
+        faked_ucpc1 = self.add_unmanaged_cpc(name='a')
+        ucpc1 = self.console.unmanaged_cpcs.find(name=faked_ucpc1.name)
+
+        # Execute the code to be tested
+        repr_str = repr(ucpc1)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=ucpc1.__class__.__name__,
+                               id=id(ucpc1)),
+                        repr_str)

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1,0 +1,470 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _user module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+import copy
+
+from zhmcclient import Client, HTTPError, NotFound, User
+from zhmcclient_mock import FakedSession
+from .utils import assert_resources
+
+
+class TestUser(object):
+    """All tests for the User and UserManager classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        self.console = self.client.consoles.find(name=self.faked_console.name)
+
+    def add_user(self, name, type_):
+        faked_user = self.faked_console.users.add({
+            'object-id': 'oid-{}'.format(name),
+            # object-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'user',
+            'name': name,
+            'description': 'User {}'.format(name),
+            'type': type_,
+            'authentication-type': 'local',
+        })
+        return faked_user
+
+    def add_user_role(self, name, type_):
+        faked_user_role = self.faked_console.user_roles.add({
+            'object-id': 'oid-{}'.format(name),
+            # object-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'user-role',
+            'name': name,
+            'description': 'User Role {}'.format(name),
+            'type': type_,
+        })
+        return faked_user_role
+
+    def test_user_manager_repr(self):
+        """Test UserManager.__repr__()."""
+
+        user_mgr = self.console.users
+
+        # Execute the code to be tested
+        repr_str = repr(user_mgr)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=user_mgr.__class__.__name__,
+                               id=id(user_mgr)),
+                        repr_str)
+
+    def test_user_manager_initial_attrs(self):
+        """Test initial attributes of UserManager."""
+
+        user_mgr = self.console.users
+
+        # Verify all public properties of the manager object
+        assert user_mgr.resource_class == User
+        assert user_mgr.class_name == 'user'
+        assert user_mgr.session is self.session
+        assert user_mgr.parent is self.console
+        assert user_mgr.console is self.console
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(full_properties=False),
+             ['object-uri']),
+            (dict(full_properties=True),
+             ['object-uri', 'name']),
+            (dict(),  # test default for full_properties (True)
+             ['object-uri', 'name']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args, exp_names", [
+            (None,
+             ['a', 'b']),
+            ({},
+             ['a', 'b']),
+            ({'name': 'a'},
+             ['a']),
+        ]
+    )
+    def test_user_manager_list(
+            self, filter_args, exp_names, full_properties_kwargs, prop_names):
+        """Test UserManager.list()."""
+
+        faked_user1 = self.add_user(name='a', type_='standard')
+        faked_user2 = self.add_user(name='b', type_='standard')
+        faked_users = [faked_user1, faked_user2]
+        exp_faked_users = [u for u in faked_users if u.name in exp_names]
+        user_mgr = self.console.users
+
+        # Execute the code to be tested
+        users = user_mgr.list(filter_args=filter_args,
+                              **full_properties_kwargs)
+
+        assert_resources(users, exp_faked_users, prop_names)
+
+    @pytest.mark.parametrize(
+        "input_props, exp_prop_names, exp_exc", [
+            ({},
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X'},
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'name': 'fake-name-x'},
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'name': 'fake-name-x',
+              'type': 'standard'},
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'name': 'fake-name-x',
+              'type': 'standard',
+              'authentication-type': 'local'},
+             ['object-uri', 'name', 'type', 'authentication-type'],
+             None),
+            ({'name': 'fake-name-x',
+              'type': 'standard',
+              'authentication-type': 'local',
+              'description': 'fake description X'},
+             ['object-uri', 'name', 'type', 'authentication-type',
+              'description'],
+             None),
+        ]
+    )
+    def test_user_manager_create(self, input_props, exp_prop_names, exp_exc):
+        """Test UserManager.create()."""
+
+        user_mgr = self.console.users
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user_mgr.create(properties=input_props)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+        else:
+
+            # Execute the code to be tested.
+            user = user_mgr.create(properties=input_props)
+
+            # Check the resource for consistency within itself
+            assert isinstance(user, User)
+            user_name = user.name
+            exp_user_name = user.properties['name']
+            assert user_name == exp_user_name
+            user_uri = user.uri
+            exp_user_uri = user.properties['object-uri']
+            assert user_uri == exp_user_uri
+
+            # Check the properties against the expected names and values
+            for prop_name in exp_prop_names:
+                assert prop_name in user.properties
+                if prop_name in input_props:
+                    value = user.properties[prop_name]
+                    exp_value = input_props[prop_name]
+                    assert value == exp_value
+
+    def test_user_repr(self):
+        """Test User.__repr__()."""
+
+        faked_user1 = self.add_user(name='a', type_='standard')
+        user1 = self.console.users.find(name=faked_user1.name)
+
+        # Execute the code to be tested
+        repr_str = repr(user1)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=user1.__class__.__name__,
+                               id=id(user1)),
+                        repr_str)
+
+    @pytest.mark.parametrize(
+        "input_name, input_type, exp_exc", [
+            ('a', 'standard', None),
+            ('b', 'template', None),
+            ('c', 'pattern-based',
+             HTTPError({'http-status': 400, 'reason': 312})),
+            ('d', 'system-defined', None),
+        ]
+    )
+    def test_user_delete(self, input_name, input_type, exp_exc):
+        """Test User.delete()."""
+
+        faked_user = self.add_user(name=input_name, type_=input_type)
+        user_mgr = self.console.users
+        user = user_mgr.find(name=faked_user.name)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user.delete()
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the user still exists
+            user_mgr.find(name=faked_user.name)
+
+        else:
+
+            # Execute the code to be tested.
+            user.delete()
+
+            # Check that the user no longer exists
+            with pytest.raises(NotFound) as exc_info:
+                user_mgr.find(name=faked_user.name)
+
+    def test_user_delete_create_same_name(self):
+        """Test User.delete() followed by create() with same name."""
+
+        user_name = 'faked_a'
+
+        # Add the user to be tested
+        self.add_user(name=user_name, type_='standard')
+
+        # Input properties for a user with the same name
+        sn_user_props = {
+            'name': user_name,
+            'description': 'User with same name',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+
+        user_mgr = self.console.users
+        user = user_mgr.find(name=user_name)
+
+        # Execute the deletion code to be tested
+        user.delete()
+
+        # Check that the user no longer exists
+        with pytest.raises(NotFound):
+            user_mgr.find(name=user_name)
+
+        # Execute the creation code to be tested.
+        user_mgr.create(sn_user_props)
+
+        # Check that the user exists again under that name
+        sn_user = user_mgr.find(name=user_name)
+        description = sn_user.get_property('description')
+        assert description == sn_user_props['description']
+
+    @pytest.mark.parametrize(
+        "input_props", [
+            {},
+            {'description': 'New user description'},
+            {'authentication-type': 'ldap',
+             'description': 'New user description'},
+        ]
+    )
+    def test_user_update_properties(self, input_props):
+        """Test User.update_properties()."""
+
+        # Add the user to be tested
+        faked_user = self.add_user(name='a', type_='standard')
+
+        user_mgr = self.console.users
+        user = user_mgr.find(name=faked_user.name)
+
+        user.pull_full_properties()
+        saved_props = copy.deepcopy(user.properties)
+
+        # Execute the code to be tested
+        user.update_properties(properties=input_props)
+
+        # Verify that the resource object already reflects the property
+        # updates.
+        for prop_name in saved_props:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_props[prop_name]
+            assert prop_name in user.properties
+            prop_value = user.properties[prop_name]
+            assert prop_value == exp_prop_value, \
+                "Unexpected value for property {!r}".format(prop_name)
+
+        # Refresh the resource object and verify that the resource object
+        # still reflects the property updates.
+        user.pull_full_properties()
+        for prop_name in saved_props:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_props[prop_name]
+            assert prop_name in user.properties
+            prop_value = user.properties[prop_name]
+            assert prop_value == exp_prop_value
+
+    @pytest.mark.parametrize(
+        "user_name, user_type, exp_exc", [
+            ('a', 'standard', None),
+            ('b', 'template', None),
+            ('c', 'pattern-based',
+             HTTPError({'http-status': 400, 'reason': 314})),
+            ('d', 'system-defined',
+             HTTPError({'http-status': 400, 'reason': 314})),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "role_name, role_type", [
+            ('ra', 'user-defined'),
+            ('rb', 'system-defined'),
+        ]
+    )
+    def test_user_add_user_role(
+            self, role_name, role_type, user_name, user_type, exp_exc):
+        """Test User.add_user_role()."""
+
+        faked_user = self.add_user(name=user_name, type_=user_type)
+        user_mgr = self.console.users
+        user = user_mgr.find(name=faked_user.name)
+
+        faked_user_role = self.add_user_role(name=role_name, type_=role_type)
+        user_role_mgr = self.console.user_roles
+        user_role = user_role_mgr.find(name=faked_user_role.name)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user.add_user_role(user_role)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the user does not have that user role
+            user.pull_full_properties()
+            if 'user-roles' in user.properties:
+                user_role_uris = user.properties['user-roles']
+                user_role_uri = user_role.uri
+                assert user_role_uri not in user_role_uris
+
+        else:
+
+            # Execute the code to be tested.
+            ret = user.add_user_role(user_role)
+
+            assert ret is None
+
+            # Check that the user has that user role
+            user.pull_full_properties()
+            assert 'user-roles' in user.properties
+            user_role_uris = user.properties['user-roles']
+            user_role_uri = user_role.uri
+            assert user_role_uri in user_role_uris
+
+    @pytest.mark.parametrize(
+        "user_name, user_type, exp_exc", [
+            ('a', 'standard', None),
+            ('b', 'template', None),
+            ('c', 'pattern-based',
+             HTTPError({'http-status': 400, 'reason': 314})),
+            ('d', 'system-defined',
+             HTTPError({'http-status': 400, 'reason': 314})),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "role_name, role_type", [
+            ('ra', 'user-defined'),
+            ('rb', 'system-defined'),
+        ]
+    )
+    def test_user_remove_user_role(
+            self, role_name, role_type, user_name, user_type, exp_exc):
+        """Test User.remove_user_role()."""
+
+        faked_user = self.add_user(name=user_name, type_=user_type)
+        user_mgr = self.console.users
+        user = user_mgr.find(name=faked_user.name)
+
+        faked_user_role = self.add_user_role(name=role_name, type_=role_type)
+        user_role_mgr = self.console.user_roles
+        user_role = user_role_mgr.find(name=faked_user_role.name)
+
+        # Prepare the user with the initial user role
+        if 'user-roles' not in faked_user.properties:
+            faked_user.properties['user-roles'] = []
+        faked_user.properties['user-roles'].append(faked_user_role.uri)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user.remove_user_role(user_role)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the user still has that user role
+            user.pull_full_properties()
+            if 'user-roles' in user.properties:
+                user_role_uris = user.properties['user-roles']
+                user_role_uri = user_role.uri
+                assert user_role_uri in user_role_uris
+
+        else:
+
+            # Execute the code to be tested.
+            ret = user.remove_user_role(user_role)
+
+            assert ret is None
+
+            # Check that the user no longer has that user role
+            user.pull_full_properties()
+            assert 'user-roles' in user.properties
+            user_role_uris = user.properties['user-roles']
+            user_role_uri = user_role.uri
+            assert user_role_uri not in user_role_uris

--- a/tests/unit/test_user_pattern.py
+++ b/tests/unit/test_user_pattern.py
@@ -1,0 +1,392 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _user_pattern module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+import copy
+
+from zhmcclient import Client, HTTPError, NotFound, UserPattern
+from zhmcclient_mock import FakedSession
+from .utils import assert_resources
+
+
+class TestUserPattern(object):
+    """All tests for the UserPattern and UserPatternManager classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        self.console = self.client.consoles.find(name=self.faked_console.name)
+
+    def add_user_pattern(self, name, pattern, type_, user_template_uri):
+        faked_user_pattern = self.faked_console.user_patterns.add({
+            'element-id': 'oid-{}'.format(name),
+            # element-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'user-pattern',
+            'name': name,
+            'description': 'User Pattern {}'.format(name),
+            'pattern': pattern,
+            'type': type_,
+            'retention-time': 0,
+            'user-template-uri': user_template_uri,
+        })
+        return faked_user_pattern
+
+    def add_user(self, name, type_):
+        faked_user = self.faked_console.users.add({
+            'object-id': 'oid-{}'.format(name),
+            # object-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'user',
+            'name': name,
+            'description': 'User {}'.format(name),
+            'type': type_,
+            'authentication-type': 'local',
+        })
+        return faked_user
+
+    def test_user_pattern_manager_repr(self):
+        """Test UserPatternManager.__repr__()."""
+
+        user_pattern_mgr = self.console.user_patterns
+
+        # Execute the code to be tested
+        repr_str = repr(user_pattern_mgr)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=user_pattern_mgr.__class__.__name__,
+                               id=id(user_pattern_mgr)),
+                        repr_str)
+
+    def test_user_pattern_manager_initial_attrs(self):
+        """Test initial attributes of UserPatternManager."""
+
+        user_pattern_mgr = self.console.user_patterns
+
+        # Verify all public properties of the manager object
+        assert user_pattern_mgr.resource_class == UserPattern
+        assert user_pattern_mgr.class_name == 'user-pattern'
+        assert user_pattern_mgr.session is self.session
+        assert user_pattern_mgr.parent is self.console
+        assert user_pattern_mgr.console is self.console
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(full_properties=False),
+             ['element-uri']),
+            (dict(full_properties=True),
+             ['element-uri', 'name']),
+            (dict(),  # test default for full_properties (True)
+             ['element-uri', 'name']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args, exp_names", [
+            (None,
+             ['a', 'b']),
+            ({},
+             ['a', 'b']),
+            ({'name': 'a'},
+             ['a']),
+        ]
+    )
+    def test_user_pattern_manager_list(
+            self, filter_args, exp_names, full_properties_kwargs, prop_names):
+        """Test UserPatternManager.list()."""
+
+        faked_user1 = self.add_user(name='a', type_='standard')
+        faked_user2 = self.add_user(name='b', type_='standard')
+
+        faked_user_pattern1 = self.add_user_pattern(
+            name='a', pattern='a_*', type_='glob-like',
+            user_template_uri=faked_user1.uri)
+        faked_user_pattern2 = self.add_user_pattern(
+            name='b', pattern='b_.*', type_='regular-expression',
+            user_template_uri=faked_user2.uri)
+        faked_user_patterns = [faked_user_pattern1, faked_user_pattern2]
+        exp_faked_user_patterns = [u for u in faked_user_patterns
+                                   if u.name in exp_names]
+        user_pattern_mgr = self.console.user_patterns
+
+        # Execute the code to be tested
+        user_patterns = user_pattern_mgr.list(filter_args=filter_args,
+                                              **full_properties_kwargs)
+
+        assert_resources(user_patterns, exp_faked_user_patterns, prop_names)
+
+    @pytest.mark.parametrize(
+        "input_props, exp_prop_names, exp_exc", [
+            ({},  # props missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X'},  # props missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X',
+              'name': 'a',
+              'pattern': 'a*'},  # several missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X',
+              'name': 'a',
+              'pattern': 'a*'},  # several missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X',
+              'name': 'a',
+              'pattern': 'a*',
+              'type': 'glob-like'},  # props missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X',
+              'name': 'a',
+              'pattern': 'a*',
+              'type': 'glob-like',
+              'retention-time': 0},  # props missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X',
+              'name': 'a',
+              'pattern': 'a*',
+              'type': 'glob-like',
+              'retention-time': 28,
+              'user-template-uri': '/api/users/oid-tpl'},
+             ['element-uri', 'name', 'description', 'pattern', 'type',
+              'retention-time', 'user-template-uri'],
+             None),
+        ]
+    )
+    def test_user_pattern_manager_create(self, input_props, exp_prop_names,
+                                         exp_exc):
+        """Test UserPatternManager.create()."""
+
+        faked_user_template = self.add_user(name='tpl', type_='template')
+        assert faked_user_template.uri == '/api/users/oid-tpl'
+
+        user_pattern_mgr = self.console.user_patterns
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user_pattern_mgr.create(properties=input_props)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+        else:
+
+            # Execute the code to be tested.
+            user_pattern = user_pattern_mgr.create(properties=input_props)
+
+            # Check the resource for consistency within itself
+            assert isinstance(user_pattern, UserPattern)
+            user_pattern_name = user_pattern.name
+            exp_user_pattern_name = user_pattern.properties['name']
+            assert user_pattern_name == exp_user_pattern_name
+            user_pattern_uri = user_pattern.uri
+            exp_user_pattern_uri = user_pattern.properties['element-uri']
+            assert user_pattern_uri == exp_user_pattern_uri
+
+            # Check the properties against the expected names and values
+            for prop_name in exp_prop_names:
+                assert prop_name in user_pattern.properties
+                if prop_name in input_props:
+                    value = user_pattern.properties[prop_name]
+                    exp_value = input_props[prop_name]
+                    assert value == exp_value
+
+    def test_user_pattern_repr(self):
+        """Test UserPattern.__repr__()."""
+
+        faked_user1 = self.add_user(name='a', type_='standard')
+        faked_user_pattern1 = self.add_user_pattern(
+            name='a', pattern='a_*', type_='glob-like',
+            user_template_uri=faked_user1.uri)
+        user_pattern1 = self.console.user_patterns.find(
+            name=faked_user_pattern1.name)
+
+        # Execute the code to be tested
+        repr_str = repr(user_pattern1)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=user_pattern1.__class__.__name__,
+                               id=id(user_pattern1)),
+                        repr_str)
+
+    @pytest.mark.parametrize(
+        "input_props, exp_exc", [
+            ({'name': 'a',
+              'description': 'fake description X',
+              'pattern': 'a*',
+              'type': 'glob-like',
+              'retention-time': 28,
+              'user-template-uri': '/api/users/oid-tpl'},
+             None),
+        ]
+    )
+    def test_user_pattern_delete(self, input_props, exp_exc):
+        """Test UserPattern.delete()."""
+
+        faked_user_pattern = self.add_user_pattern(
+            name=input_props['name'],
+            pattern=input_props['pattern'],
+            type_=input_props['type'],
+            user_template_uri=input_props['user-template-uri'])
+
+        user_pattern_mgr = self.console.user_patterns
+        user_pattern = user_pattern_mgr.find(name=faked_user_pattern.name)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user_pattern.delete()
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the user pattern still exists
+            user_pattern_mgr.find(name=faked_user_pattern.name)
+
+        else:
+
+            # Execute the code to be tested.
+            user_pattern.delete()
+
+            # Check that the user pattern no longer exists
+            with pytest.raises(NotFound) as exc_info:
+                user_pattern_mgr.find(name=faked_user_pattern.name)
+
+    def test_user_pattern_delete_create_same_name(self):
+        """Test UserPattern.delete() followed by create() with same name."""
+
+        user_pattern_name = 'faked_a'
+
+        faked_user1 = self.add_user(name='a', type_='standard')
+
+        # Add the user pattern to be tested
+        self.add_user_pattern(
+            name=user_pattern_name, pattern='a_*', type_='glob-like',
+            user_template_uri=faked_user1.uri)
+
+        # Input properties for a user pattern with the same name
+        sn_user_pattern_props = {
+            'name': user_pattern_name,
+            'description': 'User Pattern with same name',
+            'pattern': 'a*',
+            'type': 'glob-like',
+            'retention-time': 28,
+            'user-template-uri': '/api/users/oid-tpl',
+        }
+
+        user_pattern_mgr = self.console.user_patterns
+        user_pattern = user_pattern_mgr.find(name=user_pattern_name)
+
+        # Execute the deletion code to be tested
+        user_pattern.delete()
+
+        # Check that the user pattern no longer exists
+        with pytest.raises(NotFound):
+            user_pattern_mgr.find(name=user_pattern_name)
+
+        # Execute the creation code to be tested.
+        user_pattern_mgr.create(sn_user_pattern_props)
+
+        # Check that the user pattern exists again under that name
+        sn_user_pattern = user_pattern_mgr.find(name=user_pattern_name)
+        description = sn_user_pattern.get_property('description')
+        assert description == sn_user_pattern_props['description']
+
+    @pytest.mark.parametrize(
+        "input_props", [
+            {},
+            {'description': 'New user pattern description'},
+        ]
+    )
+    def test_user_pattern_update_properties(self, input_props):
+        """Test UserPattern.update_properties()."""
+
+        user_pattern_name = 'faked_a'
+
+        faked_user1 = self.add_user(name='a', type_='standard')
+
+        # Add the user pattern to be tested
+        self.add_user_pattern(
+            name=user_pattern_name, pattern='a_*', type_='glob-like',
+            user_template_uri=faked_user1.uri)
+
+        user_pattern_mgr = self.console.user_patterns
+        user_pattern = user_pattern_mgr.find(name=user_pattern_name)
+
+        user_pattern.pull_full_properties()
+        saved_properties = copy.deepcopy(user_pattern.properties)
+
+        # Execute the code to be tested
+        user_pattern.update_properties(properties=input_props)
+
+        # Verify that the resource object already reflects the property
+        # updates.
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in user_pattern.properties
+            prop_value = user_pattern.properties[prop_name]
+            assert prop_value == exp_prop_value, \
+                "Unexpected value for property {!r}".format(prop_name)
+
+        # Refresh the resource object and verify that the resource object
+        # still reflects the property updates.
+        user_pattern.pull_full_properties()
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in user_pattern.properties
+            prop_value = user_pattern.properties[prop_name]
+            assert prop_value == exp_prop_value

--- a/tests/unit/test_user_role.py
+++ b/tests/unit/test_user_role.py
@@ -1,0 +1,463 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _user_role module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+import copy
+import six
+
+from zhmcclient import Client, HTTPError, NotFound, BaseResource, UserRole
+from zhmcclient_mock import FakedSession
+from .utils import assert_resources
+
+
+class TestUserRole(object):
+    """All tests for the UserRole and UserRoleManager classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        self.console = self.client.consoles.find(name=self.faked_console.name)
+
+    def add_user_role(self, name, type_):
+        faked_user_role = self.faked_console.user_roles.add({
+            'object-id': 'oid-{}'.format(name),
+            # object-uri will be automatically set
+            'parent': '/api/console',
+            'class': 'user-role',
+            'name': name,
+            'description': 'User Role {}'.format(name),
+            'type': type_,
+        })
+        return faked_user_role
+
+    def test_user_role_manager_repr(self):
+        """Test UserRoleManager.__repr__()."""
+
+        user_role_mgr = self.console.user_roles
+
+        # Execute the code to be tested
+        repr_str = repr(user_role_mgr)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=user_role_mgr.__class__.__name__,
+                               id=id(user_role_mgr)),
+                        repr_str)
+
+    def test_user_role_manager_initial_attrs(self):
+        """Test initial attributes of UserRoleManager."""
+
+        user_role_mgr = self.console.user_roles
+
+        # Verify all public properties of the manager object
+        assert user_role_mgr.resource_class == UserRole
+        assert user_role_mgr.class_name == 'user-role'
+        assert user_role_mgr.session is self.session
+        assert user_role_mgr.parent is self.console
+        assert user_role_mgr.console is self.console
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, prop_names", [
+            (dict(full_properties=False),
+             ['object-uri']),
+            (dict(full_properties=True),
+             ['object-uri', 'name']),
+            (dict(),  # test default for full_properties (True)
+             ['object-uri', 'name']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args, exp_names", [
+            (None,
+             ['a', 'b']),
+            ({},
+             ['a', 'b']),
+            ({'name': 'a'},
+             ['a']),
+        ]
+    )
+    def test_user_role_manager_list(
+            self, filter_args, exp_names, full_properties_kwargs, prop_names):
+        """Test UserRoleManager.list()."""
+
+        faked_user_role1 = self.add_user_role(name='a', type_='user-defined')
+        faked_user_role2 = self.add_user_role(name='b', type_='user-defined')
+        faked_user_roles = [faked_user_role1, faked_user_role2]
+        exp_faked_user_roles = [u for u in faked_user_roles
+                                if u.name in exp_names]
+        user_role_mgr = self.console.user_roles
+
+        # Execute the code to be tested
+        user_roles = user_role_mgr.list(filter_args=filter_args,
+                                        **full_properties_kwargs)
+
+        assert_resources(user_roles, exp_faked_user_roles, prop_names)
+
+    @pytest.mark.parametrize(
+        "input_props, exp_prop_names, exp_exc", [
+            ({},  # name missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X'},  # name missing
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'name': 'fake-name-x',
+              'type': 'user-defined'},  # type not allowed
+             None,
+             HTTPError({'http-status': 400, 'reason': 6})),
+            ({'name': 'fake-name-x',
+              'type': 'system-defined'},  # type not allowed
+             None,
+             HTTPError({'http-status': 400, 'reason': 6})),
+            ({'name': 'fake-name-x'},
+             ['object-uri', 'name'],
+             None),
+            ({'name': 'fake-name-x',
+              'description': 'fake description X'},
+             ['object-uri', 'name', 'description'],
+             None),
+        ]
+    )
+    def test_user_role_manager_create(self, input_props, exp_prop_names,
+                                      exp_exc):
+        """Test UserRoleManager.create()."""
+
+        user_role_mgr = self.console.user_roles
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user_role_mgr.create(properties=input_props)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+        else:
+
+            # Execute the code to be tested.
+            user_role = user_role_mgr.create(properties=input_props)
+
+            # Check the resource for consistency within itself
+            assert isinstance(user_role, UserRole)
+            user_role_name = user_role.name
+            exp_user_role_name = user_role.properties['name']
+            assert user_role_name == exp_user_role_name
+            user_role_uri = user_role.uri
+            exp_user_role_uri = user_role.properties['object-uri']
+            assert user_role_uri == exp_user_role_uri
+
+            # Check the properties against the expected names and values
+            for prop_name in exp_prop_names:
+                assert prop_name in user_role.properties
+                if prop_name in input_props:
+                    value = user_role.properties[prop_name]
+                    exp_value = input_props[prop_name]
+                    assert value == exp_value
+
+    def test_user_role_repr(self):
+        """Test UserRole.__repr__()."""
+
+        faked_user_role1 = self.add_user_role(name='a', type_='user-defined')
+        user_role1 = self.console.user_roles.find(name=faked_user_role1.name)
+
+        # Execute the code to be tested
+        repr_str = repr(user_role1)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=user_role1.__class__.__name__,
+                               id=id(user_role1)),
+                        repr_str)
+
+    @pytest.mark.parametrize(
+        "input_name, input_type, exp_exc", [
+            ('a', 'user-defined', None),
+            # ('b', 'system-defined',
+            #  HTTPError({'http-status': 400, 'reason': 312})),
+            # TODO: Re-enable once rejection for system-defined roles supported
+        ]
+    )
+    def test_user_role_delete(self, input_name, input_type, exp_exc):
+        """Test UserRole.delete()."""
+
+        faked_user_role = self.add_user_role(name=input_name, type_=input_type)
+        user_role_mgr = self.console.user_roles
+        user_role = user_role_mgr.find(name=faked_user_role.name)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user_role.delete()
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the user role still exists
+            user_role_mgr.find(name=faked_user_role.name)
+
+        else:
+
+            # Execute the code to be tested.
+            user_role.delete()
+
+            # Check that the user role no longer exists
+            with pytest.raises(NotFound) as exc_info:
+                user_role_mgr.find(name=faked_user_role.name)
+
+    def test_user_role_delete_create_same_name(self):
+        """Test UserRole.delete() followed by create() with same name."""
+
+        user_role_name = 'faked_a'
+
+        # Add the user role to be tested
+        self.add_user_role(name=user_role_name, type_='user-defined')
+
+        # Input properties for a user role with the same name
+        sn_user_role_props = {
+            'name': user_role_name,
+            'description': 'User Role with same name',
+        }
+
+        user_role_mgr = self.console.user_roles
+        user_role = user_role_mgr.find(name=user_role_name)
+
+        # Execute the deletion code to be tested
+        user_role.delete()
+
+        # Check that the user role no longer exists
+        with pytest.raises(NotFound):
+            user_role_mgr.find(name=user_role_name)
+
+        # Execute the creation code to be tested.
+        user_role_mgr.create(sn_user_role_props)
+
+        # Check that the user role exists again under that name
+        sn_user_role = user_role_mgr.find(name=user_role_name)
+        description = sn_user_role.get_property('description')
+        assert description == sn_user_role_props['description']
+
+    @pytest.mark.parametrize(
+        "input_props", [
+            {},
+            {'description': 'New user role description'},
+        ]
+    )
+    def test_user_role_update_properties(self, input_props):
+        """Test UserRole.update_properties()."""
+
+        # Add the user role to be tested
+        faked_user_role = self.add_user_role(name='a', type_='user-defined')
+
+        user_role_mgr = self.console.user_roles
+        user_role = user_role_mgr.find(name=faked_user_role.name)
+
+        user_role.pull_full_properties()
+        saved_properties = copy.deepcopy(user_role.properties)
+
+        # Execute the code to be tested
+        user_role.update_properties(properties=input_props)
+
+        # Verify that the resource object already reflects the property
+        # updates.
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in user_role.properties
+            prop_value = user_role.properties[prop_name]
+            assert prop_value == exp_prop_value, \
+                "Unexpected value for property {!r}".format(prop_name)
+
+        # Refresh the resource object and verify that the resource object
+        # still reflects the property updates.
+        user_role.pull_full_properties()
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in user_role.properties
+            prop_value = user_role.properties[prop_name]
+            assert prop_value == exp_prop_value
+
+    @pytest.mark.parametrize(
+        "role_name, role_type, exp_exc", [
+            ('ra', 'user-defined', None),
+            ('rb', 'system-defined',
+             HTTPError({'http-status': 400, 'reason': 314})),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "perm_args", [
+            {'permitted_object': 'cpc',
+             'include_members': True,
+             'view_only': False},
+        ]
+    )
+    def test_user_role_add_permission(
+            self, perm_args, role_name, role_type, exp_exc):
+        """Test UserRole.add_permission()."""
+
+        faked_user_role = self.add_user_role(name=role_name, type_=role_type)
+        user_role_mgr = self.console.user_roles
+        user_role = user_role_mgr.find(name=faked_user_role.name)
+
+        permitted_object = perm_args['permitted_object']
+        if isinstance(permitted_object, BaseResource):
+            perm_obj = permitted_object.uri
+            perm_type = 'object'
+        else:
+            assert isinstance(permitted_object, six.string_types)
+            perm_obj = permitted_object
+            perm_type = 'object-class'
+        permission_parms = {
+            'permitted-object': perm_obj,
+            'permitted-object-type': perm_type,
+            'include-members': perm_args['include_members'],
+            'view-only-mode': perm_args['view_only'],
+        }
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user_role.add_permission(**perm_args)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the user role still does not have that permission
+            user_role.pull_full_properties()
+            if 'permissions' in user_role.properties:
+                permissions = user_role.properties['permissions']
+                assert permission_parms not in permissions
+
+        else:
+
+            # Execute the code to be tested.
+            ret = user_role.add_permission(**perm_args)
+
+            assert ret is None
+
+            # Check that the user role now has that permission
+            user_role.pull_full_properties()
+            permissions = user_role.properties['permissions']
+            assert permission_parms in permissions
+
+    @pytest.mark.parametrize(
+        "role_name, role_type, exp_exc", [
+            ('ra', 'user-defined', None),
+            ('rb', 'system-defined',
+             HTTPError({'http-status': 400, 'reason': 314})),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "perm_args", [
+            {'permitted_object': 'cpc',
+             'include_members': True,
+             'view_only': False},
+        ]
+    )
+    def test_user_role_remove_permission(
+            self, perm_args, role_name, role_type, exp_exc):
+        """Test UserRole.remove_permission()."""
+
+        faked_user_role = self.add_user_role(name=role_name, type_=role_type)
+        user_role_mgr = self.console.user_roles
+        user_role = user_role_mgr.find(name=faked_user_role.name)
+
+        permitted_object = perm_args['permitted_object']
+        if isinstance(permitted_object, BaseResource):
+            perm_obj = permitted_object.uri
+            perm_type = 'object'
+        else:
+            assert isinstance(permitted_object, six.string_types)
+            perm_obj = permitted_object
+            perm_type = 'object-class'
+        permission_parms = {
+            'permitted-object': perm_obj,
+            'permitted-object-type': perm_type,
+            'include-members': perm_args['include_members'],
+            'view-only-mode': perm_args['view_only'],
+        }
+
+        # Prepare the user role with the initial permission
+        if 'permissions' not in faked_user_role.properties:
+            faked_user_role.properties['permissions'] = []
+        faked_user_role.properties['permissions'].append(permission_parms)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                user_role.remove_permission(**perm_args)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+            # Check that the user role still has that permission
+            user_role.pull_full_properties()
+            permissions = user_role.properties['permissions']
+            assert permission_parms in permissions
+
+        else:
+
+            # Execute the code to be tested.
+            ret = user_role.remove_permission(**perm_args)
+
+            assert ret is None
+
+            # Check that the user role no longer has that permission
+            user_role.pull_full_properties()
+            if 'permissions' in user_role.properties:
+                permissions = user_role.properties['permissions']
+                assert permission_parms not in permissions

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -29,10 +29,24 @@ from mock import MagicMock
 from zhmcclient_mock._hmc import FakedHmc
 
 from zhmcclient_mock._urihandler import HTTPError, InvalidResourceError, \
-    InvalidMethodError, CpcNotInDpmError, CpcInDpmError, \
+    InvalidMethodError, CpcNotInDpmError, CpcInDpmError, BadRequestError, \
+    ConflictError, ConnectionError, \
     parse_query_parms, UriHandler, \
     GenericGetPropertiesHandler, GenericUpdatePropertiesHandler, \
+    GenericDeleteHandler, \
     VersionHandler, \
+    ConsoleHandler, ConsoleRestartHandler, ConsoleShutdownHandler, \
+    ConsoleMakePrimaryHandler, ConsoleReorderUserPatternsHandler, \
+    ConsoleGetAuditLogHandler, ConsoleGetSecurityLogHandler, \
+    ConsoleListUnmanagedCpcsHandler, \
+    UsersHandler, UserHandler, UserAddUserRoleHandler, \
+    UserRemoveUserRoleHandler, \
+    UserRolesHandler, UserRoleHandler, UserRoleAddPermissionHandler, \
+    UserRoleRemovePermissionHandler, \
+    TasksHandler, TaskHandler, \
+    UserPatternsHandler, UserPatternHandler, \
+    PasswordRulesHandler, PasswordRuleHandler, \
+    LdapServerDefinitionsHandler, LdapServerDefinitionHandler, \
     CpcsHandler, CpcHandler, CpcStartHandler, CpcStopHandler, \
     CpcImportProfilesHandler, CpcExportProfilesHandler, \
     CpcExportPortNamesListHandler, \
@@ -93,6 +107,21 @@ class HTTPErrorTests(unittest.TestCase):
         response = exc.response()
 
         self.assertEqual(response, expected_response)
+
+
+class ConnectionErrorTests(unittest.TestCase):
+    """All tests for class ConnectionError."""
+
+    def setUp(self):
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
+        self.cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
+
+    def test_attributes(self):
+        msg = "fake error message"
+
+        exc = ConnectionError(msg)
+
+        self.assertEqual(exc.message, msg)
 
 
 class DummyHandler1(object):
@@ -438,7 +467,7 @@ class UriHandlerMethodTests(unittest.TestCase):
         DummyHandler2.delete = staticmethod(MagicMock(
             return_value=None))
         self.urihandler = UriHandler(self.uris)
-        self.hmc = 'fake-hmc-object'
+        self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
 
     def tearDown(self):
         delattr(DummyHandler1, 'get')
@@ -503,6 +532,82 @@ def standard_test_hmc():
     for testing.
     """
     hmc_resources = {
+        'consoles': [
+            {
+                'properties': {
+                    'name': 'fake_console_name',
+                },
+                'users': [
+                    {
+                        'properties': {
+                            'object-id': 'fake-user-oid-1',
+                            'name': 'fake_user_name_1',
+                            'description': 'User #1',
+                            'type': 'system-defined',
+                        },
+                    },
+                ],
+                'user_roles': [
+                    {
+                        'properties': {
+                            'object-id': 'fake-user-role-oid-1',
+                            'name': 'fake_user_role_name_1',
+                            'description': 'User Role #1',
+                            'type': 'system-defined',
+                        },
+                    },
+                ],
+                'user_patterns': [
+                    {
+                        'properties': {
+                            'element-id': 'fake-user-pattern-oid-1',
+                            'name': 'fake_user_pattern_name_1',
+                            'description': 'User Pattern #1',
+                            'pattern': 'fake_user_name_*',
+                            'type': 'glob-like',
+                            'retention-time': 0,
+                            'user-template-uri': '/api/users/fake-user-oid-1',
+                        },
+                    },
+                ],
+                'password_rules': [
+                    {
+                        'properties': {
+                            'element-id': 'fake-password-rule-oid-1',
+                            'name': 'fake_password_rule_name_1',
+                            'description': 'Password Rule #1',
+                            'type': 'system-defined',
+                        },
+                    },
+                ],
+                'tasks': [
+                    {
+                        'properties': {
+                            'element-id': 'fake-task-oid-1',
+                            'name': 'fake_task_name_1',
+                            'description': 'Task #1',
+                        },
+                    },
+                    {
+                        'properties': {
+                            'element-id': 'fake-task-oid-2',
+                            'name': 'fake_task_name_2',
+                            'description': 'Task #2',
+                        },
+                    },
+                ],
+                'ldap_server_definitions': [
+                    {
+                        'properties': {
+                            'element-id': 'fake-ldap-srv-def-oid-1',
+                            'name': 'fake_ldap_srv_def_name_1',
+                            'description': 'LDAP Srv Def #1',
+                            'primary-hostname-ipaddr': '10.11.12.13',
+                        },
+                    },
+                ],
+            }
+        ],
         'cpcs': [
             {
                 'properties': {
@@ -737,6 +842,14 @@ class GenericGetPropertiesHandlerTests(unittest.TestCase):
         }
         self.assertEqual(cpc1, exp_cpc1)
 
+    def test_get_error_offline(self):
+
+        self.hmc.disable()
+
+        with self.assertRaises(ConnectionError):
+            # the function to be tested:
+            self.urihandler.get(self.hmc, '/api/cpcs/1', True)
+
 
 class _GenericGetUpdatePropertiesHandler(GenericGetPropertiesHandler,
                                          GenericUpdatePropertiesHandler):
@@ -766,6 +879,54 @@ class GenericUpdatePropertiesHandlerTests(unittest.TestCase):
         cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
         self.assertEqual(cpc1['description'], 'CPC #1 (updated)')
 
+    def test_post_error_offline(self):
+
+        self.hmc.disable()
+
+        update_cpc1 = {
+            'description': 'CPC #1 (updated)',
+        }
+
+        with self.assertRaises(ConnectionError):
+            # the function to be tested:
+            self.urihandler.post(self.hmc, '/api/cpcs/1', update_cpc1, True,
+                                 True)
+
+
+class GenericDeleteHandlerTests(unittest.TestCase):
+    """All tests for class GenericDeleteHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        self.uris = (
+            ('/api/console/ldap-server-definitions/([^/]+)',
+             GenericDeleteHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_delete(self):
+
+        uri = '/api/console/ldap-server-definitions/fake-ldap-srv-def-oid-1'
+
+        # the function to be tested:
+        ret = self.urihandler.delete(self.hmc, uri, True)
+
+        self.assertIsNone(ret)
+
+        # Verify it no longer exists:
+        with self.assertRaises(KeyError):
+            self.hmc.lookup_by_uri(uri)
+
+    def test_delete_error_offline(self):
+
+        self.hmc.disable()
+
+        uri = '/api/console/ldap-server-definitions/fake-ldap-srv-def-oid-1'
+
+        with self.assertRaises(ConnectionError):
+            # the function to be tested:
+            self.urihandler.delete(self.hmc, uri, True)
+
 
 class VersionHandlerTests(unittest.TestCase):
     """All tests for class VersionHandler."""
@@ -790,6 +951,1745 @@ class VersionHandlerTests(unittest.TestCase):
             'api-minor-version': int(api_minor),
         }
         self.assertEqual(resp, exp_resp)
+
+
+class ConsoleHandlerTests(unittest.TestCase):
+    """All tests for class ConsoleHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console', ConsoleHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    # Note: There is no test_list() function because there is no List
+    # operation for Console resources.
+
+    def test_get(self):
+
+        # the function to be tested:
+        console = self.urihandler.get(self.hmc, '/api/console', True)
+
+        exp_console = {
+            'object-uri': '/api/console',
+            'name': 'fake_console_name',
+        }
+        self.assertEqual(console, exp_console)
+
+
+class ConsoleRestartHandlerTests(unittest.TestCase):
+    """All tests for class ConsoleRestartHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console', ConsoleHandler),
+            ('/api/console/operations/restart', ConsoleRestartHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_restart_success(self):
+        body = {
+            'force': False,
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/operations/restart', body, True, True)
+
+        self.assertTrue(self.hmc.enabled)
+        self.assertIsNone(resp)
+
+    def test_restart_error_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        body = {
+            'force': False,
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(
+                self.hmc, '/api/console/operations/restart', body, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+
+class ConsoleShutdownHandlerTests(unittest.TestCase):
+    """All tests for class ConsoleShutdownHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console', ConsoleHandler),
+            ('/api/console/operations/shutdown', ConsoleShutdownHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_shutdown_success(self):
+        body = {
+            'force': False,
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/operations/shutdown', body, True, True)
+
+        self.assertFalse(self.hmc.enabled)
+        self.assertIsNone(resp)
+
+    def test_shutdown_error_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        body = {
+            'force': False,
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(
+                self.hmc, '/api/console/operations/shutdown', body, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+
+class ConsoleMakePrimaryHandlerTests(unittest.TestCase):
+    """All tests for class ConsoleMakePrimaryHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console', ConsoleHandler),
+            ('/api/console/operations/make-primary',
+             ConsoleMakePrimaryHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_make_primary_success(self):
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/operations/make-primary', None, True, True)
+
+        self.assertTrue(self.hmc.enabled)
+        self.assertIsNone(resp)
+
+    def test_make_primary_error_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        body = {
+            'force': False,
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(
+                self.hmc, '/api/console/operations/make-primary', body, True,
+                True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+
+class ConsoleReorderUserPatternsHandlerTests(unittest.TestCase):
+    """All tests for class ConsoleReorderUserPatternsHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        # Remove the standard User Pattern objects for this test
+        console = self.hmc.lookup_by_uri('/api/console')
+        user_pattern_objs = console.user_patterns.list()
+        for obj in user_pattern_objs:
+            console.user_patterns.remove(obj.oid)
+
+        self.uris = (
+            ('/api/console', ConsoleHandler),
+            ('/api/console/user-patterns(?:\?(.*))?', UserPatternsHandler),
+            ('/api/console/user-patterns/([^/]+)', UserPatternHandler),
+            ('/api/console/operations/reorder-user-patterns',
+             ConsoleReorderUserPatternsHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_reorder_all(self):
+        testcases = [
+            # (initial_order, new_order)
+            (['a', 'b'], ['a', 'b']),
+            (['a', 'b'], ['b', 'a']),
+            (['a', 'b', 'c'], ['a', 'c', 'b']),
+            (['a', 'b', 'c'], ['c', 'b', 'a']),
+        ]
+        for initial_order, new_order in testcases:
+            self._test_reorder_one(initial_order, new_order)
+
+    def _test_reorder_one(self, initial_order, new_order):
+
+        # Create User Pattern objects in the initial order and build
+        # name-to-URI mapping
+        uri_by_name = {}
+        for name in initial_order:
+            user_pattern = {
+                'element-id': name + '-oid',
+                'name': name,
+                'pattern': name + '*',
+                'type': 'glob-like',
+                'retention-time': 0,
+                'user-template-uri': 'fake-uri',
+            }
+            resp = self.urihandler.post(self.hmc, '/api/console/user-patterns',
+                                        user_pattern, True, True)
+            uri = resp['element-uri']
+            uri_by_name[name] = uri
+
+        new_uris = [uri_by_name[name] for name in new_order]
+
+        body = {
+            'user-pattern-uris': new_uris
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/operations/reorder-user-patterns', body,
+            True, True)
+
+        # Retrieve the actual order of User Pattern objects
+        resp = self.urihandler.get(self.hmc, '/api/console/user-patterns',
+                                   True)
+        act_user_patterns = resp['user-patterns']
+        act_uris = [up['element-uri'] for up in act_user_patterns]
+
+        # Verify that the actual order is the new (expected) order:
+        self.assertEqual(act_uris, new_uris)
+
+    def test_reorder_error_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        body = {
+            'user-pattern-uris': []
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+
+            self.urihandler.post(
+                self.hmc, '/api/console/operations/reorder-user-patterns',
+                body, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+
+class ConsoleGetAuditLogHandlerTests(unittest.TestCase):
+    """All tests for class ConsoleGetAuditLogHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console', ConsoleHandler),
+            ('/api/console/operations/get-audit-log',
+             ConsoleGetAuditLogHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_get_audit_log_success(self):
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/operations/get-audit-log', None, True,
+            True)
+
+        self.assertEqual(resp, [])
+
+    # TODO: Add testcases with non-empty audit log (once supported in mock)
+
+    def test_get_audit_log_error_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(
+                self.hmc, '/api/console/operations/get-audit-log', None, True,
+                True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+
+class ConsoleGetSecurityLogHandlerTests(unittest.TestCase):
+    """All tests for class ConsoleGetSecurityLogHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console', ConsoleHandler),
+            ('/api/console/operations/get-security-log',
+             ConsoleGetSecurityLogHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_get_security_log_success_empty(self):
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/operations/get-security-log', None, True,
+            True)
+
+        self.assertEqual(resp, [])
+
+    # TODO: Add testcases with non-empty security log (once supported in mock)
+
+    def test_get_security_log_error_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(
+                self.hmc, '/api/console/operations/get-security-log', None,
+                True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+
+class ConsoleListUnmanagedCpcsHandlerTests(unittest.TestCase):
+    """All tests for class ConsoleListUnmanagedCpcsHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console', ConsoleHandler),
+            ('/api/console/operations/list-unmanaged-cpcs(?:\?(.*))?',
+             ConsoleListUnmanagedCpcsHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list_success_empty(self):
+
+        # the function to be tested:
+        resp = self.urihandler.get(
+            self.hmc, '/api/console/operations/list-unmanaged-cpcs', True)
+
+        cpcs = resp['cpcs']
+        self.assertEqual(cpcs, [])
+
+    # TODO: Add testcases for non-empty list of unmanaged CPCs
+
+    def test_list_error_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.get(
+                self.hmc, '/api/console/operations/list-unmanaged-cpcs', True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+
+class UserHandlersTests(unittest.TestCase):
+    """All tests for classes UsersHandler and UserHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console/users(?:\?(.*))?', UsersHandler),
+            ('/api/users/([^/]+)', UserHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        users = self.urihandler.get(self.hmc, '/api/console/users', True)
+
+        exp_users = {  # properties reduced to those returned by List
+            'users': [
+                {
+                    'object-uri': '/api/users/fake-user-oid-1',
+                    'name': 'fake_user_name_1',
+                    'type': 'system-defined',
+                },
+            ]
+        }
+        self.assertEqual(users, exp_users)
+
+    def test_list_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.get(self.hmc, '/api/console/users', True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_get(self):
+
+        # the function to be tested:
+        user1 = self.urihandler.get(self.hmc, '/api/users/fake-user-oid-1',
+                                    True)
+
+        exp_user1 = {  # properties reduced to those in standard test HMC
+            'object-id': 'fake-user-oid-1',
+            'object-uri': '/api/users/fake-user-oid-1',
+            'name': 'fake_user_name_1',
+            'description': 'User #1',
+            'type': 'system-defined',
+        }
+        self.assertEqual(user1, exp_user1)
+
+    def test_create_verify(self):
+        new_user2 = {
+            'object-id': '2',
+            'name': 'user_2',
+            'description': 'User #2',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(self.hmc, '/api/console/users',
+                                    new_user2, True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('object-uri', resp)
+        new_user2_uri = resp['object-uri']
+        self.assertEqual(new_user2_uri, '/api/users/2')
+
+        exp_user2 = {
+            'object-id': '2',
+            'object-uri': '/api/users/2',
+            'name': 'user_2',
+            'description': 'User #2',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+
+        # the function to be tested:
+        user2 = self.urihandler.get(self.hmc, '/api/users/2', True)
+
+        self.assertEqual(user2, exp_user2)
+
+    def test_create_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        new_user2 = {
+            'object-id': '2',
+            'name': 'user_2',
+            'description': 'User #2',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, '/api/console/users', new_user2,
+                                 True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_update_verify(self):
+        update_user1 = {
+            'description': 'updated user #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(self.hmc, '/api/users/fake-user-oid-1',
+                             update_user1, True, True)
+
+        user1 = self.urihandler.get(self.hmc, '/api/users/fake-user-oid-1',
+                                    True)
+        self.assertEqual(user1['description'], 'updated user #1')
+
+    def test_delete_verify_all(self):
+        testcases = [
+            # (user_props, exp_exc_tuple)
+            ({
+                'object-id': '2',
+                'name': 'user_2',
+                'description': 'User #2',
+                'type': 'standard',
+                'authentication-type': 'local'},
+             None),
+            ({
+                'object-id': '3',
+                'name': 'user_3',
+                'description': 'User #3',
+                'type': 'template',
+                'authentication-type': 'local'},
+             None),
+            ({
+                'object-id': '4',
+                'name': 'user_4',
+                'description': 'User #4',
+                'type': 'pattern-based',
+                'authentication-type': 'local'},
+             (400, 312)),
+        ]
+        for user_props, exp_exc_tuple in testcases:
+            self._test_delete_verify_one(user_props, exp_exc_tuple)
+
+    def _test_delete_verify_one(self, user_props, exp_exc_tuple):
+
+        user_oid = user_props['object-id']
+        user_uri = '/api/users/{}'.format(user_oid)
+
+        # Create the user
+        self.urihandler.post(self.hmc, '/api/console/users', user_props, True,
+                             True)
+
+        # Verify that it exists
+        self.urihandler.get(self.hmc, user_uri, True)
+
+        if exp_exc_tuple is not None:
+
+            with self.assertRaises(HTTPError) as cm:
+
+                # Execute the code to be tested
+                self.urihandler.delete(self.hmc, user_uri, True)
+
+            exc = cm.exception
+            assert exc.http_status == exp_exc_tuple[0]
+            assert exc.reason == exp_exc_tuple[1]
+
+            # Verify that it still exists
+            self.urihandler.get(self.hmc, user_uri, True)
+
+        else:
+
+            # Execute the code to be tested
+            self.urihandler.delete(self.hmc, user_uri, True)
+
+            # Verify that it has been deleted
+            with self.assertRaises(InvalidResourceError):
+                self.urihandler.get(self.hmc, user_uri, True)
+
+
+class UserAddUserRoleHandlerTests(unittest.TestCase):
+    """All tests for class UserAddUserRoleHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        # Has a system-defined User (oid=fake-user-oid-1)
+        # Has a system-defined User Role (oid=fake-user-role-oid-1)
+
+        self.uris = (
+            ('/api/console/users(?:\?(.*))?', UsersHandler),
+            ('/api/users/([^/]+)', UserHandler),
+            ('/api/users/([^/]+)/operations/add-user-role',
+             UserAddUserRoleHandler),
+            ('/api/console/user-roles(?:\?(.*))?', UserRolesHandler),
+            ('/api/user-roles/([^/]+)', UserRoleHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_add_success(self):
+        """Test successful addition of a user role to a user."""
+
+        # Add a user-defined User for our tests
+        user2 = {
+            'name': 'user2',
+            'description': 'User #2',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/users', user2, True, True)
+        self.user2_uri = resp['object-uri']
+        self.user2_props = self.urihandler.get(
+            self.hmc, self.user2_uri, True)
+
+        # Add a user-defined User Role for our tests
+        user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', user_role2, True, True)
+        self.user_role2_uri = resp['object-uri']
+        self.user_role2_props = self.urihandler.get(
+            self.hmc, self.user_role2_uri, True)
+
+        uri = self.user2_uri + '/operations/add-user-role'
+        input_parms = {
+            'user-role-uri': self.user_role2_uri
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        self.assertIsNone(resp)
+        user2_props = self.urihandler.get(self.hmc, self.user2_uri, True)
+        self.assertTrue('user-roles' in user2_props)
+        user_roles = user2_props['user-roles']
+        self.assertEqual(len(user_roles), 1)
+        user_role_uri = user_roles[0]
+        self.assertEqual(user_role_uri, self.user_role2_uri)
+
+    def test_add_error_bad_user(self):
+        """Test failed addition of a user role to a bad user."""
+
+        # Add a user-defined User Role for our tests
+        user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', user_role2, True, True)
+        self.user_role2_uri = resp['object-uri']
+        self.user_role2_props = self.urihandler.get(
+            self.hmc, self.user_role2_uri, True)
+
+        bad_user_uri = '/api/users/not-found-oid'
+
+        uri = bad_user_uri + '/operations/add-user-role'
+        input_parms = {
+            'user-role-uri': self.user_role2_uri
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    # TODO: Add testcase for adding to system-defined or pattern-based user
+
+    def test_add_error_bad_user_role(self):
+        """Test failed addition of a bad user role to a user."""
+
+        # Add a user-defined User for our tests
+        user2 = {
+            'name': 'user2',
+            'description': 'User #2',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/users', user2, True, True)
+        self.user2_uri = resp['object-uri']
+        self.user2_props = self.urihandler.get(
+            self.hmc, self.user2_uri, True)
+
+        bad_user_role_uri = '/api/user-roles/not-found-oid'
+
+        uri = self.user2_uri + '/operations/add-user-role'
+        input_parms = {
+            'user-role-uri': bad_user_role_uri
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 2)
+
+
+class UserRemoveUserRoleHandlerTests(unittest.TestCase):
+    """All tests for class UserRemoveUserRoleHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        # Has a system-defined User (oid=fake-user-oid-1)
+        # Has a system-defined User Role (oid=fake-user-role-oid-1)
+
+        self.uris = (
+            ('/api/console/users(?:\?(.*))?', UsersHandler),
+            ('/api/users/([^/]+)', UserHandler),
+            ('/api/users/([^/]+)/operations/add-user-role',
+             UserAddUserRoleHandler),
+            ('/api/users/([^/]+)/operations/remove-user-role',
+             UserRemoveUserRoleHandler),
+            ('/api/console/user-roles(?:\?(.*))?', UserRolesHandler),
+            ('/api/user-roles/([^/]+)', UserRoleHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_remove_success(self):
+        """Test successful removal of a user role from a user."""
+
+        # Add a user-defined User for our tests
+        user2 = {
+            'name': 'user2',
+            'description': 'User #2',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/users', user2, True, True)
+        self.user2_uri = resp['object-uri']
+        self.user2_props = self.urihandler.get(
+            self.hmc, self.user2_uri, True)
+
+        # Add a user-defined User Role for our tests
+        user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', user_role2, True, True)
+        self.user_role2_uri = resp['object-uri']
+        self.user_role2_props = self.urihandler.get(
+            self.hmc, self.user_role2_uri, True)
+
+        # Add the user role to the user
+        uri = self.user2_uri + '/operations/add-user-role'
+        input_parms = {
+            'user-role-uri': self.user_role2_uri
+        }
+        self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        uri = self.user2_uri + '/operations/remove-user-role'
+        input_parms = {
+            'user-role-uri': self.user_role2_uri
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        self.assertIsNone(resp)
+        user2_props = self.urihandler.get(self.hmc, self.user2_uri, True)
+        self.assertTrue('user-roles' in user2_props)
+        user_roles = user2_props['user-roles']
+        self.assertEqual(len(user_roles), 0)
+
+    def test_remove_error_bad_user(self):
+        """Test failed removal of a user role from a bad user."""
+
+        # Add a user-defined User Role for our tests
+        user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', user_role2, True, True)
+        self.user_role2_uri = resp['object-uri']
+        self.user_role2_props = self.urihandler.get(
+            self.hmc, self.user_role2_uri, True)
+
+        bad_user_uri = '/api/users/not-found-oid'
+
+        uri = bad_user_uri + '/operations/remove-user-role'
+        input_parms = {
+            'user-role-uri': self.user_role2_uri
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    # TODO: Add testcase for removing from system-defined or pattern-based user
+
+    def test_remove_error_bad_user_role(self):
+        """Test failed removal of a bad user role from a user."""
+
+        # Add a user-defined User for our tests
+        user2 = {
+            'name': 'user2',
+            'description': 'User #2',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/users', user2, True, True)
+        self.user2_uri = resp['object-uri']
+        self.user2_props = self.urihandler.get(
+            self.hmc, self.user2_uri, True)
+
+        bad_user_role_uri = '/api/user-roles/not-found-oid'
+
+        uri = self.user2_uri + '/operations/remove-user-role'
+        input_parms = {
+            'user-role-uri': bad_user_role_uri
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 2)
+
+    def test_remove_error_no_user_role(self):
+        """Test failed removal of a user role that a user does not have."""
+
+        # Add a user-defined User for our tests
+        user2 = {
+            'name': 'user2',
+            'description': 'User #2',
+            'type': 'standard',
+            'authentication-type': 'local',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/users', user2, True, True)
+        self.user2_uri = resp['object-uri']
+        self.user2_props = self.urihandler.get(
+            self.hmc, self.user2_uri, True)
+
+        # Add a user-defined User Role for our tests
+        user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', user_role2, True, True)
+        self.user_role2_uri = resp['object-uri']
+        self.user_role2_props = self.urihandler.get(
+            self.hmc, self.user_role2_uri, True)
+
+        # Do not(!) add the user role to the user
+
+        uri = self.user2_uri + '/operations/remove-user-role'
+        input_parms = {
+            'user-role-uri': self.user_role2_uri
+        }
+        with self.assertRaises(ConflictError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 316)
+
+
+class UserRoleHandlersTests(unittest.TestCase):
+    """All tests for classes UserRolesHandler and UserRoleHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console/user-roles(?:\?(.*))?', UserRolesHandler),
+            ('/api/user-roles/([^/]+)', UserRoleHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        user_roles = self.urihandler.get(self.hmc, '/api/console/user-roles',
+                                         True)
+
+        exp_user_roles = {  # properties reduced to those returned by List
+            'user-roles': [
+                {
+                    'object-uri': '/api/user-roles/fake-user-role-oid-1',
+                    'name': 'fake_user_role_name_1',
+                    'type': 'system-defined',
+                },
+            ]
+        }
+        self.assertEqual(user_roles, exp_user_roles)
+
+    def test_list_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.get(self.hmc, '/api/console/user-roles', True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_get(self):
+
+        # the function to be tested:
+        user_role1 = self.urihandler.get(
+            self.hmc, '/api/user-roles/fake-user-role-oid-1', True)
+
+        exp_user_role1 = {  # properties reduced to those in standard test HMC
+            'object-id': 'fake-user-role-oid-1',
+            'object-uri': '/api/user-roles/fake-user-role-oid-1',
+            'name': 'fake_user_role_name_1',
+            'description': 'User Role #1',
+            'type': 'system-defined',
+        }
+        self.assertEqual(user_role1, exp_user_role1)
+
+    def test_create_verify(self):
+        new_user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', new_user_role2, True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('object-uri', resp)
+        new_user_role2_uri = resp['object-uri']
+
+        # the function to be tested:
+        user_role2 = self.urihandler.get(self.hmc, new_user_role2_uri, True)
+
+        self.assertEqual(user_role2['type'], 'user-defined')
+
+    def test_create_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        new_user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, '/api/console/user-roles',
+                                 new_user_role2, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_create_error_type(self):
+
+        new_user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+            'type': 'user-defined',  # error: type is implied
+        }
+
+        with self.assertRaises(BadRequestError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, '/api/console/user-roles',
+                                 new_user_role2, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 6)
+
+    def test_update_verify(self):
+        update_user_role1 = {
+            'description': 'updated user #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(
+            self.hmc, '/api/user-roles/fake-user-role-oid-1',
+            update_user_role1, True, True)
+
+        user_role1 = self.urihandler.get(
+            self.hmc, '/api/user-roles/fake-user-role-oid-1', True)
+        self.assertEqual(user_role1['description'], 'updated user #1')
+
+    def test_delete_verify(self):
+
+        new_user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+
+        # Create the user role
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', new_user_role2, True, True)
+
+        new_user_role2_uri = resp['object-uri']
+
+        # Verify that it exists
+        self.urihandler.get(self.hmc, new_user_role2_uri, True)
+
+        # the function to be tested:
+        self.urihandler.delete(self.hmc, new_user_role2_uri, True)
+
+        # Verify that it has been deleted
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.get(self.hmc, new_user_role2_uri, True)
+
+
+class UserRoleAddPermissionHandlerTests(unittest.TestCase):
+    """All tests for class UserRoleAddPermissionHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        # Has a system-defined User Role (oid=fake-user-role-oid-1)
+
+        self.uris = (
+            ('/api/console/user-roles(?:\?(.*))?', UserRolesHandler),
+            ('/api/user-roles/([^/]+)', UserRoleHandler),
+            ('/api/user-roles/([^/]+)/operations/add-permission',
+             UserRoleAddPermissionHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_add_all(self):
+        """All tests for adding permissions to a User Role."""
+        testcases = [
+            # (input_permission, exp_permission)
+            (
+                {
+                    'permitted-object': 'partition',
+                    'permitted-object-type': 'object-class',
+                    'include-members': True,
+                    'view-only-mode': False,
+                },
+                {
+                    'permitted-object': 'partition',
+                    'permitted-object-type': 'object-class',
+                    'include-members': True,
+                    'view-only-mode': False,
+                },
+            ),
+            (
+                {
+                    'permitted-object': 'adapter',
+                    'permitted-object-type': 'object-class',
+                },
+                {
+                    'permitted-object': 'adapter',
+                    'permitted-object-type': 'object-class',
+                    'include-members': False,
+                    'view-only-mode': True,
+                },
+            ),
+        ]
+        for input_permission, exp_permission in testcases:
+            self._test_add_one(input_permission, exp_permission)
+
+    def _test_add_one(self, input_permission, exp_permission):
+
+        # Add a user-defined User Role for our tests
+        user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', user_role2, True, True)
+        self.user_role2_uri = resp['object-uri']
+        self.user_role2_props = self.urihandler.get(
+            self.hmc, self.user_role2_uri, True)
+
+        uri = self.user_role2_uri + '/operations/add-permission'
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, uri, input_permission, True, True)
+
+        self.assertIsNone(resp)
+        props = self.urihandler.get(self.hmc, self.user_role2_uri, True)
+        self.assertTrue('permissions' in props)
+        permissions = props['permissions']
+        self.assertEqual(len(permissions), 1)
+        perm = permissions[0]
+        self.assertEqual(perm, exp_permission)
+
+    def test_add_error_bad_user_role(self):
+        """Test failed addition of a permission to a bad User Role."""
+
+        bad_user_role_uri = '/api/user-roles/not-found-oid'
+
+        uri = bad_user_role_uri + '/operations/add-permission'
+        input_parms = {
+            'permitted-object': 'partition',
+            'permitted-object-type': 'object-class',
+            'include-members': True,
+            'view-only-mode': False,
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_add_error_system_user_role(self):
+        """Test failed addition of a permission to a system-defined User
+        Role."""
+
+        system_user_role_uri = '/api/user-roles/fake-user-role-oid-1'
+
+        uri = system_user_role_uri + '/operations/add-permission'
+        input_parms = {
+            'permitted-object': 'partition',
+            'permitted-object-type': 'object-class',
+            'include-members': True,
+            'view-only-mode': False,
+        }
+        with self.assertRaises(BadRequestError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 314)
+
+
+class UserRoleRemovePermissionHandlerTests(unittest.TestCase):
+    """All tests for class UserRoleRemovePermissionHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+        # Has a system-defined User Role (oid=fake-user-role-oid-1)
+
+        self.uris = (
+            ('/api/console/user-roles(?:\?(.*))?', UserRolesHandler),
+            ('/api/user-roles/([^/]+)', UserRoleHandler),
+            ('/api/user-roles/([^/]+)/operations/add-permission',
+             UserRoleAddPermissionHandler),
+            ('/api/user-roles/([^/]+)/operations/remove-permission',
+             UserRoleRemovePermissionHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_remove_all(self):
+        """All tests for removing permissions from a User Role."""
+        testcases = [
+            # (input_permission, removed_permission)
+            (
+                {
+                    'permitted-object': 'partition',
+                    'permitted-object-type': 'object-class',
+                    'include-members': True,
+                    'view-only-mode': False,
+                },
+                {
+                    'permitted-object': 'partition',
+                    'permitted-object-type': 'object-class',
+                    'include-members': True,
+                    'view-only-mode': False,
+                },
+            ),
+            (
+                {
+                    'permitted-object': 'adapter',
+                    'permitted-object-type': 'object-class',
+                },
+                {
+                    'permitted-object': 'adapter',
+                    'permitted-object-type': 'object-class',
+                    'include-members': False,
+                    'view-only-mode': True,
+                },
+            ),
+        ]
+        for input_permission, removed_permission in testcases:
+            self._test_remove_one(input_permission, removed_permission)
+
+    def _test_remove_one(self, input_permission, removed_permission):
+
+        # Add a user-defined User Role for our tests
+        user_role2 = {
+            'name': 'user_role_2',
+            'description': 'User Role #2',
+        }
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-roles', user_role2, True, True)
+        self.user_role2_uri = resp['object-uri']
+        self.user_role2_props = self.urihandler.get(
+            self.hmc, self.user_role2_uri, True)
+
+        # Add the permission to be removed to the User Role:
+        uri = self.user_role2_uri + '/operations/add-permission'
+        resp = self.urihandler.post(
+            self.hmc, uri, removed_permission, True, True)
+
+        uri = self.user_role2_uri + '/operations/remove-permission'
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, uri, input_permission, True, True)
+
+        self.assertIsNone(resp)
+        props = self.urihandler.get(self.hmc, self.user_role2_uri, True)
+        self.assertTrue('permissions' in props)
+        permissions = props['permissions']
+        self.assertEqual(len(permissions), 0)
+
+    def test_remove_error_bad_user_role(self):
+        """Test failed removal of a permission from a bad User Role."""
+
+        bad_user_role_uri = '/api/user-roles/not-found-oid'
+
+        uri = bad_user_role_uri + '/operations/remove-permission'
+        input_parms = {
+            'permitted-object': 'partition',
+            'permitted-object-type': 'object-class',
+            'include-members': True,
+            'view-only-mode': False,
+        }
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_remove_error_system_user_role(self):
+        """Test failed removal of a permission from a system-defined User
+        Role."""
+
+        system_user_role_uri = '/api/user-roles/fake-user-role-oid-1'
+
+        uri = system_user_role_uri + '/operations/remove-permission'
+        input_parms = {
+            'permitted-object': 'partition',
+            'permitted-object-type': 'object-class',
+            'include-members': True,
+            'view-only-mode': False,
+        }
+        with self.assertRaises(BadRequestError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, uri, input_parms, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 314)
+
+
+class TaskHandlersTests(unittest.TestCase):
+    """All tests for classes TasksHandler and TaskHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console/tasks(?:\?(.*))?', TasksHandler),
+            ('/api/console/tasks/([^/]+)', TaskHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        tasks = self.urihandler.get(self.hmc, '/api/console/tasks', True)
+
+        exp_tasks = {  # properties reduced to those returned by List
+            'tasks': [
+                {
+                    'element-uri': '/api/console/tasks/fake-task-oid-1',
+                    'name': 'fake_task_name_1',
+                },
+                {
+                    'element-uri': '/api/console/tasks/fake-task-oid-2',
+                    'name': 'fake_task_name_2',
+                },
+            ]
+        }
+        self.assertEqual(tasks, exp_tasks)
+
+    def test_list_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.get(self.hmc, '/api/console/tasks', True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_get(self):
+
+        # the function to be tested:
+        task1 = self.urihandler.get(
+            self.hmc, '/api/console/tasks/fake-task-oid-1', True)
+
+        exp_task1 = {  # properties reduced to those in standard test HMC
+            'element-id': 'fake-task-oid-1',
+            'element-uri': '/api/console/tasks/fake-task-oid-1',
+            'name': 'fake_task_name_1',
+            'description': 'Task #1',
+        }
+        self.assertEqual(task1, exp_task1)
+
+
+class UserPatternHandlersTests(unittest.TestCase):
+    """All tests for classes UserPatternsHandler and UserPatternHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console/user-patterns(?:\?(.*))?', UserPatternsHandler),
+            ('/api/console/user-patterns/([^/]+)', UserPatternHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        user_patterns = self.urihandler.get(
+            self.hmc, '/api/console/user-patterns', True)
+
+        exp_user_patterns = {  # properties reduced to those returned by List
+            'user-patterns': [
+                {
+                    'element-uri':
+                        '/api/console/user-patterns/fake-user-pattern-oid-1',
+                    'name': 'fake_user_pattern_name_1',
+                    'type': 'glob-like',
+                },
+            ]
+        }
+        self.assertEqual(user_patterns, exp_user_patterns)
+
+    def test_list_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.get(self.hmc, '/api/console/user-patterns', True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_get(self):
+
+        # the function to be tested:
+        user_pattern1 = self.urihandler.get(
+            self.hmc, '/api/console/user-patterns/fake-user-pattern-oid-1',
+            True)
+
+        exp_user_pattern1 = {  # properties reduced to those in std test HMC
+            'element-id': 'fake-user-pattern-oid-1',
+            'element-uri':
+                '/api/console/user-patterns/fake-user-pattern-oid-1',
+            'name': 'fake_user_pattern_name_1',
+            'description': 'User Pattern #1',
+            'pattern': 'fake_user_name_*',
+            'type': 'glob-like',
+            'retention-time': 0,
+            'user-template-uri': '/api/users/fake-user-oid-1',
+        }
+        self.assertEqual(user_pattern1, exp_user_pattern1)
+
+    def test_create_verify(self):
+        new_user_pattern_input = {
+            'name': 'user_pattern_X',
+            'description': 'User Pattern #X',
+            'pattern': 'user*',
+            'type': 'glob-like',
+            'retention-time': 0,
+            'user-template-uri': '/api/users/fake-user-oid-1',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-patterns', new_user_pattern_input,
+            True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('element-uri', resp)
+        new_user_pattern_uri = resp['element-uri']
+
+        # the function to be tested:
+        new_user_pattern = self.urihandler.get(
+            self.hmc, new_user_pattern_uri, True)
+
+        new_name = new_user_pattern['name']
+        input_name = new_user_pattern_input['name']
+        self.assertEqual(new_name, input_name)
+
+    def test_create_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        new_user_pattern_input = {
+            'name': 'user_pattern_X',
+            'description': 'User Pattern #X',
+        }
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, '/api/console/user-patterns',
+                                 new_user_pattern_input, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_update_verify(self):
+        update_user_pattern1 = {
+            'description': 'updated user pattern #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(
+            self.hmc, '/api/console/user-patterns/fake-user-pattern-oid-1',
+            update_user_pattern1, True, True)
+
+        user_pattern1 = self.urihandler.get(
+            self.hmc, '/api/console/user-patterns/fake-user-pattern-oid-1',
+            True)
+        self.assertEqual(user_pattern1['description'],
+                         'updated user pattern #1')
+
+    def test_delete_verify(self):
+
+        new_user_pattern_input = {
+            'name': 'user_pattern_x',
+            'description': 'User Pattern #X',
+            'pattern': 'user*',
+            'type': 'glob-like',
+            'retention-time': 0,
+            'user-template-uri': '/api/users/fake-user-oid-1',
+        }
+
+        # Create the User Pattern
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/user-patterns', new_user_pattern_input,
+            True, True)
+
+        new_user_pattern_uri = resp['element-uri']
+
+        # Verify that it exists
+        self.urihandler.get(self.hmc, new_user_pattern_uri, True)
+
+        # the function to be tested:
+        self.urihandler.delete(self.hmc, new_user_pattern_uri, True)
+
+        # Verify that it has been deleted
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.get(self.hmc, new_user_pattern_uri, True)
+
+
+class PasswordRuleHandlersTests(unittest.TestCase):
+    """All tests for classes PasswordRulesHandler and PasswordRuleHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console/password-rules(?:\?(.*))?', PasswordRulesHandler),
+            ('/api/console/password-rules/([^/]+)', PasswordRuleHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        password_rules = self.urihandler.get(
+            self.hmc, '/api/console/password-rules', True)
+
+        exp_password_rules = {  # properties reduced to those returned by List
+            'password-rules': [
+                {
+                    'element-uri':
+                        '/api/console/password-rules/fake-password-rule-oid-1',
+                    'name': 'fake_password_rule_name_1',
+                    'type': 'system-defined',
+                },
+            ]
+        }
+        self.assertEqual(password_rules, exp_password_rules)
+
+    def test_list_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.get(self.hmc, '/api/console/password-rules', True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_get(self):
+
+        # the function to be tested:
+        password_rule1 = self.urihandler.get(
+            self.hmc, '/api/console/password-rules/fake-password-rule-oid-1',
+            True)
+
+        exp_password_rule1 = {  # properties reduced to those in std test HMC
+            'element-id': 'fake-password-rule-oid-1',
+            'element-uri':
+                '/api/console/password-rules/fake-password-rule-oid-1',
+            'name': 'fake_password_rule_name_1',
+            'description': 'Password Rule #1',
+            'type': 'system-defined',
+        }
+        self.assertEqual(password_rule1, exp_password_rule1)
+
+    def test_create_verify(self):
+        new_password_rule_input = {
+            'name': 'password_rule_X',
+            'description': 'Password Rule #X',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/password-rules', new_password_rule_input,
+            True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('element-uri', resp)
+        new_password_rule_uri = resp['element-uri']
+
+        # the function to be tested:
+        new_password_rule = self.urihandler.get(
+            self.hmc, new_password_rule_uri, True)
+
+        new_name = new_password_rule['name']
+        input_name = new_password_rule_input['name']
+        self.assertEqual(new_name, input_name)
+
+    def test_create_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        new_password_rule_input = {
+            'name': 'password_rule_X',
+            'description': 'Password Rule #X',
+        }
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(self.hmc, '/api/console/password-rules',
+                                 new_password_rule_input, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_update_verify(self):
+        update_password_rule1 = {
+            'description': 'updated password rule #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(
+            self.hmc, '/api/console/password-rules/fake-password-rule-oid-1',
+            update_password_rule1, True, True)
+
+        password_rule1 = self.urihandler.get(
+            self.hmc, '/api/console/password-rules/fake-password-rule-oid-1',
+            True)
+        self.assertEqual(password_rule1['description'],
+                         'updated password rule #1')
+
+    def test_delete_verify(self):
+
+        new_password_rule_input = {
+            'name': 'password_rule_X',
+            'description': 'Password Rule #X',
+        }
+
+        # Create the Password Rule
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/password-rules', new_password_rule_input,
+            True, True)
+
+        new_password_rule_uri = resp['element-uri']
+
+        # Verify that it exists
+        self.urihandler.get(self.hmc, new_password_rule_uri, True)
+
+        # the function to be tested:
+        self.urihandler.delete(self.hmc, new_password_rule_uri, True)
+
+        # Verify that it has been deleted
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.get(self.hmc, new_password_rule_uri, True)
+
+
+class LdapServerDefinitionHandlersTests(unittest.TestCase):
+    """All tests for classes LdapServerDefinitionsHandler and
+    LdapServerDefinitionHandler."""
+
+    def setUp(self):
+        self.hmc, self.hmc_resources = standard_test_hmc()
+
+        self.uris = (
+            ('/api/console/ldap-server-definitions(?:\?(.*))?',
+             LdapServerDefinitionsHandler),
+            ('/api/console/ldap-server-definitions/([^/]+)',
+             LdapServerDefinitionHandler),
+        )
+        self.urihandler = UriHandler(self.uris)
+
+    def test_list(self):
+
+        # the function to be tested:
+        ldap_srv_defs = self.urihandler.get(
+            self.hmc, '/api/console/ldap-server-definitions', True)
+
+        exp_ldap_srv_defs = {  # properties reduced to those returned by List
+            'ldap-server-definitions': [
+                {
+                    'element-uri':
+                        '/api/console/ldap-server-definitions/'
+                        'fake-ldap-srv-def-oid-1',
+                    'name': 'fake_ldap_srv_def_name_1',
+                },
+            ]
+        }
+        self.assertEqual(ldap_srv_defs, exp_ldap_srv_defs)
+
+    def test_list_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.get(
+                self.hmc, '/api/console/ldap-server-definitions', True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_get(self):
+
+        # the function to be tested:
+        ldap_srv_def1 = self.urihandler.get(
+            self.hmc,
+            '/api/console/ldap-server-definitions/fake-ldap-srv-def-oid-1',
+            True)
+
+        exp_ldap_srv_def1 = {  # properties reduced to those in std test HMC
+            'element-id': 'fake-ldap-srv-def-oid-1',
+            'element-uri':
+                '/api/console/ldap-server-definitions/'
+                'fake-ldap-srv-def-oid-1',
+            'name': 'fake_ldap_srv_def_name_1',
+            'description': 'LDAP Srv Def #1',
+            'primary-hostname-ipaddr': '10.11.12.13',
+        }
+        self.assertEqual(ldap_srv_def1, exp_ldap_srv_def1)
+
+    def test_create_verify(self):
+        new_ldap_srv_def_input = {
+            'name': 'ldap_srv_def_X',
+            'description': 'LDAP Srv Def #X',
+        }
+
+        # the function to be tested:
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/ldap-server-definitions',
+            new_ldap_srv_def_input, True, True)
+
+        self.assertEqual(len(resp), 1)
+        self.assertIn('element-uri', resp)
+        new_ldap_srv_def_uri = resp['element-uri']
+
+        # the function to be tested:
+        new_ldap_srv_def = self.urihandler.get(
+            self.hmc, new_ldap_srv_def_uri, True)
+
+        new_name = new_ldap_srv_def['name']
+        input_name = new_ldap_srv_def_input['name']
+        self.assertEqual(new_name, input_name)
+
+    def test_create_error_console_not_found(self):
+
+        # Remove the faked Console object
+        self.hmc.consoles.remove(None)
+
+        new_ldap_srv_def_input = {
+            'name': 'ldap_srv_def_X',
+            'description': 'LDAP Srv Def #X',
+        }
+
+        with self.assertRaises(InvalidResourceError) as cm:
+
+            # the function to be tested:
+            self.urihandler.post(
+                self.hmc, '/api/console/ldap-server-definitions',
+                new_ldap_srv_def_input, True, True)
+
+        exc = cm.exception
+        self.assertEqual(exc.reason, 1)
+
+    def test_update_verify(self):
+        update_ldap_srv_def1 = {
+            'description': 'updated LDAP Srv Def #1',
+        }
+
+        # the function to be tested:
+        self.urihandler.post(
+            self.hmc,
+            '/api/console/ldap-server-definitions/fake-ldap-srv-def-oid-1',
+            update_ldap_srv_def1, True, True)
+
+        ldap_srv_def1 = self.urihandler.get(
+            self.hmc,
+            '/api/console/ldap-server-definitions/fake-ldap-srv-def-oid-1',
+            True)
+        self.assertEqual(ldap_srv_def1['description'],
+                         'updated LDAP Srv Def #1')
+
+    def test_delete_verify(self):
+
+        new_ldap_srv_def_input = {
+            'name': 'ldap_srv_def_X',
+            'description': 'LDAP Srv Def #X',
+        }
+
+        # Create the LDAP Srv Def
+        resp = self.urihandler.post(
+            self.hmc, '/api/console/ldap-server-definitions',
+            new_ldap_srv_def_input, True, True)
+
+        new_ldap_srv_def_uri = resp['element-uri']
+
+        # Verify that it exists
+        self.urihandler.get(self.hmc, new_ldap_srv_def_uri, True)
+
+        # the function to be tested:
+        self.urihandler.delete(self.hmc, new_ldap_srv_def_uri, True)
+
+        # Verify that it has been deleted
+        with self.assertRaises(InvalidResourceError):
+            self.urihandler.get(self.hmc, new_ldap_srv_def_uri, True)
 
 
 class CpcHandlersTests(unittest.TestCase):

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -43,3 +43,11 @@ from ._port import *          # noqa: F401
 from ._notification import *  # noqa: F401
 from ._metrics import *       # noqa: F401
 from ._utils import *         # noqa: F401
+from ._console import *       # noqa: F401
+from ._user import *          # noqa: F401
+from ._user_role import *     # noqa: F401
+from ._user_pattern import *  # noqa: F401
+from ._password_rule import *          # noqa: F401
+from ._task import *          # noqa: F401
+from ._ldap_server_definition import *         # noqa: F401
+from ._unmanaged_cpc import *          # noqa: F401

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -1,0 +1,518 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`Console` resource represents an HMC.
+
+In a paired setup with primary and alternate HMC, each HMC is represented as
+a separate :term:`Console` resource.
+"""
+
+from __future__ import absolute_import
+
+import time
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+from ._utils import timestamp_from_datetime
+from ._user import UserManager
+from ._user_role import UserRoleManager
+from ._user_pattern import UserPatternManager
+from ._password_rule import PasswordRuleManager
+from ._task import TaskManager
+from ._ldap_server_definition import LdapServerDefinitionManager
+from ._unmanaged_cpc import UnmanagedCpcManager
+
+
+__all__ = ['ConsoleManager', 'Console']
+
+LOG = get_logger(__name__)
+
+
+class ConsoleManager(BaseManager):
+    """
+    Manager providing access to the :term:`Console` representing the HMC this
+    client is connected to.
+
+    In a paired setup with primary and alternate HMC, each HMC is represented
+    as a separate :term:`Console` resource.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.Client` object:
+
+    * :attr:`zhmcclient.Client.consoles`
+    """
+
+    def __init__(self, client):
+        # This function should not go into the docs.
+        # Parameters:
+        #   client (:class:`~zhmcclient.Client`):
+        #      Client object for the HMC to be used.
+
+        super(ConsoleManager, self).__init__(
+            resource_class=Console,
+            class_name='console',
+            session=client.session,
+            parent=None,
+            base_uri='/api/console',
+            oid_prop='object-id',
+            uri_prop='object-uri',
+            name_prop='name',
+            query_props=None,
+            list_has_name=False)
+        self._client = client
+
+    @property
+    def client(self):
+        """
+        :class:`~zhmcclient.Client`:
+          The client defining the scope for this manager.
+        """
+        return self._client
+
+    @logged_api_call
+    def list(self, full_properties=True, filter_args=None):
+        """
+        List the (one) :term:`Console` representing the HMC this client is
+        connected to.
+
+        Authorization requirements:
+
+        * None
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only a short set consisting of 'object-uri'.
+
+          filter_args (dict):
+            This parameter exists for consistency with other list() methods
+            and will be ignored.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.Console` objects, containing the one
+          :term:`Console` representing the HMC this client is connected to.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        uri = self._base_uri  # There is only one console object.
+        if full_properties:
+            props = self.session.get(uri)
+        else:
+            # Note: The Console resource's Object ID is not part of its URI.
+            props = {
+                self._uri_prop: uri,
+            }
+        resource_obj = self.resource_class(
+            manager=self,
+            uri=props[self._uri_prop],
+            name=props.get(self._name_prop, None),
+            properties=props)
+        return [resource_obj]
+
+
+class Console(BaseResource):
+    """
+    Representation of a :term:`Console`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.ConsoleManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.ConsoleManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, ConsoleManager), \
+            "Console init: Expected manager type %s, got %s" % \
+            (ConsoleManager, type(manager))
+        super(Console, self).__init__(manager, uri, name, properties)
+
+        # The manager objects for child resources (with lazy initialization):
+        self._users = None
+        self._user_roles = None
+        self._user_patterns = None
+        self._password_rules = None
+        self._tasks = None
+        self._ldap_server_definitions = None
+        self._unmanaged_cpcs = None
+
+    @property
+    def users(self):
+        """
+        :class:`~zhmcclient.UserManager`: Access to the :term:`Users <User>` in
+        this Console.
+        """
+        # We do here some lazy loading.
+        if not self._users:
+            self._users = UserManager(self)
+        return self._users
+
+    @property
+    def user_roles(self):
+        """
+        :class:`~zhmcclient.UserRoleManager`: Access to the
+        :term:`User Roles <User Role>` in this Console.
+        """
+        # We do here some lazy loading.
+        if not self._user_roles:
+            self._user_roles = UserRoleManager(self)
+        return self._user_roles
+
+    @property
+    def user_patterns(self):
+        """
+        :class:`~zhmcclient.UserPatternManager`: Access to the
+        :term:`User Patterns <User Pattern>` in this Console.
+        """
+        # We do here some lazy loading.
+        if not self._user_patterns:
+            self._user_patterns = UserPatternManager(self)
+        return self._user_patterns
+
+    @property
+    def password_rules(self):
+        """
+        :class:`~zhmcclient.PasswordRuleManager`: Access to the
+        :term:`Password Rules <Password Rule>` in this Console.
+        """
+        # We do here some lazy loading.
+        if not self._password_rules:
+            self._password_rules = PasswordRuleManager(self)
+        return self._password_rules
+
+    @property
+    def tasks(self):
+        """
+        :class:`~zhmcclient.TaskManager`: Access to the :term:`Tasks <Task>` in
+        this Console.
+        """
+        # We do here some lazy loading.
+        if not self._tasks:
+            self._tasks = TaskManager(self)
+        return self._tasks
+
+    @property
+    def ldap_server_definitions(self):
+        """
+        :class:`~zhmcclient.LdapServerDefinitionManager`: Access to the
+        :term:`LDAP Server Definitions <LDAP Server Definition>` in this
+        Console.
+        """
+        # We do here some lazy loading.
+        if not self._ldap_server_definitions:
+            self._ldap_server_definitions = LdapServerDefinitionManager(self)
+        return self._ldap_server_definitions
+
+    @property
+    def unmanaged_cpcs(self):
+        """
+        :class:`~zhmcclient.UnmanagedCpcManager`: Access to the unmanaged
+        :term:`CPCs <CPC>` in this Console.
+        """
+        # We do here some lazy loading.
+        if not self._unmanaged_cpcs:
+            self._unmanaged_cpcs = UnmanagedCpcManager(self)
+        return self._unmanaged_cpcs
+
+    @logged_api_call
+    def restart(self, force=False, wait_for_available=True,
+                operation_timeout=None):
+        """
+        Restart the HMC represented by this Console object.
+
+        Once the HMC is online again, this Console object, as well as any other
+        resource objects accessed through this HMC, can continue to be used.
+        An automatic re-logon will be performed under the covers, because the
+        HMC restart invalidates the currently used HMC session.
+
+        Authorization requirements:
+
+        * Task permission for the "Shutdown/Restart" task.
+        * "Remote Restart" must be enabled on the HMC.
+
+        Parameters:
+
+          force (bool):
+            Boolean controlling whether the restart operation is processed when
+            users are connected (`True`) or not (`False`). Users in this sense
+            are local or remote GUI users. HMC WS API clients do not count as
+            users for this purpose.
+
+          wait_for_available (bool):
+            Boolean controlling whether this method should wait for the HMC to
+            become available again after the restart, as follows:
+
+            * If `True`, this method will wait until the HMC has restarted and
+              is available again. The
+              :meth:`~zhmcclient.Client.query_api_version` method will be used
+              to check for availability of the HMC.
+
+            * If `False`, this method will return immediately once the HMC
+              has accepted the request to be restarted.
+
+          operation_timeout (:term:`number`):
+            Timeout in seconds, for waiting for HMC availability after the
+            restart. The special value 0 means that no timeout is set. `None`
+            means that the default async operation timeout of the session is
+            used. If the timeout expires when `wait_for_available=True`, a
+            :exc:`~zhmcclient.OperationTimeout` is raised.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
+            waiting for the HMC to become available again after the restart.
+        """
+        body = {'force': force}
+        self.manager.session.post(self.uri + '/operations/restart', body=body)
+        if wait_for_available:
+            time.sleep(10)
+            self.manager.client.wait_for_available(
+                operation_timeout=operation_timeout)
+
+    @logged_api_call
+    def shutdown(self, force=False):
+        """
+        Shut down and power off the HMC represented by this Console object.
+
+        While the HMC is powered off, any Python resource objects retrieved
+        from this HMC may raise exceptions upon further use.
+
+        In order to continue using Python resource objects retrieved from this
+        HMC, the HMC needs to be started again (e.g. by powering it on
+        locally). Once the HMC is available again, Python resource objects
+        retrieved from that HMC can continue to be used.
+        An automatic re-logon will be performed under the covers, because the
+        HMC startup invalidates the currently used HMC session.
+
+        Authorization requirements:
+
+        * Task permission for the "Shutdown/Restart" task.
+        * "Remote Shutdown" must be enabled on the HMC.
+
+        Parameters:
+
+          force (bool):
+            Boolean controlling whether the shutdown operation is processed
+            when users are connected (`True`) or not (`False`). Users in this
+            sense are local or remote GUI users. HMC WS API clients do not
+            count as users for this purpose.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {'force': force}
+        self.manager.session.post(self.uri + '/operations/shutdown', body=body)
+
+    @logged_api_call
+    def make_primary(self):
+        """
+        Change the role of the alternate HMC represented by this Console object
+        to become the primary HMC.
+
+        If that HMC is already the primary HMC, this method does not change its
+        rols and succeeds.
+
+        The HMC represented by this Console object must participate in a
+        {primary, alternate} pairing.
+
+        Authorization requirements:
+
+        * Task permission for the "Manage Alternate HMC" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self.uri + '/operations/make-primary')
+
+    @staticmethod
+    def _time_query_parms(begin_time, end_time):
+        """Return the URI query paramterer string for the specified begin time
+        and end time."""
+        query_parms = []
+        if begin_time is not None:
+            begin_ts = timestamp_from_datetime(begin_time)
+            qp = 'begin-time={}'.format(begin_ts)
+            query_parms.append(qp)
+        if end_time is not None:
+            end_ts = timestamp_from_datetime(end_time)
+            qp = 'end-time={}'.format(end_ts)
+            query_parms.append(qp)
+        query_parms_str = '&'.join(query_parms)
+        if query_parms_str:
+            query_parms_str = '?' + query_parms_str
+        return query_parms_str
+
+    @logged_api_call
+    def get_audit_log(self, begin_time=None, end_time=None):
+        """
+        Return the console audit log entries, optionally filtered by their
+        creation time.
+
+        Authorization requirements:
+
+        * Task permission to the "Audit and Log Management" task.
+
+        Parameters:
+
+          begin_time (:class:`~py:datetime.datetime`):
+            Begin time for filtering. Log entries with a creation time older
+            than the begin time will be omitted from the results.
+
+            If `None`, no such filtering is performed (and the oldest available
+            log entries will be included).
+
+          end_time (:class:`~py:datetime.datetime`):
+            End time for filtering. Log entries with a creation time newer
+            than the end time will be omitted from the results.
+
+            If `None`, no such filtering is performed (and the newest available
+            log entries will be included).
+
+        Returns:
+
+          :term:`json object`:
+            A JSON object with the log entries, as described in section
+            'Response body contents' of operation 'Get Console Audit Log' in
+            the :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        query_parms = self._time_query_parms(begin_time, end_time)
+        uri = self.uri + '/operations/get-audit-log' + query_parms
+        result = self.manager.session.post(uri)
+        return result
+
+    @logged_api_call
+    def get_security_log(self, begin_time=None, end_time=None):
+        """
+        Return the console security log entries, optionally filtered by their
+        creation time.
+
+        Authorization requirements:
+
+        * Task permission to the "View Security Logs" task.
+
+        Parameters:
+
+          begin_time (:class:`~py:datetime.datetime`):
+            Begin time for filtering. Log entries with a creation time older
+            than the begin time will be omitted from the results.
+
+            If `None`, no such filtering is performed (and the oldest available
+            log entries will be included).
+
+          end_time (:class:`~py:datetime.datetime`):
+            End time for filtering. Log entries with a creation time newer
+            than the end time will be omitted from the results.
+
+            If `None`, no such filtering is performed (and the newest available
+            log entries will be included).
+
+        Returns:
+
+          :term:`json object`:
+            A JSON object with the log entries, as described in section
+            'Response body contents' of operation 'Get Console Security Log' in
+            the :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        query_parms = self._time_query_parms(begin_time, end_time)
+        uri = self.uri + '/operations/get-security-log' + query_parms
+        result = self.manager.session.post(uri)
+        return result
+
+    @logged_api_call
+    def list_unmanaged_cpcs(self, name=None):
+        """
+        List the unmanaged CPCs of this HMC.
+
+        For details, see :meth:`~zhmcclient.UnmanagedCpc.list`.
+
+        Authorization requirements:
+
+        * None
+
+        Parameters:
+
+          name (:term:`string`):
+            Regular expression pattern for the CPC name, as a filter that
+            narrows the list of returned CPCs to those whose name property
+            matches the specified pattern.
+
+            `None` causes no filtering to happen, i.e. all unmanaged CPCs
+            discovered by the HMC are returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.UnmanagedCpc` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        filter_args = dict()
+        if name is not None:
+            filter_args['name'] = name
+        cpcs = self.unmanaged_cpcs.list(filter_args=filter_args)
+        return cpcs

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -16,7 +16,13 @@
 A :term:`CPC` (Central Processor Complex) is a physical IBM Z or LinuxONE
 computer.
 
-A particular HMC can manage multiple CPCs.
+A particular HMC can manage multiple CPCs and can discover other CPCs that
+are not managed by that HMC. Such other CPCs are called "unmanaged CPCs" and
+they may or may not be managed by another HMC.
+
+This section describes the interface for *managed* CPCs using resource class
+:class:`~zhmcclient.Cpc` and the corresponding manager class
+:class:`~zhmcclient.CpcManager`.
 
 The HMC can manage a range of old and new CPC generations. Some older CPC
 generations are not capable of supporting the HMC Web Services API; these older
@@ -61,8 +67,8 @@ LOG = get_logger(__name__)
 
 class CpcManager(BaseManager):
     """
-    Manager providing access to the :term:`CPCs <CPC>` exposed by the HMC this
-    client is connected to.
+    Manager providing access to the managed :term:`CPCs <CPC>` exposed by the
+    HMC this client is connected to.
 
     Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
     and attributes.
@@ -100,7 +106,7 @@ class CpcManager(BaseManager):
     @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """
-        List the CPCs exposed by the HMC this client is connected to.
+        List the CPCs managed by the HMC this client is connected to.
 
         Authorization requirements:
 
@@ -165,7 +171,7 @@ class CpcManager(BaseManager):
 
 class Cpc(BaseResource):
     """
-    Representation of a :term:`CPC`.
+    Representation of a managed :term:`CPC`.
 
     Derived from :class:`~zhmcclient.BaseResource`; see there for common
     methods and attributes.

--- a/zhmcclient/_ldap_server_definition.py
+++ b/zhmcclient/_ldap_server_definition.py
@@ -1,0 +1,267 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`LDAP Server Definition` resource represents a definition that contains
+information about an LDAP server that may be used for HMC user authentication
+purposes.
+"""
+
+from __future__ import absolute_import
+
+import copy
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['LdapServerDefinitionManager', 'LdapServerDefinition']
+
+LOG = get_logger(__name__)
+
+
+class LdapServerDefinitionManager(BaseManager):
+    """
+    Manager providing access to the :term:`LDAP Server Definition` resources of
+    a HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.Console` object:
+
+    * :attr:`zhmcclient.Console.ldap_server_definitions`
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #      Console object representing the HMC.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+        ]
+
+        super(LdapServerDefinitionManager, self).__init__(
+            resource_class=LdapServerDefinition,
+            class_name='ldap-server-definition',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/console/ldap-server-definitions',
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: :term:`Console` defining the scope for
+        this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=True, filter_args=None):
+        """
+        List the :term:`LDAP Server Definition` resources representing the
+        definitions of LDAp servers in this HMC.
+
+        Authorization requirements:
+
+        * User-related-access permission to the LDAP Server Definition objects
+          included in the result, or task permission to the "Manage LDAP Server
+          Definitions" task.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.LdapServerDefinition` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        resource_obj_list = []
+        query_parms, client_filters = self._divide_filter_args(filter_args)
+        resources_name = 'ldap-server-definitions'
+        uri = '{}/{}{}'.format(self.console.uri, resources_name, query_parms)
+
+        result = self.session.get(uri)
+        if result:
+            props_list = result[resources_name]
+            for props in props_list:
+
+                resource_obj = self.resource_class(
+                    manager=self,
+                    uri=props[self._uri_prop],
+                    name=props.get(self._name_prop, None),
+                    properties=props)
+
+                if self._matches_filters(resource_obj, client_filters):
+                    resource_obj_list.append(resource_obj)
+                    if full_properties:
+                        resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties):
+        """
+        Create a new LDAP Server Definition in this HMC.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage LDAP Server Definitions" task.
+
+        Parameters:
+
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create LDAP Server Definition' in the :term:`HMC API`
+            book.
+
+        Returns:
+
+          LdapServerDefinition:
+            The resource object for the new LDAP Server Definition.
+            The object will have its 'object-uri' property set as returned by
+            the HMC, and will also have the input properties set.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        result = self.session.post(
+            self.console.uri + '/ldap-server-definitions', body=properties)
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = copy.deepcopy(properties)
+        props.update(result)
+        name = props.get(self._name_prop, None)
+        uri = props[self._uri_prop]
+        ldap_server_definition = LdapServerDefinition(self, uri, name, props)
+        self._name_uri_cache.update(name, uri)
+        return ldap_server_definition
+
+
+class LdapServerDefinition(BaseResource):
+    """
+    Representation of a :term:`LDAP Server Definition`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.LdapServerDefinitionManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.LdapServerDefinitionManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, LdapServerDefinitionManager), \
+            "Console init: Expected manager type %s, got %s" % \
+            (LdapServerDefinitionManager, type(manager))
+        super(LdapServerDefinition, self).__init__(
+            manager, uri, name, properties)
+
+    @logged_api_call
+    def delete(self):
+        """
+        Delete this LDAP Server Definition.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage LDAP Server Definitions" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.delete(self.uri)
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this LDAP Server Definitions.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage LDAP Server Definitions" task.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model' in section 'LDAP Server Definition object' in
+            the :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self.uri, body=properties)
+
+        # The name of LDAP Server Definitions cannot be updated. An attempt to
+        # do so should cause HTTPError to be raised in the POST above, so we
+        # assert that here, because we omit the extra code for handling name
+        # updates:
+        assert self.manager._name_prop not in properties
+        self.properties.update(copy.deepcopy(properties))

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -224,7 +224,7 @@ class BaseManager(object):
         #     List of names of resource properties that are supported as filter
         #     query parameters in HMC list operations for this type of resource
         #     (i.e. for server-side filtering).
-        #     Must not be `None`.
+        #     May be `None`.
         #     If the support for a resource property changes within the set of
         #     HMC versions that support this type of resource, this list must
         #     represent the version of the HMC this session is connected to.
@@ -242,7 +242,6 @@ class BaseManager(object):
         assert oid_prop is not None
         assert uri_prop is not None
         assert name_prop is not None
-        assert query_props is not None
 
         self._resource_class = resource_class
         self._class_name = class_name

--- a/zhmcclient/_password_rule.py
+++ b/zhmcclient/_password_rule.py
@@ -1,0 +1,271 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`Password Rule` resource represents a rule which an HMC user must
+follow when creating a HMC logon password. Each HMC user using local
+authentication (i.e. not LDAP) is assigned a password rule. There are certain
+system-defined password rules available for use.
+"""
+
+from __future__ import absolute_import
+
+import copy
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['PasswordRuleManager', 'PasswordRule']
+
+LOG = get_logger(__name__)
+
+
+class PasswordRuleManager(BaseManager):
+    """
+    Manager providing access to the :term:`Password Rule` resources of a HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.Console` object:
+
+    * :attr:`zhmcclient.Console.password_rules`
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #      Console object representing the HMC.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+            'type',
+        ]
+
+        super(PasswordRuleManager, self).__init__(
+            resource_class=PasswordRule,
+            class_name='password-rule',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/console/password-rules',
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: :term:`Console` defining the scope for
+        this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=True, filter_args=None):
+        """
+        List the :term:`Password Rule` resources representing the password
+        rules defined in this HMC.
+
+        Authorization requirements:
+
+        * User-related-access permission to the Password Rule objects included
+          in the result, or task permission to the "Manage Password Rules"
+          task.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.PasswordRule` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        resource_obj_list = []
+        query_parms, client_filters = self._divide_filter_args(filter_args)
+        resources_name = 'password-rules'
+        uri = '{}/{}{}'.format(self.console.uri, resources_name, query_parms)
+
+        result = self.session.get(uri)
+        if result:
+            props_list = result[resources_name]
+            for props in props_list:
+
+                resource_obj = self.resource_class(
+                    manager=self,
+                    uri=props[self._uri_prop],
+                    name=props.get(self._name_prop, None),
+                    properties=props)
+
+                if self._matches_filters(resource_obj, client_filters):
+                    resource_obj_list.append(resource_obj)
+                    if full_properties:
+                        resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties):
+        """
+        Create a new Password Rule in this HMC.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage Password Rules" task.
+
+        Parameters:
+
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create Password Rule' in the :term:`HMC API` book.
+
+        Returns:
+
+          PasswordRule:
+            The resource object for the new Password Rule.
+            The object will have its 'element-uri' property set as returned by
+            the HMC, and will also have the input properties set.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        result = self.session.post(self.console.uri + '/password-rules',
+                                   body=properties)
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = copy.deepcopy(properties)
+        props.update(result)
+        name = props.get(self._name_prop, None)
+        uri = props[self._uri_prop]
+        password_rule = PasswordRule(self, uri, name, props)
+        self._name_uri_cache.update(name, uri)
+        return password_rule
+
+
+class PasswordRule(BaseResource):
+    """
+    Representation of a :term:`Password Rule`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.PasswordRuleManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.PasswordRuleManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, PasswordRuleManager), \
+            "Console init: Expected manager type %s, got %s" % \
+            (PasswordRuleManager, type(manager))
+        super(PasswordRule, self).__init__(manager, uri, name, properties)
+
+    @logged_api_call
+    def delete(self):
+        """
+        Delete this Password Rule.
+
+        The Password Rule must be user-defined. System-defined Password Rules
+        cannot be deleted.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage Password Rules" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.delete(self.uri)
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this PasswordRule.
+
+        The Password Rule must be user-defined. System-defined Password Rules
+        cannot be updated.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage Password Rules" task.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model' in section 'Password Rule object' in the
+            :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self.uri, body=properties)
+
+        # The name of Password Rules cannot be updated. An attempt to do so
+        # should cause HTTPError to be raised in the POST above, so we assert
+        # that here, because we omit the extra code for handling name updates:
+        assert self.manager._name_prop not in properties
+        self.properties.update(copy.deepcopy(properties))

--- a/zhmcclient/_task.py
+++ b/zhmcclient/_task.py
@@ -1,0 +1,168 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`Task` resource represents an action that an HMC user with appropriate
+authority can perform. These actions could be available via the HMC's graphical
+user interface, the Web Services APIs or both.
+
+Tasks are predefined by the HMC and cannot be created, modified or deleted.
+"""
+
+from __future__ import absolute_import
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['TaskManager', 'Task']
+
+LOG = get_logger(__name__)
+
+
+class TaskManager(BaseManager):
+    """
+    Manager providing access to the :term:`Task` resources of a HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.Console` object:
+
+    * :attr:`zhmcclient.Console.tasks`
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #      Console object representing the HMC.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+        ]
+
+        super(TaskManager, self).__init__(
+            resource_class=Task,
+            class_name='task',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/console/tasks',
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: :term:`Console` defining the scope for
+        this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=True, filter_args=None):
+        """
+        List the :term:`Task` resources representing the tasks defined in this
+        HMC.
+
+        Authorization requirements:
+
+        * None
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.Task` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        resource_obj_list = []
+        query_parms, client_filters = self._divide_filter_args(filter_args)
+        resources_name = 'tasks'
+        uri = '{}/{}{}'.format(self.console.uri, resources_name, query_parms)
+
+        result = self.session.get(uri)
+        if result:
+            props_list = result[resources_name]
+            for props in props_list:
+
+                resource_obj = self.resource_class(
+                    manager=self,
+                    uri=props[self._uri_prop],
+                    name=props.get(self._name_prop, None),
+                    properties=props)
+
+                if self._matches_filters(resource_obj, client_filters):
+                    resource_obj_list.append(resource_obj)
+                    if full_properties:
+                        resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+
+class Task(BaseResource):
+    """
+    Representation of a :term:`Task`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.TaskManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.TaskManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, TaskManager), \
+            "Console init: Expected manager type %s, got %s" % \
+            (TaskManager, type(manager))
+        super(Task, self).__init__(manager, uri, name, properties)

--- a/zhmcclient/_unmanaged_cpc.py
+++ b/zhmcclient/_unmanaged_cpc.py
@@ -1,0 +1,180 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`CPC` (Central Processor Complex) is a physical IBM Z or LinuxONE
+computer.
+
+A particular HMC can manage multiple CPCs and can discover other CPCs that
+are not managed by that HMC. Such other CPCs are called "unmanaged CPCs" and
+they may or may not be managed by another HMC.
+
+This section describes the interface for *unmanaged* CPCs using resource class
+:class:`~zhmcclient.UnmanagedCpc` and the corresponding manager class
+:class:`~zhmcclient.UnmanagedCpcManager`.
+"""
+
+from __future__ import absolute_import
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['UnmanagedCpcManager', 'UnmanagedCpc']
+
+LOG = get_logger(__name__)
+
+
+class UnmanagedCpcManager(BaseManager):
+    """
+    Manager providing access to the :term:`CPCs <CPC>` that have been
+    discovered by the HMC this client is connected to, but are not managed by
+    it. They may or may not be managed by another HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.Console` object:
+
+    * :attr:`~zhmcclient.Console.unmanaged_cpcs`
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #      Console object for the HMC to be used.
+
+        # Resource properties that are supported as filter query parameters
+        # (for server-side filtering).
+        query_props = [
+            'name',
+        ]
+
+        super(UnmanagedCpcManager, self).__init__(
+            resource_class=UnmanagedCpc,
+            class_name='cpc',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/console',
+            oid_prop='object-id',
+            uri_prop='object-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: :term:`Console` defining the scope for
+        this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=False, filter_args=None):
+        """
+        List the unmanaged CPCs exposed by the HMC this client is connected to.
+
+        Because the CPCs are unmanaged, the returned
+        :class:`~zhmcclient.UnmanagedCpc` objects cannot perform any operations
+        and will have only the following properties:
+
+        * ``object-uri``
+        * ``name``
+
+        Authorization requirements:
+
+        * None
+
+        Parameters:
+
+          full_properties (bool):
+            Ignored (exists for consistency with other list() methods).
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.UnmanagedCpc` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        resource_obj_list = []
+        resource_obj = self._try_optimized_lookup(filter_args)
+        if resource_obj:
+            resource_obj_list.append(resource_obj)
+        else:
+            query_parms, client_filters = self._divide_filter_args(filter_args)
+
+            uri = self.parent.uri + '/operations/list-unmanaged-cpcs' + \
+                query_parms
+
+            result = self.session.get(uri)
+            if result:
+                props_list = result['cpcs']
+                for props in props_list:
+
+                    resource_obj = self.resource_class(
+                        manager=self,
+                        uri=props[self._uri_prop],
+                        name=props.get(self._name_prop, None),
+                        properties=props)
+
+                    if self._matches_filters(resource_obj, client_filters):
+                        resource_obj_list.append(resource_obj)
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+
+class UnmanagedCpc(BaseResource):
+    """
+    Representation of an unmanaged :term:`CPC`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.UnmanagedCpcManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.UnmanagedCpcManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, UnmanagedCpcManager), \
+            "UnmanagedCpc init: Expected manager type %s, got %s" % \
+            (UnmanagedCpcManager, type(manager))
+        super(UnmanagedCpc, self).__init__(manager, uri, name, properties)

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -1,0 +1,331 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`User` resource represents a user configured in the HMC.
+"""
+
+from __future__ import absolute_import
+
+import copy
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['UserManager', 'User']
+
+LOG = get_logger(__name__)
+
+
+class UserManager(BaseManager):
+    """
+    Manager providing access to the :term:`User` resources of a HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.Console` object:
+
+    * :attr:`zhmcclient.Console.users`
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #      Console object representing the HMC.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+            'type',
+        ]
+
+        super(UserManager, self).__init__(
+            resource_class=User,
+            class_name='user',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/users',
+            oid_prop='object-id',
+            uri_prop='object-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: :term:`Console` defining the scope for
+        this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=True, filter_args=None):
+        """
+        List the :term:`User` resources representing the users defined in this
+        HMC.
+
+        Authorization requirements:
+
+        * User-related-access permission to the User object included in the
+          result, or, depending on the type of User object, task permission to
+          the "Manage Users" task or the "Manage User Templates" task.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.User` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        resource_obj_list = []
+        query_parms, client_filters = self._divide_filter_args(filter_args)
+        resources_name = 'users'
+        uri = '{}/{}{}'.format(self.console.uri, resources_name, query_parms)
+
+        result = self.session.get(uri)
+        if result:
+            props_list = result[resources_name]
+            for props in props_list:
+
+                resource_obj = self.resource_class(
+                    manager=self,
+                    uri=props[self._uri_prop],
+                    name=props.get(self._name_prop, None),
+                    properties=props)
+
+                if self._matches_filters(resource_obj, client_filters):
+                    resource_obj_list.append(resource_obj)
+                    if full_properties:
+                        resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties):
+        """
+        Create a new User in this HMC.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage Users" task to create a standard user
+          or the "Manage User Templates" task to create a template user.
+
+        Parameters:
+
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create User' in the :term:`HMC API` book.
+
+        Returns:
+
+          User:
+            The resource object for the new User.
+            The object will have its 'object-uri' property set as returned by
+            the HMC, and will also have the input properties set.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        result = self.session.post(self.console.uri + '/users',
+                                   body=properties)
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = copy.deepcopy(properties)
+        props.update(result)
+        name = props.get(self._name_prop, None)
+        uri = props[self._uri_prop]
+        user = User(self, uri, name, props)
+        self._name_uri_cache.update(name, uri)
+        return user
+
+
+class User(BaseResource):
+    """
+    Representation of a :term:`User`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.UserManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.UserManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, UserManager), \
+            "Console init: Expected manager type %s, got %s" % \
+            (UserManager, type(manager))
+        super(User, self).__init__(manager, uri, name, properties)
+
+    @logged_api_call
+    def delete(self):
+        """
+        Delete this User.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage Users" task to delete a non-template
+          user, or the "Manage User Templates" task to delete a template user.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.delete(self.uri)
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this User.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage Users" task to update a non-template
+          user, or the "Manage User Templates" task to update a template user.
+        * For a user to update their own password or default-group-uri
+          property, user-related-access permission to the user represented
+          by this User object, or task permission to the "Manage Users" task is
+          required.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model' in section 'User object' in the
+            :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self.uri, body=properties)
+
+        # The name of Users cannot be updated. An attempt to do so should cause
+        # HTTPError to be raised in the POST above, so we assert that here,
+        # because we omit the extra code for handling name updates:
+        assert self.manager._name_prop not in properties
+        self.properties.update(copy.deepcopy(properties))
+
+    @logged_api_call
+    def add_user_role(self, user_role):
+        """
+        Add the specified User Role to this User.
+
+        This User must not be a system-defined or pattern-based user.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage Users" task to modify a standard user
+          or the "Manage User Templates" task to modify a template user.
+
+        Parameters:
+
+          user_role (:class:`~zhmcclient.UserRole`): User Role to be added.
+            Must not be `None`.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {
+            'user-role-uri': user_role.uri
+        }
+        self.manager.session.post(
+            self.uri + '/operations/add-user-role',
+            body=body)
+
+    @logged_api_call
+    def remove_user_role(self, user_role):
+        """
+        Remove the specified User Role from this User.
+
+        This User must not be a system-defined or pattern-based user.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage Users" task to modify a standard user
+          or the "Manage User Templates" task to modify a template user.
+
+        Parameters:
+
+          user_role (:class:`~zhmcclient.UserRole`): User Role to be removed.
+            Must not be `None`.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {
+            'user-role-uri': user_role.uri
+        }
+        self.manager.session.post(
+            self.uri + '/operations/remove-user-role',
+            body=body)

--- a/zhmcclient/_user_pattern.py
+++ b/zhmcclient/_user_pattern.py
@@ -1,0 +1,310 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`User Pattern` resource represents a pattern for HMC user IDs that are
+not defined on the HMC but can be verified by an LDAP server for user
+authentication.
+
+User Patterns and user templates allow a system administrator to define a group
+of HMC users at once whose user IDs all match a certain pattern (for example,
+a regular expression) and who have a certain set of attributes. Each pattern
+identifies a template User object which defines many characteristics of such
+users. A successful logon with a user ID that matches a User Pattern results in
+the creation of a pattern-based user, with many of its attributes coming from
+the associated template.
+
+User Patterns are searched in a defined order during logon processing. That
+order can be customized through the
+:meth:`~zhmcclient.UserPatternManager.reorder` method.
+"""
+
+from __future__ import absolute_import
+
+import copy
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['UserPatternManager', 'UserPattern']
+
+LOG = get_logger(__name__)
+
+
+class UserPatternManager(BaseManager):
+    """
+    Manager providing access to the :term:`User Pattern` resources of a HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.Console` object:
+
+    * :attr:`zhmcclient.Console.user_patterns`
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #      Console object representing the HMC.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+            'type',
+        ]
+
+        super(UserPatternManager, self).__init__(
+            resource_class=UserPattern,
+            class_name='user-pattern',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/console/user-patterns',
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: :term:`Console` defining the scope for
+        this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=True, filter_args=None):
+        """
+        List the :term:`User Pattern` resources representing the user patterns
+        defined in this HMC.
+
+        Authorization requirements:
+
+        * User-related-access permission to the User Pattern objects included
+          in the result, or task permission to the "Manage User Patterns" task.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.UserPattern` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        resource_obj_list = []
+        query_parms, client_filters = self._divide_filter_args(filter_args)
+        resources_name = 'user-patterns'
+        uri = '{}/{}{}'.format(self.console.uri, resources_name, query_parms)
+
+        result = self.session.get(uri)
+        if result:
+            props_list = result[resources_name]
+            for props in props_list:
+
+                resource_obj = self.resource_class(
+                    manager=self,
+                    uri=props[self._uri_prop],
+                    name=props.get(self._name_prop, None),
+                    properties=props)
+
+                if self._matches_filters(resource_obj, client_filters):
+                    resource_obj_list.append(resource_obj)
+                    if full_properties:
+                        resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties):
+        """
+        Create a new User Pattern in this HMC.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Patterns" task.
+
+        Parameters:
+
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create User Pattern' in the :term:`HMC API` book.
+
+        Returns:
+
+          UserPattern:
+            The resource object for the new User Pattern.
+            The object will have its 'element-uri' property set as returned by
+            the HMC, and will also have the input properties set.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        result = self.session.post(self.console.uri + '/user-patterns',
+                                   body=properties)
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = copy.deepcopy(properties)
+        props.update(result)
+        name = props.get(self._name_prop, None)
+        uri = props[self._uri_prop]
+        user_pattern = UserPattern(self, uri, name, props)
+        self._name_uri_cache.update(name, uri)
+        return user_pattern
+
+    @logged_api_call
+    def reorder(self, user_patterns):
+        """
+        Reorder the User Patterns of the HMC as specified.
+
+        The order of User Patterns determines the search order during logon
+        processing.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Patterns" task.
+
+        Parameters:
+
+          user_patterns (list of :class:`~zhmcclient.UserPattern`):
+            The User Patterns in the desired order.
+
+            Must not be `None`.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """  # noqa: E501
+        body = {
+            'user-pattern-uris': [up.uri for up in user_patterns]
+        }
+        self.manager.session.post(
+            '/api/console/operations/reorder-user-patterns',
+            body=body)
+
+
+class UserPattern(BaseResource):
+    """
+    Representation of a :term:`User Pattern`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.UserPatternManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.UserPatternManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, UserPatternManager), \
+            "Console init: Expected manager type %s, got %s" % \
+            (UserPatternManager, type(manager))
+        super(UserPattern, self).__init__(manager, uri, name, properties)
+
+    @logged_api_call
+    def delete(self):
+        """
+        Delete this User Pattern.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Patterns" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.delete(self.uri)
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this UserPattern.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Patterns" task.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model' in section 'User Pattern object' in the
+            :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self.uri, body=properties)
+        is_rename = self.manager._name_prop in properties
+        if is_rename:
+            # Delete the old name from the cache
+            self.manager._name_uri_cache.delete(self.name)
+        self.properties.update(copy.deepcopy(properties))
+        if is_rename:
+            # Add the new name to the cache
+            self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_user_role.py
+++ b/zhmcclient/_user_role.py
@@ -1,0 +1,428 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`User Role` resource represents an authority role which can be assigned
+to one or more HMC users.
+
+A User Role may allow access to specific managed objects, classes of managed
+objects, groups and/or tasks. There are two types of User Roles: user-defined
+and system-defined. User-defined User Roles are created by an HMC user, whereas
+the system-defined User Roles are pre-defined, standard User Roles supplied
+with the HMC.
+"""
+
+from __future__ import absolute_import
+
+import copy
+import six
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['UserRoleManager', 'UserRole']
+
+LOG = get_logger(__name__)
+
+
+class UserRoleManager(BaseManager):
+    """
+    Manager providing access to the :term:`User Role` resources of a HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.Console` object:
+
+    * :attr:`zhmcclient.Console.user_roles`
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #      Console object representing the HMC.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+            'type',
+        ]
+
+        super(UserRoleManager, self).__init__(
+            resource_class=UserRole,
+            class_name='user-role',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/user-roles',
+            oid_prop='object-id',
+            uri_prop='object-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: :term:`Console` defining the scope for
+        this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=True, filter_args=None):
+        """
+        List the :term:`User Role` resources representing the user roles
+        defined in this HMC.
+
+        Authorization requirements:
+
+        * User-related-access permission to the User Role objects included in
+          the result, or task permission to the "Manage User Roles" task.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.UserRole` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        resource_obj_list = []
+        query_parms, client_filters = self._divide_filter_args(filter_args)
+        resources_name = 'user-roles'
+        uri = '{}/{}{}'.format(self.console.uri, resources_name, query_parms)
+
+        result = self.session.get(uri)
+        if result:
+            props_list = result[resources_name]
+            for props in props_list:
+
+                resource_obj = self.resource_class(
+                    manager=self,
+                    uri=props[self._uri_prop],
+                    name=props.get(self._name_prop, None),
+                    properties=props)
+
+                if self._matches_filters(resource_obj, client_filters):
+                    resource_obj_list.append(resource_obj)
+                    if full_properties:
+                        resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties):
+        """
+        Create a new (user-defined) User Role in this HMC.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Roles" task.
+
+        Parameters:
+
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create User Role' in the :term:`HMC API` book.
+
+        Returns:
+
+          UserRole:
+            The resource object for the new User Role.
+            The object will have its 'object-uri' property set as returned by
+            the HMC, and will also have the input properties set.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        result = self.session.post(self.console.uri + '/user-roles',
+                                   body=properties)
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = copy.deepcopy(properties)
+        props.update(result)
+        name = props.get(self._name_prop, None)
+        uri = props[self._uri_prop]
+        user_role = UserRole(self, uri, name, props)
+        self._name_uri_cache.update(name, uri)
+        return user_role
+
+
+class UserRole(BaseResource):
+    """
+    Representation of a :term:`User Role`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.UserRoleManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.UserRoleManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, UserRoleManager), \
+            "Console init: Expected manager type %s, got %s" % \
+            (UserRoleManager, type(manager))
+        super(UserRole, self).__init__(manager, uri, name, properties)
+
+    @logged_api_call
+    def delete(self):
+        """
+        Delete this User Role.
+
+        The User Role must be user-defined. System-defined User Roles cannot be
+        deleted.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Roles" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.delete(self.uri)
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this User Role.
+
+        The User Role must be user-defined. System-defined User Roles cannot be
+        updated.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Roles" task.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model' in section 'User Role object' in the
+            :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self.uri, body=properties)
+
+        # The name of User Roles cannot be updated. An attempt to do so should
+        # cause HTTPError to be raised in the POST above, so we assert that
+        # here, because we omit the extra code for handling name updates:
+        assert self.manager._name_prop not in properties
+        self.properties.update(copy.deepcopy(properties))
+
+    @logged_api_call
+    def add_permission(self, permitted_object, include_members=False,
+                       view_only=True):
+        """
+        Add permission for the specified permitted object(s) to this User Role,
+        thereby granting that permission to all users that have this User Role.
+
+        The granted permission depends on the resource class of the permitted
+        object(s):
+
+        * For Task resources, the granted permission is task permission for
+          that task.
+
+        * For Group resources, the granted permission is object access
+          permission for the group resource, and optionally also for the
+          group members.
+
+        * For any other resources, the granted permission is object access
+          permission for these resources.
+
+        The User Role must be user-defined.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Roles" task.
+
+        Parameters:
+
+          permitted_object (:class:`~zhmcclient.BaseResource` or :term:`string`):
+            Permitted object(s), either as a Python resource object (e.g.
+            :class:`~zhmcclient.Partition`), or as a resource class string (e.g.
+            'partition').
+
+            Must not be `None`.
+
+          include_members (bool): Controls whether for Group resources, the
+            operation applies additionally to its group member resources.
+
+            This parameter will be ignored when the permitted object does not
+            specify Group resources.
+
+          view_only (bool): Controls whether for Task resources, the operation
+            aplies to the view-only version of the task (if `True`), or to
+            the full version of the task (if `False`). Only certain tasks
+            support a view-only version.
+
+            This parameter will be ignored when the permitted object does not
+            specify Task resources.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """  # noqa: E501
+        if isinstance(permitted_object, BaseResource):
+            perm_obj = permitted_object.uri
+            perm_type = 'object'
+        elif isinstance(permitted_object, six.string_types):
+            perm_obj = permitted_object
+            perm_type = 'object-class'
+        else:
+            raise TypeError(
+                "permitted_object must be a string or BaseResource, but is: "
+                "{}".format(type(permitted_object)))
+        body = {
+            'permitted-object': perm_obj,
+            'permitted-object-type': perm_type,
+            'include-members': include_members,
+            'view-only-mode': view_only,
+        }
+        self.manager.session.post(
+            self.uri + '/operations/add-permission',
+            body=body)
+
+    @logged_api_call
+    def remove_permission(self, permitted_object, include_members=False,
+                          view_only=True):
+        """
+        Remove permission for the specified permitted object(s) from this User
+        Role, thereby no longer granting that permission to all users that have
+        this User Role.
+
+        The granted permission depends on the resource class of the permitted
+        object(s):
+
+        * For Task resources, the granted permission is task permission for
+          that task.
+
+        * For Group resources, the granted permission is object access
+          permission for the group resource, and optionally also for the
+          group members.
+
+        * For any other resources, the granted permission is object access
+          permission for these resources.
+
+        The User Role must be user-defined.
+
+        Authorization requirements:
+
+        * Task permission to the "Manage User Roles" task.
+
+        Parameters:
+
+          permitted_object (:class:`~zhmcclient.BaseResource` or :term:`string`):
+            Permitted object(s), either as a Python resource object (e.g.
+            :class:`~zhmcclient.Partition`), or as a resource class string (e.g.
+            'partition').
+
+            Must not be `None`.
+
+          include_members (bool): Controls whether for Group resources, the
+            operation applies additionally to its group member resources.
+
+            This parameter will be ignored when the permitted object does not
+            specify Group resources.
+
+          view_only (bool): Controls whether for Task resources, the operation
+            aplies to the view-only version of the task (if `True`), or to
+            the full version of the task (if `False`). Only certain tasks
+            support a view-only version.
+
+            This parameter will be ignored when the permitted object does not
+            specify Task resources.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """  # noqa: E501
+        if isinstance(permitted_object, BaseResource):
+            perm_obj = permitted_object.uri
+            perm_type = 'object'
+        elif isinstance(permitted_object, six.string_types):
+            perm_obj = permitted_object
+            perm_type = 'object-class'
+        else:
+            raise TypeError(
+                "permitted_object must be a string or BaseResource, but is: "
+                "{}".format(type(permitted_object)))
+        body = {
+            'permitted-object': perm_obj,
+            'permitted-object-type': perm_type,
+            'include-members': include_members,
+            'view-only-mode': view_only,
+        }
+        self.manager.session.post(
+            self.uri + '/operations/remove-permission',
+            body=body)

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 import zhmcclient
 
 from ._hmc import FakedHmc
-from ._urihandler import UriHandler, HTTPError, URIS
+from ._urihandler import UriHandler, HTTPError, ConnectionError, URIS
 
 __all__ = ['FakedSession']
 
@@ -144,12 +144,14 @@ class FakedSession(zhmcclient.Session):
           :exc:`~zhmcclient.HTTPError`
           :exc:`~zhmcclient.ParseError` (not implemented)
           :exc:`~zhmcclient.AuthError` (not implemented)
-          :exc:`~zhmcclient.ConnectionError` (not implemented)
+          :exc:`~zhmcclient.ConnectionError`
         """
         try:
             return self._urihandler.get(self._hmc, uri, logon_required)
         except HTTPError as exc:
             raise zhmcclient.HTTPError(exc.response())
+        except ConnectionError as exc:
+            raise zhmcclient.ConnectionError(exc.message, None)
 
     def post(self, uri, body=None, logon_required=True,
              wait_for_completion=True, operation_timeout=None):
@@ -254,13 +256,15 @@ class FakedSession(zhmcclient.Session):
           :exc:`~zhmcclient.HTTPError`
           :exc:`~zhmcclient.ParseError` (not implemented)
           :exc:`~zhmcclient.AuthError` (not implemented)
-          :exc:`~zhmcclient.ConnectionError` (not implemented)
+          :exc:`~zhmcclient.ConnectionError`
         """
         try:
             return self._urihandler.post(self._hmc, uri, body, logon_required,
                                          wait_for_completion)
         except HTTPError as exc:
             raise zhmcclient.HTTPError(exc.response())
+        except ConnectionError as exc:
+            raise zhmcclient.ConnectionError(exc.message, None)
 
     def delete(self, uri, logon_required=True):
         """
@@ -289,9 +293,11 @@ class FakedSession(zhmcclient.Session):
           :exc:`~zhmcclient.HTTPError`
           :exc:`~zhmcclient.ParseError` (not implemented)
           :exc:`~zhmcclient.AuthError` (not implemented)
-          :exc:`~zhmcclient.ConnectionError` (not implemented)
+          :exc:`~zhmcclient.ConnectionError`
         """
         try:
             self._urihandler.delete(self._hmc, uri, logon_required)
         except HTTPError as exc:
             raise zhmcclient.HTTPError(exc.response())
+        except ConnectionError as exc:
+            raise zhmcclient.ConnectionError(exc.message, None)

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -20,6 +20,8 @@ faked HMC.
 from __future__ import absolute_import
 
 import re
+import time
+import copy
 from requests.utils import unquote
 
 from ._hmc import InputError
@@ -44,6 +46,12 @@ class HTTPError(Exception):
             'reason': self.reason,
             'message': self.message,
         }
+
+
+class ConnectionError(Exception):
+
+    def __init__(self, message):
+        self.message = message
 
 
 class InvalidResourceError(HTTPError):
@@ -302,12 +310,16 @@ class UriHandler(object):
         raise InvalidResourceError(method, uri)
 
     def get(self, hmc, uri, logon_required):
+        if not hmc.enabled:
+            raise ConnectionError("HMC is not enabled.")
         handler_class, uri_parms = self.handler(uri, 'GET')
         if not getattr(handler_class, 'get', None):
             raise InvalidMethodError('GET', uri, handler_class)
         return handler_class.get('GET', hmc, uri, uri_parms, logon_required)
 
     def post(self, hmc, uri, body, logon_required, wait_for_completion):
+        if not hmc.enabled:
+            raise ConnectionError("HMC is not enabled.")
         handler_class, uri_parms = self.handler(uri, 'POST')
         if not getattr(handler_class, 'post', None):
             raise InvalidMethodError('POST', uri, handler_class)
@@ -315,6 +327,8 @@ class UriHandler(object):
                                   logon_required, wait_for_completion)
 
     def delete(self, hmc, uri, logon_required):
+        if not hmc.enabled:
+            raise ConnectionError("HMC is not enabled.")
         handler_class, uri_parms = self.handler(uri, 'DELETE')
         if not getattr(handler_class, 'delete', None):
             raise InvalidMethodError('DELETE', uri, handler_class)
@@ -347,6 +361,18 @@ class GenericUpdatePropertiesHandler(object):
         resource.update(body)
 
 
+class GenericDeleteHandler(object):
+
+    @staticmethod
+    def delete(method, hmc, uri, uri_parms, logon_required):
+        """Operation: Delete <resource>."""
+        try:
+            resource = hmc.lookup_by_uri(uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        resource.manager.remove(resource.oid)
+
+
 class VersionHandler(object):
 
     @staticmethod
@@ -358,6 +384,528 @@ class VersionHandler(object):
             'api-major-version': int(api_major),
             'api-minor-version': int(api_minor),
         }
+
+
+class ConsoleHandler(GenericGetPropertiesHandler):
+    pass
+
+
+class ConsoleRestartHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Restart Console."""
+        assert wait_for_completion is True  # synchronous operation
+        console_uri = '/api/console'
+        try:
+            hmc.lookup_by_uri(console_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        hmc.disable()
+        time.sleep(5)
+        hmc.enable()
+        # Note: The HTTP status 202 that the real HMC operation returns, is
+        # not visible for the caller of FakedSession (or Session).
+
+
+class ConsoleShutdownHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Shutdown Console."""
+        assert wait_for_completion is True  # synchronous operation
+        console_uri = '/api/console'
+        try:
+            hmc.lookup_by_uri(console_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        hmc.disable()
+        # Note: The HTTP status 202 that the real HMC operation returns, is
+        # not visible for the caller of FakedSession (or Session).
+
+
+class ConsoleMakePrimaryHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Make Console Primary."""
+        assert wait_for_completion is True  # synchronous operation
+        console_uri = '/api/console'
+        try:
+            hmc.lookup_by_uri(console_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        # Nothing to do, as long as the faked HMC does not need to know whether
+        # it is primary or alternate.
+
+
+class ConsoleReorderUserPatternsHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Reorder User Patterns."""
+        assert wait_for_completion is True  # synchronous operation
+        console_uri = '/api/console'
+        try:
+            console = hmc.lookup_by_uri(console_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body, ['user-pattern-uris'])
+        new_order_uris = body['user-pattern-uris']
+        objs = console.user_patterns.list()
+        obj_by_uri = {}
+        for obj in objs:
+            obj_by_uri[obj.uri] = obj
+        # Perform the reordering in the faked HMC:
+        for uri in new_order_uris:
+            obj = obj_by_uri[uri]
+            console.user_patterns.remove(obj.oid)  # remove from old position
+            console.user_patterns.add(obj.properties)  # append to end
+
+
+class ConsoleGetAuditLogHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Get Console Audit Log."""
+        assert wait_for_completion is True  # synchronous operation
+        console_uri = '/api/console'
+        try:
+            hmc.lookup_by_uri(console_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        resp = []
+        # TODO: Add the ability to return audit log entries in mock support.
+        return resp
+
+
+class ConsoleGetSecurityLogHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Get Console Security Log."""
+        assert wait_for_completion is True  # synchronous operation
+        console_uri = '/api/console'
+        try:
+            hmc.lookup_by_uri(console_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        resp = []
+        # TODO: Add the ability to return security log entries in mock support.
+        return resp
+
+
+class ConsoleListUnmanagedCpcsHandler(object):
+
+    @staticmethod
+    def get(method, hmc, uri, uri_parms, logon_required):
+        """Operation: List Unmanaged CPCs."""
+        query_str = uri_parms[0]
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+
+        result_ucpcs = []
+        filter_args = parse_query_parms(method, uri, query_str)
+        for ucpc in console.unmanaged_cpcs.list(filter_args):
+            result_ucpc = {}
+            for prop in ucpc.properties:
+                if prop in ('object-uri', 'name'):
+                    result_ucpc[prop] = ucpc.properties[prop]
+            result_ucpcs.append(result_ucpc)
+        return {'cpcs': result_ucpcs}
+
+
+class UsersHandler(object):
+
+    @staticmethod
+    def get(method, hmc, uri, uri_parms, logon_required):
+        """Operation: List Users."""
+        query_str = uri_parms[0]
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        result_users = []
+        filter_args = parse_query_parms(method, uri, query_str)
+        for user in console.users.list(filter_args):
+            result_user = {}
+            for prop in user.properties:
+                if prop in ('object-uri', 'name', 'type'):
+                    result_user[prop] = user.properties[prop]
+            result_users.append(result_user)
+        return {'users': result_users}
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Create User."""
+        assert wait_for_completion is True  # synchronous operation
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body,
+                              ['name', 'type', 'authentication-type'])
+        # TODO: There are some more input properties that are required under
+        # certain conditions.
+        new_user = console.users.add(body)
+        return {'object-uri': new_user.uri}
+
+
+class UserHandler(GenericGetPropertiesHandler,
+                  GenericUpdatePropertiesHandler):
+
+    # TODO: Add post() for Update User that rejects name update
+
+    @staticmethod
+    def delete(method, hmc, uri, uri_parms, logon_required):
+        """Operation: Delete User."""
+        try:
+            user = hmc.lookup_by_uri(uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        # Check user type
+        type_ = user.properties['type']
+        if type_ == 'pattern-based':
+            raise BadRequestError(
+                method, uri, reason=312,
+                message="Cannot delete pattern-based user {!r}".
+                format(user.name))
+        # Delete the mocked resource
+        user.manager.remove(user.oid)
+
+
+class UserAddUserRoleHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Add User Role to User."""
+        assert wait_for_completion is True  # synchronous operation
+        user_oid = uri_parms[0]
+        user_uri = '/api/users/' + user_oid
+        try:
+            user = hmc.lookup_by_uri(user_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body, ['user-role-uri'])
+        user_type = user.properties['type']
+        if user_type in ('pattern-based', 'system-defined'):
+            raise BadRequestError(
+                method, uri, reason=314,
+                message="Cannot add user role to user of type {}: {}".
+                format(user_type, user_uri))
+        user_role_uri = body['user-role-uri']
+        try:
+            hmc.lookup_by_uri(user_role_uri)
+        except KeyError:
+            raise InvalidResourceError(method, user_role_uri, reason=2)
+        if user.properties.get('user-roles', None) is None:
+            user.properties['user-roles'] = []
+        user.properties['user-roles'].append(user_role_uri)
+
+
+class UserRemoveUserRoleHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Remove User Role from User."""
+        assert wait_for_completion is True  # synchronous operation
+        user_oid = uri_parms[0]
+        user_uri = '/api/users/' + user_oid
+        try:
+            user = hmc.lookup_by_uri(user_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body, ['user-role-uri'])
+        user_type = user.properties['type']
+        if user_type in ('pattern-based', 'system-defined'):
+            raise BadRequestError(
+                method, uri, reason=314,
+                message="Cannot remove user role from user of type {}: {}".
+                format(user_type, user_uri))
+        user_role_uri = body['user-role-uri']
+        try:
+            user_role = hmc.lookup_by_uri(user_role_uri)
+        except KeyError:
+            raise InvalidResourceError(method, user_role_uri, reason=2)
+        if user.properties.get('user-roles', None) is None \
+                or user_role_uri not in user.properties['user-roles']:
+            raise ConflictError(
+                method, uri, reason=316,
+                message="User {!r} does not have User Role {!r}".
+                format(user.name, user_role.name))
+        user.properties['user-roles'].remove(user_role_uri)
+
+
+class UserRolesHandler(object):
+
+    @staticmethod
+    def get(method, hmc, uri, uri_parms, logon_required):
+        """Operation: List User Roles."""
+        query_str = uri_parms[0]
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        result_user_roles = []
+        filter_args = parse_query_parms(method, uri, query_str)
+        for user_role in console.user_roles.list(filter_args):
+            result_user_role = {}
+            for prop in user_role.properties:
+                if prop in ('object-uri', 'name', 'type'):
+                    result_user_role[prop] = user_role.properties[prop]
+            result_user_roles.append(result_user_role)
+        return {'user-roles': result_user_roles}
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Create User Role."""
+        assert wait_for_completion is True  # synchronous operation
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body, ['name'])
+        properties = copy.deepcopy(body)
+        if 'type' in properties:
+            raise BadRequestError(
+                method, uri, reason=6,
+                message="Type specified when creating a user role: {!r}".
+                format(properties['type']))
+        properties['type'] = 'user-defined'
+        new_user_role = console.user_roles.add(properties)
+        return {'object-uri': new_user_role.uri}
+
+
+class UserRoleHandler(GenericGetPropertiesHandler,
+                      GenericUpdatePropertiesHandler,
+                      GenericDeleteHandler):
+    pass
+    # TODO: Add post() for Update UserRole that rejects name update
+    # TODO: Add delete() for Delete UserRole that rejects system-defined type
+
+
+class UserRoleAddPermissionHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Add Permission to User Role."""
+        assert wait_for_completion is True  # synchronous operation
+        user_role_oid = uri_parms[0]
+        user_role_uri = '/api/user-roles/' + user_role_oid
+        try:
+            user_role = hmc.lookup_by_uri(user_role_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body,
+                              ['permitted-object', 'permitted-object-type'])
+        # Reject if User Role is system-defined:
+        if user_role.properties['type'] == 'system-defined':
+            raise BadRequestError(
+                method, uri, reason=314, message="Cannot add permission to "
+                "system-defined user role: {}".format(user_role_uri))
+        # Apply defaults, so our internally stored copy has all fields:
+        permission = copy.deepcopy(body)
+        if 'include-members' not in permission:
+            permission['include-members'] = False
+        if 'view-only-mode' not in permission:
+            permission['view-only-mode'] = True
+        # Add the permission to its store (the faked User Role object):
+        if user_role.properties.get('permissions', None) is None:
+            user_role.properties['permissions'] = []
+        user_role.properties['permissions'].append(permission)
+
+
+class UserRoleRemovePermissionHandler(object):
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Remove Permission from User Role."""
+        assert wait_for_completion is True  # synchronous operation
+        user_role_oid = uri_parms[0]
+        user_role_uri = '/api/user-roles/' + user_role_oid
+        try:
+            user_role = hmc.lookup_by_uri(user_role_uri)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body,
+                              ['permitted-object', 'permitted-object-type'])
+        # Reject if User Role is system-defined:
+        if user_role.properties['type'] == 'system-defined':
+            raise BadRequestError(
+                method, uri, reason=314, message="Cannot remove permission "
+                "from system-defined user role: {}".format(user_role_uri))
+        # Apply defaults, so we can locate it based upon all fields:
+        permission = copy.deepcopy(body)
+        if 'include-members' not in permission:
+            permission['include-members'] = False
+        if 'view-only-mode' not in permission:
+            permission['view-only-mode'] = True
+        # Remove the permission from its store (the faked User Role object):
+        if user_role.properties.get('permissions', None) is not None:
+            user_role.properties['permissions'].remove(permission)
+
+
+class TasksHandler(object):
+
+    @staticmethod
+    def get(method, hmc, uri, uri_parms, logon_required):
+        """Operation: List Tasks."""
+        query_str = uri_parms[0]
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        result_tasks = []
+        filter_args = parse_query_parms(method, uri, query_str)
+        for task in console.tasks.list(filter_args):
+            result_task = {}
+            for prop in task.properties:
+                if prop in ('element-uri', 'name'):
+                    result_task[prop] = task.properties[prop]
+            result_tasks.append(result_task)
+        return {'tasks': result_tasks}
+
+
+class TaskHandler(GenericGetPropertiesHandler):
+    pass
+
+
+class UserPatternsHandler(object):
+
+    @staticmethod
+    def get(method, hmc, uri, uri_parms, logon_required):
+        """Operation: List User Patterns."""
+        query_str = uri_parms[0]
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        result_user_patterns = []
+        filter_args = parse_query_parms(method, uri, query_str)
+        for user_pattern in console.user_patterns.list(filter_args):
+            result_user_pattern = {}
+            for prop in user_pattern.properties:
+                if prop in ('element-uri', 'name', 'type'):
+                    result_user_pattern[prop] = user_pattern.properties[prop]
+            result_user_patterns.append(result_user_pattern)
+        return {'user-patterns': result_user_patterns}
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Create User Pattern."""
+        assert wait_for_completion is True  # synchronous operation
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body,
+                              ['name', 'pattern', 'type', 'retention-time',
+                               'user-template-uri'])
+        new_user_pattern = console.user_patterns.add(body)
+        return {'element-uri': new_user_pattern.uri}
+
+
+class UserPatternHandler(GenericGetPropertiesHandler,
+                         GenericUpdatePropertiesHandler,
+                         GenericDeleteHandler):
+    pass
+
+
+class PasswordRulesHandler(object):
+
+    @staticmethod
+    def get(method, hmc, uri, uri_parms, logon_required):
+        """Operation: List Password Rules."""
+        query_str = uri_parms[0]
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        result_password_rules = []
+        filter_args = parse_query_parms(method, uri, query_str)
+        for password_rule in console.password_rules.list(filter_args):
+            result_password_rule = {}
+            for prop in password_rule.properties:
+                if prop in ('element-uri', 'name', 'type'):
+                    result_password_rule[prop] = password_rule.properties[prop]
+            result_password_rules.append(result_password_rule)
+        return {'password-rules': result_password_rules}
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Create Password Rule."""
+        assert wait_for_completion is True  # synchronous operation
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body, ['name'])
+        new_password_rule = console.password_rules.add(body)
+        return {'element-uri': new_password_rule.uri}
+
+
+class PasswordRuleHandler(GenericGetPropertiesHandler,
+                          GenericUpdatePropertiesHandler,
+                          GenericDeleteHandler):
+    pass
+    # TODO: Add post() for Update PasswordRule that rejects name update
+
+
+class LdapServerDefinitionsHandler(object):
+
+    @staticmethod
+    def get(method, hmc, uri, uri_parms, logon_required):
+        """Operation: List LDAP Server Definitions."""
+        query_str = uri_parms[0]
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        result_ldap_srv_defs = []
+        filter_args = parse_query_parms(method, uri, query_str)
+        for ldap_srv_def in console.ldap_server_definitions.list(filter_args):
+            result_ldap_srv_def = {}
+            for prop in ldap_srv_def.properties:
+                if prop in ('element-uri', 'name', 'type'):
+                    result_ldap_srv_def[prop] = ldap_srv_def.properties[prop]
+            result_ldap_srv_defs.append(result_ldap_srv_def)
+        return {'ldap-server-definitions': result_ldap_srv_defs}
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        """Operation: Create LDAP Server Definition."""
+        assert wait_for_completion is True  # synchronous operation
+        try:
+            console = hmc.consoles.lookup_by_oid(None)
+        except KeyError:
+            raise InvalidResourceError(method, uri)
+        check_required_fields(method, uri, body, ['name'])
+        new_ldap_srv_def = console.ldap_server_definitions.add(body)
+        return {'element-uri': new_ldap_srv_def.uri}
+
+
+class LdapServerDefinitionHandler(GenericGetPropertiesHandler,
+                                  GenericUpdatePropertiesHandler,
+                                  GenericDeleteHandler):
+    pass
+    # TODO: Add post() for Update LdapServerDefinition that rejects name update
 
 
 class CpcsHandler(object):
@@ -1471,6 +2019,47 @@ URIS = (
     # In all modes:
 
     (r'/api/version', VersionHandler),
+
+    (r'/api/console', ConsoleHandler),
+    (r'/api/console/operations/restart', ConsoleRestartHandler),
+    (r'/api/console/operations/shutdown', ConsoleShutdownHandler),
+    (r'/api/console/operations/make-primary', ConsoleMakePrimaryHandler),
+    (r'/api/console/operations/reorder-user-patterns',
+     ConsoleReorderUserPatternsHandler),
+    (r'/api/console/operations/get-audit-log(?:\?(.*))?',
+     ConsoleGetAuditLogHandler),
+    (r'/api/console/operations/get-security-log(?:\?(.*))?',
+     ConsoleGetSecurityLogHandler),
+    (r'/api/console/operations/list-unmanaged-cpcs(?:\?(.*))?',
+     ConsoleListUnmanagedCpcsHandler),
+
+    (r'/api/console/users(?:\?(.*))?', UsersHandler),
+    (r'/api/users/([^/]+)', UserHandler),
+    (r'/api/users/([^/]+)/operations/add-user-role',
+     UserAddUserRoleHandler),
+    (r'/api/users/([^/]+)/operations/remove-user-role',
+     UserRemoveUserRoleHandler),
+
+    (r'/api/console/user-roles(?:\?(.*))?', UserRolesHandler),
+    (r'/api/user-roles/([^/]+)', UserRoleHandler),
+    (r'/api/user-roles/([^/]+)/operations/add-permission',
+     UserRoleAddPermissionHandler),
+    (r'/api/user-roles/([^/]+)/operations/remove-permission',
+     UserRoleRemovePermissionHandler),
+
+    (r'/api/console/tasks(?:\?(.*))?', TasksHandler),
+    (r'/api/console/tasks/([^/]+)', TaskHandler),
+
+    (r'/api/console/user-patterns(?:\?(.*))?', UserPatternsHandler),
+    (r'/api/console/user-patterns/([^/]+)', UserPatternHandler),
+
+    (r'/api/console/password-rules(?:\?(.*))?', PasswordRulesHandler),
+    (r'/api/console/password-rules/([^/]+)', PasswordRuleHandler),
+
+    (r'/api/console/ldap-server-definitions(?:\?(.*))?',
+     LdapServerDefinitionsHandler),
+    (r'/api/console/ldap-server-definitions/([^/]+)',
+     LdapServerDefinitionHandler),
 
     (r'/api/cpcs(?:\?(.*))?', CpcsHandler),
     (r'/api/cpcs/([^/]+)', CpcHandler),


### PR DESCRIPTION
This PR is ready for review and merge.

**Review hints:** This PR contains a lot of code. Instead of reviewing all the code, you may want to focus your review on some key areas:

* Introduction of the `Console` resource class. See discussion point about merging Console into Client.
* Introduction of the `UnmanagedCpc` resource class (as opposed to using the `Cpc` resource class for both managed and unmanaged CPCs).
* Introduction of a `wait_for_available()` method on the `Client` class. It is used by `Console.restart()`, but is also made available as part of the public API. Should it be part of the public API? Is it on the right class? Does it have the right method name?
* Introduction of `datetime_from_timestamp()` and `timestamp_from_datetime()` functions. They are used by some operations that take datetime values as arguments and need to convert them to HMC timestamp numbers, and they are used by the metrics module, but they are also made available as part of the public API. Should they be part of the public API? Do they have the right function name? Is it ok that `timestamp_from_datetime()` assumes a default timezone of UTC for timezone-naive input (e.g. as opposed to the local timezone)?
* Fixed/extended `Session.post()` to now allow for empty response body for HTTP status 202. This status code so far was always assumed to indicate that an async job had been started, but it can happen in some Console operations (e.g. `restart()` and `shutdown()`) without an async job.
* Improved the error information in the `ParseError` exception, by adding the "Content-Type" header in cases where that is interesting.

**Discussion points:**

* DONE **Merge Console into Client:** With the introduction of the Console class in this PR, we now have console-specific resources hanging off of both Client and Console. This results in an inconsistent resource model the zhmcclient API is presenting to its users. Proposal is to merge the Console features into the Client class, to rename the Client class to Console, and (for compatibility) to still have the Client class as a deprecated synonym for Console. The deprecation warning would suggest to owners of current code using the API with the `Client` class, to change the name to `Console`.
  **Update:** Juergen and Andy discussed this and decided that we would continue to represent the parent-child relationship of the HMC resource objects in the Python object hierarchy of the zhmcclient. This means the Console object would remain a sibling of the Cpc object and both would hang off of the Client. This approach is reflected in this PR as it stands right now.