### PR TITLE
(#4) Enabled Travis and Appveyor for manual-ci-run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,26 +30,41 @@ matrix:
       python: "3.4"
       env:
         - PACKAGE_LEVEL=minimum
-    - os: linux
-      language: python
-      python: "3.5"
-      env:
-        - PACKAGE_LEVEL=minimum
-      before_install:
-        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
+#    - os: linux
+#      language: python
+#      python: "3.4"
+#      env:
+#        - PACKAGE_LEVEL=latest
+#    - os: linux
+#      language: python
+#      python: "3.5"
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#    - os: linux
+#      language: python
+#      python: "3.5"
+#      env:
+#        - PACKAGE_LEVEL=latest
+#    - os: linux
+#      language: python
+#      python: "3.6"
+#      env:
+#        - PACKAGE_LEVEL=minimum
     - os: linux
       language: python
       python: "3.6"
       env:
         - PACKAGE_LEVEL=latest
-    - os: linux
-      language: python
-      python: "pypy-5.3.1"  # Python 2.7.10
-      env:
-        - PACKAGE_LEVEL=minimum
-      before_install:
-        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
-# TODO: Re-enable osx support once Travis has better OS-X capacity
+#    - os: linux
+#      language: python
+#      python: "pypy-5.3.1"  # Python 2.7.10
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#    - os: linux
+#      language: python
+#      python: "pypy-5.3.1"  # Python 2.7.10
+#      env:
+#        - PACKAGE_LEVEL=latest
 #    - os: osx
 #      language: generic
 #      python:
@@ -62,16 +77,12 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=latest
 #        - PYTHON=2
-#      before_install:
-#        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
 #    - os: osx
 #      language: generic
 #      python:
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #        - PYTHON=3
-#      before_install:
-#        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
 #    - os: osx
 #      language: generic
 #      python:
@@ -79,8 +90,20 @@ matrix:
 #        - PACKAGE_LEVEL=latest
 #        - PYTHON=3
 
+before_install:
+  - if [[ "$TRAVIS_BRANCH" == "manual-ci-run" ]]; then
+      export _NEED_REBASE=true;
+    fi
+  - if [[ -n $_NEED_REBASE ]]; then git fetch origin master; fi
+  - if [[ -n $_NEED_REBASE ]]; then git branch master FETCH_HEAD; fi
+  - if [[ -n $_NEED_REBASE ]]; then git rebase master; fi
+  - git branch -av
+
 # commands to install dependencies
 install:
+  - if [[ "$TRAVIS_BRANCH" == "manual-ci-run" || "$TRAVIS_PULL_REQUEST_BRANCH" == "manual-ci-run" ]]; then
+      export _MANUAL_CI_RUN=true;
+    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "${PYTHON:0:1}" == "2" ]]; then
         export PYTHON_CMD=python;
@@ -124,11 +147,10 @@ install:
 # commands to run builds & tests
 script:
   - make check
+  - if [[ -n $_MANUAL_CI_RUN ]]; then make pylint; fi
   - make test
-  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
-      make build;
-      make builddoc;
-    fi
+  - if [[ -n $_MANUAL_CI_RUN ]]; then make build; fi
+  - if [[ -n $_MANUAL_CI_RUN ]]; then make builddoc; fi
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "2.7" && "$PACKAGE_LEVEL" == "latest" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,12 @@ environment:
     - PYTHON_VERSION: 2.7
       PYTHON_ARCH: 32
       PYTHON_HOME: C:\Python27
-    - PYTHON_VERSION: 2.7
-      PYTHON_ARCH: 64
-      PYTHON_HOME: C:\Python27-x64
-    - PYTHON_VERSION: 3.4
-      PYTHON_ARCH: 32
-      PYTHON_HOME: C:\Python34
+#    - PYTHON_VERSION: 2.7
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python27-x64
+#    - PYTHON_VERSION: 3.4
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python34
 #    - PYTHON_VERSION: 3.4
 #      PYTHON_ARCH: 64
 #      PYTHON_HOME: C:\Python34-x64
@@ -34,6 +34,16 @@ configuration:
   - latest
 
 install:
+
+  - if %APPVEYOR_REPO_BRANCH%.==manual-ci-run. set _NEED_REBASE=true
+  - if %_NEED_REBASE%.==true. git fetch origin master
+  - if %_NEED_REBASE%.==true. git branch master FETCH_HEAD
+  - if %_NEED_REBASE%.==true. git rebase master
+  - git branch -av
+
+  # TODO: Use the _MANUAL_CI_RUN variable in tox.ini to run certain parts only when set
+  - if %APPVEYOR_REPO_BRANCH%.==manual-ci-run. set _MANUAL_CI_RUN=true
+  - if %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%.==manual-ci-run. set _MANUAL_CI_RUN=true
 
   # Set PACKAGE_LEVEL for make
   - set PACKAGE_LEVEL=%configuration%

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,26 @@ Change log
 ----------
 
 
+Version 0.19.0
+^^^^^^^^^^^^^^
+
+Released: not yet
+
+**Incompatible changes:**
+
+**Deprecations:**
+
+**Bug fixes:**
+
+**Enhancements:**
+
+**Known issues:**
+
+* See `list of open issues`_.
+
+.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
+
+
 Version 0.18.0
 ^^^^^^^^^^^^^^
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,7 +22,7 @@ Change log
 Version 0.18.0
 ^^^^^^^^^^^^^^
 
-Released: not yet
+Released: 2017-10-19
 
 **Incompatible changes:**
 
@@ -40,22 +40,12 @@ Released: not yet
     - python-utils  (from progressbar2)
     - wcwidth  (from prompt-toolkit -> click-repl)
 
-**Deprecations:**
-
 **Bug fixes:**
 
 * Fixed a flawed setup of setuptools in Python 2.7 on the Travis CI, where
   the metadata directory of setuptools existed twice, by adding a script
   `remove_duplicate_setuptools.py` that removes the moot copy of the metadata
   directory (issue #434).
-
-**Enhancements:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-  .. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
 
 
 Version 0.17.0


### PR DESCRIPTION
**Note:** This PR is on top of PR #454.
Ready for review and merge.
    
Details:
- This change enables Travis and Appveyor to distinguish between quick runs and full runs. Runs from branch manual-ci-run are run as full runs (after locally rebasing to master), and all other branches are run as quick runs.