### PR TITLE
Fixes #355: Expanded the regular cron-triggered Travis run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,39 +30,47 @@ matrix:
       python: "3.4"
       env:
         - PACKAGE_LEVEL=minimum
-#    - os: linux
-#      language: python
-#      python: "3.5"
-#      env:
-#        - PACKAGE_LEVEL=minimum
+    - os: linux
+      language: python
+      python: "3.5"
+      env:
+        - PACKAGE_LEVEL=minimum
+      before_install:
+        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
     - os: linux
       language: python
       python: "3.6"
       env:
         - PACKAGE_LEVEL=latest
-#    - os: linux
-#      language: python
-#      python: "pypy-5.3.1"  # Python 2.7.10
-#      env:
-#        - PACKAGE_LEVEL=minimum
+    - os: linux
+      language: python
+      python: "pypy-5.3.1"  # Python 2.7.10
+      env:
+        - PACKAGE_LEVEL=minimum
+      before_install:
+        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
     - os: osx
       language: generic
       python:
       env:
         - PACKAGE_LEVEL=minimum
         - PYTHON=2
-#    - os: osx
-#      language: generic
-#      python:
-#      env:
-#        - PACKAGE_LEVEL=latest
-#        - PYTHON=2
-#    - os: osx
-#      language: generic
-#      python:
-#      env:
-#        - PACKAGE_LEVEL=minimum
-#        - PYTHON=3
+    - os: osx
+      language: generic
+      python:
+      env:
+        - PACKAGE_LEVEL=latest
+        - PYTHON=2
+      before_install:
+        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
+    - os: osx
+      language: generic
+      python:
+      env:
+        - PACKAGE_LEVEL=minimum
+        - PYTHON=3
+      before_install:
+        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
     - os: osx
       language: generic
       python:
@@ -124,6 +132,6 @@ script:
     fi
 
 after_success:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$PACKAGE_LEVEL" == "latest" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "2.7" && "$PACKAGE_LEVEL" == "latest" ]]; then
       coveralls;
     fi


### PR DESCRIPTION
For details, see commit message.

For reviewing this:

* Look at the Travis results for this PR. You will see more combinations than before,  and those with a short run time are the ones that will only perform real check work in a cron-triggered Travis run. They end quickly in a PR-triggered Travis run (like this one).
* The cron-triggered Travis runs run daily but only on the master branch, so checking that the cron-triggered runs actually check something can only be done once this PR has been merged to master.
* For a comparison of the elapsed time for Travis runs, there are two data points:

  * [Travis build #2258](https://travis-ci.org/zhmcclient/python-zhmcclient/builds/271590863) of this PR has an elapsed time of 11:35
  * [Travis build #2253](https://travis-ci.org/zhmcclient/python-zhmcclient/builds/270752597) is a rerun of PR #419 and has an elapsed time of 10:43

  Both runs were done in the German morning hours where there is not so much traffic on Travis, but at the end they are just two data points.