### PR TITLE
Removed sudo requirement from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,37 +16,31 @@ notifications:
 matrix:
   include:
     - os: linux
-      sudo: required
       language: python
       python: "2.7"
       env:
         - PACKAGE_LEVEL=minimum
     - os: linux
-      sudo: required
       language: python
       python: "2.7"
       env:
         - PACKAGE_LEVEL=latest
     - os: linux
-      sudo: required
       language: python
       python: "3.4"
       env:
         - PACKAGE_LEVEL=minimum
 #    - os: linux
-#      sudo: required
 #      language: python
 #      python: "3.5"
 #      env:
 #        - PACKAGE_LEVEL=minimum
     - os: linux
-      sudo: required
       language: python
       python: "3.6"
       env:
         - PACKAGE_LEVEL=latest
 #    - os: linux
-#      sudo: required
 #      language: python
 #      python: "pypy-5.3.1"  # Python 2.7.10
 #      env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,28 +46,24 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=minimum
     - os: osx
-      sudo: required
       language: generic
       python:
       env:
         - PACKAGE_LEVEL=minimum
         - PYTHON=2
 #    - os: osx
-#      sudo: required
 #      language: generic
 #      python:
 #      env:
 #        - PACKAGE_LEVEL=latest
 #        - PYTHON=2
 #    - os: osx
-#      sudo: required
 #      language: generic
 #      python:
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #        - PYTHON=3
     - os: osx
-      sudo: required
       language: generic
       python:
       env:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,25 @@
 Change log
 ----------
 
+Version 0.17.0
+^^^^^^^^^^^^^^
+
+Released: not yet
+
+**Incompatible changes:**
+
+**Deprecations:**
+
+**Bug fixes:**
+
+**Enhancements:**
+
+**Known issues:**
+
+* See `list of open issues`_.
+
+.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
+
 
 Version 0.16.0
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
The sudo requirement is not needed, and not requiring sudo has the benefit that Travis CI will deploy the test runs into containers, instead of creating virtual systems.