### PR TITLE
(#7) Fixes #458: Migrated remaining test cases from unittest to py.test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,26 +30,41 @@ matrix:
       python: "3.4"
       env:
         - PACKAGE_LEVEL=minimum
-    - os: linux
-      language: python
-      python: "3.5"
-      env:
-        - PACKAGE_LEVEL=minimum
-      before_install:
-        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
+#    - os: linux
+#      language: python
+#      python: "3.4"
+#      env:
+#        - PACKAGE_LEVEL=latest
+#    - os: linux
+#      language: python
+#      python: "3.5"
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#    - os: linux
+#      language: python
+#      python: "3.5"
+#      env:
+#        - PACKAGE_LEVEL=latest
+#    - os: linux
+#      language: python
+#      python: "3.6"
+#      env:
+#        - PACKAGE_LEVEL=minimum
     - os: linux
       language: python
       python: "3.6"
       env:
         - PACKAGE_LEVEL=latest
-    - os: linux
-      language: python
-      python: "pypy-5.3.1"  # Python 2.7.10
-      env:
-        - PACKAGE_LEVEL=minimum
-      before_install:
-        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
-# TODO: Re-enable osx support once Travis has better OS-X capacity
+#    - os: linux
+#      language: python
+#      python: "pypy-5.3.1"  # Python 2.7.10
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#    - os: linux
+#      language: python
+#      python: "pypy-5.3.1"  # Python 2.7.10
+#      env:
+#        - PACKAGE_LEVEL=latest
 #    - os: osx
 #      language: generic
 #      python:
@@ -62,16 +77,12 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=latest
 #        - PYTHON=2
-#      before_install:
-#        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
 #    - os: osx
 #      language: generic
 #      python:
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #        - PYTHON=3
-#      before_install:
-#        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
 #    - os: osx
 #      language: generic
 #      python:
@@ -79,8 +90,20 @@ matrix:
 #        - PACKAGE_LEVEL=latest
 #        - PYTHON=3
 
+before_install:
+  - if [[ "$TRAVIS_BRANCH" == "manual-ci-run" ]]; then
+      export _NEED_REBASE=true;
+    fi
+  - if [[ -n $_NEED_REBASE ]]; then git fetch origin master; fi
+  - if [[ -n $_NEED_REBASE ]]; then git branch master FETCH_HEAD; fi
+  - if [[ -n $_NEED_REBASE ]]; then git rebase master; fi
+  - git branch -av
+
 # commands to install dependencies
 install:
+  - if [[ "$TRAVIS_BRANCH" == "manual-ci-run" || "$TRAVIS_PULL_REQUEST_BRANCH" == "manual-ci-run" ]]; then
+      export _MANUAL_CI_RUN=true;
+    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "${PYTHON:0:1}" == "2" ]]; then
         export PYTHON_CMD=python;
@@ -124,11 +147,10 @@ install:
 # commands to run builds & tests
 script:
   - make check
+  - if [[ -n $_MANUAL_CI_RUN ]]; then make pylint; fi
   - make test
-  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
-      make build;
-      make builddoc;
-    fi
+  - if [[ -n $_MANUAL_CI_RUN ]]; then make build; fi
+  - if [[ -n $_MANUAL_CI_RUN ]]; then make builddoc; fi
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "2.7" && "$PACKAGE_LEVEL" == "latest" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,12 @@ environment:
     - PYTHON_VERSION: 2.7
       PYTHON_ARCH: 32
       PYTHON_HOME: C:\Python27
-    - PYTHON_VERSION: 2.7
-      PYTHON_ARCH: 64
-      PYTHON_HOME: C:\Python27-x64
-    - PYTHON_VERSION: 3.4
-      PYTHON_ARCH: 32
-      PYTHON_HOME: C:\Python34
+#    - PYTHON_VERSION: 2.7
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python27-x64
+#    - PYTHON_VERSION: 3.4
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python34
 #    - PYTHON_VERSION: 3.4
 #      PYTHON_ARCH: 64
 #      PYTHON_HOME: C:\Python34-x64
@@ -34,6 +34,16 @@ configuration:
   - latest
 
 install:
+
+  - if %APPVEYOR_REPO_BRANCH%.==manual-ci-run. set _NEED_REBASE=true
+  - if %_NEED_REBASE%.==true. git fetch origin master
+  - if %_NEED_REBASE%.==true. git branch master FETCH_HEAD
+  - if %_NEED_REBASE%.==true. git rebase master
+  - git branch -av
+
+  # TODO: Use the _MANUAL_CI_RUN variable in tox.ini to run certain parts only when set
+  - if %APPVEYOR_REPO_BRANCH%.==manual-ci-run. set _MANUAL_CI_RUN=true
+  - if %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%.==manual-ci-run. set _MANUAL_CI_RUN=true
 
   # Set PACKAGE_LEVEL for make
   - set PACKAGE_LEVEL=%configuration%

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,26 @@ Change log
 ----------
 
 
