### PR TITLE
Fix warnings and (unproblematic) exceptions during Travis runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ package_name := zhmcclient
 cli_package_name := zhmccli
 
 # Package version (full version, including any pre-release suffixes, e.g. "0.1.0-alpha1")
-package_version := $(shell $(PYTHON_CMD) -c "import sys, $(package_name); sys.stdout.write($(package_name).__version__)")
+# package_version := $(shell $(PYTHON_CMD) -c "import sys, $(package_name); sys.stdout.write($(package_name).__version__)")
+package_version := $(shell $(PYTHON_CMD) -c "from pbr.version import VersionInfo; vi=VersionInfo('zhmcclient'); print(vi.version_string_with_vcs())")
 
 # Python major version
 python_major_version := $(shell $(PYTHON_CMD) -c "import sys; sys.stdout.write('%s'%sys.version_info[0])")

--- a/Makefile
+++ b/Makefile
@@ -170,11 +170,12 @@ help:
 
 .PHONY: _pip
 _pip:
-	@echo 'Installing/upgrading pip, setuptools and wheel with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
-	$(PIP_CMD) install --upgrade pip
-	$(PIP_CMD) install $(pip_level_opts) pip
+	@echo 'Installing/upgrading pip, setuptools, wheel and pbr with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
+	$(PIP_CMD) install $(pip_level_opts) pip setuptools wheel pbr
+	@echo "Temp fix: Install setuptools a second time to circumvent import error for build_clib on Travis"
 	$(PIP_CMD) install $(pip_level_opts) setuptools
-	$(PIP_CMD) install $(pip_level_opts) wheel
+	$(PIP_CMD) list
+	# TODO: Final solution for the above temp fix. See also pip issue https://github.com/pypa/pip/issues/4724
 
 .PHONY: develop
 develop: _pip

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -91,7 +91,7 @@ sphinx-git===10.0.0
 GitPython===2.1.1
 
 # PyLint (no imports, invoked via pylint script):
-pylint===1.6.4; python_version == '2.7'
+pylint===1.6.4 #; python_version == '2.7'
 
 # Flake8 (no imports, invoked via flake8 script):
 flake8===3.2.1
@@ -106,9 +106,9 @@ jupyter===1.0.0
 # Indirect dependencies for development (must be consistent with dev-requirements.txt)
 
 alabaster===0.7.9
-appnope===0.1.0; sys_platform == "darwin"
+appnope===0.1.0 #; sys_platform == "darwin"
 args===0.1.0
-astroid===1.4.9; python_version == '2.7'
+astroid===1.4.9 #; python_version == '2.7'
 Babel===2.3.4
 backports-abc===0.5
 backports.functools-lru-cache===1.3
@@ -121,8 +121,8 @@ coverage===4.0.3
 docutils===0.13.1
 entrypoints===0.2.2
 enum34===1.1.6
-funcsigs===1.0.2; python_version < '3.3'
-functools32===3.2.3.post2; python_version == '2.7'
+funcsigs===1.0.2 #; python_version < '3.3'
+functools32===3.2.3.post2 #; python_version == '2.7'
 gitdb2===2.0.0
 html5lib===0.9999999
 imagesize===0.7.1

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -15,11 +15,32 @@
 # the minimum versions required in requirements.txt and dev-requirements.txt.
 
 
-# Dependencies for installation with Pip:
+# Dependencies for installation with Pip (must be installed in a separate pip call)
+#
+# Info: OS-installed package versions for some Linux distros:
+# * RHEL/CentOS 7.4.1708:
+#   Python      2.7.5     2013-05-15
+#   pip         8.1.2     2016-05-11 (epel)
+#   setuptools  0.9.8     2013-07-25
+#   wheel       0.24.0    2014-07-06 (epel)
+#   pbr         1.8.1     2015-10-07 (epel)
+# * Ubuntu 16.04.03:
+#   Python      2.7.12    2016-11-19
+#   pip         8.1.1     2016-03-17
+#   setuptools  20.7.0    2016-04-10
+#   wheel       0.29.0    2016-02-06
+#   pbr         1.8.0     2015-09-14
+# * Ubuntu 17.04:
+#   Python      2.7.12    2016-11-19
+#   pip         9.0.1     2016-11-06
+#   setuptools  33.1.1    2017-01-16
+#   wheel       0.29.0    2016-02-06
+#   pbr         1.10.0    2016-05-23
 
 pip===9.0.1
-setuptools===30.0.0
+setuptools===33.1.1
 wheel===0.29.0
+pbr===1.10.0
 
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
@@ -28,7 +49,6 @@ click===6.6
 click-repl===0.1.0
 click-spinner===0.1.6
 decorator===4.0.10
-pbr===1.10.0
 progressbar2===3.12.0
 pytz===2016.10
 requests===2.12.4


### PR DESCRIPTION
**Note:** This PR is on top of PR #431.

This change eliminates two kinds of things that appear during Travis runs:
* Warnings that statements with environment markers in the constraints file are being ignored due to not being in that environment. A constraints file does not need environment markers at all.
* Exceptions when the makefile tries to determine the package version before the packages needed for importing zhmcclient are installed. They did not hurt because that variable was not used in make runs where this occurred.