### PR TITLE
Circumvented ImportError for build_clib on Travis with Py 2.7.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,11 +170,12 @@ help:
 
 .PHONY: _pip
 _pip:
-	@echo 'Installing/upgrading pip, setuptools and wheel with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
-	$(PIP_CMD) install --upgrade pip
-	$(PIP_CMD) install $(pip_level_opts) pip
+	@echo 'Installing/upgrading pip, setuptools, wheel and pbr with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
+	$(PIP_CMD) install $(pip_level_opts) pip setuptools wheel pbr
+	@echo "Temp fix: Install setuptools a second time to circumvent import error for build_clib on Travis"
 	$(PIP_CMD) install $(pip_level_opts) setuptools
-	$(PIP_CMD) install $(pip_level_opts) wheel
+	$(PIP_CMD) list
+	# TODO: Final solution for the above temp fix. See also pip issue https://github.com/pypa/pip/issues/4724
 
 .PHONY: develop
 develop: _pip

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -15,11 +15,32 @@
 # the minimum versions required in requirements.txt and dev-requirements.txt.
 
 
-# Dependencies for installation with Pip:
+# Dependencies for installation with Pip (must be installed in a separate pip call)
+#
+# Info: OS-installed package versions for some Linux distros:
+# * RHEL/CentOS 7.4.1708:
+#   Python      2.7.5     2013-05-15
+#   pip         8.1.2     2016-05-11 (epel)
+#   setuptools  0.9.8     2013-07-25
+#   wheel       0.24.0    2014-07-06 (epel)
+#   pbr         1.8.1     2015-10-07 (epel)
+# * Ubuntu 16.04.03:
+#   Python      2.7.12    2016-11-19
+#   pip         8.1.1     2016-03-17
+#   setuptools  20.7.0    2016-04-10
+#   wheel       0.29.0    2016-02-06
+#   pbr         1.8.0     2015-09-14
+# * Ubuntu 17.04:
+#   Python      2.7.12    2016-11-19
+#   pip         9.0.1     2016-11-06
+#   setuptools  33.1.1    2017-01-16
+#   wheel       0.29.0    2016-02-06
+#   pbr         1.10.0    2016-05-23
 
 pip===9.0.1
-setuptools===30.0.0
+setuptools===33.1.1
 wheel===0.29.0
+pbr===1.10.0
 
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
@@ -28,7 +49,6 @@ click===6.6
 click-repl===0.1.0
 click-spinner===0.1.6
 decorator===4.0.10
-pbr===1.10.0
 progressbar2===3.12.0
 pytz===2016.10
 requests===2.12.4


### PR DESCRIPTION
This change contains a circumvention for issue #434.
Ready to be reviewed and merged.