+Version 0.19.0
+^^^^^^^^^^^^^^
+
+Released: not yet
+
+**Incompatible changes:**
+
+**Deprecations:**
+
+**Bug fixes:**
+
+**Enhancements:**
+
+**Known issues:**
+
+* See `list of open issues`_.
+
+.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
+
+
 Version 0.18.0
 ^^^^^^^^^^^^^^
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,7 +30,19 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed a flawed setup of setuptools in Python 2.7 on the Travis CI, where
+  the metadata directory of setuptools existed twice, by adding a script
+  `remove_duplicate_setuptools.py` that removes the moot copy of the metadata
+  directory (issue #434).
+
+* Fixed a bug where multiple Session objects shared the same set of
+  HTTP header fields, causing confusion in the logon status.
+
 **Enhancements:**
+
+* Migrated all remaining test cases from unittest to pytest, and started
+  improving the testcases using pytest specific features such as
+  parametrization.
 
 **Known issues:**
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,7 +22,7 @@ Change log
 Version 0.18.0
 ^^^^^^^^^^^^^^
 
-Released: not yet
+Released: 2017-10-19
 
 **Incompatible changes:**
 
@@ -40,22 +40,12 @@ Released: not yet
     - python-utils  (from progressbar2)
     - wcwidth  (from prompt-toolkit -> click-repl)
 
-**Deprecations:**
-
 **Bug fixes:**
 
 * Fixed a flawed setup of setuptools in Python 2.7 on the Travis CI, where
   the metadata directory of setuptools existed twice, by adding a script
   `remove_duplicate_setuptools.py` that removes the moot copy of the metadata
   directory (issue #434).
-
-**Enhancements:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-  .. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
 
 
 Version 0.17.0

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -128,7 +128,7 @@ class TestUtilsAssertResources(object):
             exp_resources[0].properties['description'] = 'changed description'
 
         # Execute the code to be tested
-        with pytest.raises(AssertionError) as exc_info:
+        with pytest.raises(AssertionError):
             assert_resources(resources, exp_resources, prop_names)
 
     @pytest.mark.parametrize(
@@ -148,5 +148,5 @@ class TestUtilsAssertResources(object):
         prop_names = exp_resources[0].properties.keys()
 
         # Execute the code to be tested
-        with pytest.raises(AssertionError) as exc_info:
+        with pytest.raises(AssertionError):
             assert_resources(resources, exp_resources, prop_names)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_hba.py
+++ b/tests/unit/test_hba.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_lpar.py
+++ b/tests/unit/test_lpar.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,16 +18,16 @@ Unit tests for _lpar module.
 
 from __future__ import absolute_import, print_function
 
-import unittest
+# FIXME: Migrate requests_mock to zhmcclient_mock.
 import requests_mock
 
 from zhmcclient import Session, Client
 
 
-class LparTests(unittest.TestCase):
+class TestLpar(object):
     """All tests for Lpar and LparManager classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.session = Session('fake-host', 'fake-user', 'fake-id')
         self.client = Client(self.session)
         with requests_mock.mock() as m:
@@ -52,7 +51,7 @@ class LparTests(unittest.TestCase):
             cpcs = self.cpc_mgr.list(full_properties=False)
             self.cpc = cpcs[0]
 
-    def tearDown(self):
+    def teardown_method(self):
         with requests_mock.mock() as m:
             m.delete('/api/sessions/this-session', status_code=204)
             self.session.logoff()
@@ -60,7 +59,7 @@ class LparTests(unittest.TestCase):
     def test_init(self):
         """Test __init__() on LparManager instance in CPC."""
         lpar_mgr = self.cpc.lpars
-        self.assertEqual(lpar_mgr.cpc, self.cpc)
+        assert lpar_mgr.cpc == self.cpc
 
     def test_list_short_ok(self):
         """
@@ -87,16 +86,13 @@ class LparTests(unittest.TestCase):
 
             lpars = lpar_mgr.list(full_properties=False)
 
-            self.assertEqual(len(lpars), len(result['logical-partitions']))
+            assert len(lpars) == len(result['logical-partitions'])
             for idx, lpar in enumerate(lpars):
-                self.assertEqual(
-                    lpar.properties,
-                    result['logical-partitions'][idx])
-                self.assertEqual(
-                    lpar.uri,
-                    result['logical-partitions'][idx]['object-uri'])
-                self.assertFalse(lpar.full_properties)
-                self.assertEqual(lpar.manager, lpar_mgr)
+                assert lpar.properties == result['logical-partitions'][idx]
+                assert lpar.uri == \
+                    result['logical-partitions'][idx]['object-uri']
+                assert not lpar.full_properties
+                assert lpar.manager == lpar_mgr
 
     def test_list_full_ok(self):
         """
@@ -143,15 +139,14 @@ class LparTests(unittest.TestCase):
 
             lpars = lpar_mgr.list(full_properties=True)
 
-            self.assertEqual(len(lpars), len(result['logical-partitions']))
+            assert len(lpars) == len(result['logical-partitions'])
             for idx, lpar in enumerate(lpars):
-                self.assertEqual(lpar.properties['name'],
-                                 result['logical-partitions'][idx]['name'])
-                self.assertEqual(
-                    lpar.uri,
-                    result['logical-partitions'][idx]['object-uri'])
-                self.assertTrue(lpar.full_properties)
-                self.assertEqual(lpar.manager, lpar_mgr)
+                assert lpar.properties['name'] == \
+                    result['logical-partitions'][idx]['name']
+                assert lpar.uri == \
+                    result['logical-partitions'][idx]['object-uri']
+                assert lpar.full_properties
+                assert lpar.manager == lpar_mgr
 
     def test_activate(self):
         """
@@ -185,7 +180,7 @@ class LparTests(unittest.TestCase):
             m.post("/api/logical-partitions/fake-lpar-id-1/operations/"
                    "activate", json=result)
             status = lpar.activate(wait_for_completion=False)
-            self.assertEqual(status, result)
+            assert status == result
 
     def test_deactivate(self):
         """
@@ -219,7 +214,7 @@ class LparTests(unittest.TestCase):
             m.post("/api/logical-partitions/fake-lpar-id-1/operations/"
                    "deactivate", json=result)
             status = lpar.deactivate(wait_for_completion=False)
-            self.assertEqual(status, result)
+            assert status == result
 
     def test_load(self):
         """
@@ -254,8 +249,4 @@ class LparTests(unittest.TestCase):
             m.post("/api/logical-partitions/fake-lpar-id-1/operations/load",
                    json=result)
             status = lpar.load(load_address='5162', wait_for_completion=False)
-            self.assertEqual(status, result)
-
-
-if __name__ == '__main__':
-    unittest.main()
+            assert status == result

--- a/tests/unit/test_nic.py
+++ b/tests/unit/test_nic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,9 +21,9 @@ requests_mock package.
 
 from __future__ import absolute_import, print_function
 
-import unittest
 import json
 import threading
+# FIXME: Migrate mock to zhmcclient_mock.
 from mock import patch
 
 from zhmcclient._notification import NotificationReceiver
@@ -125,9 +124,9 @@ def receive_notifications(receiver):
     return msg_items
 
 
-class NotificationTests(unittest.TestCase):
+class TestNotification(object):
 
-    def setUp(self):
+    def setup_method(self):
         self.topic = 'fake-topic'
         self.hmc = 'fake-hmc'
         self.userid = 'fake-userid'
@@ -148,7 +147,7 @@ class NotificationTests(unittest.TestCase):
         conn.mock_start()
         msg_items = receive_notifications(receiver)
 
-        self.assertEqual(msg_items, [])
+        assert msg_items == []
 
     @patch(target='stomp.Connection', new=MockedStompConnection)
     def test_one_message(self):
@@ -163,8 +162,8 @@ class NotificationTests(unittest.TestCase):
         conn.mock_start()
         msg_items = receive_notifications(receiver)
 
-        self.assertEqual(len(msg_items), 1)
+        assert len(msg_items) == 1
 
         msg0 = msg_items[0]
-        self.assertEqual(msg0[0], self.std_headers)
-        self.assertEqual(msg0[1], message_obj)
+        assert msg0[0] == self.std_headers
+        assert msg0[1] == message_obj

--- a/tests/unit/test_port.py
+++ b/tests/unit/test_port.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,16 +18,16 @@ Unit tests for _port module.
 
 from __future__ import absolute_import, print_function
 
-import unittest
+# FIXME: Migrate requests_mock to zhmcclient_mock.
 import requests_mock
 
 from zhmcclient import Session, Client
 
 
-class PortTests(unittest.TestCase):
+class TestPort(object):
     """All tests for Port and PortManager classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.session = Session('port-dpm-host', 'port-user',
                                'port-pwd')
         self.client = Client(self.session)
@@ -110,7 +109,7 @@ class PortTests(unittest.TestCase):
             adapters = adapter_mgr.list(full_properties=False)
             self.adapters = adapters
 
-    def tearDown(self):
+    def teardown_method(self):
         with requests_mock.mock() as m:
             m.delete('/api/sessions/this-session', status_code=204)
             self.session.logoff()
@@ -118,7 +117,7 @@ class PortTests(unittest.TestCase):
     def test_init(self):
         """Test __init__() on PortManager instance in Adapter."""
         port_mgr = self.adapters[0].ports
-        self.assertEqual(port_mgr.adapter, self.adapters[0])
+        assert port_mgr.adapter == self.adapters[0]
 
     def test_list_short_ok(self):
         """
@@ -139,15 +138,15 @@ class PortTests(unittest.TestCase):
                 else:
                     network_uris = result_adapter['network-port-uris']
                     uris = network_uris
-                self.assertEqual(adapter.properties['port-count'], len(uris))
+                assert adapter.properties['port-count'] == len(uris)
             else:
                 uris = []
 
-            self.assertEqual(len(ports), len(uris))
+            assert len(ports) == len(uris)
             for idx, port in enumerate(ports):
-                self.assertTrue(port.properties['element-uri'] in uris)
-                self.assertFalse(port.full_properties)
-                self.assertEqual(port.manager, port_mgr)
+                assert port.properties['element-uri'] in uris
+                assert not port.full_properties
+                assert port.manager == port_mgr
 
     def test_list_full_ok(self):
         """
@@ -177,18 +176,15 @@ class PortTests(unittest.TestCase):
             ports = port_mgr.list(full_properties=True)
             if len(ports) != 0:
                 storage_uris = self.result['adapters'][0]['storage-port-uris']
-                self.assertEqual(adapter.properties['port-count'],
-                                 len(storage_uris))
+                assert adapter.properties['port-count'] == len(storage_uris)
             else:
                 storage_uris = []
 
-            self.assertEqual(len(ports), len(storage_uris))
+            assert len(ports) == len(storage_uris)
             for idx, port in enumerate(ports):
-                self.assertEqual(
-                    port.properties['element-uri'],
-                    storage_uris[idx])
-                self.assertTrue(port.full_properties)
-                self.assertEqual(port.manager, port_mgr)
+                assert port.properties['element-uri'] == storage_uris[idx]
+                assert port.full_properties
+                assert port.manager == port_mgr
 
     def test_list_filter_name_ok(self):
         """
@@ -218,15 +214,14 @@ class PortTests(unittest.TestCase):
             filter_args = {'name': 'Port 0'}
             ports = port_mgr.list(filter_args=filter_args)
 
-            self.assertEqual(len(ports), 1)
+            assert len(ports) == 1
             port = ports[0]
-            self.assertEqual(port.name, 'Port 0')
-            self.assertEqual(
-                port.uri,
-                '/api/adapters/fake-adapter-id-1/storage-ports/0')
-            self.assertEqual(port.properties['name'], 'Port 0')
-            self.assertEqual(port.properties['element-id'], '0')
-            self.assertEqual(port.manager, port_mgr)
+            assert port.name == 'Port 0'
+            assert port.uri == \
+                '/api/adapters/fake-adapter-id-1/storage-ports/0'
+            assert port.properties['name'] == 'Port 0'
+            assert port.properties['element-id'] == '0'
+            assert port.manager == port_mgr
 
     def test_list_filter_elementid_ok(self):
         """
@@ -256,15 +251,14 @@ class PortTests(unittest.TestCase):
             filter_args = {'element-id': '0'}
             ports = port_mgr.list(filter_args=filter_args)
 
-            self.assertEqual(len(ports), 1)
+            assert len(ports) == 1
             port = ports[0]
-            self.assertEqual(port.name, 'Port 0')
-            self.assertEqual(
-                port.uri,
-                '/api/adapters/fake-adapter-id-1/storage-ports/0')
-            self.assertEqual(port.properties['name'], 'Port 0')
-            self.assertEqual(port.properties['element-id'], '0')
-            self.assertEqual(port.manager, port_mgr)
+            assert port.name == 'Port 0'
+            assert port.uri == \
+                '/api/adapters/fake-adapter-id-1/storage-ports/0'
+            assert port.properties['name'] == 'Port 0'
+            assert port.properties['element-id'] == '0'
+            assert port.manager == port_mgr
 
     def test_update_properties(self):
         """
@@ -277,7 +271,3 @@ class PortTests(unittest.TestCase):
             m.post('/api/adapters/fake-adapter-id-1/storage-ports/0',
                    status_code=204)
             port.update_properties(properties={})
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +18,8 @@ Unit tests for _resource module.
 
 from __future__ import absolute_import, print_function
 
-import unittest
 import time
+import re
 from collections import OrderedDict
 
 from zhmcclient import BaseResource, BaseManager, Session
@@ -66,12 +65,12 @@ class MyManager(BaseManager):
         raise NotImplemented
 
 
-class ResourceTestCase(unittest.TestCase):
+class ResourceTestCase(object):
     """
     Base class for all tests in this file.
     """
 
-    def setUp(self):
+    def setup_method(self):
         self.session = Session(host='fake-host')
         self.mgr = MyManager(self.session)
         self.uri = self.mgr._base_uri + '/deadbeef-beef-beef-beef-deadbeefbeef'
@@ -85,23 +84,21 @@ class ResourceTestCase(unittest.TestCase):
         """
 
         # Check that the properties member is a dict
-        self.assertTrue(isinstance(resource.properties, dict))
+        assert isinstance(resource.properties, dict)
 
         # Verify that the resource properties are as expected
-        self.assertEqual(
-            len(resource.properties), len(exp_props),
-            "Set of properties does not match. Expected {!r}, got {!r}".
-            format(resource.properties.keys(), exp_props.keys()))
+        assert len(resource.properties) == len(exp_props), \
+            "Set of properties does not match. Expected {!r}, got {!r}". \
+            format(resource.properties.keys(), exp_props.keys())
 
         for name, exp_value in exp_props.items():
             act_value = resource.properties[name]
-            self.assertEqual(
-                act_value, exp_value,
-                "Property {!r} does not match. Expected {!r}, got {!r}".
-                format(name, exp_value, act_value))
+            assert act_value == exp_value, \
+                "Property {!r} does not match. Expected {!r}, got {!r}". \
+                format(name, exp_value, act_value)
 
 
-class InitTests(ResourceTestCase):
+class TestInit(ResourceTestCase):
     """Test BaseResource initialization."""
 
     def test_empty_name(self):
@@ -114,12 +111,12 @@ class InitTests(ResourceTestCase):
 
         res = MyResource(self.mgr, self.uri, self.name, init_props)
 
-        self.assertTrue(res.manager is self.mgr)
-        self.assertEqual(res.uri, self.uri)
-        self.assertEqual(res.name, self.name)
+        assert res.manager is self.mgr
+        assert res.uri == self.uri
+        assert res.name == self.name
         self.assert_properties(res, res_props)
-        self.assertTrue(int(time.time()) - res.properties_timestamp <= 1)
-        self.assertEqual(res.full_properties, False)
+        assert int(time.time()) - res.properties_timestamp <= 1
+        assert res.full_properties is False
 
     def test_empty_no_name(self):
         """Test with an empty set of input properties, without 'name'."""
@@ -130,11 +127,11 @@ class InitTests(ResourceTestCase):
 
         res = MyResource(self.mgr, self.uri, None, init_props)
 
-        self.assertTrue(res.manager is self.mgr)
-        self.assertEqual(res.uri, self.uri)
+        assert res.manager is self.mgr
+        assert res.uri == self.uri
         self.assert_properties(res, res_props)
-        self.assertTrue(int(time.time()) - res.properties_timestamp <= 1)
-        self.assertEqual(res.full_properties, False)
+        assert int(time.time()) - res.properties_timestamp <= 1
+        assert res.full_properties is False
 
     def test_simple(self):
         """Test with a simple set of input properties."""
@@ -150,11 +147,11 @@ class InitTests(ResourceTestCase):
 
         res = MyResource(self.mgr, self.uri, None, init_props)
 
-        self.assertTrue(res.manager is self.mgr)
-        self.assertEqual(res.uri, self.uri)
+        assert res.manager is self.mgr
+        assert res.uri == self.uri
         self.assert_properties(res, res_props)
-        self.assertTrue(int(time.time()) - res.properties_timestamp <= 1)
-        self.assertEqual(res.full_properties, False)
+        assert int(time.time()) - res.properties_timestamp <= 1
+        assert res.full_properties is False
 
     def test_prop_case(self):
         """Test case sensitivity for the input properties."""
@@ -170,11 +167,11 @@ class InitTests(ResourceTestCase):
 
         res = MyResource(self.mgr, self.uri, None, init_props)
 
-        self.assertTrue(res.manager is self.mgr)
-        self.assertEqual(res.uri, self.uri)
+        assert res.manager is self.mgr
+        assert res.uri == self.uri
         self.assert_properties(res, res_props)
-        self.assertTrue(int(time.time()) - res.properties_timestamp <= 1)
-        self.assertEqual(res.full_properties, False)
+        assert int(time.time()) - res.properties_timestamp <= 1
+        assert res.full_properties is False
 
     def test_invalid_type(self):
         """Test that input properties with an invalid type fail."""
@@ -201,10 +198,9 @@ class InitTests(ResourceTestCase):
 
         str_str = str_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            str_str,
-            r'^{classname}\s*\(.*'.format(
-                classname=resource.__class__.__name__))
+        assert re.match(r'^{classname}\s*\(.*'.
+                        format(classname=resource.__class__.__name__),
+                        str_str)
 
     def test_repr(self):
         """Test BaseResource.__repr__()."""
@@ -218,14 +214,13 @@ class InitTests(ResourceTestCase):
 
         repr_str = repr_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            repr_str,
-            r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.format(
-                classname=resource.__class__.__name__,
-                id=id(resource)))
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=resource.__class__.__name__,
+                               id=id(resource)),
+                        repr_str)
 
 
-class PropertySetTests(ResourceTestCase):
+class TestPropertySet(ResourceTestCase):
     """Test BaseResource by setting properties."""
 
     def test_add_to_empty(self):
@@ -271,7 +266,7 @@ class PropertySetTests(ResourceTestCase):
         self.assert_properties(res, res_props)
 
 
-class PropertyDelTests(ResourceTestCase):
+class TestPropertyDel(ResourceTestCase):
     """Test BaseResource by deleting properties."""
 
     def test_del_one(self):
@@ -344,10 +339,10 @@ class PropertyDelTests(ResourceTestCase):
 
         res.properties.clear()
 
-        self.assertEqual(len(res.properties), 0)
+        assert len(res.properties) == 0
 
 
-class ManagerDivideFilterTests(ResourceTestCase):
+class TestManagerDivideFilter(ResourceTestCase):
     """Test the _divide_filter_args() method of BaseManager."""
 
     # Reserved chars are defined in RFC 3986 as gen-delims and sub-delims.
@@ -369,8 +364,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '')
-        self.assertEqual(cf_args, {})
+        assert parm_str == ''
+        assert cf_args == {}
 
     def test_empty(self):
         """Test with an empty set of filter arguments."""
@@ -378,8 +373,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '')
-        self.assertEqual(cf_args, {})
+        assert parm_str == ''
+        assert cf_args == {}
 
     def test_one_string_qp(self):
         """Test with one string filter argument that is a query parm."""
@@ -387,8 +382,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?qp1=bar')
-        self.assertEqual(cf_args, {})
+        assert parm_str == '?qp1=bar'
+        assert cf_args == {}
 
     def test_one_string_cf(self):
         """Test with one string filter argument that is a client filter."""
@@ -396,8 +391,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '')
-        self.assertEqual(cf_args, {'foo': 'bar'})
+        assert parm_str == ''
+        assert cf_args == {'foo': 'bar'}
 
     def test_one_integer_qp(self):
         """Test with one integer filter argument that is a query parm."""
@@ -405,8 +400,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?qp2=42')
-        self.assertEqual(cf_args, {})
+        assert parm_str == '?qp2=42'
+        assert cf_args == {}
 
     def test_one_integer_cf(self):
         """Test with one integer filter argument that is a client filter."""
@@ -414,8 +409,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '')
-        self.assertEqual(cf_args, {'foo': 42})
+        assert parm_str == ''
+        assert cf_args == {'foo': 42}
 
     def test_one_str_reserved_val_qp(self):
         """Test with one string filter argument with reserved URI chars in
@@ -426,8 +421,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?qp1={}'.format(escape_str))
-        self.assertEqual(cf_args, {})
+        assert parm_str == '?qp1={}'.format(escape_str)
+        assert cf_args == {}
 
     def test_one_str_reserved_val_cf(self):
         """Test with one string filter argument with reserved URI chars in
@@ -437,8 +432,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '')
-        self.assertEqual(cf_args, {'foo': char_str})
+        assert parm_str == ''
+        assert cf_args == {'foo': char_str}
 
     def test_one_str_dash_name_qp(self):
         """Test with one string filter argument with a dash in its name that is
@@ -448,8 +443,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?foo-boo=bar')
-        self.assertEqual(cf_args, {})
+        assert parm_str == '?foo-boo=bar'
+        assert cf_args == {}
 
     def test_one_str_reserved_name_qp(self):
         """Test with one string filter argument with reserved URI chars in
@@ -461,8 +456,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?{}=bar'.format(escape_str))
-        self.assertEqual(cf_args, {})
+        assert parm_str == '?{}=bar'.format(escape_str)
+        assert cf_args == {}
 
     def test_two_qp(self):
         """Test with two filter arguments that are query parms."""
@@ -470,8 +465,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?qp1=bar&qp2=42')
-        self.assertEqual(cf_args, {})
+        assert parm_str == '?qp1=bar&qp2=42'
+        assert cf_args == {}
 
     def test_two_qp_cf(self):
         """Test with two filter arguments where one is a query parm and one is
@@ -480,8 +475,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?qp1=bar')
-        self.assertEqual(cf_args, {'foo': 42})
+        assert parm_str == '?qp1=bar'
+        assert cf_args == {'foo': 42}
 
     def test_two_cf_qp(self):
         """Test with two filter arguments where one is a client filter and one
@@ -490,8 +485,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?qp1=42')
-        self.assertEqual(cf_args, {'foo': 'bar'})
+        assert parm_str == '?qp1=42'
+        assert cf_args == {'foo': 'bar'}
 
     def test_two_two_qp(self):
         """Test with two filter arguments, one of which is a list of two, and
@@ -500,8 +495,8 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?qp1=bar&qp2=42&qp2=7')
-        self.assertEqual(cf_args, {})
+        assert parm_str == '?qp1=bar&qp2=42&qp2=7'
+        assert cf_args == {}
 
     def test_two_str_reserved_val_qp(self):
         """Test with two filter arguments, one of which is a list of two, and
@@ -512,9 +507,5 @@ class ManagerDivideFilterTests(ResourceTestCase):
 
         parm_str, cf_args = self.mgr._divide_filter_args(filter_args)
 
-        self.assertEqual(parm_str, '?qp1=bar&qp2=42&qp2={}'.format(escape_str))
-        self.assertEqual(cf_args, {})
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert parm_str == '?qp1=bar&qp2=42&qp2={}'.format(escape_str)
+        assert cf_args == {}

--- a/tests/unit/test_timestats.py
+++ b/tests/unit/test_timestats.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +19,7 @@ Tests for time statistics (`_timestats` module).
 from __future__ import absolute_import, print_function
 
 import time
-import unittest
+import pytest
 
 from zhmcclient import TimeStatsKeeper, TimeStats
 
@@ -56,7 +55,7 @@ def measure(stats, duration):
     return end - begin
 
 
-class TimeStatsTests(unittest.TestCase):
+class TestTimeStats(object):
     """All tests for TimeStatsKeeper and TimeStats."""
 
     def test_enabling(self):
@@ -64,70 +63,67 @@ class TimeStatsTests(unittest.TestCase):
 
         keeper = TimeStatsKeeper()
 
-        self.assertFalse(keeper.enabled,
-                         "Verify that initial state is disabled")
+        assert not keeper.enabled, \
+            "Verify that initial state is disabled"
 
         keeper.disable()
-        self.assertFalse(keeper.enabled,
-                         "Verify that disabling a disabled keeper works")
+        assert not keeper.enabled, \
+            "Verify that disabling a disabled keeper works"
 
         keeper.enable()
-        self.assertTrue(keeper.enabled,
-                        "Verify that enabling a disabled keeper works")
+        assert keeper.enabled, \
+            "Verify that enabling a disabled keeper works"
 
         keeper.enable()
-        self.assertTrue(keeper.enabled,
-                        "Verify that enabling an enabled keeper works")
+        assert keeper.enabled, \
+            "Verify that enabling an enabled keeper works"
 
         keeper.disable()
-        self.assertFalse(keeper.enabled,
-                         "Verify that disabling an enabled keeper works")
+        assert not keeper.enabled, \
+            "Verify that disabling an enabled keeper works"
 
     def test_get(self):
         """Test getting time statistics."""
 
         keeper = TimeStatsKeeper()
         snapshot_length = len(keeper.snapshot())
-        self.assertEqual(snapshot_length, 0,
-                         "Verify that initial state has no time statistics. "
-                         "Actual number = %d" % snapshot_length)
+        assert snapshot_length == 0, \
+            "Verify that initial state has no time statistics. " \
+            "Actual number = %d" % snapshot_length
 
         stats = keeper.get_stats('foo')
         snapshot_length = len(keeper.snapshot())
-        self.assertEqual(snapshot_length, 0,
-                         "Verify that getting a new stats with a disabled "
-                         "keeper results in no time statistics. "
-                         "Actual number = %d" % snapshot_length)
-        self.assertEqual(stats.keeper, keeper)
-        self.assertEqual(stats.name, "disabled")  # stats for disabled keeper
-        self.assertEqual(stats.count, 0)
-        self.assertEqual(stats.avg_time, 0)
-        self.assertEqual(stats.min_time, float('inf'))
-        self.assertEqual(stats.max_time, 0)
+        assert snapshot_length == 0, \
+            "Verify that getting a new stats with a disabled keeper results " \
+            "in no time statistics. Actual number = %d" % snapshot_length
+        assert stats.keeper == keeper
+        assert stats.name == "disabled"  # stats for disabled keeper
+        assert stats.count == 0
+        assert stats.avg_time == 0
+        assert stats.min_time == float('inf')
+        assert stats.max_time == 0
 
         keeper.enable()
 
         stats = keeper.get_stats('foo')
         snapshot_length = len(keeper.snapshot())
-        self.assertEqual(snapshot_length, 1,
-                         "Verify that getting a new stats with an enabled "
-                         "keeper results in one time statistics. "
-                         "Actual number = %d" % snapshot_length)
+        assert snapshot_length == 1, \
+            "Verify that getting a new stats with an enabled keeper results " \
+            "in one time statistics. Actual number = %d" % snapshot_length
 
-        self.assertEqual(stats.keeper, keeper)
-        self.assertEqual(stats.name, 'foo')
-        self.assertEqual(stats.count, 0)
-        self.assertEqual(stats.avg_time, 0)
-        self.assertEqual(stats.min_time, float('inf'))
-        self.assertEqual(stats.max_time, 0)
+        assert stats.keeper == keeper
+        assert stats.name == 'foo'
+        assert stats.count == 0
+        assert stats.avg_time == 0
+        assert stats.min_time == float('inf')
+        assert stats.max_time == 0
 
         keeper.get_stats('foo')
         snapshot_length = len(keeper.snapshot())
-        self.assertEqual(snapshot_length, 1,
-                         "Verify that getting an existing stats with an "
-                         "enabled keeper results in the same number of time "
-                         "statistics. "
-                         "Actual number = %d" % snapshot_length)
+        assert snapshot_length == 1, \
+            "Verify that getting an existing stats with an enabled keeper " \
+            "results in the same number of time statistics. " \
+            "Actual number = %d" % snapshot_length
 
     def test_measure_enabled(self):
         """Test measuring time with enabled keeper."""
@@ -145,22 +141,22 @@ class TimeStatsTests(unittest.TestCase):
         stats_dict = keeper.snapshot()
         for op_name in stats_dict:
             stats = stats_dict[op_name]
-            self.assertEqual(stats.count, 1)
-            self.assertLess(time_abs_delta(stats.avg_time, dur), delta,
-                            "avg time: actual: %f, expected: %f, delta: %f" %
-                            (stats.avg_time, dur, delta))
-            self.assertLess(time_abs_delta(stats.min_time, dur), delta,
-                            "min time: actual: %f, expected: %f, delta: %f" %
-                            (stats.min_time, dur, delta))
-            self.assertLess(time_abs_delta(stats.max_time, dur), delta,
-                            "max time: actual: %f, expected: %f, delta: %f" %
-                            (stats.max_time, dur, delta))
+            assert stats.count == 1
+            assert time_abs_delta(stats.avg_time, dur) < delta, \
+                "avg time: actual: %f, expected: %f, delta: %f" % \
+                (stats.avg_time, dur, delta)
+            assert time_abs_delta(stats.min_time, dur) < delta, \
+                "min time: actual: %f, expected: %f, delta: %f" % \
+                (stats.min_time, dur, delta)
+            assert time_abs_delta(stats.max_time, dur) < delta, \
+                "max time: actual: %f, expected: %f, delta: %f" % \
+                (stats.max_time, dur, delta)
 
         stats.reset()
-        self.assertEqual(stats.count, 0)
-        self.assertEqual(stats.avg_time, 0)
-        self.assertEqual(stats.min_time, float('inf'))
-        self.assertEqual(stats.max_time, 0)
+        assert stats.count == 0
+        assert stats.avg_time == 0
+        assert stats.min_time == float('inf')
+        assert stats.max_time == 0
 
     def test_measure_disabled(self):
         """Test measuring time with disabled keeper."""
@@ -170,7 +166,7 @@ class TimeStatsTests(unittest.TestCase):
         duration = 0.2
 
         stats = keeper.get_stats('foo')
-        self.assertEqual(stats.name, 'disabled')
+        assert stats.name == 'disabled'
 
         stats.begin()
         time.sleep(duration)
@@ -179,10 +175,10 @@ class TimeStatsTests(unittest.TestCase):
         stats_dict = keeper.snapshot()
         for op_name in stats_dict:
             stats = stats_dict[op_name]
-            self.assertEqual(stats.count, 0)
-            self.assertEqual(stats.avg_time, 0)
-            self.assertEqual(stats.min_time, float('inf'))
-            self.assertEqual(stats.max_time, 0)
+            assert stats.count == 0
+            assert stats.avg_time == 0
+            assert stats.min_time == float('inf')
+            assert stats.max_time == 0
 
     def test_snapshot(self):
         """Test that snapshot() takes a stable snapshot."""
@@ -210,10 +206,10 @@ class TimeStatsTests(unittest.TestCase):
         # verify that only the first data item is in the snapshot
         for op_name in snap_stats_dict:
             snap_stats = snap_stats_dict[op_name]
-            self.assertEqual(snap_stats.count, 1)
+            assert snap_stats.count == 1
 
         # verify that both data items are in the original stats object
-        self.assertEqual(stats.count, 2)
+        assert stats.count == 2
 
     def test_measure_avg_min_max(self):
         """Test measuring avg min max values."""
@@ -238,16 +234,16 @@ class TimeStatsTests(unittest.TestCase):
         stats_dict = keeper.snapshot()
         for op_name in stats_dict:
             stats = stats_dict[op_name]
-            self.assertEqual(stats.count, 3)
-            self.assertLess(time_abs_delta(stats.avg_time, avg_dur), delta,
-                            "avg time: actual: %f, expected: %f, delta: %f" %
-                            (stats.avg_time, avg_dur, delta))
-            self.assertLess(time_abs_delta(stats.min_time, min_dur), delta,
-                            "min time: actual: %f, expected: %f, delta: %f" %
-                            (stats.min_time, min_dur, delta))
-            self.assertLess(time_abs_delta(stats.max_time, max_dur), delta,
-                            "max time: actual: %f, expected: %f, delta: %f" %
-                            (stats.max_time, max_dur, delta))
+            assert stats.count == 3
+            assert time_abs_delta(stats.avg_time, avg_dur) < delta, \
+                "avg time: actual: %f, expected: %f, delta: %f" % \
+                (stats.avg_time, avg_dur, delta)
+            assert time_abs_delta(stats.min_time, min_dur) < delta, \
+                "min time: actual: %f, expected: %f, delta: %f" % \
+                (stats.min_time, min_dur, delta)
+            assert time_abs_delta(stats.max_time, max_dur) < delta, \
+                "max time: actual: %f, expected: %f, delta: %f" % \
+                (stats.max_time, max_dur, delta)
 
     def test_only_end(self):
         """Test that invoking end() before begin() has ever been called raises
@@ -257,7 +253,7 @@ class TimeStatsTests(unittest.TestCase):
         keeper.enable()
         stats = keeper.get_stats('foo')
 
-        with self.assertRaises(RuntimeError):
+        with pytest.raises(RuntimeError):
             stats.end()
 
     def test_end_after_end(self):
@@ -272,7 +268,7 @@ class TimeStatsTests(unittest.TestCase):
         time.sleep(0.01)
         stats.end()
 
-        with self.assertRaises(RuntimeError):
+        with pytest.raises(RuntimeError):
             stats.end()
 
     def test_str_empty(self):
@@ -281,14 +277,14 @@ class TimeStatsTests(unittest.TestCase):
         keeper = TimeStatsKeeper()
         keeper.enable()
         s = str(keeper)
-        self.assertEqual(s, PRINT_HEADER)
+        assert s == PRINT_HEADER
 
     def test_str_disabled(self):
         """Test TimestatsKeeper.__str__() for a disabled keeper."""
 
         keeper = TimeStatsKeeper()
         s = str(keeper)
-        self.assertEqual(s, PRINT_HEADER_DISABLED)
+        assert s == PRINT_HEADER_DISABLED
 
     def test_str_one(self):
         """Test TimestatsKeeper.__str__() for an enabled keeper with one data
@@ -307,11 +303,11 @@ class TimeStatsTests(unittest.TestCase):
         stats.end()
 
         s = str(keeper)
-        self.assertTrue(s.startswith(PRINT_HEADER),
-                        "Unexpected str(keeper): %r" % s)
+        assert s.startswith(PRINT_HEADER), \
+            "Unexpected str(keeper): %r" % s
         num_lines = len(s.split('\n'))
-        self.assertEqual(num_lines, 3,
-                         "Unexpected str(keeper): %r" % s)
+        assert num_lines == 3, \
+            "Unexpected str(keeper): %r" % s
 
     def test_ts_str(self):
         """Test Timestats.__str__()."""
@@ -320,12 +316,8 @@ class TimeStatsTests(unittest.TestCase):
         timestats = TimeStats(keeper, "foo")
 
         s = str(timestats)
-        self.assertTrue(s.startswith("TimeStats:"),
-                        "Unexpected str(timestats): %r" % s)
+        assert s.startswith("TimeStats:"), \
+            "Unexpected str(timestats): %r" % s
         num_lines = len(s.split('\n'))
-        self.assertEqual(num_lines, 1,
-                         "Unexpected str(timestats): %r" % s)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert num_lines == 1, \
+            "Unexpected str(timestats): %r" % s

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -162,7 +162,7 @@ class TestPythonDatetime(object):
         st = time.gmtime(0)
         assert st == epoch_st
 
-    def test_print_gmtime_max(self):
+    def x_test_print_gmtime_max(self):
         """Print the maximum for time.gmtime()."""
         max_ts = find_max_value(time.gmtime, 1)
         max_st = time.gmtime(max_ts)
@@ -170,7 +170,7 @@ class TestPythonDatetime(object):
               format(max_ts, max_st))
         sys.stdout.flush()
 
-    def test_print_fromtimestamp_max(self):
+    def x_test_print_fromtimestamp_max(self):
         """Print the maximum for datetime.fromtimestamp(utc)."""
 
         def datetime_fromtimestamp_utc(ts):
@@ -183,7 +183,7 @@ class TestPythonDatetime(object):
               format(max_ts, max_dt))
         sys.stdout.flush()
 
-    def test_print_datetime_max(self):
+    def x_test_print_datetime_max(self):
         """Print datetime.max."""
         print("\nMax value for Python datetime (datetime.max): {!r}".
               format(datetime.max))
@@ -233,7 +233,7 @@ class TestDatetimeFromTimestamp(object):
         # Verify the result
         assert isinstance(exc_info.value, exc_type)
 
-    def test_print_max_datetime_from_timestamp(self):
+    def x_test_print_max_datetime_from_timestamp(self):
         """Print the maximum for datetime_from_timestamp()."""
         max_ts = find_max_value(datetime_from_timestamp, 1)
         max_dt = datetime_from_timestamp(max_ts)

--- a/tests/unit/test_virtual_function.py
+++ b/tests/unit/test_virtual_function.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,18 +18,18 @@ Unit tests for _virtual_function module.
 
 from __future__ import absolute_import, print_function
 
-import unittest
+# FIXME: Migrate requests_mock to zhmcclient_mock.
 import requests_mock
 
 from zhmcclient import Session, Client, VirtualFunction
 
 
-class VirtualFunctionTests(unittest.TestCase):
+class TestVirtualFunction(object):
     """
     All tests for VirtualFunction and VirtualFunctionManager classes.
     """
 
-    def setUp(self):
+    def setup_method(self):
         self.session = Session('test-dpm-host', 'test-user', 'test-id')
         self.client = Client(self.session)
         with requests_mock.mock() as m:
@@ -108,7 +107,7 @@ class VirtualFunctionTests(unittest.TestCase):
             partitions = partition_mgr.list(full_properties=True)
             self.partition = partitions[0]
 
-    def tearDown(self):
+    def teardown_method(self):
         with requests_mock.mock() as m:
             m.delete('/api/sessions/this-session', status_code=204)
             self.session.logoff()
@@ -116,7 +115,7 @@ class VirtualFunctionTests(unittest.TestCase):
     def test_init(self):
         """Test __init__() on VirtualFunctionManager instance in Partition."""
         vf_mgr = self.partition.virtual_functions
-        self.assertEqual(vf_mgr.partition, self.partition)
+        assert vf_mgr.partition == self.partition
 
     def test_list_short_ok(self):
         """
@@ -126,18 +125,15 @@ class VirtualFunctionTests(unittest.TestCase):
         vf_mgr = self.partition.virtual_functions
         vfs = vf_mgr.list(full_properties=False)
 
-        self.assertEqual(
-            len(vfs),
-            len(self.partition.properties['virtual-function-uris']))
+        assert len(vfs) == \
+            len(self.partition.properties['virtual-function-uris'])
         for idx, vf in enumerate(vfs):
-            self.assertEqual(
-                vf.properties['element-uri'],
-                self.partition.properties['virtual-function-uris'][idx])
-            self.assertEqual(
-                vf.uri,
-                self.partition.properties['virtual-function-uris'][idx])
-            self.assertFalse(vf.full_properties)
-            self.assertEqual(vf.manager, vf_mgr)
+            assert vf.properties['element-uri'] == \
+                self.partition.properties['virtual-function-uris'][idx]
+            assert vf.uri == \
+                self.partition.properties['virtual-function-uris'][idx]
+            assert not vf.full_properties
+            assert vf.manager == vf_mgr
 
     def test_list_full_ok(self):
         """
@@ -179,18 +175,15 @@ class VirtualFunctionTests(unittest.TestCase):
 
             vfs = vf_mgr.list(full_properties=True)
 
-            self.assertEqual(
-                len(vfs),
-                len(self.partition.properties['virtual-function-uris']))
+            assert len(vfs) == \
+                len(self.partition.properties['virtual-function-uris'])
             for idx, vf in enumerate(vfs):
-                self.assertEqual(
-                    vf.properties['element-uri'],
-                    self.partition.properties['virtual-function-uris'][idx])
-                self.assertEqual(
-                    vf.uri,
-                    self.partition.properties['virtual-function-uris'][idx])
-                self.assertTrue(vf.full_properties)
-                self.assertEqual(vf.manager, vf_mgr)
+                assert vf.properties['element-uri'] == \
+                    self.partition.properties['virtual-function-uris'][idx]
+                assert vf.uri == \
+                    self.partition.properties['virtual-function-uris'][idx]
+                assert vf.full_properties
+                assert vf.manager == vf_mgr
 
     def test_list_filter_name_ok(self):
         """
@@ -233,16 +226,15 @@ class VirtualFunctionTests(unittest.TestCase):
             filter_args = {'name': 'vf2'}
             vfs = vf_mgr.list(filter_args=filter_args)
 
-            self.assertEqual(len(vfs), 1)
+            assert len(vfs) == 1
             vf = vfs[0]
-            self.assertEqual(vf.name, 'vf2')
-            self.assertEqual(
-                vf.uri,
-                '/api/partitions/fake-part-id-1/virtual-functions/'
-                'fake-vf-id-2')
-            self.assertEqual(vf.properties['name'], 'vf2')
-            self.assertEqual(vf.properties['element-id'], 'fake-vf-id-2')
-            self.assertEqual(vf.manager, vf_mgr)
+            assert vf.name == 'vf2'
+            assert vf.uri == \
+                '/api/partitions/fake-part-id-1/virtual-functions/' \
+                'fake-vf-id-2'
+            assert vf.properties['name'] == 'vf2'
+            assert vf.properties['element-id'] == 'fake-vf-id-2'
+            assert vf.manager == vf_mgr
 
     def test_list_filter_elementid_ok(self):
         """
@@ -285,16 +277,15 @@ class VirtualFunctionTests(unittest.TestCase):
             filter_args = {'element-id': 'fake-vf-id-2'}
             vfs = vf_mgr.list(filter_args=filter_args)
 
-            self.assertEqual(len(vfs), 1)
+            assert len(vfs) == 1
             vf = vfs[0]
-            self.assertEqual(vf.name, 'vf2')
-            self.assertEqual(
-                vf.uri,
-                '/api/partitions/fake-part-id-1/virtual-functions/'
-                'fake-vf-id-2')
-            self.assertEqual(vf.properties['name'], 'vf2')
-            self.assertEqual(vf.properties['element-id'], 'fake-vf-id-2')
-            self.assertEqual(vf.manager, vf_mgr)
+            assert vf.name == 'vf2'
+            assert vf.uri == \
+                '/api/partitions/fake-part-id-1/virtual-functions/' \
+                'fake-vf-id-2'
+            assert vf.properties['name'] == 'vf2'
+            assert vf.properties['element-id'] == 'fake-vf-id-2'
+            assert vf.manager == vf_mgr
 
     def test_create(self):
         """
@@ -312,9 +303,9 @@ class VirtualFunctionTests(unittest.TestCase):
 
             vf = vf_mgr.create(properties={})
 
-            self.assertTrue(isinstance(vf, VirtualFunction))
-            self.assertEqual(vf.properties, result)
-            self.assertEqual(vf.uri, result['element-uri'])
+            assert isinstance(vf, VirtualFunction)
+            assert vf.properties == result
+            assert vf.uri == result['element-uri']
 
     def test_delete(self):
         """
@@ -339,7 +330,3 @@ class VirtualFunctionTests(unittest.TestCase):
             m.post('/api/partitions/fake-part-id-1/virtual-functions/'
                    'fake-vf-id-1', status_code=204)
             vf.update_properties(properties={})
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/unit/test_virtual_switch.py
+++ b/tests/unit/test_virtual_switch.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,17 +18,17 @@ Unit tests for _virtual_switch module.
 
 from __future__ import absolute_import, print_function
 
-import unittest
 import re
+# FIXME: Migrate requests_mock to zhmcclient_mock.
 import requests_mock
 
 from zhmcclient import Session, Client, Nic
 
 
-class VirtualSwitchTests(unittest.TestCase):
+class TestVirtualSwitch(object):
     """All tests for VirtualSwitch and VirtualSwitchManager classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.session = Session('vswitch-dpm-host', 'vswitch-user',
                                'vswitch-pwd')
         self.client = Client(self.session)
@@ -55,7 +54,7 @@ class VirtualSwitchTests(unittest.TestCase):
             cpcs = self.cpc_mgr.list()
             self.cpc = cpcs[0]
 
-    def tearDown(self):
+    def teardown_method(self):
         with requests_mock.mock() as m:
             m.delete('/api/sessions/this-session', status_code=204)
             self.session.logoff()
@@ -63,7 +62,7 @@ class VirtualSwitchTests(unittest.TestCase):
     def test_init(self):
         """Test __init__() on VirtualSwitchManager instance in CPC."""
         vswitch_mgr = self.cpc.virtual_switches
-        self.assertEqual(vswitch_mgr.cpc, self.cpc)
+        assert vswitch_mgr.cpc == self.cpc
 
     def test_list_short_ok(self):
         """
@@ -91,16 +90,14 @@ class VirtualSwitchTests(unittest.TestCase):
 
             vswitches = vswitch_mgr.list(full_properties=False)
 
-            self.assertEqual(len(vswitches), len(result['virtual-switches']))
+            assert len(vswitches) == len(result['virtual-switches'])
             for idx, vswitch in enumerate(vswitches):
-                self.assertEqual(
-                    vswitch.properties,
-                    result['virtual-switches'][idx])
-                self.assertEqual(
-                    vswitch.uri,
-                    result['virtual-switches'][idx]['object-uri'])
-                self.assertFalse(vswitch.full_properties)
-                self.assertEqual(vswitch.manager, vswitch_mgr)
+                assert vswitch.properties == \
+                    result['virtual-switches'][idx]
+                assert vswitch.uri == \
+                    result['virtual-switches'][idx]['object-uri']
+                assert not vswitch.full_properties
+                assert vswitch.manager == vswitch_mgr
 
     def test_list_full_ok(self):
         """
@@ -149,15 +146,14 @@ class VirtualSwitchTests(unittest.TestCase):
 
             vswitches = vswitch_mgr.list(full_properties=True)
 
-            self.assertEqual(len(vswitches), len(result['virtual-switches']))
+            assert len(vswitches) == len(result['virtual-switches'])
             for idx, vswitch in enumerate(vswitches):
-                self.assertEqual(vswitch.properties['name'],
-                                 result['virtual-switches'][idx]['name'])
-                self.assertEqual(
-                    vswitch.uri,
-                    result['virtual-switches'][idx]['object-uri'])
-                self.assertTrue(vswitch.full_properties)
-                self.assertEqual(vswitch.manager, vswitch_mgr)
+                assert vswitch.properties['name'] == \
+                    result['virtual-switches'][idx]['name']
+                assert vswitch.uri == \
+                    result['virtual-switches'][idx]['object-uri']
+                assert vswitch.full_properties
+                assert vswitch.manager == vswitch_mgr
 
     def test_update_properties(self):
         """
@@ -225,17 +221,13 @@ class VirtualSwitchTests(unittest.TestCase):
 
             nics = vswitch.get_connected_nics()
 
-            self.assertTrue(isinstance(nics, list))
+            assert isinstance(nics, list)
             for i, nic in enumerate(nics):
-                self.assertTrue(isinstance(nic, Nic))
+                assert isinstance(nic, Nic)
                 nic_uri = result['connected-vnic-uris'][i]
-                self.assertEqual(nic.uri, nic_uri)
-                self.assertEqual(nic.properties['element-uri'], nic_uri)
+                assert nic.uri == nic_uri
+                assert nic.properties['element-uri'] == nic_uri
                 m = re.match(r"^/api/partitions/([^/]+)/nics/([^/]+)/?$",
                              nic_uri)
                 nic_id = m.group(2)
-                self.assertEqual(nic.properties['element-id'], nic_id)
-
-
-if __name__ == '__main__':
-    unittest.main()
+                assert nic.properties['element-id'] == nic_id

--- a/tests/unit/zhmcclient_mock/test_example.py
+++ b/tests/unit/zhmcclient_mock/test_example.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +19,14 @@ Example unit test for a user of the zhmcclient package.
 from __future__ import absolute_import, print_function
 
 import requests.packages.urllib3
-import unittest
+
 import zhmcclient
 import zhmcclient_mock
 
+requests.packages.urllib3.disable_warnings()
 
-class MyTests(unittest.TestCase):
+
+class TestMy(object):
 
     @staticmethod
     def create_session_1():
@@ -153,40 +154,40 @@ class MyTests(unittest.TestCase):
         Check the faked session and its faked HMC.
         """
 
-        self.assertEqual(self.session.host, 'fake-host')
+        assert self.session.host == 'fake-host'
 
-        self.assertEqual(self.client.version_info(), (1, 8))
+        assert self.client.version_info() == (1, 8)
 
         cpcs = self.client.cpcs.list()
-        self.assertEqual(len(cpcs), 2)
+        assert len(cpcs) == 2
 
         cpc1 = cpcs[0]  # a CPC in classic mode
-        self.assertEqual(cpc1.get_property('name'), 'cpc_1')
-        self.assertFalse(cpc1.dpm_enabled)
+        assert cpc1.get_property('name') == 'cpc_1'
+        assert not cpc1.dpm_enabled
 
         lpars = cpc1.lpars.list()
-        self.assertEqual(len(lpars), 1)
+        assert len(lpars) == 1
         lpar1 = lpars[0]
-        self.assertEqual(lpar1.get_property('name'), 'lpar_1')
+        assert lpar1.get_property('name') == 'lpar_1'
 
         cpc2 = cpcs[1]  # a CPC in DPM mode
-        self.assertEqual(cpc2.get_property('name'), 'cpc_2')
-        self.assertTrue(cpc2.dpm_enabled)
+        assert cpc2.get_property('name') == 'cpc_2'
+        assert cpc2.dpm_enabled
 
         partitions = cpc2.partitions.list()
-        self.assertEqual(len(partitions), 1)
+        assert len(partitions) == 1
         partition1 = partitions[0]
-        self.assertEqual(partition1.get_property('name'), 'partition_1')
+        assert partition1.get_property('name') == 'partition_1'
 
         adapters = cpc2.adapters.list()
-        self.assertEqual(len(adapters), 1)
+        assert len(adapters) == 1
         adapter1 = adapters[0]
-        self.assertEqual(adapter1.get_property('name'), 'osa_1')
+        assert adapter1.get_property('name') == 'osa_1'
 
         ports = adapter1.ports.list()
-        self.assertEqual(len(ports), 1)
+        assert len(ports) == 1
         port1 = ports[0]
-        self.assertEqual(port1.get_property('name'), 'osa_1_port_1')
+        assert port1.get_property('name') == 'osa_1_port_1'
 
     def test_session_1(self):
         self.session = self.create_session_1()
@@ -197,8 +198,3 @@ class MyTests(unittest.TestCase):
         self.session = self.create_session_2()
         self.client = zhmcclient.Client(self.session)
         self.check()
-
-
-if __name__ == '__main__':
-    requests.packages.urllib3.disable_warnings()
-    unittest.main()

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +18,9 @@ Unit tests for _hmc module of the zhmcclient_mock package.
 
 from __future__ import absolute_import, print_function
 
-import unittest
+import re
 from datetime import datetime
+import pytest
 
 from zhmcclient_mock._hmc import FakedHmc, \
     FakedBaseManager, FakedBaseResource, \
@@ -38,10 +38,10 @@ from zhmcclient_mock._hmc import FakedHmc, \
     FakedMetricGroupDefinition, FakedMetricObjectValues
 
 
-class FakedHmcTests(unittest.TestCase):
+class TestFakedHmc(object):
     """All tests for the zhmcclient_mock.FakedHmc class."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
 
     def test_repr(self):
@@ -52,22 +52,20 @@ class FakedHmcTests(unittest.TestCase):
 
         repr_str = repr_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            repr_str,
-            r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.format(
-                classname=hmc.__class__.__name__,
-                id=id(hmc)))
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=hmc.__class__.__name__, id=id(hmc)),
+                        repr_str)
 
     def test_hmc(self):
-        self.assertEqual(self.hmc.hmc_name, 'fake-hmc')
-        self.assertEqual(self.hmc.hmc_version, '2.13.1')
-        self.assertEqual(self.hmc.api_version, '1.8')
-        self.assertIsInstance(self.hmc.cpcs, FakedCpcManager)
+        assert self.hmc.hmc_name == 'fake-hmc'
+        assert self.hmc.hmc_version == '2.13.1'
+        assert self.hmc.api_version == '1.8'
+        assert isinstance(self.hmc.cpcs, FakedCpcManager)
 
         # the function to be tested:
         cpcs = self.hmc.cpcs.list()
 
-        self.assertEqual(len(cpcs), 0)
+        assert len(cpcs) == 0
 
     def test_hmc_1_cpc(self):
         cpc1_in_props = {'name': 'cpc1'}
@@ -87,12 +85,12 @@ class FakedHmcTests(unittest.TestCase):
         # the function to be tested:
         cpcs = self.hmc.cpcs.list()
 
-        self.assertEqual(len(cpcs), 1)
-        self.assertEqual(cpcs[0], cpc1)
+        assert len(cpcs) == 1
+        assert cpcs[0] == cpc1
 
-        self.assertIsInstance(cpc1, FakedCpc)
-        self.assertEqual(cpc1.properties, cpc1_out_props)
-        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+        assert isinstance(cpc1, FakedCpc)
+        assert cpc1.properties == cpc1_out_props
+        assert cpc1.manager == self.hmc.cpcs
 
     def test_hmc_2_cpcs(self):
         cpc1_in_props = {'name': 'cpc1'}
@@ -126,18 +124,18 @@ class FakedHmcTests(unittest.TestCase):
         # the function to be tested:
         cpcs = self.hmc.cpcs.list()
 
-        self.assertEqual(len(cpcs), 2)
+        assert len(cpcs) == 2
         # We expect the order of addition to be maintained:
-        self.assertEqual(cpcs[0], cpc1)
-        self.assertEqual(cpcs[1], cpc2)
+        assert cpcs[0] == cpc1
+        assert cpcs[1] == cpc2
 
-        self.assertIsInstance(cpc1, FakedCpc)
-        self.assertEqual(cpc1.properties, cpc1_out_props)
-        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+        assert isinstance(cpc1, FakedCpc)
+        assert cpc1.properties == cpc1_out_props
+        assert cpc1.manager == self.hmc.cpcs
 
-        self.assertIsInstance(cpc2, FakedCpc)
-        self.assertEqual(cpc2.properties, cpc2_out_props)
-        self.assertEqual(cpc2.manager, self.hmc.cpcs)
+        assert isinstance(cpc2, FakedCpc)
+        assert cpc2.properties == cpc2_out_props
+        assert cpc2.manager == self.hmc.cpcs
 
     def test_res_dict(self):
         cpc1_in_props = {'name': 'cpc1'}
@@ -165,7 +163,7 @@ class FakedHmcTests(unittest.TestCase):
 
         cpcs = self.hmc.cpcs.list()
 
-        self.assertEqual(len(cpcs), 1)
+        assert len(cpcs) == 1
 
         cpc1 = cpcs[0]
         cpc1_out_props = cpc1_in_props.copy()
@@ -176,18 +174,18 @@ class FakedHmcTests(unittest.TestCase):
             'is-ensemble-member': False,
             'status': 'operating',
         })
-        self.assertIsInstance(cpc1, FakedCpc)
-        self.assertEqual(cpc1.properties, cpc1_out_props)
-        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+        assert isinstance(cpc1, FakedCpc)
+        assert cpc1.properties == cpc1_out_props
+        assert cpc1.manager == self.hmc.cpcs
 
         cpc1_adapters = cpc1.adapters.list()
 
-        self.assertEqual(len(cpc1_adapters), 1)
+        assert len(cpc1_adapters) == 1
         adapter1 = cpc1_adapters[0]
 
         adapter1_ports = adapter1.ports.list()
 
-        self.assertEqual(len(adapter1_ports), 1)
+        assert len(adapter1_ports) == 1
         port1 = adapter1_ports[0]
 
         adapter1_out_props = adapter1_in_props.copy()
@@ -197,24 +195,24 @@ class FakedHmcTests(unittest.TestCase):
             'status': 'active',
             'network-port-uris': [port1.uri],
         })
-        self.assertIsInstance(adapter1, FakedAdapter)
-        self.assertEqual(adapter1.properties, adapter1_out_props)
-        self.assertEqual(adapter1.manager, cpc1.adapters)
+        assert isinstance(adapter1, FakedAdapter)
+        assert adapter1.properties == adapter1_out_props
+        assert adapter1.manager == cpc1.adapters
 
         port1_out_props = port1_in_props.copy()
         port1_out_props.update({
             'element-id': port1.oid,
             'element-uri': port1.uri,
         })
-        self.assertIsInstance(port1, FakedPort)
-        self.assertEqual(port1.properties, port1_out_props)
-        self.assertEqual(port1.manager, adapter1.ports)
+        assert isinstance(port1, FakedPort)
+        assert port1.properties == port1_out_props
+        assert port1.manager == adapter1.ports
 
 
-class FakedBaseTests(unittest.TestCase):
+class TestFakedBase(object):
     """All tests for the FakedBaseManager and FakedBaseResource classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
 
         self.cpc1_oid = '42-abc-543'
@@ -250,11 +248,10 @@ class FakedBaseTests(unittest.TestCase):
 
         repr_str = repr_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            repr_str,
-            r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.format(
-                classname=resource.__class__.__name__,
-                id=id(resource)))
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=resource.__class__.__name__,
+                               id=id(resource)),
+                        repr_str)
 
     def test_manager_repr(self):
         """Test FakedBaseManager.__repr__()."""
