### PR TITLE
Add CLI support for mount and unmount an ISO

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -105,8 +105,8 @@ Released: not yet
 
 * Clarified in the description of `HbaManager.list()` that only the
   'element-uri' property is returned and can be used for filtering.
-  
-* The mock support for the "Create NIC" operation now performs more 
+
+* The mock support for the "Create NIC" operation now performs more
   checking on the URIs specified in the 'network-adapter-port' or
   'virtual-switch-uri' input properties, raising HTTP status 404 (Not Found)
   as specified in the HMC API book.
@@ -145,6 +145,8 @@ Released: not yet
 
 * Improved the error information in the ``ParseError`` exception, by adding
   the "Content-Type" header in cases where that is interesting.
+
+* Add CLI commmands to mount and unmount an ISO to a Partition.
 
 **Known issues:**
 


### PR DESCRIPTION
With the new CLI command 'zhmc partition mountiso'
an user provided ISO image can be uploaded.
The uploaded ISO image is the image that gets attached
to the partition. If an ISO is attached to a partition,
it can be shown by the partition property 'boot-iso-image-name'.
To boot from this ISO image the partition property
'boot-device' must be set to 'iso-image' before starting
the partition.

With the new CLI command 'zhmc partition unmountiso'
the user unmounts the currently mounted ISO from
the partition. The partition property 'boot-iso-image-name'
is empty then.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>