@@ -264,42 +261,39 @@ class FakedBaseTests(unittest.TestCase):
 
         repr_str = repr_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            repr_str,
-            r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.format(
-                classname=manager.__class__.__name__,
-                id=id(manager)))
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=manager.__class__.__name__,
+                               id=id(manager)),
+                        repr_str)
 
     def test_manager_attr(self):
         """Test FakedBaseManager attributes."""
 
-        self.assertIsInstance(self.cpc_manager, FakedBaseManager)
+        assert isinstance(self.cpc_manager, FakedBaseManager)
 
-        self.assertEqual(self.cpc_manager.hmc, self.hmc)
-        self.assertEqual(self.cpc_manager.parent, self.hmc)
-        self.assertEqual(self.cpc_manager.resource_class, FakedCpc)
-        self.assertEqual(self.cpc_manager.base_uri, '/api/cpcs')
-        self.assertEqual(self.cpc_manager.oid_prop, 'object-id')
-        self.assertEqual(self.cpc_manager.uri_prop, 'object-uri')
+        assert self.cpc_manager.hmc == self.hmc
+        assert self.cpc_manager.parent == self.hmc
+        assert self.cpc_manager.resource_class == FakedCpc
+        assert self.cpc_manager.base_uri == '/api/cpcs'
+        assert self.cpc_manager.oid_prop == 'object-id'
+        assert self.cpc_manager.uri_prop == 'object-uri'
 
     def test_resource_attr(self):
         """Test FakedBaseResource attributes."""
 
-        self.assertIsInstance(self.cpc_resource, FakedBaseResource)
+        assert isinstance(self.cpc_resource, FakedBaseResource)
 
-        self.assertEqual(self.cpc_resource.manager, self.cpc_manager)
-        self.assertEqual(self.cpc_resource.properties, self.cpc1_out_props)
-        self.assertEqual(self.cpc_resource.oid,
-                         self.cpc1_out_props['object-id'])
-        self.assertEqual(self.cpc_resource.uri,
-                         self.cpc1_out_props['object-uri'])
+        assert self.cpc_resource.manager == self.cpc_manager
+        assert self.cpc_resource.properties == self.cpc1_out_props
+        assert self.cpc_resource.oid == self.cpc1_out_props['object-id']
+        assert self.cpc_resource.uri == self.cpc1_out_props['object-uri']
 
 
-class FakedActivationProfileTests(unittest.TestCase):
+class TestFakedActivationProfile(object):
     """All tests for the FakedActivationProfileManager and
     FakedActivationProfile classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.resetprofile1_in_props = {'name': 'resetprofile1'}
@@ -331,27 +325,27 @@ class FakedActivationProfileTests(unittest.TestCase):
 
         # Test reset activation profiles
 
-        self.assertIsInstance(cpc1.reset_activation_profiles,
-                              FakedActivationProfileManager)
-        self.assertEqual(cpc1.reset_activation_profiles.profile_type, 'reset')
-        self.assertRegexpMatches(cpc1.reset_activation_profiles.base_uri,
-                                 r'/api/cpcs/[^/]+/reset-activation-profiles')
+        assert isinstance(cpc1.reset_activation_profiles,
+                          FakedActivationProfileManager)
+        assert cpc1.reset_activation_profiles.profile_type == 'reset'
+        assert re.match(r'/api/cpcs/[^/]+/reset-activation-profiles',
+                        cpc1.reset_activation_profiles.base_uri)
 
         # Test image activation profiles
 
-        self.assertIsInstance(cpc1.image_activation_profiles,
-                              FakedActivationProfileManager)
-        self.assertEqual(cpc1.image_activation_profiles.profile_type, 'image')
-        self.assertRegexpMatches(cpc1.image_activation_profiles.base_uri,
-                                 r'/api/cpcs/[^/]+/image-activation-profiles')
+        assert isinstance(cpc1.image_activation_profiles,
+                          FakedActivationProfileManager)
+        assert cpc1.image_activation_profiles.profile_type == 'image'
+        assert re.match(r'/api/cpcs/[^/]+/image-activation-profiles',
+                        cpc1.image_activation_profiles.base_uri)
 
         # Test load activation profiles
 
-        self.assertIsInstance(cpc1.load_activation_profiles,
-                              FakedActivationProfileManager)
-        self.assertEqual(cpc1.load_activation_profiles.profile_type, 'load')
-        self.assertRegexpMatches(cpc1.load_activation_profiles.base_uri,
-                                 r'/api/cpcs/[^/]+/load-activation-profiles')
+        assert isinstance(cpc1.load_activation_profiles,
+                          FakedActivationProfileManager)
+        assert cpc1.load_activation_profiles.profile_type == 'load'
+        assert re.match(r'/api/cpcs/[^/]+/load-activation-profiles',
+                        cpc1.load_activation_profiles.base_uri)
 
     def test_profiles_list(self):
         """Test list() of FakedActivationProfileManager."""
@@ -362,53 +356,53 @@ class FakedActivationProfileTests(unittest.TestCase):
 
         resetprofiles = cpc1.reset_activation_profiles.list()
 
-        self.assertEqual(len(resetprofiles), 1)
+        assert len(resetprofiles) == 1
         resetprofile1 = resetprofiles[0]
         resetprofile1_out_props = self.resetprofile1_in_props.copy()
         resetprofile1_out_props.update({
             'name': resetprofile1.oid,
             'element-uri': resetprofile1.uri,
         })
-        self.assertIsInstance(resetprofile1, FakedActivationProfile)
-        self.assertEqual(resetprofile1.properties, resetprofile1_out_props)
-        self.assertEqual(resetprofile1.manager, cpc1.reset_activation_profiles)
+        assert isinstance(resetprofile1, FakedActivationProfile)
+        assert resetprofile1.properties == resetprofile1_out_props
+        assert resetprofile1.manager == cpc1.reset_activation_profiles
 
         # Test image activation profiles
 
         imageprofiles = cpc1.image_activation_profiles.list()
 
-        self.assertEqual(len(imageprofiles), 1)
+        assert len(imageprofiles) == 1
         imageprofile1 = imageprofiles[0]
         imageprofile1_out_props = self.imageprofile1_in_props.copy()
         imageprofile1_out_props.update({
             'name': imageprofile1.oid,
             'element-uri': imageprofile1.uri,
         })
-        self.assertIsInstance(imageprofile1, FakedActivationProfile)
-        self.assertEqual(imageprofile1.properties, imageprofile1_out_props)
-        self.assertEqual(imageprofile1.manager, cpc1.image_activation_profiles)
+        assert isinstance(imageprofile1, FakedActivationProfile)
+        assert imageprofile1.properties == imageprofile1_out_props
+        assert imageprofile1.manager == cpc1.image_activation_profiles
 
         # Test load activation profiles
 
         loadprofiles = cpc1.load_activation_profiles.list()
 
-        self.assertEqual(len(loadprofiles), 1)
+        assert len(loadprofiles) == 1
         loadprofile1 = loadprofiles[0]
         loadprofile1_out_props = self.loadprofile1_in_props.copy()
         loadprofile1_out_props.update({
             'name': loadprofile1.oid,
             'element-uri': loadprofile1.uri,
         })
-        self.assertIsInstance(loadprofile1, FakedActivationProfile)
-        self.assertEqual(loadprofile1.properties, loadprofile1_out_props)
-        self.assertEqual(loadprofile1.manager, cpc1.load_activation_profiles)
+        assert isinstance(loadprofile1, FakedActivationProfile)
+        assert loadprofile1.properties == loadprofile1_out_props
+        assert loadprofile1.manager == cpc1.load_activation_profiles
 
     def test_profiles_add(self):
         """Test add() of FakedActivationProfileManager."""
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
         resetprofiles = cpc1.reset_activation_profiles.list()
-        self.assertEqual(len(resetprofiles), 1)
+        assert len(resetprofiles) == 1
 
         resetprofile2_in_props = {'name': 'resetprofile2'}
 
@@ -417,23 +411,23 @@ class FakedActivationProfileTests(unittest.TestCase):
             resetprofile2_in_props)
 
         resetprofiles = cpc1.reset_activation_profiles.list()
-        self.assertEqual(len(resetprofiles), 2)
+        assert len(resetprofiles) == 2
 
         resetprofile2 = [p for p in resetprofiles
                          if p.properties['name'] ==
                          resetprofile2_in_props['name']][0]
 
-        self.assertEqual(new_resetprofile.properties, resetprofile2.properties)
-        self.assertEqual(new_resetprofile.manager, resetprofile2.manager)
+        assert new_resetprofile.properties == resetprofile2.properties
+        assert new_resetprofile.manager == resetprofile2.manager
 
         resetprofile2_out_props = resetprofile2_in_props.copy()
         resetprofile2_out_props.update({
             'name': resetprofile2.oid,
             'element-uri': resetprofile2.uri,
         })
-        self.assertIsInstance(resetprofile2, FakedActivationProfile)
-        self.assertEqual(resetprofile2.properties, resetprofile2_out_props)
-        self.assertEqual(resetprofile2.manager, cpc1.reset_activation_profiles)
+        assert isinstance(resetprofile2, FakedActivationProfile)
+        assert resetprofile2.properties == resetprofile2_out_props
+        assert resetprofile2.manager == cpc1.reset_activation_profiles
 
         # Because we know that the image and load profile managers are of the
         # same class, we don't need to test them.
@@ -444,22 +438,22 @@ class FakedActivationProfileTests(unittest.TestCase):
         cpc1 = cpcs[0]
         resetprofiles = cpc1.reset_activation_profiles.list()
         resetprofile1 = resetprofiles[0]
-        self.assertEqual(len(resetprofiles), 1)
+        assert len(resetprofiles) == 1
 
         # the function to be tested:
         cpc1.reset_activation_profiles.remove(resetprofile1.oid)
 
         resetprofiles = cpc1.reset_activation_profiles.list()
-        self.assertEqual(len(resetprofiles), 0)
+        assert len(resetprofiles) == 0
 
         # Because we know that the image and load profile managers are of the
         # same class, we don't need to test them.
 
 
-class FakedAdapterTests(unittest.TestCase):
+class TestFakedAdapter(object):
     """All tests for the FakedAdapterManager and FakedAdapter classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.adapter1_in_props = {'name': 'adapter1', 'type': 'roce'}
@@ -487,19 +481,18 @@ class FakedAdapterTests(unittest.TestCase):
 
         repr_str = repr_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            repr_str,
-            r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.format(
-                classname=adapter.__class__.__name__,
-                id=id(adapter)))
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=adapter.__class__.__name__,
+                               id=id(adapter)),
+                        repr_str)
 
     def test_adapters_attr(self):
         """Test CPC 'adapters' attribute."""
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
 
-        self.assertIsInstance(cpc1.adapters, FakedAdapterManager)
-        self.assertRegexpMatches(cpc1.adapters.base_uri, r'/api/adapters')
+        assert isinstance(cpc1.adapters, FakedAdapterManager)
+        assert re.match(r'/api/adapters', cpc1.adapters.base_uri)
 
     def test_adapters_list(self):
         """Test list() of FakedAdapterManager."""
@@ -509,7 +502,7 @@ class FakedAdapterTests(unittest.TestCase):
         # the function to be tested:
         adapters = cpc1.adapters.list()
 
-        self.assertEqual(len(adapters), 1)
+        assert len(adapters) == 1
         adapter1 = adapters[0]
         adapter1_out_props = self.adapter1_in_props.copy()
         adapter1_out_props.update({
@@ -519,19 +512,19 @@ class FakedAdapterTests(unittest.TestCase):
             'adapter-family': 'roce',
             'network-port-uris': [],
         })
-        self.assertIsInstance(adapter1, FakedAdapter)
-        self.assertEqual(adapter1.properties, adapter1_out_props)
-        self.assertEqual(adapter1.manager, cpc1.adapters)
+        assert isinstance(adapter1, FakedAdapter)
+        assert adapter1.properties == adapter1_out_props
+        assert adapter1.manager == cpc1.adapters
 
         # Quick check of child resources:
-        self.assertIsInstance(adapter1.ports, FakedPortManager)
+        assert isinstance(adapter1.ports, FakedPortManager)
 
     def test_adapters_add(self):
         """Test add() of FakedAdapterManager."""
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
         adapters = cpc1.adapters.list()
-        self.assertEqual(len(adapters), 1)
+        assert len(adapters) == 1
 
         adapter2_in_props = {'name': 'adapter2', 'adapter-family': 'ficon'}
 
@@ -540,13 +533,13 @@ class FakedAdapterTests(unittest.TestCase):
             adapter2_in_props)
 
         adapters = cpc1.adapters.list()
-        self.assertEqual(len(adapters), 2)
+        assert len(adapters) == 2
 
         adapter2 = [a for a in adapters
                     if a.properties['name'] == adapter2_in_props['name']][0]
 
-        self.assertEqual(new_adapter.properties, adapter2.properties)
-        self.assertEqual(new_adapter.manager, adapter2.manager)
+        assert new_adapter.properties == adapter2.properties
+        assert new_adapter.manager == adapter2.manager
 
         adapter2_out_props = adapter2_in_props.copy()
         adapter2_out_props.update({
@@ -555,9 +548,9 @@ class FakedAdapterTests(unittest.TestCase):
             'status': 'active',
             'storage-port-uris': [],
         })
-        self.assertIsInstance(adapter2, FakedAdapter)
-        self.assertEqual(adapter2.properties, adapter2_out_props)
-        self.assertEqual(adapter2.manager, cpc1.adapters)
+        assert isinstance(adapter2, FakedAdapter)
+        assert adapter2.properties == adapter2_out_props
+        assert adapter2.manager == cpc1.adapters
 
     def test_adapters_remove(self):
         """Test remove() of FakedAdapterManager."""
@@ -565,19 +558,19 @@ class FakedAdapterTests(unittest.TestCase):
         cpc1 = cpcs[0]
         adapters = cpc1.adapters.list()
         adapter1 = adapters[0]
-        self.assertEqual(len(adapters), 1)
+        assert len(adapters) == 1
 
         # the function to be tested:
         cpc1.adapters.remove(adapter1.oid)
 
         adapters = cpc1.adapters.list()
-        self.assertEqual(len(adapters), 0)
+        assert len(adapters) == 0
 
 
-class FakedCpcTests(unittest.TestCase):
+class TestFakedCpc(object):
     """All tests for the FakedCpcManager and FakedCpc classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         rd = {
@@ -599,16 +592,14 @@ class FakedCpcTests(unittest.TestCase):
 
         repr_str = repr_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            repr_str,
-            r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.format(
-                classname=cpc.__class__.__name__,
-                id=id(cpc)))
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=cpc.__class__.__name__, id=id(cpc)),
+                        repr_str)
 
     def test_cpcs_attr(self):
         """Test HMC 'cpcs' attribute."""
-        self.assertIsInstance(self.hmc.cpcs, FakedCpcManager)
-        self.assertRegexpMatches(self.hmc.cpcs.base_uri, r'/api/cpcs')
+        assert isinstance(self.hmc.cpcs, FakedCpcManager)
+        assert re.match(r'/api/cpcs', self.hmc.cpcs.base_uri)
 
     def test_cpcs_list(self):
         """Test list() of FakedCpcManager."""
@@ -625,26 +616,26 @@ class FakedCpcTests(unittest.TestCase):
             'is-ensemble-member': False,
             'status': 'operating',
         })
-        self.assertIsInstance(cpc1, FakedCpc)
-        self.assertEqual(cpc1.properties, cpc1_out_props)
-        self.assertEqual(cpc1.manager, self.hmc.cpcs)
+        assert isinstance(cpc1, FakedCpc)
+        assert cpc1.properties == cpc1_out_props
+        assert cpc1.manager == self.hmc.cpcs
 
         # Quick check of child resources:
-        self.assertIsInstance(cpc1.lpars, FakedLparManager)
-        self.assertIsInstance(cpc1.partitions, FakedPartitionManager)
-        self.assertIsInstance(cpc1.adapters, FakedAdapterManager)
-        self.assertIsInstance(cpc1.virtual_switches, FakedVirtualSwitchManager)
-        self.assertIsInstance(cpc1.reset_activation_profiles,
-                              FakedActivationProfileManager)
-        self.assertIsInstance(cpc1.image_activation_profiles,
-                              FakedActivationProfileManager)
-        self.assertIsInstance(cpc1.load_activation_profiles,
-                              FakedActivationProfileManager)
+        assert isinstance(cpc1.lpars, FakedLparManager)
+        assert isinstance(cpc1.partitions, FakedPartitionManager)
+        assert isinstance(cpc1.adapters, FakedAdapterManager)
+        assert isinstance(cpc1.virtual_switches, FakedVirtualSwitchManager)
+        assert isinstance(cpc1.reset_activation_profiles,
+                          FakedActivationProfileManager)
+        assert isinstance(cpc1.image_activation_profiles,
+                          FakedActivationProfileManager)
+        assert isinstance(cpc1.load_activation_profiles,
+                          FakedActivationProfileManager)
 
     def test_cpcs_add(self):
         """Test add() of FakedCpcManager."""
         cpcs = self.hmc.cpcs.list()
-        self.assertEqual(len(cpcs), 1)
+        assert len(cpcs) == 1
 
         cpc2_in_props = {'name': 'cpc2'}
 
@@ -652,13 +643,13 @@ class FakedCpcTests(unittest.TestCase):
         new_cpc = self.hmc.cpcs.add(cpc2_in_props)
 
         cpcs = self.hmc.cpcs.list()
-        self.assertEqual(len(cpcs), 2)
+        assert len(cpcs) == 2
 
         cpc2 = [cpc for cpc in cpcs
                 if cpc.properties['name'] == cpc2_in_props['name']][0]
 
-        self.assertEqual(new_cpc.properties, cpc2.properties)
-        self.assertEqual(new_cpc.manager, cpc2.manager)
+        assert new_cpc.properties == cpc2.properties
+        assert new_cpc.manager == cpc2.manager
 
         cpc2_out_props = cpc2_in_props.copy()
         cpc2_out_props.update({
@@ -668,27 +659,27 @@ class FakedCpcTests(unittest.TestCase):
             'is-ensemble-member': False,
             'status': 'operating',
         })
-        self.assertIsInstance(cpc2, FakedCpc)
-        self.assertEqual(cpc2.properties, cpc2_out_props)
-        self.assertEqual(cpc2.manager, self.hmc.cpcs)
+        assert isinstance(cpc2, FakedCpc)
+        assert cpc2.properties == cpc2_out_props
+        assert cpc2.manager == self.hmc.cpcs
 
     def test_cpcs_remove(self):
         """Test remove() of FakedCpcManager."""
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
-        self.assertEqual(len(cpcs), 1)
+        assert len(cpcs) == 1
 
         # the function to be tested:
         self.hmc.cpcs.remove(cpc1.oid)
 
         cpcs = self.hmc.cpcs.list()
-        self.assertEqual(len(cpcs), 0)
+        assert len(cpcs) == 0
 
 
-class FakedHbaTests(unittest.TestCase):
+class TestFakedHba(object):
     """All tests for the FakedHbaManager and FakedHba classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
 
         self.adapter1_oid = '747-abc-12345'
@@ -747,9 +738,9 @@ class FakedHbaTests(unittest.TestCase):
         partitions = cpc1.partitions.list()
         partition1 = partitions[0]
 
-        self.assertIsInstance(partition1.hbas, FakedHbaManager)
-        self.assertRegexpMatches(partition1.hbas.base_uri,
-                                 r'/api/partitions/[^/]+/hbas')
+        assert isinstance(partition1.hbas, FakedHbaManager)
+        assert re.match(r'/api/partitions/[^/]+/hbas',
+                        partition1.hbas.base_uri)
 
     def test_hbas_list(self):
         """Test list() of FakedHbaManager."""
@@ -761,7 +752,7 @@ class FakedHbaTests(unittest.TestCase):
         # the function to be tested:
         hbas = partition1.hbas.list()
 
-        self.assertEqual(len(hbas), 1)
+        assert len(hbas) == 1
         hba1 = hbas[0]
         hba1_out_props = self.hba1_in_props.copy()
         hba1_out_props.update({
@@ -770,9 +761,9 @@ class FakedHbaTests(unittest.TestCase):
             'device-number': hba1.properties['device-number'],
             'wwpn': hba1.properties['wwpn'],
         })
-        self.assertIsInstance(hba1, FakedHba)
-        self.assertEqual(hba1.properties, hba1_out_props)
-        self.assertEqual(hba1.manager, partition1.hbas)
+        assert isinstance(hba1, FakedHba)
+        assert hba1.properties == hba1_out_props
+        assert hba1.manager == partition1.hbas
 
     def test_hbas_add(self):
         """Test add() of FakedHbaManager."""
@@ -781,7 +772,7 @@ class FakedHbaTests(unittest.TestCase):
         partitions = cpc1.partitions.list()
         partition1 = partitions[0]
         hbas = partition1.hbas.list()
-        self.assertEqual(len(hbas), 1)
+        assert len(hbas) == 1
 
         hba2_oid = '22-55-xy'
         port_uri = '/api/adapters/abc-123/storage-ports/42'
@@ -799,22 +790,22 @@ class FakedHbaTests(unittest.TestCase):
             hba2_in_props)
 
         hbas = partition1.hbas.list()
-        self.assertEqual(len(hbas), 2)
+        assert len(hbas) == 2
 
         hba2 = [hba for hba in hbas
                 if hba.properties['name'] == hba2_in_props['name']][0]
 
-        self.assertEqual(new_hba.properties, hba2.properties)
-        self.assertEqual(new_hba.manager, hba2.manager)
+        assert new_hba.properties == hba2.properties
+        assert new_hba.manager == hba2.manager
 
         hba2_out_props = hba2_in_props.copy()
         hba2_out_props.update({
             'element-id': hba2_oid,
             'element-uri': hba2.uri,
         })
-        self.assertIsInstance(hba2, FakedHba)
-        self.assertEqual(hba2.properties, hba2_out_props)
-        self.assertEqual(hba2.manager, partition1.hbas)
+        assert isinstance(hba2, FakedHba)
+        assert hba2.properties == hba2_out_props
+        assert hba2.manager == partition1.hbas
 
     def test_hbas_remove(self):
         """Test remove() of FakedHbaManager."""
@@ -824,21 +815,21 @@ class FakedHbaTests(unittest.TestCase):
         partition1 = partitions[0]
         hbas = partition1.hbas.list()
         hba1 = hbas[0]
-        self.assertEqual(len(hbas), 1)
+        assert len(hbas) == 1
 
         # the function to be tested:
         partition1.hbas.remove(hba1.oid)
 
         hbas = partition1.hbas.list()
-        self.assertEqual(len(hbas), 0)
+        assert len(hbas) == 0
 
     # TODO: Add testcases for updating 'hba-uris' parent property
 
 
-class FakedLparTests(unittest.TestCase):
+class TestFakedLpar(object):
     """All tests for the FakedLparManager and FakedLpar classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.lpar1_in_props = {'name': 'lpar1'}
@@ -860,9 +851,8 @@ class FakedLparTests(unittest.TestCase):
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
 
-        self.assertIsInstance(cpc1.lpars, FakedLparManager)
-        self.assertRegexpMatches(cpc1.lpars.base_uri,
-                                 r'/api/logical-partitions')
+        assert isinstance(cpc1.lpars, FakedLparManager)
+        assert re.match(r'/api/logical-partitions', cpc1.lpars.base_uri)
 
     def test_lpars_list(self):
         """Test list() of FakedLparManager."""
@@ -872,7 +862,7 @@ class FakedLparTests(unittest.TestCase):
         # the function to be tested:
         lpars = cpc1.lpars.list()
 
-        self.assertEqual(len(lpars), 1)
+        assert len(lpars) == 1
         lpar1 = lpars[0]
         lpar1_out_props = self.lpar1_in_props.copy()
         lpar1_out_props.update({
@@ -880,16 +870,16 @@ class FakedLparTests(unittest.TestCase):
             'object-uri': lpar1.uri,
             'status': 'not-activated',
         })
-        self.assertIsInstance(lpar1, FakedLpar)
-        self.assertEqual(lpar1.properties, lpar1_out_props)
-        self.assertEqual(lpar1.manager, cpc1.lpars)
+        assert isinstance(lpar1, FakedLpar)
+        assert lpar1.properties == lpar1_out_props
+        assert lpar1.manager == cpc1.lpars
 
     def test_lpars_add(self):
         """Test add() of FakedLparManager."""
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
         lpars = cpc1.lpars.list()
-        self.assertEqual(len(lpars), 1)
+        assert len(lpars) == 1
 
         lpar2_in_props = {'name': 'lpar2'}
 
@@ -898,13 +888,13 @@ class FakedLparTests(unittest.TestCase):
             lpar2_in_props)
 
         lpars = cpc1.lpars.list()
-        self.assertEqual(len(lpars), 2)
+        assert len(lpars) == 2
 
         lpar2 = [p for p in lpars
                  if p.properties['name'] == lpar2_in_props['name']][0]
 
-        self.assertEqual(new_lpar.properties, lpar2.properties)
-        self.assertEqual(new_lpar.manager, lpar2.manager)
+        assert new_lpar.properties == lpar2.properties
+        assert new_lpar.manager == lpar2.manager
 
         lpar2_out_props = lpar2_in_props.copy()
         lpar2_out_props.update({
@@ -912,9 +902,9 @@ class FakedLparTests(unittest.TestCase):
             'object-uri': lpar2.uri,
             'status': 'not-activated',
         })
-        self.assertIsInstance(lpar2, FakedLpar)
-        self.assertEqual(lpar2.properties, lpar2_out_props)
-        self.assertEqual(lpar2.manager, cpc1.lpars)
+        assert isinstance(lpar2, FakedLpar)
+        assert lpar2.properties == lpar2_out_props
+        assert lpar2.manager == cpc1.lpars
 
     def test_lpars_remove(self):
         """Test remove() of FakedLparManager."""
@@ -922,19 +912,19 @@ class FakedLparTests(unittest.TestCase):
         cpc1 = cpcs[0]
         lpars = cpc1.lpars.list()
         lpar1 = lpars[0]
-        self.assertEqual(len(lpars), 1)
+        assert len(lpars) == 1
 
         # the function to be tested:
         cpc1.lpars.remove(lpar1.oid)
 
         lpars = cpc1.lpars.list()
-        self.assertEqual(len(lpars), 0)
+        assert len(lpars) == 0
 
 
-class FakedNicTests(unittest.TestCase):
+class TestFakedNic(object):
     """All tests for the FakedNicManager and FakedNic classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
 
         self.adapter1_oid = '380-xyz-12345'
@@ -993,9 +983,9 @@ class FakedNicTests(unittest.TestCase):
         partitions = cpc1.partitions.list()
         partition1 = partitions[0]
 
-        self.assertIsInstance(partition1.nics, FakedNicManager)
-        self.assertRegexpMatches(partition1.nics.base_uri,
-                                 r'/api/partitions/[^/]+/nics')
+        assert isinstance(partition1.nics, FakedNicManager)
+        assert re.match(r'/api/partitions/[^/]+/nics',
+                        partition1.nics.base_uri)
 
     def test_nics_list(self):
         """Test list() of FakedNicManager."""
@@ -1007,7 +997,7 @@ class FakedNicTests(unittest.TestCase):
         # the function to be tested:
         nics = partition1.nics.list()
 
-        self.assertEqual(len(nics), 1)
+        assert len(nics) == 1
         nic1 = nics[0]
         nic1_out_props = self.nic1_in_props.copy()
         nic1_out_props.update({
@@ -1015,9 +1005,9 @@ class FakedNicTests(unittest.TestCase):
             'element-uri': nic1.uri,
             'device-number': nic1.properties['device-number'],
         })
-        self.assertIsInstance(nic1, FakedNic)
-        self.assertEqual(nic1.properties, nic1_out_props)
-        self.assertEqual(nic1.manager, partition1.nics)
+        assert isinstance(nic1, FakedNic)
+        assert nic1.properties == nic1_out_props
+        assert nic1.manager == partition1.nics
 
     def test_nics_add(self):
         """Test add() of FakedNicManager."""
@@ -1026,7 +1016,7 @@ class FakedNicTests(unittest.TestCase):
         partitions = cpc1.partitions.list()
         partition1 = partitions[0]
         nics = partition1.nics.list()
-        self.assertEqual(len(nics), 1)
+        assert len(nics) == 1
 
         nic2_oid = '77-55-ab'
         port_uri = '/api/adapters/abc-123/network-ports/42'
@@ -1042,13 +1032,13 @@ class FakedNicTests(unittest.TestCase):
             nic2_in_props)
 
         nics = partition1.nics.list()
-        self.assertEqual(len(nics), 2)
+        assert len(nics) == 2
 
         nic2 = [nic for nic in nics
                 if nic.properties['name'] == nic2_in_props['name']][0]
 
-        self.assertEqual(new_nic.properties, nic2.properties)
-        self.assertEqual(new_nic.manager, nic2.manager)
+        assert new_nic.properties == nic2.properties
+        assert new_nic.manager == nic2.manager
 
         nic2_out_props = nic2_in_props.copy()
         nic2_out_props.update({
@@ -1056,9 +1046,9 @@ class FakedNicTests(unittest.TestCase):
             'element-uri': nic2.uri,
             'device-number': nic2.properties['device-number'],
         })
-        self.assertIsInstance(nic2, FakedNic)
-        self.assertEqual(nic2.properties, nic2_out_props)
-        self.assertEqual(nic2.manager, partition1.nics)
+        assert isinstance(nic2, FakedNic)
+        assert nic2.properties == nic2_out_props
+        assert nic2.manager == partition1.nics
 
     def test_nics_remove(self):
         """Test remove() of FakedNicManager."""
@@ -1068,21 +1058,21 @@ class FakedNicTests(unittest.TestCase):
         partition1 = partitions[0]
         nics = partition1.nics.list()
         nic1 = nics[0]
-        self.assertEqual(len(nics), 1)
+        assert len(nics) == 1
 
         # the function to be tested:
         partition1.nics.remove(nic1.oid)
 
         nics = partition1.nics.list()
-        self.assertEqual(len(nics), 0)
+        assert len(nics) == 0
 
     # TODO: Add testcases for updating 'nic-uris' parent property
 
 
-class FakedPartitionTests(unittest.TestCase):
+class TestFakedPartition(object):
     """All tests for the FakedPartitionManager and FakedPartition classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.partition1_in_props = {'name': 'partition1'}
@@ -1110,19 +1100,18 @@ class FakedPartitionTests(unittest.TestCase):
 
         repr_str = repr_str.replace('\n', '\\n')
         # We check just the begin of the string:
-        self.assertRegexpMatches(
-            repr_str,
-            r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.format(
-                classname=partition.__class__.__name__,
-                id=id(partition)))
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=partition.__class__.__name__,
+                               id=id(partition)),
+                        repr_str)
 
     def test_partitions_attr(self):
         """Test CPC 'partitions' attribute."""
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
 
-        self.assertIsInstance(cpc1.partitions, FakedPartitionManager)
-        self.assertRegexpMatches(cpc1.partitions.base_uri, r'/api/partitions')
+        assert isinstance(cpc1.partitions, FakedPartitionManager)
+        assert re.match(r'/api/partitions', cpc1.partitions.base_uri)
 
     def test_partitions_list(self):
         """Test list() of FakedPartitionManager."""
@@ -1132,7 +1121,7 @@ class FakedPartitionTests(unittest.TestCase):
         # the function to be tested:
         partitions = cpc1.partitions.list()
 
-        self.assertEqual(len(partitions), 1)
+        assert len(partitions) == 1
         partition1 = partitions[0]
         partition1_out_props = self.partition1_in_props.copy()
         partition1_out_props.update({
@@ -1143,16 +1132,16 @@ class FakedPartitionTests(unittest.TestCase):
             'nic-uris': [],
             'virtual-function-uris': [],
         })
-        self.assertIsInstance(partition1, FakedPartition)
-        self.assertEqual(partition1.properties, partition1_out_props)
-        self.assertEqual(partition1.manager, cpc1.partitions)
+        assert isinstance(partition1, FakedPartition)
+        assert partition1.properties == partition1_out_props
+        assert partition1.manager == cpc1.partitions
 
     def test_partitions_add(self):
         """Test add() of FakedPartitionManager."""
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
         partitions = cpc1.partitions.list()
-        self.assertEqual(len(partitions), 1)
+        assert len(partitions) == 1
 
         partition2_in_props = {'name': 'partition2'}
 
@@ -1161,14 +1150,14 @@ class FakedPartitionTests(unittest.TestCase):
             partition2_in_props)
 
         partitions = cpc1.partitions.list()
-        self.assertEqual(len(partitions), 2)
+        assert len(partitions) == 2
 
         partition2 = [p for p in partitions
                       if p.properties['name'] ==
                       partition2_in_props['name']][0]
 
-        self.assertEqual(new_partition.properties, partition2.properties)
-        self.assertEqual(new_partition.manager, partition2.manager)
+        assert new_partition.properties == partition2.properties
+        assert new_partition.manager == partition2.manager
 
         partition2_out_props = partition2_in_props.copy()
         partition2_out_props.update({
@@ -1179,9 +1168,9 @@ class FakedPartitionTests(unittest.TestCase):
             'nic-uris': [],
             'virtual-function-uris': [],
         })
-        self.assertIsInstance(partition2, FakedPartition)
-        self.assertEqual(partition2.properties, partition2_out_props)
-        self.assertEqual(partition2.manager, cpc1.partitions)
+        assert isinstance(partition2, FakedPartition)
+        assert partition2.properties == partition2_out_props
+        assert partition2.manager == cpc1.partitions
 
     def test_partitions_remove(self):
         """Test remove() of FakedPartitionManager."""
@@ -1189,19 +1178,19 @@ class FakedPartitionTests(unittest.TestCase):
         cpc1 = cpcs[0]
         partitions = cpc1.partitions.list()
         partition1 = partitions[0]
-        self.assertEqual(len(partitions), 1)
+        assert len(partitions) == 1
 
         # the function to be tested:
         cpc1.partitions.remove(partition1.oid)
 
         partitions = cpc1.partitions.list()
-        self.assertEqual(len(partitions), 0)
+        assert len(partitions) == 0
 
 
-class FakedPortTests(unittest.TestCase):
+class TestFakedPort(object):
     """All tests for the FakedPortManager and FakedPort classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.adapter1_in_props = {'name': 'adapter1', 'adapter-family': 'osa'}
@@ -1231,9 +1220,9 @@ class FakedPortTests(unittest.TestCase):
         adapters = cpc1.adapters.list()
         adapter1 = adapters[0]
 
-        self.assertIsInstance(adapter1.ports, FakedPortManager)
-        self.assertRegexpMatches(adapter1.ports.base_uri,
-                                 r'/api/adapters/[^/]+/network-ports')
+        assert isinstance(adapter1.ports, FakedPortManager)
+        assert re.match(r'/api/adapters/[^/]+/network-ports',
+                        adapter1.ports.base_uri)
 
     def test_ports_list(self):
         """Test list() of FakedPortManager."""
@@ -1245,16 +1234,16 @@ class FakedPortTests(unittest.TestCase):
         # the function to be tested:
         ports = adapter1.ports.list()
 
-        self.assertEqual(len(ports), 1)
+        assert len(ports) == 1
         port1 = ports[0]
         port1_out_props = self.port1_in_props.copy()
         port1_out_props.update({
             'element-id': port1.oid,
             'element-uri': port1.uri,
         })
-        self.assertIsInstance(port1, FakedPort)
-        self.assertEqual(port1.properties, port1_out_props)
-        self.assertEqual(port1.manager, adapter1.ports)
+        assert isinstance(port1, FakedPort)
+        assert port1.properties == port1_out_props
+        assert port1.manager == adapter1.ports
 
     def test_ports_add(self):
         """Test add() of FakedPortManager."""
@@ -1263,7 +1252,7 @@ class FakedPortTests(unittest.TestCase):
         adapters = cpc1.adapters.list()
         adapter1 = adapters[0]
         ports = adapter1.ports.list()
-        self.assertEqual(len(ports), 1)
+        assert len(ports) == 1
 
         port2_in_props = {'name': 'port2'}
 
@@ -1272,22 +1261,22 @@ class FakedPortTests(unittest.TestCase):
             port2_in_props)
 
         ports = adapter1.ports.list()
-        self.assertEqual(len(ports), 2)
+        assert len(ports) == 2
 
         port2 = [p for p in ports
                  if p.properties['name'] == port2_in_props['name']][0]
 
-        self.assertEqual(new_port.properties, port2.properties)
-        self.assertEqual(new_port.manager, port2.manager)
+        assert new_port.properties == port2.properties
+        assert new_port.manager == port2.manager
 
         port2_out_props = port2_in_props.copy()
         port2_out_props.update({
             'element-id': port2.oid,
             'element-uri': port2.uri,
         })
-        self.assertIsInstance(port2, FakedPort)
-        self.assertEqual(port2.properties, port2_out_props)
-        self.assertEqual(port2.manager, adapter1.ports)
+        assert isinstance(port2, FakedPort)
+        assert port2.properties == port2_out_props
+        assert port2.manager == adapter1.ports
 
     def test_ports_remove(self):
         """Test remove() of FakedPortManager."""
@@ -1297,23 +1286,23 @@ class FakedPortTests(unittest.TestCase):
         adapter1 = adapters[0]
         ports = adapter1.ports.list()
         port1 = ports[0]
-        self.assertEqual(len(ports), 1)
+        assert len(ports) == 1
 
         # the function to be tested:
         adapter1.ports.remove(port1.oid)
 
         ports = adapter1.ports.list()
-        self.assertEqual(len(ports), 0)
+        assert len(ports) == 0
 
     # TODO: Add testcases for updating 'network-port-uris' and
     #       'storage-port-uris' parent properties
 
 
-class FakedVirtualFunctionTests(unittest.TestCase):
+class TestFakedVirtualFunction(object):
     """All tests for the FakedVirtualFunctionManager and FakedVirtualFunction
     classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.partition1_in_props = {'name': 'partition1'}
@@ -1344,10 +1333,10 @@ class FakedVirtualFunctionTests(unittest.TestCase):
         partitions = cpc1.partitions.list()
         partition1 = partitions[0]
 
-        self.assertIsInstance(partition1.virtual_functions,
-                              FakedVirtualFunctionManager)
-        self.assertRegexpMatches(partition1.virtual_functions.base_uri,
-                                 r'/api/partitions/[^/]+/virtual-functions')
+        assert isinstance(partition1.virtual_functions,
+                          FakedVirtualFunctionManager)
+        assert re.match(r'/api/partitions/[^/]+/virtual-functions',
+                        partition1.virtual_functions.base_uri)
 
     def test_virtual_functions_list(self):
         """Test list() of FakedVirtualFunctionManager."""
@@ -1359,7 +1348,7 @@ class FakedVirtualFunctionTests(unittest.TestCase):
         # the function to be tested:
         virtual_functions = partition1.virtual_functions.list()
 
-        self.assertEqual(len(virtual_functions), 1)
+        assert len(virtual_functions) == 1
         virtual_function1 = virtual_functions[0]
         virtual_function1_out_props = self.virtual_function1_in_props.copy()
         virtual_function1_out_props.update({
@@ -1367,11 +1356,9 @@ class FakedVirtualFunctionTests(unittest.TestCase):
             'element-uri': virtual_function1.uri,
             'device-number': virtual_function1.properties['device-number'],
         })
-        self.assertIsInstance(virtual_function1, FakedVirtualFunction)
-        self.assertEqual(virtual_function1.properties,
-                         virtual_function1_out_props)
-        self.assertEqual(virtual_function1.manager,
-                         partition1.virtual_functions)
+        assert isinstance(virtual_function1, FakedVirtualFunction)
+        assert virtual_function1.properties == virtual_function1_out_props
+        assert virtual_function1.manager == partition1.virtual_functions
 
     def test_virtual_functions_add(self):
         """Test add() of FakedVirtualFunctionManager."""
@@ -1380,7 +1367,7 @@ class FakedVirtualFunctionTests(unittest.TestCase):
         partitions = cpc1.partitions.list()
         partition1 = partitions[0]
         virtual_functions = partition1.virtual_functions.list()
-        self.assertEqual(len(virtual_functions), 1)
+        assert len(virtual_functions) == 1
 
         virtual_function2_in_props = {'name': 'virtual_function2'}
 
@@ -1389,16 +1376,14 @@ class FakedVirtualFunctionTests(unittest.TestCase):
             virtual_function2_in_props)
 
         virtual_functions = partition1.virtual_functions.list()
-        self.assertEqual(len(virtual_functions), 2)
+        assert len(virtual_functions) == 2
 
         virtual_function2 = [vf for vf in virtual_functions
                              if vf.properties['name'] ==
                              virtual_function2_in_props['name']][0]
 
-        self.assertEqual(new_virtual_function.properties,
-                         virtual_function2.properties)
-        self.assertEqual(new_virtual_function.manager,
-                         virtual_function2.manager)
+        assert new_virtual_function.properties == virtual_function2.properties
+        assert new_virtual_function.manager == virtual_function2.manager
 
         virtual_function2_out_props = virtual_function2_in_props.copy()
         virtual_function2_out_props.update({
@@ -1406,11 +1391,9 @@ class FakedVirtualFunctionTests(unittest.TestCase):
             'element-uri': virtual_function2.uri,
             'device-number': virtual_function2.properties['device-number'],
         })
-        self.assertIsInstance(virtual_function2, FakedVirtualFunction)
-        self.assertEqual(virtual_function2.properties,
-                         virtual_function2_out_props)
-        self.assertEqual(virtual_function2.manager,
-                         partition1.virtual_functions)
+        assert isinstance(virtual_function2, FakedVirtualFunction)
+        assert virtual_function2.properties == virtual_function2_out_props
+        assert virtual_function2.manager == partition1.virtual_functions
 
     def test_virtual_functions_remove(self):
         """Test remove() of FakedVirtualFunctionManager."""
@@ -1420,22 +1403,22 @@ class FakedVirtualFunctionTests(unittest.TestCase):
         partition1 = partitions[0]
         virtual_functions = partition1.virtual_functions.list()
         virtual_function1 = virtual_functions[0]
-        self.assertEqual(len(virtual_functions), 1)
+        assert len(virtual_functions) == 1
 
         # the function to be tested:
         partition1.virtual_functions.remove(virtual_function1.oid)
 
         virtual_functions = partition1.virtual_functions.list()
-        self.assertEqual(len(virtual_functions), 0)
+        assert len(virtual_functions) == 0
 
     # TODO: Add testcases for updating 'virtual-function-uris' parent property
 
 
-class FakedVirtualSwitchTests(unittest.TestCase):
+class TestFakedVirtualSwitch(object):
     """All tests for the FakedVirtualSwitchManager and FakedVirtualSwitch
     classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.virtual_switch1_in_props = {'name': 'virtual_switch1'}
@@ -1457,9 +1440,9 @@ class FakedVirtualSwitchTests(unittest.TestCase):
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
 
-        self.assertIsInstance(cpc1.virtual_switches, FakedVirtualSwitchManager)
-        self.assertRegexpMatches(cpc1.virtual_switches.base_uri,
-                                 r'/api/virtual-switches')
+        assert isinstance(cpc1.virtual_switches, FakedVirtualSwitchManager)
+        assert re.match(r'/api/virtual-switches',
+                        cpc1.virtual_switches.base_uri)
 
     def test_virtual_switches_list(self):
         """Test list() of FakedVirtualSwitchManager."""
@@ -1469,7 +1452,7 @@ class FakedVirtualSwitchTests(unittest.TestCase):
         # the function to be tested:
         virtual_switches = cpc1.virtual_switches.list()
 
-        self.assertEqual(len(virtual_switches), 1)
+        assert len(virtual_switches) == 1
         virtual_switch1 = virtual_switches[0]
         virtual_switch1_out_props = self.virtual_switch1_in_props.copy()
         virtual_switch1_out_props.update({
@@ -1477,16 +1460,16 @@ class FakedVirtualSwitchTests(unittest.TestCase):
             'object-uri': virtual_switch1.uri,
             'connected-vnic-uris': [],
         })
-        self.assertIsInstance(virtual_switch1, FakedVirtualSwitch)
-        self.assertEqual(virtual_switch1.properties, virtual_switch1_out_props)
-        self.assertEqual(virtual_switch1.manager, cpc1.virtual_switches)
+        assert isinstance(virtual_switch1, FakedVirtualSwitch)
+        assert virtual_switch1.properties == virtual_switch1_out_props
+        assert virtual_switch1.manager == cpc1.virtual_switches
 
     def test_virtual_switches_add(self):
         """Test add() of FakedVirtualSwitchManager."""
         cpcs = self.hmc.cpcs.list()
         cpc1 = cpcs[0]
         virtual_switches = cpc1.virtual_switches.list()
-        self.assertEqual(len(virtual_switches), 1)
+        assert len(virtual_switches) == 1
 
         virtual_switch2_in_props = {'name': 'virtual_switch2'}
 
@@ -1495,16 +1478,14 @@ class FakedVirtualSwitchTests(unittest.TestCase):
             virtual_switch2_in_props)
 
         virtual_switches = cpc1.virtual_switches.list()
-        self.assertEqual(len(virtual_switches), 2)
+        assert len(virtual_switches) == 2
 
         virtual_switch2 = [p for p in virtual_switches
                            if p.properties['name'] ==
                            virtual_switch2_in_props['name']][0]
 
-        self.assertEqual(new_virtual_switch.properties,
-                         virtual_switch2.properties)
-        self.assertEqual(new_virtual_switch.manager,
-                         virtual_switch2.manager)
+        assert new_virtual_switch.properties == virtual_switch2.properties
+        assert new_virtual_switch.manager == virtual_switch2.manager
 
         virtual_switch2_out_props = virtual_switch2_in_props.copy()
         virtual_switch2_out_props.update({
@@ -1512,9 +1493,9 @@ class FakedVirtualSwitchTests(unittest.TestCase):
             'object-uri': virtual_switch2.uri,
             'connected-vnic-uris': [],
         })
-        self.assertIsInstance(virtual_switch2, FakedVirtualSwitch)
-        self.assertEqual(virtual_switch2.properties, virtual_switch2_out_props)
-        self.assertEqual(virtual_switch2.manager, cpc1.virtual_switches)
+        assert isinstance(virtual_switch2, FakedVirtualSwitch)
+        assert virtual_switch2.properties == virtual_switch2_out_props
+        assert virtual_switch2.manager == cpc1.virtual_switches
 
     def test_virtual_switches_remove(self):
         """Test remove() of FakedVirtualSwitchManager."""
@@ -1522,20 +1503,20 @@ class FakedVirtualSwitchTests(unittest.TestCase):
         cpc1 = cpcs[0]
         virtual_switches = cpc1.virtual_switches.list()
         virtual_switch1 = virtual_switches[0]
-        self.assertEqual(len(virtual_switches), 1)
+        assert len(virtual_switches) == 1
 
         # the function to be tested:
         cpc1.virtual_switches.remove(virtual_switch1.oid)
 
         virtual_switches = cpc1.virtual_switches.list()
-        self.assertEqual(len(virtual_switches), 0)
+        assert len(virtual_switches) == 0
 
 
-class FakedMetricsContextTests(unittest.TestCase):
+class TestFakedMetricsContext(object):
     """All tests for the FakedMetricsContextManager and FakedMetricsContext
     classes."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1_in_props = {'name': 'cpc1'}
         self.partition1_in_props = {'name': 'partition1'}
@@ -1557,10 +1538,10 @@ class FakedMetricsContextTests(unittest.TestCase):
         """Test faked HMC 'metrics_contexts' attribute."""
         faked_hmc = self.hmc
 
-        self.assertIsInstance(faked_hmc.metrics_contexts,
-                              FakedMetricsContextManager)
-        self.assertRegexpMatches(faked_hmc.metrics_contexts.base_uri,
-                                 r'api/services/metrics/context')
+        assert isinstance(faked_hmc.metrics_contexts,
+                          FakedMetricsContextManager)
+        assert re.match(r'/api/services/metrics/context',
+                        faked_hmc.metrics_contexts.base_uri)
 
     def test_metrics_contexts_add(self):
         """Test add() of FakedMetricsContextManager."""
@@ -1574,16 +1555,15 @@ class FakedMetricsContextTests(unittest.TestCase):
         # the function to be tested:
         mc = faked_hmc.metrics_contexts.add(mc_in_props)
 
-        self.assertIsInstance(mc, FakedMetricsContext)
-        self.assertRegexpMatches(mc.uri,
-                                 r'api/services/metrics/context/[^/]+')
-        self.assertIs(mc.manager, faked_hmc.metrics_contexts)
+        assert isinstance(mc, FakedMetricsContext)
+        assert re.match(r'/api/services/metrics/context/[^/]+', mc.uri)
+        assert mc.manager is faked_hmc.metrics_contexts
         mc_props = mc_in_props.copy()
         mc_props.update({
             'fake-id': mc.oid,
             'fake-uri': mc.uri,
         })
-        self.assertEqual(mc.properties, mc_props)
+        assert mc.properties == mc_props
 
     def test_metrics_contexts_add_get_mg_def(self):
         """Test add_metric_group_definition(), get_metric_group_definition(),
@@ -1603,38 +1583,36 @@ class FakedMetricsContextTests(unittest.TestCase):
 
         # Verify the initial M.G.Def names
         mg_def_names = mc_mgr.get_metric_group_definition_names()
-        self.assertEqual(list(mg_def_names), [])
+        assert list(mg_def_names) == []
 
         # Verify that a M.G.Def can be added
         mc_mgr.add_metric_group_definition(mg_def_input)
 
         # Verify the M.G.Def names after having added one
         mg_def_names = mc_mgr.get_metric_group_definition_names()
-        self.assertEqual(list(mg_def_names), [mg_name])
+        assert list(mg_def_names) == [mg_name]
 
         # Verify that it can be retrieved
         mg_def = mc_mgr.get_metric_group_definition(mg_name)
-        self.assertEqual(mg_def, mg_def_input)
+        assert mg_def == mg_def_input
 
         # Verify that retrieving a non-existing M.G.Def fails
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             mc_mgr.get_metric_group_definition('foo')
-        exc = cm.exception
-        self.assertRegexpMatches(
-            str(exc),
-            r"^A metric group definition with this name does not exist:.*")
+        exc = exc_info.value
+        assert re.match(r"^A metric group definition with this name does "
+                        r"not exist:.*", str(exc))
 
         # Verify that adding an M.G.Def with an existing name fails
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             mc_mgr.add_metric_group_definition(mg_def_input)
-        exc = cm.exception
-        self.assertRegexpMatches(
-            str(exc),
-            r"^A metric group definition with this name already exists:.*")
+        exc = exc_info.value
+        assert re.match(r"^A metric group definition with this name already "
+                        r"exists:.*", str(exc))
 
         # Verify that the M.G.Def names have not changed in these fails
         mg_def_names = mc_mgr.get_metric_group_definition_names()
-        self.assertEqual(list(mg_def_names), [mg_name])
+        assert list(mg_def_names) == [mg_name]
 
     def test_metrics_contexts_add_get_metric_values(self):
         """Test add_metric_values(), get_metric_values(), and
@@ -1663,26 +1641,25 @@ class FakedMetricsContextTests(unittest.TestCase):
 
         # Verify the initial M.O.Val group names
         mo_val_group_names = mc_mgr.get_metric_values_group_names()
-        self.assertEqual(list(mo_val_group_names), [])
+        assert list(mo_val_group_names) == []
 
         # Verify that a first M.O.Val can be added
         mc_mgr.add_metric_values(mo_val_input)
 
         # Verify the M.O.Val group names after having added one
         mo_val_group_names = mc_mgr.get_metric_values_group_names()
-        self.assertEqual(list(mo_val_group_names), [mg_name])
+        assert list(mo_val_group_names) == [mg_name]
 
         # Verify that the M.O.Vals can be retrieved and contain the first one
         mo_vals = mc_mgr.get_metric_values(mg_name)
-        self.assertEqual(list(mo_vals), [mo_val_input])
+        assert list(mo_vals) == [mo_val_input]
 
         # Verify that retrieving a non-existing M.O.Val fails
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as exc_info:
             mc_mgr.get_metric_values('foo')
-        exc = cm.exception
-        self.assertRegexpMatches(
-            str(exc),
-            r"^Metric values for this group name do not exist:.*")
+        exc = exc_info.value
+        assert re.match(r"^Metric values for this group name do not "
+                        r"exist:.*", str(exc))
 
         # Verify that a second M.O.Val can be added for the same group name
         mc_mgr.add_metric_values(mo_val2_input)
@@ -1690,11 +1667,11 @@ class FakedMetricsContextTests(unittest.TestCase):
         # Verify the M.O.Val group names after having added a second M.O.Val
         # for the same group name -> still just one group name
         mo_val_group_names = mc_mgr.get_metric_values_group_names()
-        self.assertEqual(list(mo_val_group_names), [mg_name])
+        assert list(mo_val_group_names) == [mg_name]
 
         # Verify that the M.O.Vals can be retrieved and contain both
         mo_vals = mc_mgr.get_metric_values(mg_name)
-        self.assertEqual(list(mo_vals), [mo_val_input, mo_val2_input])
+        assert list(mo_vals) == [mo_val_input, mo_val2_input]
 
     def test_metrics_context_get_mg_defs(self):
         """Test get_metric_group_definitions() of FakedMetricsContext."""
@@ -1732,7 +1709,7 @@ class FakedMetricsContextTests(unittest.TestCase):
         mg_defs = mc.get_metric_group_definitions()
 
         # Verify the returned M.G.Defs
-        self.assertEqual(list(mg_defs), exp_mg_defs)
+        assert list(mg_defs) == exp_mg_defs
 
         # Test case where the default for M.G.Defs is tested
         mc_in_props = {
@@ -1746,7 +1723,7 @@ class FakedMetricsContextTests(unittest.TestCase):
         mg_defs = mc.get_metric_group_definitions()
 
         # Verify the returned M.G.Defs
-        self.assertEqual(list(mg_defs), exp_mg_defs)
+        assert list(mg_defs) == exp_mg_defs
 
     def test_metrics_context_get_mg_infos(self):
         """Test get_metric_group_infos() of FakedMetricsContext."""
@@ -1810,7 +1787,7 @@ class FakedMetricsContextTests(unittest.TestCase):
         mg_infos = mc.get_metric_group_infos()
 
         # Verify the returned M.G.Defs
-        self.assertEqual(list(mg_infos), exp_mg_infos)
+        assert list(mg_infos) == exp_mg_infos
 
         # Test case where the default for M.G.Defs is tested
         mc_in_props = {
@@ -1824,7 +1801,7 @@ class FakedMetricsContextTests(unittest.TestCase):
         mg_infos = mc.get_metric_group_infos()
 
         # Verify the returned M.G.Defs
-        self.assertEqual(list(mg_infos), exp_mg_infos)
+        assert list(mg_infos) == exp_mg_infos
 
     def test_metrics_context_get_m_values(self):
         """Test get_metric_values() of FakedMetricsContext."""
@@ -1871,10 +1848,10 @@ class FakedMetricsContextTests(unittest.TestCase):
         # the function to be tested:
         mv_list = mc.get_metric_values()
 
-        self.assertEqual(len(mv_list), 1)
+        assert len(mv_list) == 1
         mv = mv_list[0]
-        self.assertEqual(mv[0], mg_name)
-        self.assertEqual(mv[1], exp_mo_vals)
+        assert mv[0] == mg_name
+        assert mv[1] == exp_mo_vals
 
     def test_metrics_context_get_m_values_response(self):
         """Test get_metric_values_response() of FakedMetricsContext."""
@@ -1959,14 +1936,13 @@ class FakedMetricsContextTests(unittest.TestCase):
         # the function to be tested:
         mv_resp = mc.get_metric_values_response()
 
-        self.assertEqual(
-            mv_resp, exp_mv_resp,
-            "Actual response string:\n{!r}\n"
-            "Expected response string:\n{!r}\n".
-            format(mv_resp, exp_mv_resp))
+        assert mv_resp == exp_mv_resp, \
+            "Actual response string:\n{!r}\n" \
+            "Expected response string:\n{!r}\n". \
+            format(mv_resp, exp_mv_resp)
 
 
-class FakedMetricGroupDefinitionTests(unittest.TestCase):
+class TestFakedMetricGroupDefinition(object):
     """All tests for the FakedMetricGroupDefinition class."""
 
     def test_metric_group_definition_attr(self):
@@ -1983,12 +1959,12 @@ class FakedMetricGroupDefinitionTests(unittest.TestCase):
         # the function to be tested:
         new_mgd = FakedMetricGroupDefinition(**in_kwargs)
 
-        self.assertEqual(new_mgd.name, in_kwargs['name'])
-        self.assertEqual(new_mgd.types, in_kwargs['types'])
-        self.assertIsNot(new_mgd.types, in_kwargs['types'])  # was copied
+        assert new_mgd.name == in_kwargs['name']
+        assert new_mgd.types == in_kwargs['types']
+        assert new_mgd.types is not in_kwargs['types']  # was copied
 
 
-class FakedMetricObjectValuesTests(unittest.TestCase):
+class TestFakedMetricObjectValues(object):
     """All tests for the FakedMetricObjectValues class."""
 
     def test_metric_object_values_attr(self):
@@ -2007,12 +1983,8 @@ class FakedMetricObjectValuesTests(unittest.TestCase):
         # the function to be tested:
         new_mov = FakedMetricObjectValues(**in_kwargs)
 
-        self.assertEqual(new_mov.group_name, in_kwargs['group_name'])
-        self.assertEqual(new_mov.resource_uri, in_kwargs['resource_uri'])
-        self.assertEqual(new_mov.timestamp, in_kwargs['timestamp'])
-        self.assertEqual(new_mov.values, in_kwargs['values'])
-        self.assertIsNot(new_mov.values, in_kwargs['values'])  # was copied
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert new_mov.group_name == in_kwargs['group_name']
+        assert new_mov.resource_uri == in_kwargs['resource_uri']
+        assert new_mov.timestamp == in_kwargs['timestamp']
+        assert new_mov.values == in_kwargs['values']
+        assert new_mov.values is not in_kwargs['values']  # was copied

--- a/tests/unit/zhmcclient_mock/test_idpool.py
+++ b/tests/unit/zhmcclient_mock/test_idpool.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,30 +19,32 @@ Unit test cases for the _idpool module of the zhmcclient_mock package.
 from __future__ import absolute_import, print_function
 
 import requests.packages.urllib3
-import unittest
+import pytest
 
 from zhmcclient_mock._idpool import IdPool
 
+requests.packages.urllib3.disable_warnings()
 
-class IdPoolTests(unittest.TestCase):
+
+class TestIdPool(object):
     """All tests for class IdPool."""
 
     def test_init_error_1(self):
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             IdPool(7, 6)
 
     def test_invalid_free_error_1(self):
 
         pool = IdPool(5, 5)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             pool.free(4)  # not in range
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             pool.free(5)  # in range but not allocated
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             pool.free(6)  # not in range
 
     def test_invalid_free_error_2(self):
@@ -70,10 +71,10 @@ class IdPoolTests(unittest.TestCase):
 
         # Verify uniqueness of the ID values
         id_set = set(id_list)
-        self.assertEqual(len(id_set), len(id_list))
+        assert len(id_set) == len(id_list)
 
         # Verify that the pool is exhausted
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             pool.alloc()
 
     def _test_free_for_lo_hi(self, lowest, highest):
@@ -93,7 +94,7 @@ class IdPoolTests(unittest.TestCase):
             pool.free(id)
 
         # Verify that nothing is used in the pool
-        self.assertEqual(len(pool._used), 0)
+        assert len(pool._used) == 0
 
         # Exhaust the pool
         id_list2 = []
@@ -102,10 +103,10 @@ class IdPoolTests(unittest.TestCase):
             id_list2.append(id)
 
         # Verify that the same ID values came back as last time
-        self.assertEqual(set(id_list1), set(id_list2))
+        assert set(id_list1) == set(id_list2)
 
         # Verify that the pool is exhausted
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             pool.alloc()
 
     def _test_all_for_lo_hi(self, lowest, highest):
@@ -147,8 +148,3 @@ class IdPoolTests(unittest.TestCase):
         self._test_all_for_lo_hi(11, 20)
         self._test_all_for_lo_hi(11, 21)
         self._test_all_for_lo_hi(11, 22)
-
-
-if __name__ == '__main__':
-    requests.packages.urllib3.disable_warnings()
-    unittest.main()

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2017 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,9 +19,10 @@ Unit tests for _urihandler module of the zhmcclient_mock package.
 from __future__ import absolute_import, print_function
 
 import requests.packages.urllib3
-import unittest
 from datetime import datetime
+# FIXME: Migrate mock to zhmcclient_mock
 from mock import MagicMock
+import pytest
 
 from zhmcclient_mock._hmc import FakedHmc, FakedMetricGroupDefinition, \
     FakedMetricObjectValues
@@ -69,8 +69,10 @@ from zhmcclient_mock._urihandler import HTTPError, InvalidResourceError, \
     ImageActProfilesHandler, ImageActProfileHandler, \
     LoadActProfilesHandler, LoadActProfileHandler
 
+requests.packages.urllib3.disable_warnings()
 
-class HTTPErrorTests(unittest.TestCase):
+
+class TestHTTPError(object):
     """All tests for class HTTPError."""
 
     def test_attributes(self):
@@ -82,11 +84,11 @@ class HTTPErrorTests(unittest.TestCase):
 
         exc = HTTPError(method, uri, http_status, reason, message)
 
-        self.assertEqual(exc.method, method)
-        self.assertEqual(exc.uri, uri)
-        self.assertEqual(exc.http_status, http_status)
-        self.assertEqual(exc.reason, reason)
-        self.assertEqual(exc.message, message)
+        assert exc.method == method
+        assert exc.uri == uri
+        assert exc.http_status == http_status
+        assert exc.reason == reason
+        assert exc.message == message
 
     def test_response(self):
         method = 'GET'
@@ -105,13 +107,13 @@ class HTTPErrorTests(unittest.TestCase):
 
         response = exc.response()
 
-        self.assertEqual(response, expected_response)
+        assert response == expected_response
 
 
-class ConnectionErrorTests(unittest.TestCase):
+class TestConnectionError(object):
     """All tests for class ConnectionError."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
 
@@ -120,7 +122,7 @@ class ConnectionErrorTests(unittest.TestCase):
 
         exc = ConnectionError(msg)
 
-        self.assertEqual(exc.message, msg)
+        assert exc.message == msg
 
 
 class DummyHandler1(object):
@@ -135,7 +137,7 @@ class DummyHandler3(object):
     pass
 
 
-class InvalidResourceErrorTests(unittest.TestCase):
+class TestInvalidResourceError(object):
     """All tests for class InvalidResourceError."""
 
     def test_attributes_with_handler(self):
@@ -146,11 +148,11 @@ class InvalidResourceErrorTests(unittest.TestCase):
 
         exc = InvalidResourceError(method, uri, DummyHandler1)
 
-        self.assertEqual(exc.method, method)
-        self.assertEqual(exc.uri, uri)
-        self.assertEqual(exc.http_status, exp_http_status)
-        self.assertEqual(exc.reason, exp_reason)
-        self.assertIn(uri, exc.message)
+        assert exc.method == method
+        assert exc.uri == uri
+        assert exc.http_status == exp_http_status
+        assert exc.reason == exp_reason
+        assert uri in exc.message
 
         # next test case
         exp_reason = 2
@@ -158,7 +160,7 @@ class InvalidResourceErrorTests(unittest.TestCase):
         exc = InvalidResourceError(method, uri, DummyHandler1,
                                    reason=exp_reason)
 
-        self.assertEqual(exc.reason, exp_reason)
+        assert exc.reason == exp_reason
 
         # next test case
         exp_resource_uri = '/api/resource'
@@ -166,7 +168,7 @@ class InvalidResourceErrorTests(unittest.TestCase):
         exc = InvalidResourceError(method, uri, DummyHandler1,
                                    resource_uri=exp_resource_uri)
 
-        self.assertIn(exp_resource_uri, exc.message)
+        assert exp_resource_uri in exc.message
 
     def test_attributes_no_handler(self):
         method = 'GET'
@@ -176,13 +178,13 @@ class InvalidResourceErrorTests(unittest.TestCase):
 
         exc = InvalidResourceError(method, uri, None)
 
-        self.assertEqual(exc.method, method)
-        self.assertEqual(exc.uri, uri)
-        self.assertEqual(exc.http_status, exp_http_status)
-        self.assertEqual(exc.reason, exp_reason)
+        assert exc.method == method
+        assert exc.uri == uri
+        assert exc.http_status == exp_http_status
+        assert exc.reason == exp_reason
 
 
-class InvalidMethodErrorTests(unittest.TestCase):
+class TestInvalidMethodError(object):
     """All tests for class InvalidMethodError."""
 
     def test_attributes_with_handler(self):
@@ -193,10 +195,10 @@ class InvalidMethodErrorTests(unittest.TestCase):
 
         exc = InvalidMethodError(method, uri, DummyHandler1)
 
-        self.assertEqual(exc.method, method)
-        self.assertEqual(exc.uri, uri)
-        self.assertEqual(exc.http_status, exp_http_status)
-        self.assertEqual(exc.reason, exp_reason)
+        assert exc.method == method
+        assert exc.uri == uri
+        assert exc.http_status == exp_http_status
+        assert exc.reason == exp_reason
 
     def test_attributes_no_handler(self):
         method = 'DELETE'
@@ -206,16 +208,16 @@ class InvalidMethodErrorTests(unittest.TestCase):
 
         exc = InvalidMethodError(method, uri, None)
 
-        self.assertEqual(exc.method, method)
-        self.assertEqual(exc.uri, uri)
-        self.assertEqual(exc.http_status, exp_http_status)
-        self.assertEqual(exc.reason, exp_reason)
+        assert exc.method == method
+        assert exc.uri == uri
+        assert exc.http_status == exp_http_status
+        assert exc.reason == exp_reason
 
 
-class CpcNotInDpmErrorTests(unittest.TestCase):
+class TestCpcNotInDpmError(object):
     """All tests for class CpcNotInDpmError."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
 
@@ -227,16 +229,16 @@ class CpcNotInDpmErrorTests(unittest.TestCase):
 
         exc = CpcNotInDpmError(method, uri, self.cpc1)
 
-        self.assertEqual(exc.method, method)
-        self.assertEqual(exc.uri, uri)
-        self.assertEqual(exc.http_status, exp_http_status)
-        self.assertEqual(exc.reason, exp_reason)
+        assert exc.method == method
+        assert exc.uri == uri
+        assert exc.http_status == exp_http_status
+        assert exc.reason == exp_reason
 
 
-class CpcInDpmErrorTests(unittest.TestCase):
+class TestCpcInDpmError(object):
     """All tests for class CpcInDpmError."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
         self.cpc1 = self.hmc.cpcs.add({'name': 'cpc1'})
 
@@ -248,129 +250,129 @@ class CpcInDpmErrorTests(unittest.TestCase):
 
         exc = CpcInDpmError(method, uri, self.cpc1)
 
-        self.assertEqual(exc.method, method)
-        self.assertEqual(exc.uri, uri)
-        self.assertEqual(exc.http_status, exp_http_status)
-        self.assertEqual(exc.reason, exp_reason)
+        assert exc.method == method
+        assert exc.uri == uri
+        assert exc.http_status == exp_http_status
+        assert exc.reason == exp_reason
 
 
-class ParseQueryParmsTests(unittest.TestCase):
+class TestParseQueryParms(object):
     """All tests for parse_query_parms()."""
 
     def test_none(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', None)
-        self.assertIsNone(filter_args)
+        assert filter_args is None
 
     def test_empty(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', '')
-        self.assertIsNone(filter_args)
+        assert filter_args is None
 
     def test_one_normal(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=b')
-        self.assertEqual(filter_args, {'a': 'b'})
+        assert filter_args == {'a': 'b'}
 
     def test_two_normal(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=b&c=d')
-        self.assertEqual(filter_args, {'a': 'b', 'c': 'd'})
+        assert filter_args == {'a': 'b', 'c': 'd'}
 
     def test_one_trailing_amp(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=b&')
-        self.assertEqual(filter_args, {'a': 'b'})
+        assert filter_args == {'a': 'b'}
 
     def test_one_leading_amp(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', '&a=b')
-        self.assertEqual(filter_args, {'a': 'b'})
+        assert filter_args == {'a': 'b'}
 
     def test_one_missing_value(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=')
-        self.assertEqual(filter_args, {'a': ''})
+        assert filter_args == {'a': ''}
 
     def test_one_missing_name(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', '=b')
-        self.assertEqual(filter_args, {'': 'b'})
+        assert filter_args == {'': 'b'}
 
     def test_two_same_normal(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=b&a=c')
-        self.assertEqual(filter_args, {'a': ['b', 'c']})
+        assert filter_args == {'a': ['b', 'c']}
 
     def test_two_same_one_normal(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=b&d=e&a=c')
-        self.assertEqual(filter_args, {'a': ['b', 'c'], 'd': 'e'})
+        assert filter_args == {'a': ['b', 'c'], 'd': 'e'}
 
     def test_space_value_1(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=b%20c')
-        self.assertEqual(filter_args, {'a': 'b c'})
+        assert filter_args == {'a': 'b c'}
 
     def test_space_value_2(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=%20c')
-        self.assertEqual(filter_args, {'a': ' c'})
+        assert filter_args == {'a': ' c'}
 
     def test_space_value_3(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=b%20')
-        self.assertEqual(filter_args, {'a': 'b '})
+        assert filter_args == {'a': 'b '}
 
     def test_space_value_4(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a=%20')
-        self.assertEqual(filter_args, {'a': ' '})
+        assert filter_args == {'a': ' '}
 
     def test_space_name_1(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a%20b=c')
-        self.assertEqual(filter_args, {'a b': 'c'})
+        assert filter_args == {'a b': 'c'}
 
     def test_space_name_2(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', '%20b=c')
-        self.assertEqual(filter_args, {' b': 'c'})
+        assert filter_args == {' b': 'c'}
 
     def test_space_name_3(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', 'a%20=c')
-        self.assertEqual(filter_args, {'a ': 'c'})
+        assert filter_args == {'a ': 'c'}
 
     def test_space_name_4(self):
         filter_args = parse_query_parms('fake-meth', 'fake-uri', '%20=c')
-        self.assertEqual(filter_args, {' ': 'c'})
+        assert filter_args == {' ': 'c'}
 
     def test_invalid_format_1(self):
-        with self.assertRaises(HTTPError) as cm:
+        with pytest.raises(HTTPError) as exc_info:
             parse_query_parms('fake-meth', 'fake-uri', 'a==b')
-        exc = cm.exception
-        self.assertEqual(exc.http_status, 400)
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.http_status == 400
+        assert exc.reason == 1
 
     def test_invalid_format_2(self):
-        with self.assertRaises(HTTPError) as cm:
+        with pytest.raises(HTTPError) as exc_info:
             parse_query_parms('fake-meth', 'fake-uri', 'a=b=c')
-        exc = cm.exception
-        self.assertEqual(exc.http_status, 400)
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.http_status == 400
+        assert exc.reason == 1
 
     def test_invalid_format_3(self):
-        with self.assertRaises(HTTPError) as cm:
+        with pytest.raises(HTTPError) as exc_info:
             parse_query_parms('fake-meth', 'fake-uri', 'a')
-        exc = cm.exception
-        self.assertEqual(exc.http_status, 400)
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.http_status == 400
+        assert exc.reason == 1
 
 
-class UriHandlerHandlerEmptyTests(unittest.TestCase):
+class TestUriHandlerHandlerEmpty(object):
     """All tests for UriHandler.handler() with empty URIs."""
 
-    def setUp(self):
+    def setup_method(self):
         self.uris = ()
         self.urihandler = UriHandler(self.uris)
 
     def test_uris_empty_1(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('/api/cpcs', 'GET')
 
     def test_uris_empty_2(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('', 'GET')
 
 
-class UriHandlerHandlerSimpleTests(unittest.TestCase):
+class TestUriHandlerHandlerSimple(object):
     """All tests for UriHandler.handler() with a simple set of URIs."""
 
-    def setUp(self):
+    def setup_method(self):
         self.uris = (
             (r'/api/cpcs', DummyHandler1),
             (r'/api/cpcs/([^/]+)', DummyHandler2),
@@ -381,60 +383,60 @@ class UriHandlerHandlerSimpleTests(unittest.TestCase):
     def test_ok1(self):
         handler_class, uri_parms = self.urihandler.handler(
             '/api/cpcs', 'GET')
-        self.assertEqual(handler_class, DummyHandler1)
-        self.assertEqual(len(uri_parms), 0)
+        assert handler_class == DummyHandler1
+        assert len(uri_parms) == 0
 
     def test_ok2(self):
         handler_class, uri_parms = self.urihandler.handler(
             '/api/cpcs/fake-id1', 'GET')
-        self.assertEqual(handler_class, DummyHandler2)
-        self.assertEqual(len(uri_parms), 1)
-        self.assertEqual(uri_parms[0], 'fake-id1')
+        assert handler_class == DummyHandler2
+        assert len(uri_parms) == 1
+        assert uri_parms[0] == 'fake-id1'
 
     def test_ok3(self):
         handler_class, uri_parms = self.urihandler.handler(
             '/api/cpcs/fake-id1/child', 'GET')
-        self.assertEqual(handler_class, DummyHandler3)
-        self.assertEqual(len(uri_parms), 1)
-        self.assertEqual(uri_parms[0], 'fake-id1')
+        assert handler_class == DummyHandler3
+        assert len(uri_parms) == 1
+        assert uri_parms[0] == 'fake-id1'
 
     def test_err_begin_missing(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('api/cpcs', 'GET')
 
     def test_err_begin_extra(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('x/api/cpcs', 'GET')
 
     def test_err_end_missing(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('/api/cpc', 'GET')
 
     def test_err_end_extra(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('/api/cpcs_x', 'GET')
 
     def test_err_end_slash(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('/api/cpcs/', 'GET')
 
     def test_err_end2_slash(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('/api/cpcs/fake-id1/', 'GET')
 
     def test_err_end2_missing(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('/api/cpcs/fake-id1/chil', 'GET')
 
     def test_err_end2_extra(self):
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.handler('/api/cpcs/fake-id1/child_x', 'GET')
 
 
-class UriHandlerMethodTests(unittest.TestCase):
+class TestUriHandlerMethod(object):
     """All tests for get(), post(), delete() methods of class UriHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.uris = (
             (r'/api/cpcs', DummyHandler1),
             (r'/api/cpcs/([^/]+)', DummyHandler2),
@@ -468,7 +470,7 @@ class UriHandlerMethodTests(unittest.TestCase):
         self.urihandler = UriHandler(self.uris)
         self.hmc = FakedHmc('fake-hmc', '2.13.1', '1.8')
 
-    def tearDown(self):
+    def teardown_method(self):
         delattr(DummyHandler1, 'get')
         delattr(DummyHandler1, 'post')
         delattr(DummyHandler2, 'get')
@@ -479,48 +481,48 @@ class UriHandlerMethodTests(unittest.TestCase):
         # the function to be tested
         result = self.urihandler.get(self.hmc, '/api/cpcs', True)
 
-        self.assertEqual(result, self.cpcs)
+        assert result == self.cpcs
 
         DummyHandler1.get.assert_called_with(
             'GET', self.hmc, '/api/cpcs', tuple(), True)
-        self.assertEqual(DummyHandler1.post.called, 0)
-        self.assertEqual(DummyHandler2.get.called, 0)
-        self.assertEqual(DummyHandler2.delete.called, 0)
+        assert DummyHandler1.post.called == 0
+        assert DummyHandler2.get.called == 0
+        assert DummyHandler2.delete.called == 0
 
     def test_get_cpc1(self):
 
         # the function to be tested
         result = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
 
-        self.assertEqual(result, self.cpc1)
+        assert result == self.cpc1
 
-        self.assertEqual(DummyHandler1.get.called, 0)
-        self.assertEqual(DummyHandler1.post.called, 0)
+        assert DummyHandler1.get.called == 0
+        assert DummyHandler1.post.called == 0
         DummyHandler2.get.assert_called_with(
             'GET', self.hmc, '/api/cpcs/1', tuple('1'), True)
-        self.assertEqual(DummyHandler2.delete.called, 0)
+        assert DummyHandler2.delete.called == 0
 
     def test_post_cpcs(self):
 
         # the function to be tested
         result = self.urihandler.post(self.hmc, '/api/cpcs', {}, True, True)
 
-        self.assertEqual(result, self.new_cpc)
+        assert result == self.new_cpc
 
-        self.assertEqual(DummyHandler1.get.called, 0)
+        assert DummyHandler1.get.called == 0
         DummyHandler1.post.assert_called_with(
             'POST', self.hmc, '/api/cpcs', tuple(), {}, True, True)
-        self.assertEqual(DummyHandler2.get.called, 0)
-        self.assertEqual(DummyHandler2.delete.called, 0)
+        assert DummyHandler2.get.called == 0
+        assert DummyHandler2.delete.called == 0
 
     def test_delete_cpc2(self):
 
         # the function to be tested
         self.urihandler.delete(self.hmc, '/api/cpcs/2', True)
 
-        self.assertEqual(DummyHandler1.get.called, 0)
-        self.assertEqual(DummyHandler1.post.called, 0)
-        self.assertEqual(DummyHandler2.get.called, 0)
+        assert DummyHandler1.get.called == 0
+        assert DummyHandler1.post.called == 0
+        assert DummyHandler2.get.called == 0
         DummyHandler2.delete.assert_called_with(
             'DELETE', self.hmc, '/api/cpcs/2', tuple('2'), True)
 
@@ -815,10 +817,10 @@ def standard_test_hmc():
     return hmc, hmc_resources
 
 
-class GenericGetPropertiesHandlerTests(unittest.TestCase):
+class TestGenericGetPropertiesHandler(object):
     """All tests for class GenericGetPropertiesHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)', GenericGetPropertiesHandler),
@@ -839,13 +841,13 @@ class GenericGetPropertiesHandlerTests(unittest.TestCase):
             'description': 'CPC #1 (classic mode)',
             'status': 'operating',
         }
-        self.assertEqual(cpc1, exp_cpc1)
+        assert cpc1 == exp_cpc1
 
     def test_get_error_offline(self):
 
         self.hmc.disable()
 
-        with self.assertRaises(ConnectionError):
+        with pytest.raises(ConnectionError):
             # the function to be tested:
             self.urihandler.get(self.hmc, '/api/cpcs/1', True)
 
@@ -855,10 +857,10 @@ class _GenericGetUpdatePropertiesHandler(GenericGetPropertiesHandler,
     pass
 
 
-class GenericUpdatePropertiesHandlerTests(unittest.TestCase):
+class TestGenericUpdatePropertiesHandler(object):
     """All tests for class GenericUpdatePropertiesHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)', _GenericGetUpdatePropertiesHandler),
@@ -874,9 +876,9 @@ class GenericUpdatePropertiesHandlerTests(unittest.TestCase):
         resp = self.urihandler.post(self.hmc, '/api/cpcs/1', update_cpc1, True,
                                     True)
 
-        self.assertEqual(resp, None)
+        assert resp is None
         cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
-        self.assertEqual(cpc1['description'], 'CPC #1 (updated)')
+        assert cpc1['description'] == 'CPC #1 (updated)'
 
     def test_post_error_offline(self):
 
@@ -886,16 +888,16 @@ class GenericUpdatePropertiesHandlerTests(unittest.TestCase):
             'description': 'CPC #1 (updated)',
         }
 
-        with self.assertRaises(ConnectionError):
+        with pytest.raises(ConnectionError):
             # the function to be tested:
             self.urihandler.post(self.hmc, '/api/cpcs/1', update_cpc1, True,
                                  True)
 
 
-class GenericDeleteHandlerTests(unittest.TestCase):
+class TestGenericDeleteHandler(object):
     """All tests for class GenericDeleteHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             ('/api/console/ldap-server-definitions/([^/]+)',
@@ -910,10 +912,10 @@ class GenericDeleteHandlerTests(unittest.TestCase):
         # the function to be tested:
         ret = self.urihandler.delete(self.hmc, uri, True)
 
-        self.assertIsNone(ret)
+        assert ret is None
 
         # Verify it no longer exists:
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             self.hmc.lookup_by_uri(uri)
 
     def test_delete_error_offline(self):
@@ -922,15 +924,15 @@ class GenericDeleteHandlerTests(unittest.TestCase):
 
         uri = '/api/console/ldap-server-definitions/fake-ldap-srv-def-oid-1'
 
-        with self.assertRaises(ConnectionError):
+        with pytest.raises(ConnectionError):
             # the function to be tested:
             self.urihandler.delete(self.hmc, uri, True)
 
 
-class VersionHandlerTests(unittest.TestCase):
+class TestVersionHandler(object):
     """All tests for class VersionHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/version', VersionHandler),
@@ -949,13 +951,13 @@ class VersionHandlerTests(unittest.TestCase):
             'api-major-version': int(api_major),
             'api-minor-version': int(api_minor),
         }
-        self.assertEqual(resp, exp_resp)
+        assert resp == exp_resp
 
 
-class ConsoleHandlerTests(unittest.TestCase):
+class TestConsoleHandler(object):
     """All tests for class ConsoleHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -975,13 +977,13 @@ class ConsoleHandlerTests(unittest.TestCase):
             'object-uri': '/api/console',
             'name': 'fake_console_name',
         }
-        self.assertEqual(console, exp_console)
+        assert console == exp_console
 
 
-class ConsoleRestartHandlerTests(unittest.TestCase):
+class TestConsoleRestartHandler(object):
     """All tests for class ConsoleRestartHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -999,8 +1001,8 @@ class ConsoleRestartHandlerTests(unittest.TestCase):
         resp = self.urihandler.post(
             self.hmc, '/api/console/operations/restart', body, True, True)
 
-        self.assertTrue(self.hmc.enabled)
-        self.assertIsNone(resp)
+        assert self.hmc.enabled
+        assert resp is None
 
     def test_restart_error_not_found(self):
 
@@ -1010,20 +1012,20 @@ class ConsoleRestartHandlerTests(unittest.TestCase):
         body = {
             'force': False,
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(
                 self.hmc, '/api/console/operations/restart', body, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
 
-class ConsoleShutdownHandlerTests(unittest.TestCase):
+class TestConsoleShutdownHandler(object):
     """All tests for class ConsoleShutdownHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -1041,8 +1043,8 @@ class ConsoleShutdownHandlerTests(unittest.TestCase):
         resp = self.urihandler.post(
             self.hmc, '/api/console/operations/shutdown', body, True, True)
 
-        self.assertFalse(self.hmc.enabled)
-        self.assertIsNone(resp)
+        assert not self.hmc.enabled
+        assert resp is None
 
     def test_shutdown_error_not_found(self):
 
@@ -1052,20 +1054,20 @@ class ConsoleShutdownHandlerTests(unittest.TestCase):
         body = {
             'force': False,
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(
                 self.hmc, '/api/console/operations/shutdown', body, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
 
-class ConsoleMakePrimaryHandlerTests(unittest.TestCase):
+class TestConsoleMakePrimaryHandler(object):
     """All tests for class ConsoleMakePrimaryHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -1081,8 +1083,8 @@ class ConsoleMakePrimaryHandlerTests(unittest.TestCase):
         resp = self.urihandler.post(
             self.hmc, '/api/console/operations/make-primary', None, True, True)
 
-        self.assertTrue(self.hmc.enabled)
-        self.assertIsNone(resp)
+        assert self.hmc.enabled
+        assert resp is None
 
     def test_make_primary_error_not_found(self):
 
@@ -1092,21 +1094,21 @@ class ConsoleMakePrimaryHandlerTests(unittest.TestCase):
         body = {
             'force': False,
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(
                 self.hmc, '/api/console/operations/make-primary', body, True,
                 True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
 
-class ConsoleReorderUserPatternsHandlerTests(unittest.TestCase):
+class TestConsoleReorderUserPatternsHandler(object):
     """All tests for class ConsoleReorderUserPatternsHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         # Remove the standard User Pattern objects for this test
@@ -1172,7 +1174,7 @@ class ConsoleReorderUserPatternsHandlerTests(unittest.TestCase):
         act_uris = [up['element-uri'] for up in act_user_patterns]
 
         # Verify that the actual order is the new (expected) order:
-        self.assertEqual(act_uris, new_uris)
+        assert act_uris == new_uris
 
     def test_reorder_error_not_found(self):
 
@@ -1182,7 +1184,7 @@ class ConsoleReorderUserPatternsHandlerTests(unittest.TestCase):
         body = {
             'user-pattern-uris': []
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
 
@@ -1190,14 +1192,14 @@ class ConsoleReorderUserPatternsHandlerTests(unittest.TestCase):
                 self.hmc, '/api/console/operations/reorder-user-patterns',
                 body, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
 
-class ConsoleGetAuditLogHandlerTests(unittest.TestCase):
+class TestConsoleGetAuditLogHandler(object):
     """All tests for class ConsoleGetAuditLogHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -1214,7 +1216,7 @@ class ConsoleGetAuditLogHandlerTests(unittest.TestCase):
             self.hmc, '/api/console/operations/get-audit-log', None, True,
             True)
 
-        self.assertEqual(resp, [])
+        assert resp == []
 
     # TODO: Add testcases with non-empty audit log (once supported in mock)
 
@@ -1223,21 +1225,21 @@ class ConsoleGetAuditLogHandlerTests(unittest.TestCase):
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(
                 self.hmc, '/api/console/operations/get-audit-log', None, True,
                 True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
 
-class ConsoleGetSecurityLogHandlerTests(unittest.TestCase):
+class TestConsoleGetSecurityLogHandler(object):
     """All tests for class ConsoleGetSecurityLogHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -1254,7 +1256,7 @@ class ConsoleGetSecurityLogHandlerTests(unittest.TestCase):
             self.hmc, '/api/console/operations/get-security-log', None, True,
             True)
 
-        self.assertEqual(resp, [])
+        assert resp == []
 
     # TODO: Add testcases with non-empty security log (once supported in mock)
 
@@ -1263,21 +1265,21 @@ class ConsoleGetSecurityLogHandlerTests(unittest.TestCase):
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(
                 self.hmc, '/api/console/operations/get-security-log', None,
                 True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
 
-class ConsoleListUnmanagedCpcsHandlerTests(unittest.TestCase):
+class TestConsoleListUnmanagedCpcsHandler(object):
     """All tests for class ConsoleListUnmanagedCpcsHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -1294,7 +1296,7 @@ class ConsoleListUnmanagedCpcsHandlerTests(unittest.TestCase):
             self.hmc, '/api/console/operations/list-unmanaged-cpcs', True)
 
         cpcs = resp['cpcs']
-        self.assertEqual(cpcs, [])
+        assert cpcs == []
 
     # TODO: Add testcases for non-empty list of unmanaged CPCs
 
@@ -1303,20 +1305,20 @@ class ConsoleListUnmanagedCpcsHandlerTests(unittest.TestCase):
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.get(
                 self.hmc, '/api/console/operations/list-unmanaged-cpcs', True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
 
-class UserHandlersTests(unittest.TestCase):
+class TestUserHandlers(object):
     """All tests for classes UsersHandler and UserHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -1339,20 +1341,20 @@ class UserHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(users, exp_users)
+        assert users == exp_users
 
     def test_list_error_console_not_found(self):
 
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.get(self.hmc, '/api/console/users', True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_get(self):
 
@@ -1367,7 +1369,7 @@ class UserHandlersTests(unittest.TestCase):
             'description': 'User #1',
             'type': 'system-defined',
         }
-        self.assertEqual(user1, exp_user1)
+        assert user1 == exp_user1
 
     def test_create_verify(self):
         new_user2 = {
@@ -1382,10 +1384,10 @@ class UserHandlersTests(unittest.TestCase):
         resp = self.urihandler.post(self.hmc, '/api/console/users',
                                     new_user2, True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('object-uri', resp)
+        assert len(resp) == 1
+        assert 'object-uri' in resp
         new_user2_uri = resp['object-uri']
-        self.assertEqual(new_user2_uri, '/api/users/2')
+        assert new_user2_uri == '/api/users/2'
 
         exp_user2 = {
             'object-id': '2',
@@ -1399,7 +1401,7 @@ class UserHandlersTests(unittest.TestCase):
         # the function to be tested:
         user2 = self.urihandler.get(self.hmc, '/api/users/2', True)
 
-        self.assertEqual(user2, exp_user2)
+        assert user2 == exp_user2
 
     def test_create_error_console_not_found(self):
 
@@ -1414,14 +1416,14 @@ class UserHandlersTests(unittest.TestCase):
             'authentication-type': 'local',
         }
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, '/api/console/users', new_user2,
                                  True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_update_verify(self):
         update_user1 = {
@@ -1434,7 +1436,7 @@ class UserHandlersTests(unittest.TestCase):
 
         user1 = self.urihandler.get(self.hmc, '/api/users/fake-user-oid-1',
                                     True)
-        self.assertEqual(user1['description'], 'updated user #1')
+        assert user1['description'] == 'updated user #1'
 
     def test_delete_verify_all(self):
         testcases = [
@@ -1478,12 +1480,12 @@ class UserHandlersTests(unittest.TestCase):
 
         if exp_exc_tuple is not None:
 
-            with self.assertRaises(HTTPError) as cm:
+            with pytest.raises(HTTPError) as exc_info:
 
                 # Execute the code to be tested
                 self.urihandler.delete(self.hmc, user_uri, True)
 
-            exc = cm.exception
+            exc = exc_info.value
             assert exc.http_status == exp_exc_tuple[0]
             assert exc.reason == exp_exc_tuple[1]
 
@@ -1496,14 +1498,14 @@ class UserHandlersTests(unittest.TestCase):
             self.urihandler.delete(self.hmc, user_uri, True)
 
             # Verify that it has been deleted
-            with self.assertRaises(InvalidResourceError):
+            with pytest.raises(InvalidResourceError):
                 self.urihandler.get(self.hmc, user_uri, True)
 
 
-class UserAddUserRoleHandlerTests(unittest.TestCase):
+class TestUserAddUserRoleHandler(object):
     """All tests for class UserAddUserRoleHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         # Has a system-defined User (oid=fake-user-oid-1)
         # Has a system-defined User Role (oid=fake-user-role-oid-1)
@@ -1553,13 +1555,13 @@ class UserAddUserRoleHandlerTests(unittest.TestCase):
         # the function to be tested:
         resp = self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        self.assertIsNone(resp)
+        assert resp is None
         user2_props = self.urihandler.get(self.hmc, self.user2_uri, True)
-        self.assertTrue('user-roles' in user2_props)
+        assert 'user-roles' in user2_props
         user_roles = user2_props['user-roles']
-        self.assertEqual(len(user_roles), 1)
+        assert len(user_roles) == 1
         user_role_uri = user_roles[0]
-        self.assertEqual(user_role_uri, self.user_role2_uri)
+        assert user_role_uri == self.user_role2_uri
 
     def test_add_error_bad_user(self):
         """Test failed addition of a user role to a bad user."""
@@ -1581,13 +1583,13 @@ class UserAddUserRoleHandlerTests(unittest.TestCase):
         input_parms = {
             'user-role-uri': self.user_role2_uri
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     # TODO: Add testcase for adding to system-defined or pattern-based user
 
@@ -1613,19 +1615,19 @@ class UserAddUserRoleHandlerTests(unittest.TestCase):
         input_parms = {
             'user-role-uri': bad_user_role_uri
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 2)
+        exc = exc_info.value
+        assert exc.reason == 2
 
 
-class UserRemoveUserRoleHandlerTests(unittest.TestCase):
+class TestUserRemoveUserRoleHandler(object):
     """All tests for class UserRemoveUserRoleHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         # Has a system-defined User (oid=fake-user-oid-1)
         # Has a system-defined User Role (oid=fake-user-role-oid-1)
@@ -1684,11 +1686,11 @@ class UserRemoveUserRoleHandlerTests(unittest.TestCase):
         # the function to be tested:
         resp = self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        self.assertIsNone(resp)
+        assert resp is None
         user2_props = self.urihandler.get(self.hmc, self.user2_uri, True)
-        self.assertTrue('user-roles' in user2_props)
+        assert 'user-roles' in user2_props
         user_roles = user2_props['user-roles']
-        self.assertEqual(len(user_roles), 0)
+        assert len(user_roles) == 0
 
     def test_remove_error_bad_user(self):
         """Test failed removal of a user role from a bad user."""
@@ -1710,13 +1712,13 @@ class UserRemoveUserRoleHandlerTests(unittest.TestCase):
         input_parms = {
             'user-role-uri': self.user_role2_uri
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     # TODO: Add testcase for removing from system-defined or pattern-based user
 
@@ -1742,13 +1744,13 @@ class UserRemoveUserRoleHandlerTests(unittest.TestCase):
         input_parms = {
             'user-role-uri': bad_user_role_uri
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 2)
+        exc = exc_info.value
+        assert exc.reason == 2
 
     def test_remove_error_no_user_role(self):
         """Test failed removal of a user role that a user does not have."""
@@ -1783,19 +1785,19 @@ class UserRemoveUserRoleHandlerTests(unittest.TestCase):
         input_parms = {
             'user-role-uri': self.user_role2_uri
         }
-        with self.assertRaises(ConflictError) as cm:
+        with pytest.raises(ConflictError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 316)
+        exc = exc_info.value
+        assert exc.reason == 316
 
 
-class UserRoleHandlersTests(unittest.TestCase):
+class TestUserRoleHandlers(object):
     """All tests for classes UserRolesHandler and UserRoleHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -1819,20 +1821,20 @@ class UserRoleHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(user_roles, exp_user_roles)
+        assert user_roles == exp_user_roles
 
     def test_list_error_console_not_found(self):
 
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.get(self.hmc, '/api/console/user-roles', True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_get(self):
 
@@ -1847,7 +1849,7 @@ class UserRoleHandlersTests(unittest.TestCase):
             'description': 'User Role #1',
             'type': 'system-defined',
         }
-        self.assertEqual(user_role1, exp_user_role1)
+        assert user_role1 == exp_user_role1
 
     def test_create_verify(self):
         new_user_role2 = {
@@ -1859,14 +1861,14 @@ class UserRoleHandlersTests(unittest.TestCase):
         resp = self.urihandler.post(
             self.hmc, '/api/console/user-roles', new_user_role2, True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('object-uri', resp)
+        assert len(resp) == 1
+        assert 'object-uri' in resp
         new_user_role2_uri = resp['object-uri']
 
         # the function to be tested:
         user_role2 = self.urihandler.get(self.hmc, new_user_role2_uri, True)
 
-        self.assertEqual(user_role2['type'], 'user-defined')
+        assert user_role2['type'] == 'user-defined'
 
     def test_create_error_console_not_found(self):
 
@@ -1878,14 +1880,14 @@ class UserRoleHandlersTests(unittest.TestCase):
             'description': 'User Role #2',
         }
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, '/api/console/user-roles',
                                  new_user_role2, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_create_error_type(self):
 
@@ -1895,14 +1897,14 @@ class UserRoleHandlersTests(unittest.TestCase):
             'type': 'user-defined',  # error: type is implied
         }
 
-        with self.assertRaises(BadRequestError) as cm:
+        with pytest.raises(BadRequestError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, '/api/console/user-roles',
                                  new_user_role2, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 6)
+        exc = exc_info.value
+        assert exc.reason == 6
 
     def test_update_verify(self):
         update_user_role1 = {
@@ -1916,7 +1918,7 @@ class UserRoleHandlersTests(unittest.TestCase):
 
         user_role1 = self.urihandler.get(
             self.hmc, '/api/user-roles/fake-user-role-oid-1', True)
-        self.assertEqual(user_role1['description'], 'updated user #1')
+        assert user_role1['description'] == 'updated user #1'
 
     def test_delete_verify(self):
 
@@ -1938,14 +1940,14 @@ class UserRoleHandlersTests(unittest.TestCase):
         self.urihandler.delete(self.hmc, new_user_role2_uri, True)
 
         # Verify that it has been deleted
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.get(self.hmc, new_user_role2_uri, True)
 
 
-class UserRoleAddPermissionHandlerTests(unittest.TestCase):
+class TestUserRoleAddPermissionHandler(object):
     """All tests for class UserRoleAddPermissionHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         # Has a system-defined User Role (oid=fake-user-role-oid-1)
 
@@ -2010,13 +2012,13 @@ class UserRoleAddPermissionHandlerTests(unittest.TestCase):
         resp = self.urihandler.post(
             self.hmc, uri, input_permission, True, True)
 
-        self.assertIsNone(resp)
+        assert resp is None
         props = self.urihandler.get(self.hmc, self.user_role2_uri, True)
-        self.assertTrue('permissions' in props)
+        assert 'permissions' in props
         permissions = props['permissions']
-        self.assertEqual(len(permissions), 1)
+        assert len(permissions) == 1
         perm = permissions[0]
-        self.assertEqual(perm, exp_permission)
+        assert perm == exp_permission
 
     def test_add_error_bad_user_role(self):
         """Test failed addition of a permission to a bad User Role."""
@@ -2030,13 +2032,13 @@ class UserRoleAddPermissionHandlerTests(unittest.TestCase):
             'include-members': True,
             'view-only-mode': False,
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_add_error_system_user_role(self):
         """Test failed addition of a permission to a system-defined User
@@ -2051,19 +2053,19 @@ class UserRoleAddPermissionHandlerTests(unittest.TestCase):
             'include-members': True,
             'view-only-mode': False,
         }
-        with self.assertRaises(BadRequestError) as cm:
+        with pytest.raises(BadRequestError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 314)
+        exc = exc_info.value
+        assert exc.reason == 314
 
 
-class UserRoleRemovePermissionHandlerTests(unittest.TestCase):
+class TestUserRoleRemovePermissionHandler(object):
     """All tests for class UserRoleRemovePermissionHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         # Has a system-defined User Role (oid=fake-user-role-oid-1)
 
@@ -2135,11 +2137,11 @@ class UserRoleRemovePermissionHandlerTests(unittest.TestCase):
         resp = self.urihandler.post(
             self.hmc, uri, input_permission, True, True)
 
-        self.assertIsNone(resp)
+        assert resp is None
         props = self.urihandler.get(self.hmc, self.user_role2_uri, True)
-        self.assertTrue('permissions' in props)
+        assert 'permissions' in props
         permissions = props['permissions']
-        self.assertEqual(len(permissions), 0)
+        assert len(permissions) == 0
 
     def test_remove_error_bad_user_role(self):
         """Test failed removal of a permission from a bad User Role."""
@@ -2153,13 +2155,13 @@ class UserRoleRemovePermissionHandlerTests(unittest.TestCase):
             'include-members': True,
             'view-only-mode': False,
         }
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_remove_error_system_user_role(self):
         """Test failed removal of a permission from a system-defined User
@@ -2174,19 +2176,19 @@ class UserRoleRemovePermissionHandlerTests(unittest.TestCase):
             'include-members': True,
             'view-only-mode': False,
         }
-        with self.assertRaises(BadRequestError) as cm:
+        with pytest.raises(BadRequestError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, uri, input_parms, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 314)
+        exc = exc_info.value
+        assert exc.reason == 314
 
 
-class TaskHandlersTests(unittest.TestCase):
+class TestTaskHandlers(object):
     """All tests for classes TasksHandler and TaskHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -2212,20 +2214,20 @@ class TaskHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(tasks, exp_tasks)
+        assert tasks == exp_tasks
 
     def test_list_error_console_not_found(self):
 
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.get(self.hmc, '/api/console/tasks', True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_get(self):
 
@@ -2239,13 +2241,13 @@ class TaskHandlersTests(unittest.TestCase):
             'name': 'fake_task_name_1',
             'description': 'Task #1',
         }
-        self.assertEqual(task1, exp_task1)
+        assert task1 == exp_task1
 
 
-class UserPatternHandlersTests(unittest.TestCase):
+class TestUserPatternHandlers(object):
     """All tests for classes UserPatternsHandler and UserPatternHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -2270,20 +2272,20 @@ class UserPatternHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(user_patterns, exp_user_patterns)
+        assert user_patterns == exp_user_patterns
 
     def test_list_error_console_not_found(self):
 
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.get(self.hmc, '/api/console/user-patterns', True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_get(self):
 
@@ -2303,7 +2305,7 @@ class UserPatternHandlersTests(unittest.TestCase):
             'retention-time': 0,
             'user-template-uri': '/api/users/fake-user-oid-1',
         }
-        self.assertEqual(user_pattern1, exp_user_pattern1)
+        assert user_pattern1 == exp_user_pattern1
 
     def test_create_verify(self):
         new_user_pattern_input = {
@@ -2320,8 +2322,8 @@ class UserPatternHandlersTests(unittest.TestCase):
             self.hmc, '/api/console/user-patterns', new_user_pattern_input,
             True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('element-uri', resp)
+        assert len(resp) == 1
+        assert 'element-uri' in resp
         new_user_pattern_uri = resp['element-uri']
 
         # the function to be tested:
@@ -2330,7 +2332,7 @@ class UserPatternHandlersTests(unittest.TestCase):
 
         new_name = new_user_pattern['name']
         input_name = new_user_pattern_input['name']
-        self.assertEqual(new_name, input_name)
+        assert new_name == input_name
 
     def test_create_error_console_not_found(self):
 
@@ -2342,14 +2344,14 @@ class UserPatternHandlersTests(unittest.TestCase):
             'description': 'User Pattern #X',
         }
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, '/api/console/user-patterns',
                                  new_user_pattern_input, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_update_verify(self):
         update_user_pattern1 = {
@@ -2364,8 +2366,7 @@ class UserPatternHandlersTests(unittest.TestCase):
         user_pattern1 = self.urihandler.get(
             self.hmc, '/api/console/user-patterns/fake-user-pattern-oid-1',
             True)
-        self.assertEqual(user_pattern1['description'],
-                         'updated user pattern #1')
+        assert user_pattern1['description'] == 'updated user pattern #1'
 
     def test_delete_verify(self):
 
@@ -2392,14 +2393,14 @@ class UserPatternHandlersTests(unittest.TestCase):
         self.urihandler.delete(self.hmc, new_user_pattern_uri, True)
 
         # Verify that it has been deleted
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.get(self.hmc, new_user_pattern_uri, True)
 
 
-class PasswordRuleHandlersTests(unittest.TestCase):
+class TestPasswordRuleHandlers(object):
     """All tests for classes PasswordRulesHandler and PasswordRuleHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -2424,20 +2425,20 @@ class PasswordRuleHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(password_rules, exp_password_rules)
+        assert password_rules == exp_password_rules
 
     def test_list_error_console_not_found(self):
 
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.get(self.hmc, '/api/console/password-rules', True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_get(self):
 
@@ -2454,7 +2455,7 @@ class PasswordRuleHandlersTests(unittest.TestCase):
             'description': 'Password Rule #1',
             'type': 'system-defined',
         }
-        self.assertEqual(password_rule1, exp_password_rule1)
+        assert password_rule1 == exp_password_rule1
 
     def test_create_verify(self):
         new_password_rule_input = {
@@ -2467,8 +2468,8 @@ class PasswordRuleHandlersTests(unittest.TestCase):
             self.hmc, '/api/console/password-rules', new_password_rule_input,
             True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('element-uri', resp)
+        assert len(resp) == 1
+        assert 'element-uri' in resp
         new_password_rule_uri = resp['element-uri']
 
         # the function to be tested:
@@ -2477,7 +2478,7 @@ class PasswordRuleHandlersTests(unittest.TestCase):
 
         new_name = new_password_rule['name']
         input_name = new_password_rule_input['name']
-        self.assertEqual(new_name, input_name)
+        assert new_name == input_name
 
     def test_create_error_console_not_found(self):
 
@@ -2489,14 +2490,14 @@ class PasswordRuleHandlersTests(unittest.TestCase):
             'description': 'Password Rule #X',
         }
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(self.hmc, '/api/console/password-rules',
                                  new_password_rule_input, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_update_verify(self):
         update_password_rule1 = {
@@ -2511,8 +2512,7 @@ class PasswordRuleHandlersTests(unittest.TestCase):
         password_rule1 = self.urihandler.get(
             self.hmc, '/api/console/password-rules/fake-password-rule-oid-1',
             True)
-        self.assertEqual(password_rule1['description'],
-                         'updated password rule #1')
+        assert password_rule1['description'] == 'updated password rule #1'
 
     def test_delete_verify(self):
 
@@ -2535,15 +2535,15 @@ class PasswordRuleHandlersTests(unittest.TestCase):
         self.urihandler.delete(self.hmc, new_password_rule_uri, True)
 
         # Verify that it has been deleted
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.get(self.hmc, new_password_rule_uri, True)
 
 
-class LdapServerDefinitionHandlersTests(unittest.TestCase):
+class TestLdapServerDefinitionHandlers(object):
     """All tests for classes LdapServerDefinitionsHandler and
     LdapServerDefinitionHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
 
         self.uris = (
@@ -2570,21 +2570,21 @@ class LdapServerDefinitionHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(ldap_srv_defs, exp_ldap_srv_defs)
+        assert ldap_srv_defs == exp_ldap_srv_defs
 
     def test_list_error_console_not_found(self):
 
         # Remove the faked Console object
         self.hmc.consoles.remove(None)
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.get(
                 self.hmc, '/api/console/ldap-server-definitions', True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_get(self):
 
@@ -2603,7 +2603,7 @@ class LdapServerDefinitionHandlersTests(unittest.TestCase):
             'description': 'LDAP Srv Def #1',
             'primary-hostname-ipaddr': '10.11.12.13',
         }
-        self.assertEqual(ldap_srv_def1, exp_ldap_srv_def1)
+        assert ldap_srv_def1 == exp_ldap_srv_def1
 
     def test_create_verify(self):
         new_ldap_srv_def_input = {
@@ -2616,8 +2616,8 @@ class LdapServerDefinitionHandlersTests(unittest.TestCase):
             self.hmc, '/api/console/ldap-server-definitions',
             new_ldap_srv_def_input, True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('element-uri', resp)
+        assert len(resp) == 1
+        assert 'element-uri' in resp
         new_ldap_srv_def_uri = resp['element-uri']
 
         # the function to be tested:
@@ -2626,7 +2626,7 @@ class LdapServerDefinitionHandlersTests(unittest.TestCase):
 
         new_name = new_ldap_srv_def['name']
         input_name = new_ldap_srv_def_input['name']
-        self.assertEqual(new_name, input_name)
+        assert new_name == input_name
 
     def test_create_error_console_not_found(self):
 
@@ -2638,15 +2638,15 @@ class LdapServerDefinitionHandlersTests(unittest.TestCase):
             'description': 'LDAP Srv Def #X',
         }
 
-        with self.assertRaises(InvalidResourceError) as cm:
+        with pytest.raises(InvalidResourceError) as exc_info:
 
             # the function to be tested:
             self.urihandler.post(
                 self.hmc, '/api/console/ldap-server-definitions',
                 new_ldap_srv_def_input, True, True)
 
-        exc = cm.exception
-        self.assertEqual(exc.reason, 1)
+        exc = exc_info.value
+        assert exc.reason == 1
 
     def test_update_verify(self):
         update_ldap_srv_def1 = {
@@ -2663,8 +2663,7 @@ class LdapServerDefinitionHandlersTests(unittest.TestCase):
             self.hmc,
             '/api/console/ldap-server-definitions/fake-ldap-srv-def-oid-1',
             True)
-        self.assertEqual(ldap_srv_def1['description'],
-                         'updated LDAP Srv Def #1')
+        assert ldap_srv_def1['description'] == 'updated LDAP Srv Def #1'
 
     def test_delete_verify(self):
 
@@ -2687,14 +2686,14 @@ class LdapServerDefinitionHandlersTests(unittest.TestCase):
         self.urihandler.delete(self.hmc, new_ldap_srv_def_uri, True)
 
         # Verify that it has been deleted
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.get(self.hmc, new_ldap_srv_def_uri, True)
 
 
-class CpcHandlersTests(unittest.TestCase):
+class TestCpcHandlers(object):
     """All tests for classes CpcsHandler and CpcHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs(?:\?(.*))?', CpcsHandler),
@@ -2721,7 +2720,7 @@ class CpcHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(cpcs, exp_cpcs)
+        assert cpcs == exp_cpcs
 
     def test_get(self):
 
@@ -2737,7 +2736,7 @@ class CpcHandlersTests(unittest.TestCase):
             'description': 'CPC #1 (classic mode)',
             'status': 'operating',
         }
-        self.assertEqual(cpc1, exp_cpc1)
+        assert cpc1 == exp_cpc1
 
     def test_update_verify(self):
         update_cpc1 = {
@@ -2749,13 +2748,13 @@ class CpcHandlersTests(unittest.TestCase):
                              update_cpc1, True, True)
 
         cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
-        self.assertEqual(cpc1['description'], 'updated cpc #1')
+        assert cpc1['description'] == 'updated cpc #1'
 
 
-class CpcStartStopHandlerTests(unittest.TestCase):
+class TestCpcStartStopHandler(object):
     """All tests for classes CpcStartHandler and CpcStopHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)', CpcHandler),
@@ -2767,53 +2766,53 @@ class CpcStartStopHandlerTests(unittest.TestCase):
     def test_stop_classic(self):
         # CPC1 is in classic mode
         cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
-        self.assertEqual(cpc1['status'], 'operating')
+        assert cpc1['status'] == 'operating'
 
         # the function to be tested:
-        with self.assertRaises(CpcNotInDpmError):
+        with pytest.raises(CpcNotInDpmError):
             self.urihandler.post(self.hmc, '/api/cpcs/1/operations/stop',
                                  None, True, True)
 
         cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
-        self.assertEqual(cpc1['status'], 'operating')
+        assert cpc1['status'] == 'operating'
 
     def test_start_classic(self):
         # CPC1 is in classic mode
         cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
-        self.assertEqual(cpc1['status'], 'operating')
+        assert cpc1['status'] == 'operating'
 
         # the function to be tested:
-        with self.assertRaises(CpcNotInDpmError):
+        with pytest.raises(CpcNotInDpmError):
             self.urihandler.post(self.hmc, '/api/cpcs/1/operations/start',
                                  None, True, True)
 
         cpc1 = self.urihandler.get(self.hmc, '/api/cpcs/1', True)
-        self.assertEqual(cpc1['status'], 'operating')
+        assert cpc1['status'] == 'operating'
 
     def test_stop_start_dpm(self):
         # CPC2 is in DPM mode
         cpc2 = self.urihandler.get(self.hmc, '/api/cpcs/2', True)
-        self.assertEqual(cpc2['status'], 'active')
+        assert cpc2['status'] == 'active'
 
         # the function to be tested:
         self.urihandler.post(self.hmc, '/api/cpcs/2/operations/stop',
                              None, True, True)
 
         cpc2 = self.urihandler.get(self.hmc, '/api/cpcs/2', True)
-        self.assertEqual(cpc2['status'], 'not-operating')
+        assert cpc2['status'] == 'not-operating'
 
         # the function to be tested:
         self.urihandler.post(self.hmc, '/api/cpcs/2/operations/start',
                              None, True, True)
 
         cpc2 = self.urihandler.get(self.hmc, '/api/cpcs/2', True)
-        self.assertEqual(cpc2['status'], 'active')
+        assert cpc2['status'] == 'active'
 
 
-class CpcExportPortNamesListHandlerTests(unittest.TestCase):
+class TestCpcExportPortNamesListHandler(object):
     """All tests for class CpcExportPortNamesListHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs(?:\?(.*))?', CpcsHandler),
@@ -2826,7 +2825,7 @@ class CpcExportPortNamesListHandlerTests(unittest.TestCase):
     def test_invoke_err_no_input(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/cpcs/2/operations/export-port-names-list',
                 None, True, True)
@@ -2846,16 +2845,16 @@ class CpcExportPortNamesListHandlerTests(unittest.TestCase):
             self.hmc, '/api/cpcs/2/operations/export-port-names-list',
             operation_body, True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('wwpn-list', resp)
+        assert len(resp) == 1
+        assert 'wwpn-list' in resp
         wwpn_list = resp['wwpn-list']
-        self.assertEqual(wwpn_list, exp_wwpn_list)
+        assert wwpn_list == exp_wwpn_list
 
 
-class CpcImportProfilesHandlerTests(unittest.TestCase):
+class TestCpcImportProfilesHandler(object):
     """All tests for class CpcImportProfilesHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs(?:\?(.*))?', CpcsHandler),
@@ -2868,7 +2867,7 @@ class CpcImportProfilesHandlerTests(unittest.TestCase):
     def test_invoke_err_no_input(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/cpcs/1/operations/import-profiles',
                 None, True, True)
@@ -2883,13 +2882,13 @@ class CpcImportProfilesHandlerTests(unittest.TestCase):
             self.hmc, '/api/cpcs/1/operations/import-profiles',
             operation_body, True, True)
 
-        self.assertIsNone(resp)
+        assert resp is None
 
 
-class CpcExportProfilesHandlerTests(unittest.TestCase):
+class TestCpcExportProfilesHandler(object):
     """All tests for class CpcExportProfilesHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs(?:\?(.*))?', CpcsHandler),
@@ -2902,7 +2901,7 @@ class CpcExportProfilesHandlerTests(unittest.TestCase):
     def test_invoke_err_no_input(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/cpcs/1/operations/export-profiles',
                 None, True, True)
@@ -2917,14 +2916,14 @@ class CpcExportProfilesHandlerTests(unittest.TestCase):
             self.hmc, '/api/cpcs/1/operations/export-profiles',
             operation_body, True, True)
 
-        self.assertIsNone(resp)
+        assert resp is None
 
 
-class MetricsContextHandlersTests(unittest.TestCase):
+class TestMetricsContextHandlers(object):
     """All tests for classes MetricsContextsHandler and
     MetricsContextHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/services/metrics/context', MetricsContextsHandler),
@@ -3023,13 +3022,13 @@ class MetricsContextHandlersTests(unittest.TestCase):
         resp = self.urihandler.post(self.hmc, '/api/services/metrics/context',
                                     body, True, True)
 
-        self.assertIsInstance(resp, dict)
-        self.assertIn('metrics-context-uri', resp)
+        assert isinstance(resp, dict)
+        assert 'metrics-context-uri' in resp
         uri = resp['metrics-context-uri']
-        self.assertTrue(uri.startswith('/api/services/metrics/context/'))
-        self.assertIn('metric-group-infos', resp)
+        assert uri.startswith('/api/services/metrics/context/')
+        assert 'metric-group-infos' in resp
         mg_infos = resp['metric-group-infos']
-        self.assertEqual(mg_infos, [mg_info, mg_info2])
+        assert mg_infos == [mg_info, mg_info2]
 
         # the get function to be tested:
         mv_resp = self.urihandler.get(self.hmc, uri, True)
@@ -3052,20 +3051,19 @@ class MetricsContextHandlersTests(unittest.TestCase):
 
 
 '''
-        self.assertEqual(
-            mv_resp, exp_mv_resp,
-            "Actual response string:\n{!r}\n"
-            "Expected response string:\n{!r}\n".
-            format(mv_resp, exp_mv_resp))
+        assert mv_resp == exp_mv_resp, \
+            "Actual response string:\n{!r}\n" \
+            "Expected response string:\n{!r}\n". \
+            format(mv_resp, exp_mv_resp)
 
         # the delete function to be tested:
         self.urihandler.delete(self.hmc, uri, True)
 
 
-class AdapterHandlersTests(unittest.TestCase):
+class TestAdapterHandlers(object):
     """All tests for classes AdaptersHandler and AdapterHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)/adapters(?:\?(.*))?', AdaptersHandler),
@@ -3107,7 +3105,7 @@ class AdapterHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(adapters, exp_adapters)
+        assert adapters == exp_adapters
 
     def test_get(self):
 
@@ -3124,7 +3122,7 @@ class AdapterHandlersTests(unittest.TestCase):
             'network-port-uris': ['/api/adapters/1/network-ports/1'],
             'adapter-id': 'BEF',
         }
-        self.assertEqual(adapter1, exp_adapter1)
+        assert adapter1 == exp_adapter1
 
     def test_update_verify(self):
         update_adapter1 = {
@@ -3136,13 +3134,13 @@ class AdapterHandlersTests(unittest.TestCase):
                              update_adapter1, True, True)
 
         adapter1 = self.urihandler.get(self.hmc, '/api/adapters/1', True)
-        self.assertEqual(adapter1['description'], 'updated adapter #1')
+        assert adapter1['description'] == 'updated adapter #1'
 
 
-class AdapterChangeCryptoTypeHandlerTests(unittest.TestCase):
+class TestAdapterChangeCryptoTypeHandler(object):
     """All tests for class AdapterChangeCryptoTypeHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)/adapters(?:\?(.*))?', AdaptersHandler),
@@ -3155,7 +3153,7 @@ class AdapterChangeCryptoTypeHandlerTests(unittest.TestCase):
     def test_invoke_err_no_body(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/adapters/4/operations/change-crypto-type',
@@ -3168,7 +3166,7 @@ class AdapterChangeCryptoTypeHandlerTests(unittest.TestCase):
         }
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/adapters/4/operations/change-crypto-type',
@@ -3185,13 +3183,13 @@ class AdapterChangeCryptoTypeHandlerTests(unittest.TestCase):
             '/api/adapters/4/operations/change-crypto-type',
             operation_body, True, True)
 
-        self.assertIsNone(resp)
+        assert resp is None
 
 
-class NetworkPortHandlersTests(unittest.TestCase):
+class TestNetworkPortHandlers(object):
     """All tests for class NetworkPortHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/adapters/([^/]+)/network-ports/([^/]+)',
@@ -3211,7 +3209,7 @@ class NetworkPortHandlersTests(unittest.TestCase):
             'name': 'osa_1_port_1',
             'description': 'Port #1 of OSA #1',
         }
-        self.assertEqual(port1, exp_port1)
+        assert port1 == exp_port1
 
     def test_update_verify(self):
         update_port1 = {
@@ -3224,13 +3222,13 @@ class NetworkPortHandlersTests(unittest.TestCase):
 
         port1 = self.urihandler.get(self.hmc,
                                     '/api/adapters/1/network-ports/1', True)
-        self.assertEqual(port1['description'], 'updated port #1')
+        assert port1['description'] == 'updated port #1'
 
 
-class StoragePortHandlersTests(unittest.TestCase):
+class TestStoragePortHandlers(object):
     """All tests for class StoragePortHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/adapters/([^/]+)/storage-ports/([^/]+)',
@@ -3250,7 +3248,7 @@ class StoragePortHandlersTests(unittest.TestCase):
             'name': 'fcp_2_port_1',
             'description': 'Port #1 of FCP #2',
         }
-        self.assertEqual(port1, exp_port1)
+        assert port1 == exp_port1
 
     def test_update_verify(self):
         update_port1 = {
@@ -3263,13 +3261,13 @@ class StoragePortHandlersTests(unittest.TestCase):
 
         port1 = self.urihandler.get(self.hmc,
                                     '/api/adapters/2/storage-ports/1', True)
-        self.assertEqual(port1['description'], 'updated port #1')
+        assert port1['description'] == 'updated port #1'
 
 
-class PartitionHandlersTests(unittest.TestCase):
+class TestPartitionHandlers(object):
     """All tests for classes PartitionsHandler and PartitionHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)/partitions(?:\?(.*))?', PartitionsHandler),
@@ -3292,7 +3290,7 @@ class PartitionHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(partitions, exp_partitions)
+        assert partitions == exp_partitions
 
     def test_get(self):
 
@@ -3309,7 +3307,7 @@ class PartitionHandlersTests(unittest.TestCase):
             'nic-uris': ['/api/partitions/1/nics/1'],
             'virtual-function-uris': ['/api/partitions/1/virtual-functions/1'],
         }
-        self.assertEqual(partition1, exp_partition1)
+        assert partition1 == exp_partition1
 
     def test_create_verify(self):
         new_partition2 = {
@@ -3323,10 +3321,10 @@ class PartitionHandlersTests(unittest.TestCase):
         resp = self.urihandler.post(self.hmc, '/api/cpcs/2/partitions',
                                     new_partition2, True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('object-uri', resp)
+        assert len(resp) == 1
+        assert 'object-uri' in resp
         new_partition2_uri = resp['object-uri']
-        self.assertEqual(new_partition2_uri, '/api/partitions/2')
+        assert new_partition2_uri == '/api/partitions/2'
 
         exp_partition2 = {
             'object-id': '2',
@@ -3343,7 +3341,7 @@ class PartitionHandlersTests(unittest.TestCase):
         # the function to be tested:
         partition2 = self.urihandler.get(self.hmc, '/api/partitions/2', True)
 
-        self.assertEqual(partition2, exp_partition2)
+        assert partition2 == exp_partition2
 
     def test_update_verify(self):
         update_partition1 = {
@@ -3355,7 +3353,7 @@ class PartitionHandlersTests(unittest.TestCase):
                              update_partition1, True, True)
 
         partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
-        self.assertEqual(partition1['description'], 'updated partition #1')
+        assert partition1['description'] == 'updated partition #1'
 
     def test_delete_verify(self):
 
@@ -3364,14 +3362,14 @@ class PartitionHandlersTests(unittest.TestCase):
         # the function to be tested:
         self.urihandler.delete(self.hmc, '/api/partitions/1', True)
 
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.get(self.hmc, '/api/partitions/1', True)
 
 
-class PartitionStartStopHandlerTests(unittest.TestCase):
+class TestPartitionStartStopHandler(object):
     """All tests for classes PartitionStartHandler and PartitionStopHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -3384,38 +3382,38 @@ class PartitionStartStopHandlerTests(unittest.TestCase):
     def test_start_stop(self):
         # CPC2 is in DPM mode
         partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
-        self.assertEqual(partition1['status'], 'stopped')
+        assert partition1['status'] == 'stopped'
 
         # the start() function to be tested, with a valid initial status:
         self.urihandler.post(self.hmc, '/api/partitions/1/operations/start',
                              None, True, True)
         partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
-        self.assertEqual(partition1['status'], 'active')
+        assert partition1['status'] == 'active'
 
         # the start() function to be tested, with an invalid initial status:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(self.hmc,
                                  '/api/partitions/1/operations/start',
                                  None, True, True)
 
         # the stop() function to be tested, with a valid initial status:
-        self.assertEqual(partition1['status'], 'active')
+        assert partition1['status'] == 'active'
         self.urihandler.post(self.hmc, '/api/partitions/1/operations/stop',
                              None, True, True)
         partition1 = self.urihandler.get(self.hmc, '/api/partitions/1', True)
-        self.assertEqual(partition1['status'], 'stopped')
+        assert partition1['status'] == 'stopped'
 
         # the stop() function to be tested, with an invalid initial status:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(self.hmc,
                                  '/api/partitions/1/operations/stop',
                                  None, True, True)
 
 
-class PartitionScsiDumpHandlerTests(unittest.TestCase):
+class TestPartitionScsiDumpHandler(object):
     """All tests for class PartitionScsiDumpHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -3427,7 +3425,7 @@ class PartitionScsiDumpHandlerTests(unittest.TestCase):
     def test_invoke_err_no_body(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/scsi-dump',
                 None, True, True)
@@ -3440,7 +3438,7 @@ class PartitionScsiDumpHandlerTests(unittest.TestCase):
         }
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/scsi-dump',
                 operation_body, True, True)
@@ -3453,7 +3451,7 @@ class PartitionScsiDumpHandlerTests(unittest.TestCase):
         }
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/scsi-dump',
                 operation_body, True, True)
@@ -3466,7 +3464,7 @@ class PartitionScsiDumpHandlerTests(unittest.TestCase):
         }
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/scsi-dump',
                 operation_body, True, True)
@@ -3483,7 +3481,7 @@ class PartitionScsiDumpHandlerTests(unittest.TestCase):
         partition1['status'] = 'stopped'
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/scsi-dump',
                 operation_body, True, True)
@@ -3504,13 +3502,13 @@ class PartitionScsiDumpHandlerTests(unittest.TestCase):
             self.hmc, '/api/partitions/1/operations/scsi-dump',
             operation_body, True, True)
 
-        self.assertEqual(resp, {})
+        assert resp == {}
 
 
-class PartitionPswRestartHandlerTests(unittest.TestCase):
+class TestPartitionPswRestartHandler(object):
     """All tests for class PartitionPswRestartHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -3526,7 +3524,7 @@ class PartitionPswRestartHandlerTests(unittest.TestCase):
         partition1['status'] = 'stopped'
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/psw-restart',
                 None, True, True)
@@ -3542,13 +3540,13 @@ class PartitionPswRestartHandlerTests(unittest.TestCase):
             self.hmc, '/api/partitions/1/operations/psw-restart',
             None, True, True)
 
-        self.assertEqual(resp, {})
+        assert resp == {}
 
 
-class PartitionMountIsoImageHandlerTests(unittest.TestCase):
+class TestPartitionMountIsoImageHandler(object):
     """All tests for class PartitionMountIsoImageHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -3560,7 +3558,7 @@ class PartitionMountIsoImageHandlerTests(unittest.TestCase):
     def test_invoke_err_queryparm_1(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/mount-iso-image?'
                 'image-namex=fake-image&ins-file-name=fake-ins',
@@ -3569,7 +3567,7 @@ class PartitionMountIsoImageHandlerTests(unittest.TestCase):
     def test_invoke_err_queryparm_2(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/mount-iso-image?'
                 'image-name=fake-image&ins-file-namex=fake-ins',
@@ -3582,7 +3580,7 @@ class PartitionMountIsoImageHandlerTests(unittest.TestCase):
         partition1['status'] = 'starting'
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/mount-iso-image?'
                 'image-name=fake-image&ins-file-name=fake-ins',
@@ -3600,19 +3598,19 @@ class PartitionMountIsoImageHandlerTests(unittest.TestCase):
             'image-name=fake-image&ins-file-name=fake-ins',
             None, True, True)
 
-        self.assertEqual(resp, {})
+        assert resp == {}
 
         boot_iso_image_name = partition1['boot-iso-image-name']
-        self.assertEqual(boot_iso_image_name, 'fake-image')
+        assert boot_iso_image_name == 'fake-image'
 
         boot_iso_ins_file = partition1['boot-iso-ins-file']
-        self.assertEqual(boot_iso_ins_file, 'fake-ins')
+        assert boot_iso_ins_file == 'fake-ins'
 
 
-class PartitionUnmountIsoImageHandlerTests(unittest.TestCase):
+class TestPartitionUnmountIsoImageHandler(object):
     """All tests for class PartitionUnmountIsoImageHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -3628,7 +3626,7 @@ class PartitionUnmountIsoImageHandlerTests(unittest.TestCase):
         partition1['status'] = 'starting'
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc, '/api/partitions/1/operations/unmount-iso-image',
                 None, True, True)
@@ -3644,19 +3642,19 @@ class PartitionUnmountIsoImageHandlerTests(unittest.TestCase):
             self.hmc, '/api/partitions/1/operations/unmount-iso-image',
             None, True, True)
 
-        self.assertEqual(resp, {})
+        assert resp == {}
 
         boot_iso_image_name = partition1['boot-iso-image-name']
-        self.assertIsNone(boot_iso_image_name)
+        assert boot_iso_image_name is None
 
         boot_iso_ins_file = partition1['boot-iso-ins-file']
-        self.assertIsNone(boot_iso_ins_file)
+        assert boot_iso_ins_file is None
 
 
-class PartitionIncreaseCryptoConfigHandlerTests(unittest.TestCase):
+class TestPartitionIncreaseCryptoConfigHandler(object):
     """All tests for class PartitionIncreaseCryptoConfigHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -3669,7 +3667,7 @@ class PartitionIncreaseCryptoConfigHandlerTests(unittest.TestCase):
     def test_invoke_err_missing_body(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/operations/increase-crypto-configuration',
@@ -3682,7 +3680,7 @@ class PartitionIncreaseCryptoConfigHandlerTests(unittest.TestCase):
         partition1['status'] = 'starting'
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/operations/increase-crypto-configuration',
@@ -3738,28 +3736,28 @@ class PartitionIncreaseCryptoConfigHandlerTests(unittest.TestCase):
                 '/api/partitions/1/operations/increase-crypto-configuration',
                 operation_body, True, True)
 
-            self.assertIsNone(resp)
+            assert resp is None
 
             crypto_config = partition1['crypto-configuration']
-            self.assertTrue(isinstance(crypto_config, dict))
+            assert isinstance(crypto_config, dict)
 
             adapter_uris = crypto_config['crypto-adapter-uris']
-            self.assertTrue(isinstance(adapter_uris, list))
+            assert isinstance(adapter_uris, list)
             exp_adapter_uris = input_adapter_uris \
                 if input_adapter_uris is not None else []
-            self.assertEqual(adapter_uris, exp_adapter_uris)
+            assert adapter_uris == exp_adapter_uris
 
             domain_configs = crypto_config['crypto-domain-configurations']
-            self.assertTrue(isinstance(domain_configs, list))
+            assert isinstance(domain_configs, list)
             exp_domain_configs = input_domain_configs \
                 if input_domain_configs is not None else []
-            self.assertEqual(domain_configs, exp_domain_configs)
+            assert domain_configs == exp_domain_configs
 
 
-class PartitionDecreaseCryptoConfigHandlerTests(unittest.TestCase):
+class TestPartitionDecreaseCryptoConfigHandler(object):
     """All tests for class PartitionDecreaseCryptoConfigHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -3772,7 +3770,7 @@ class PartitionDecreaseCryptoConfigHandlerTests(unittest.TestCase):
     def test_invoke_err_missing_body(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/operations/decrease-crypto-configuration',
@@ -3785,7 +3783,7 @@ class PartitionDecreaseCryptoConfigHandlerTests(unittest.TestCase):
         partition1['status'] = 'starting'
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/operations/decrease-crypto-configuration',
@@ -3847,22 +3845,22 @@ class PartitionDecreaseCryptoConfigHandlerTests(unittest.TestCase):
                 '/api/partitions/1/operations/decrease-crypto-configuration',
                 operation_body, True, True)
 
-            self.assertIsNone(resp)
+            assert resp is None
 
             crypto_config = partition1['crypto-configuration']
-            self.assertTrue(isinstance(crypto_config, dict))
+            assert isinstance(crypto_config, dict)
 
             adapter_uris = crypto_config['crypto-adapter-uris']
-            self.assertTrue(isinstance(adapter_uris, list))
+            assert isinstance(adapter_uris, list)
 
             domain_configs = crypto_config['crypto-domain-configurations']
-            self.assertTrue(isinstance(domain_configs, list))
+            assert isinstance(domain_configs, list)
 
 
-class PartitionChangeCryptoConfigHandlerTests(unittest.TestCase):
+class TestPartitionChangeCryptoConfigHandler(object):
     """All tests for class PartitionChangeCryptoConfigHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -3875,7 +3873,7 @@ class PartitionChangeCryptoConfigHandlerTests(unittest.TestCase):
     def test_invoke_err_missing_body(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/operations/'
@@ -3890,7 +3888,7 @@ class PartitionChangeCryptoConfigHandlerTests(unittest.TestCase):
         }
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/operations/'
@@ -3905,7 +3903,7 @@ class PartitionChangeCryptoConfigHandlerTests(unittest.TestCase):
         }
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/operations/'
@@ -3919,7 +3917,7 @@ class PartitionChangeCryptoConfigHandlerTests(unittest.TestCase):
         partition1['status'] = 'starting'
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/operations/'
@@ -3969,22 +3967,22 @@ class PartitionChangeCryptoConfigHandlerTests(unittest.TestCase):
                 'change-crypto-domain-configuration',
                 operation_body, True, True)
 
-            self.assertIsNone(resp)
+            assert resp is None
 
             crypto_config = partition1['crypto-configuration']
-            self.assertTrue(isinstance(crypto_config, dict))
+            assert isinstance(crypto_config, dict)
 
             adapter_uris = crypto_config['crypto-adapter-uris']
-            self.assertTrue(isinstance(adapter_uris, list))
+            assert isinstance(adapter_uris, list)
 
             domain_configs = crypto_config['crypto-domain-configurations']
-            self.assertTrue(isinstance(domain_configs, list))
+            assert isinstance(domain_configs, list)
 
 
-class HbaHandlerTests(unittest.TestCase):
+class TestHbaHandler(object):
     """All tests for classes HbasHandler and HbaHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -4003,7 +4001,7 @@ class HbaHandlerTests(unittest.TestCase):
         exp_hba_uris = [
             '/api/partitions/1/hbas/1',
         ]
-        self.assertEqual(hba_uris, exp_hba_uris)
+        assert hba_uris == exp_hba_uris
 
     def test_get(self):
 
@@ -4022,7 +4020,7 @@ class HbaHandlerTests(unittest.TestCase):
             'wwpn': 'CFFEAFFE00008001',
             'device-number': '1001',
         }
-        self.assertEqual(hba1, exp_hba1)
+        assert hba1 == exp_hba1
 
     def test_create_verify(self):
         new_hba2 = {
@@ -4035,10 +4033,10 @@ class HbaHandlerTests(unittest.TestCase):
         resp = self.urihandler.post(self.hmc, '/api/partitions/1/hbas',
                                     new_hba2, True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('element-uri', resp)
+        assert len(resp) == 1
+        assert 'element-uri' in resp
         new_hba2_uri = resp['element-uri']
-        self.assertEqual(new_hba2_uri, '/api/partitions/1/hbas/2')
+        assert new_hba2_uri == '/api/partitions/1/hbas/2'
 
         # the function to be tested:
         hba2 = self.urihandler.get(self.hmc, '/api/partitions/1/hbas/2', True)
@@ -4052,7 +4050,7 @@ class HbaHandlerTests(unittest.TestCase):
             'wwpn': hba2['wwpn'],  # auto-generated
         }
 
-        self.assertEqual(hba2, exp_hba2)
+        assert hba2 == exp_hba2
 
     def test_update_verify(self):
         update_hba1 = {
@@ -4064,7 +4062,7 @@ class HbaHandlerTests(unittest.TestCase):
                              update_hba1, True, True)
 
         hba1 = self.urihandler.get(self.hmc, '/api/partitions/1/hbas/1', True)
-        self.assertEqual(hba1['description'], 'updated hba #1')
+        assert hba1['description'] == 'updated hba #1'
 
     def test_delete_verify(self):
 
@@ -4073,14 +4071,14 @@ class HbaHandlerTests(unittest.TestCase):
         # the function to be tested:
         self.urihandler.delete(self.hmc, '/api/partitions/1/hbas/1', True)
 
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.get(self.hmc, '/api/partitions/1/hbas/1', True)
 
 
-class HbaReassignPortHandlerTests(unittest.TestCase):
+class TestHbaReassignPortHandler(object):
     """All tests for class HbaReassignPortHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -4094,7 +4092,7 @@ class HbaReassignPortHandlerTests(unittest.TestCase):
     def test_invoke_err_missing_body(self):
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/hbas/1/operations/'
@@ -4107,7 +4105,7 @@ class HbaReassignPortHandlerTests(unittest.TestCase):
         }
 
         # the function to be tested:
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             self.urihandler.post(
                 self.hmc,
                 '/api/partitions/1/hbas/1/operations/'
@@ -4127,17 +4125,17 @@ class HbaReassignPortHandlerTests(unittest.TestCase):
             'reassign-storage-adapter-port',
             operation_body, True, True)
 
-        self.assertIsNone(resp)
+        assert resp is None
 
         hba = self.urihandler.get(self.hmc, '/api/partitions/1/hbas/1', True)
         adapter_port_uri = hba['adapter-port-uri']
-        self.assertEqual(adapter_port_uri, new_adapter_port_uri)
+        assert adapter_port_uri == new_adapter_port_uri
 
 
-class NicHandlerTests(unittest.TestCase):
+class TestNicHandler(object):
     """All tests for classes NicsHandler and NicHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -4156,7 +4154,7 @@ class NicHandlerTests(unittest.TestCase):
         exp_nic_uris = [
             '/api/partitions/1/nics/1',
         ]
-        self.assertEqual(nic_uris, exp_nic_uris)
+        assert nic_uris == exp_nic_uris
 
     def test_get(self):
 
@@ -4174,7 +4172,7 @@ class NicHandlerTests(unittest.TestCase):
             'network-adapter-port-uri': '/api/adapters/3/network-ports/1',
             'device-number': '2001',
         }
-        self.assertEqual(nic1, exp_nic1)
+        assert nic1 == exp_nic1
 
     def test_create_verify(self):
         new_nic2 = {
@@ -4187,10 +4185,10 @@ class NicHandlerTests(unittest.TestCase):
         resp = self.urihandler.post(self.hmc, '/api/partitions/1/nics',
                                     new_nic2, True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('element-uri', resp)
+        assert len(resp) == 1
+        assert 'element-uri' in resp
         new_nic2_uri = resp['element-uri']
-        self.assertEqual(new_nic2_uri, '/api/partitions/1/nics/2')
+        assert new_nic2_uri == '/api/partitions/1/nics/2'
 
         # the function to be tested:
         nic2 = self.urihandler.get(self.hmc, '/api/partitions/1/nics/2', True)
@@ -4203,7 +4201,7 @@ class NicHandlerTests(unittest.TestCase):
             'device-number': nic2['device-number'],  # auto-generated
         }
 
-        self.assertEqual(nic2, exp_nic2)
+        assert nic2 == exp_nic2
 
     def test_update_verify(self):
         update_nic1 = {
@@ -4215,7 +4213,7 @@ class NicHandlerTests(unittest.TestCase):
                              update_nic1, True, True)
 
         nic1 = self.urihandler.get(self.hmc, '/api/partitions/1/nics/1', True)
-        self.assertEqual(nic1['description'], 'updated nic #1')
+        assert nic1['description'] == 'updated nic #1'
 
     def test_delete_verify(self):
 
@@ -4224,15 +4222,15 @@ class NicHandlerTests(unittest.TestCase):
         # the function to be tested:
         self.urihandler.delete(self.hmc, '/api/partitions/1/nics/1', True)
 
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.get(self.hmc, '/api/partitions/1/nics/1', True)
 
 
-class VirtualFunctionHandlerTests(unittest.TestCase):
+class TestVirtualFunctionHandler(object):
     """All tests for classes VirtualFunctionsHandler and
     VirtualFunctionHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/partitions/([^/]+)', PartitionHandler),
@@ -4253,7 +4251,7 @@ class VirtualFunctionHandlerTests(unittest.TestCase):
         exp_vf_uris = [
             '/api/partitions/1/virtual-functions/1',
         ]
-        self.assertEqual(vf_uris, exp_vf_uris)
+        assert vf_uris == exp_vf_uris
 
     def test_get(self):
 
@@ -4270,7 +4268,7 @@ class VirtualFunctionHandlerTests(unittest.TestCase):
             'description': 'VF #1 in Partition #1',
             'device-number': '3001',
         }
-        self.assertEqual(vf1, exp_vf1)
+        assert vf1 == exp_vf1
 
     def test_create_verify(self):
         new_vf2 = {
@@ -4283,10 +4281,10 @@ class VirtualFunctionHandlerTests(unittest.TestCase):
                                     '/api/partitions/1/virtual-functions',
                                     new_vf2, True, True)
 
-        self.assertEqual(len(resp), 1)
-        self.assertIn('element-uri', resp)
+        assert len(resp) == 1
+        assert 'element-uri' in resp
         new_vf2_uri = resp['element-uri']
-        self.assertEqual(new_vf2_uri, '/api/partitions/1/virtual-functions/2')
+        assert new_vf2_uri == '/api/partitions/1/virtual-functions/2'
 
         # the function to be tested:
         vf2 = self.urihandler.get(self.hmc,
@@ -4300,7 +4298,7 @@ class VirtualFunctionHandlerTests(unittest.TestCase):
             'device-number': vf2['device-number'],  # auto-generated
         }
 
-        self.assertEqual(vf2, exp_vf2)
+        assert vf2 == exp_vf2
 
     def test_update_verify(self):
         update_vf1 = {
@@ -4314,7 +4312,7 @@ class VirtualFunctionHandlerTests(unittest.TestCase):
         vf1 = self.urihandler.get(self.hmc,
                                   '/api/partitions/1/virtual-functions/1',
                                   True)
-        self.assertEqual(vf1['description'], 'updated vf #1')
+        assert vf1['description'] == 'updated vf #1'
 
     def test_delete_verify(self):
 
@@ -4325,16 +4323,16 @@ class VirtualFunctionHandlerTests(unittest.TestCase):
         self.urihandler.delete(self.hmc,
                                '/api/partitions/1/virtual-functions/1', True)
 
-        with self.assertRaises(InvalidResourceError):
+        with pytest.raises(InvalidResourceError):
             self.urihandler.get(self.hmc,
                                 '/api/partitions/1/virtual-functions/1', True)
 
 
-class VirtualSwitchHandlersTests(unittest.TestCase):
+class TestVirtualSwitchHandlers(object):
     """All tests for classes VirtualSwitchesHandler and
     VirtualSwitchHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)/virtual-switches(?:\?(.*))?',
@@ -4358,7 +4356,7 @@ class VirtualSwitchHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(vswitches, exp_vswitches)
+        assert vswitches == exp_vswitches
 
     def test_get(self):
 
@@ -4373,13 +4371,13 @@ class VirtualSwitchHandlersTests(unittest.TestCase):
             'description': 'Vswitch for OSA #1 in CPC #2',
             'connected-vnic-uris': [],  # auto-generated
         }
-        self.assertEqual(vswitch1, exp_vswitch1)
+        assert vswitch1 == exp_vswitch1
 
 
-class VirtualSwitchGetVnicsHandlerTests(unittest.TestCase):
+class TestVirtualSwitchGetVnicsHandler(object):
     """All tests for class VirtualSwitchGetVnicsHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/virtual-switches/([^/]+)', VirtualSwitchHandler),
@@ -4406,13 +4404,13 @@ class VirtualSwitchGetVnicsHandlerTests(unittest.TestCase):
         exp_resp = {
             'connected-vnic-uris': connected_nic_uris,
         }
-        self.assertEqual(resp, exp_resp)
+        assert resp == exp_resp
 
 
-class LparHandlersTests(unittest.TestCase):
+class TestLparHandlers(object):
     """All tests for classes LparsHandler and LparHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)/logical-partitions(?:\?(.*))?', LparsHandler),
@@ -4435,7 +4433,7 @@ class LparHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(lpars, exp_lpars)
+        assert lpars == exp_lpars
 
     def test_get(self):
 
@@ -4450,14 +4448,14 @@ class LparHandlersTests(unittest.TestCase):
             'status': 'not-activated',
             'description': 'LPAR #1 in CPC #1',
         }
-        self.assertEqual(lpar1, exp_lpar1)
+        assert lpar1 == exp_lpar1
 
 
-class LparActLoadDeactHandlerTests(unittest.TestCase):
+class TestLparActLoadDeactHandler(object):
     """All tests for classes LparActivateHandler, LparLoadHandler, and
     LparDeactivateHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/logical-partitions/([^/]+)',
@@ -4475,7 +4473,7 @@ class LparActLoadDeactHandlerTests(unittest.TestCase):
         # CPC1 is in classic mode
         lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
                                     True)
-        self.assertEqual(lpar1['status'], 'not-activated')
+        assert lpar1['status'] == 'not-activated'
 
         # the function to be tested:
         self.urihandler.post(self.hmc,
@@ -4484,7 +4482,7 @@ class LparActLoadDeactHandlerTests(unittest.TestCase):
 
         lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
                                     True)
-        self.assertEqual(lpar1['status'], 'not-operating')
+        assert lpar1['status'] == 'not-operating'
 
         # the function to be tested:
         self.urihandler.post(self.hmc,
@@ -4493,7 +4491,7 @@ class LparActLoadDeactHandlerTests(unittest.TestCase):
 
         lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
                                     True)
-        self.assertEqual(lpar1['status'], 'operating')
+        assert lpar1['status'] == 'operating'
 
         # the function to be tested:
         self.urihandler.post(self.hmc,
@@ -4502,14 +4500,14 @@ class LparActLoadDeactHandlerTests(unittest.TestCase):
 
         lpar1 = self.urihandler.get(self.hmc, '/api/logical-partitions/1',
                                     True)
-        self.assertEqual(lpar1['status'], 'not-activated')
+        assert lpar1['status'] == 'not-activated'
 
 
-class ResetActProfileHandlersTests(unittest.TestCase):
+class TestResetActProfileHandlers(object):
     """All tests for classes ResetActProfilesHandler and
     ResetActProfileHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)/reset-activation-profiles(?:\?(.*))?',
@@ -4534,7 +4532,7 @@ class ResetActProfileHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(raps, exp_raps)
+        assert raps == exp_raps
 
     def test_get(self):
 
@@ -4548,14 +4546,14 @@ class ResetActProfileHandlersTests(unittest.TestCase):
             'element-uri': '/api/cpcs/1/reset-activation-profiles/r1',
             'description': 'Reset profile #1 in CPC #1',
         }
-        self.assertEqual(rap1, exp_rap1)
+        assert rap1 == exp_rap1
 
 
-class ImageActProfileHandlersTests(unittest.TestCase):
+class TestImageActProfileHandlers(object):
     """All tests for classes ImageActProfilesHandler and
     ImageActProfileHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)/image-activation-profiles/([^/]+)',
@@ -4580,7 +4578,7 @@ class ImageActProfileHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(iaps, exp_iaps)
+        assert iaps == exp_iaps
 
     def test_get(self):
 
@@ -4594,14 +4592,14 @@ class ImageActProfileHandlersTests(unittest.TestCase):
             'element-uri': '/api/cpcs/1/image-activation-profiles/i1',
             'description': 'Image profile #1 in CPC #1',
         }
-        self.assertEqual(iap1, exp_iap1)
+        assert iap1 == exp_iap1
 
 
-class LoadActProfileHandlersTests(unittest.TestCase):
+class TestLoadActProfileHandlers(object):
     """All tests for classes LoadActProfilesHandler and
     LoadActProfileHandler."""
 
-    def setUp(self):
+    def setup_method(self):
         self.hmc, self.hmc_resources = standard_test_hmc()
         self.uris = (
             (r'/api/cpcs/([^/]+)/load-activation-profiles/([^/]+)',
@@ -4626,7 +4624,7 @@ class LoadActProfileHandlersTests(unittest.TestCase):
                 },
             ]
         }
-        self.assertEqual(laps, exp_laps)
+        assert laps == exp_laps
 
     def test_get(self):
 
@@ -4640,9 +4638,4 @@ class LoadActProfileHandlersTests(unittest.TestCase):
             'element-uri': '/api/cpcs/1/load-activation-profiles/L1',
             'description': 'Load profile #1 in CPC #1',
         }
-        self.assertEqual(lap1, exp_lap1)
-
-
-if __name__ == '__main__':
-    requests.packages.urllib3.disable_warnings()
-    unittest.main()
+        assert lap1 == exp_lap1

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -23,6 +23,7 @@ import time
 import re
 import collections
 import six
+from copy import copy
 try:
     from collections import OrderedDict
 except ImportError:
@@ -340,7 +341,7 @@ class Session(object):
             scheme=_HMC_SCHEME,
             host=self._host,
             port=_HMC_PORT)
-        self._headers = _STD_HEADERS  # dict with standard HTTP headers
+        self._headers = copy(_STD_HEADERS)  # dict with standard HTTP headers
         if session_id is not None:
             # Create a logged-on state (same state as in _do_logon())
             self._session_id = session_id


### PR DESCRIPTION
**Note:** This PR is on top of PR #452.
Ready for review and merge.
For details, see the commit message.
Note that migration from mock/requests_mock to zhmcclient_mock is left for a future PR.