### PR TITLE
Fixes #470: Added function test concept

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ test_py_files := \
     $(wildcard $(test_dir)/*/*.py) \
     $(wildcard $(test_dir)/*/*/*.py) \
 
+# Determine whether py.test has the --no-print-logs option.
+pytest_no_log_opt := $(shell py.test --help |grep '\--no-print-logs' >/dev/null; rc=$$?; if [[ $$rc == 0 ]]; then echo '--no-print-logs'; else echo ''; fi)
+
 # Flake8 config file
 flake8_rc_file := setup.cfg
 
@@ -368,6 +371,6 @@ flake8.log: Makefile $(flake8_rc_file) $(check_py_files)
 
 $(test_log_file): Makefile $(package__py_files) $(test_py_files) .coveragerc
 	rm -fv $@
-	bash -c 'set -o pipefail; PYTHONWARNINGS=default py.test -s $(test_dir) --cov $(package_name) --cov zhmcclient_mock --cov-config .coveragerc --cov-report=html $(pytest_opts) 2>&1 |tee $@.tmp'
+	bash -c 'set -o pipefail; PYTHONWARNINGS=default py.test $(pytest_no_log_opt) -s $(test_dir) --cov $(package_name) --cov zhmcclient_mock --cov-config .coveragerc --cov-report=html $(pytest_opts) 2>&1 |tee $@.tmp'
 	mv -f $@.tmp $@
 	@echo 'Done: Created test log file: $@'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -87,6 +87,8 @@ Released: not yet
 * The zhmcclient package no longer adds a NullHandler to the Python root
   logger (but still to the zhmcclient.api/.hmc loggers).
 
+* Added a function test concept that tests against a real HMC.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -84,6 +84,9 @@ Released: not yet
   - ``Cpc.get_energy_management_properties()`` (HMC: "Get CPC Energy
     Management Data")
 
+* The zhmcclient package no longer adds a NullHandler to the Python root
+  logger (but still to the zhmcclient.api/.hmc loggers).
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -126,6 +126,106 @@ The positional arguments of the ``tox`` command are passed to ``py.test`` using
 its ``-k`` option. Invoke ``py.test --help`` for details on the expression
 syntax of its ``-k`` option.
 
+Running function tests against a real HMC and CPC
+-------------------------------------------------
+
+The function tests (in ``tests/function/test_*.py``) can be run against a
+faked HMC/CPC (using the zhmcclient mock support), or against a real HMC/CPC.
+
+By default, the function tests are run against the faked HMC/CPC. To run them
+against a real HMC/CPC, you must:
+
+* Specify the name of the target CPC in the ``ZHMC_TEST_CPC`` environment
+  variable. This environment variable is the control point that decides
+  between using a real HMC/CPC and using the faked environment::
+
+      export ZHMC_TEST_CPC=S67B
+
+* Have an HMC credentials file at location ``examples/hmccreds.yaml`` that
+  specifies the target CPC (among possibly further CPCs) in its ``cpcs`` item::
+
+      cpcs:
+
+        S67B:
+          description: "z13s in DPM mode"
+          contact: "Joe"
+          hmc_host: "10.11.12.13"
+          hmc_userid: myuserid
+          hmc_password: mypassword
+
+        # ... more CPCs
+
+There is an example HMC credentials file in the repo, at
+``examples/example_hmccreds.yaml``. For a description of its format, see
+`Format of the HMC credentials file`_.
+
+Enabling logging for function tests
+-----------------------------------
+
+The function tests always log to stderr. What can be logged are the
+following two components:
+
+* ``api``: Calls to and returns from zhmcclient API functions (at debug level).
+* ``hmc``: Interactions with the HMC (i.e. HTTP requests and responses, at
+  debug level).
+
+By default, the log component and level is set to::
+
+    all=warning
+
+meaning that all components log at warning level or higher.
+
+To set different log levels for the log components, set the ``ZHMC_LOG``
+environment variable as follows::
+
+    export ZHMC_LOG=COMP=LEVEL[,COMP=LEVEL[,...]]
+
+Where:
+
+* ``COMP`` is one of: ``all``, ``api``, ``hmc``.
+* ``LEVEL`` is one of: ``error``, ``warning``, ``info``, ``debug``.
+
+For example, to enable logging of the zhmcclient API calls and the
+interactions with the HMC, use::
+
+    export ZHMC_LOG=api=debug,hmc=debug
+
+or, shorter::
+
+    export ZHMC_LOG=all=debug
+
+Format of the HMC credentials file
+----------------------------------
+
+The HMC credentials file is used for specifying real HMCs/CPCs to be used by
+function tests. Its syntax is YAML, and the ``cpcs`` item relevant for function
+testing has the following structure::
+
+    cpcs:
+
+      "CPC1":
+        description: "z13 test system"
+        contact: "Amy"
+        hmc_host: "10.10.10.11"           # required
+        hmc_userid: "myuser1"             # required
+        hmc_password: "mypassword1"       # required
+
+      "CPC2":
+        description: "z14 development system"
+        contact: "Bob"
+        hmc_host: "10.10.10.12"
+        hmc_userid: "myuser2"
+        hmc_password: "mypassword2"
+
+In the example above, any words in double quotes are data and can change,
+and any words without double quotes are considered keywords and must be
+specified as shown.
+
+"CPC1" and "CPC2" are CPC names that are used to select an entry in the
+file. The entry for a CPC contains data about the HMC managing that CPC,
+with its host, userid and password. If two CPCs are managed by the same
+HMC, there would be two CPC entries with the same HMC data.
+
 
 .. _`Contributing`:
 

--- a/examples/example_hmccreds.yaml
+++ b/examples/example_hmccreds.yaml
@@ -97,3 +97,13 @@ examples:
 "192.168.111.209":
    userid: ensadmin
    password: 1234
+
+cpcs:
+
+  P0000P05:
+    description: "EC12"
+    contact: "Joe"
+    hmc_host: "192.168.111.5"
+    hmc_userid: ensadmin
+    hmc_password: 1234
+

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -16,6 +16,30 @@
 Utility functions for tests.
 """
 
+import sys
+import os
+import yaml
+import logging
+
+import zhmcclient
+import zhmcclient_mock
+
+# Logger names by log component
+LOGGER_NAMES = {
+    'all': '',  # root logger
+    'api': zhmcclient.API_LOGGER_NAME,
+    'hmc': zhmcclient.HMC_LOGGER_NAME,
+}
+
+DEFAULT_LOG = 'all=warning'
+
+DEFAULT_RT_CONFIG = zhmcclient.RetryTimeoutConfig(
+    connect_timeout=10,
+    connect_retries=1,
+    operation_timeout=300,
+    status_timeout=60,
+)
+
 
 def assert_resources(resources, exp_resources, prop_names):
     """
@@ -57,3 +81,412 @@ def assert_resources(resources, exp_resources, prop_names):
             prop_value = res.properties[prop_name]
             exp_prop_value = exp_res.properties[prop_name]
             assert prop_value == exp_prop_value
+
+
+def info(capsys, format_str, format_args=None):
+    """
+    Print an information message during test execution that is not being
+    captured by py.test (i.e. it is shown even when py.test is not invoked
+    with '-s').
+
+    Parameters:
+
+      capsys: The pytest 'capsys' fixture the testcase function must specify as
+        an argument and pass to this function here.
+
+      format_str (string): Percent-based format string.
+
+      format_args: Argument(s) for the format string.
+    """
+
+    if format_args is not None:
+        msg = (format_str % format_args)
+    else:
+        msg = format_str
+
+    with capsys.disabled():
+        print("Info: " + msg)
+
+
+class HmcCredentials(object):
+    """
+    Utility class to encapsulate the data in an HMC credentials file (for the
+    purpose of zhmcclient function tests).
+
+    The HMC credentials file must be in YAML and must have entries for each
+    CPC specify certain data about the HMC managing it, as in the following
+    example::
+
+        cpcs:
+
+          "CPC1":
+            description: "z13 test system"
+            contact: "Amy"
+            hmc_host: "10.10.10.11"           # required
+            hmc_userid: "myuser1"             # required
+            hmc_password: "mypassword1"       # required
+
+          "CPC2":
+            description: "z14 development system"
+            contact: "Bob"
+            hmc_host: "10.10.10.12"
+            hmc_userid: "myuser2"
+            hmc_password: "mypassword2"
+
+    In the example above, any words in double quotes are data and can change,
+    and any words without double quotes are considered keywords and must be
+    specified as shown.
+
+    "CPC1" and "CPC2" are CPC names that are used to select an entry in the
+    file. The entry for a CPC contains data about the HMC managing that CPC,
+    with its host, userid and password. If two CPCs are managed by the same
+    HMC, there would be two CPC entries with the same HMC data.
+    """
+
+    default_filepath = 'examples/hmccreds.yaml'
+
+    def __init__(self, filepath=None):
+        if filepath is None:
+            filepath = self.default_filepath
+        self._filepath = filepath
+
+    @property
+    def filepath(self):
+        """
+        File path of this HMC credentials file.
+        """
+        return self._filepath
+
+    def get_cpc_items(self):
+        """
+        Return a list of CPC data items from this HMC credentials file.
+
+        Returns:
+
+          list of dict:
+            If the HMC credentials file could be opened and successfully be
+            processed, returns a list of data items for all CPCs in the HMC
+            credentials file, where each data item is a dictionary with with
+            the following keys:
+
+              * description: Short description of the CPC (optional)
+              * contact: Contact info for the CPC (optional)
+              * hmc_host: Hostname or IP address of HMC managing the CPC (req)
+              * hmc_userid: Userid to log on to that HMC (required)
+              * hmc_password: Password to log on to that HMC (required)
+
+            If the HMC credentials file did not exist or could not be opened
+            for reading, returns `None`.
+
+        Raises:
+
+          yaml.parser.ParserError: YAML parsing error in HMC credentials file.
+
+          KeyError: Required 'cpcs' key not found in HMC credentials file.
+        """
+
+        try:
+            with open(self.filepath, 'r') as fp:
+                hmccreds_data = yaml.load(fp)
+        except IOError:
+            return None
+
+        cpc_items = hmccreds_data['cpcs']
+        return cpc_items
+
+    def get_cpc_item(self, cpc_name):
+        """
+        Return the CPC data item for a given CPC from this HMC credentials
+        file.
+
+        Parameters:
+
+          cpc_name (string): CPC name used to select the corresponding HMC
+            entry in the HMC credentials file.
+
+        Returns:
+
+          dict:
+            If the HMC credentials file could be opened and successfully be
+            processed, returns a CPC data item for the specified CPC, with the
+            following keys:
+
+              * description: Short description of the CPC (optional)
+              * contact: Contact info for the CPC (optional)
+              * hmc_host: Hostname or IP address of HMC managing the CPC (req)
+              * hmc_userid: Userid to log on to that HMC (required)
+              * hmc_password: Password to log on to that HMC (required)
+
+            If the HMC credentials file did not exist or could not be opened
+            for reading, returns `None`.
+
+        Raises:
+
+          yaml.parser.ParserError: YAML parsing error in HMC credentials file.
+
+          KeyError: Required 'cpcs' key not found in HMC credentials file.
+
+          ValueError: CPC item not found or required keys missing in CPC item.
+        """
+
+        cpc_items = self.get_cpc_items()
+        if cpc_items is None:
+            return None
+
+        cpc_item = cpc_items.get(cpc_name, None)
+        if cpc_item is None:
+            raise ValueError(
+                "No item found for CPC {!r} in HMC credentials file {!r}".
+                format(cpc_name, self.filepath))
+
+        # Required keys in a CPC data item in the HMC credentials file
+        required_keys = ['hmc_host', 'hmc_userid', 'hmc_password']
+
+        # Check required keys in CPC data item:
+        for key in required_keys:
+            if key not in cpc_item or not cpc_item[key]:
+                raise ValueError(
+                    "Required key {!r} missing in item for CPC {!r} in "
+                    "HMC credentials file {!r}".
+                    format(key, cpc_name, self.filepath))
+
+        return cpc_item
+
+
+def get_test_cpc():
+    """
+    Return the CPC name of the CPC to be tested.
+
+    This is taken from the value of the 'ZHMC_TEST_CPC' environment variable.
+    If that variable is not set or empty, `None` is returned.
+
+    Returns:
+
+      string: Name of CPC to be tested, or `None` if no CPC has been defined.
+    """
+    cpc_name = os.environ.get('ZHMC_TEST_CPC', None)
+    return cpc_name
+
+
+def setup_cpc(capsys, hmc_creds, fake_data, rt_config=None):
+    """
+    Set up and return some objects for the CPC that is to be used for testing.
+
+    This function uses the get_test_cpc() function to determine the CPC to be
+    used for testing. If no CPC has been defined, this function sets up a faked
+    CPC using the zhmcclient mock support.
+
+    Parameters:
+
+      capsys: The pytest 'capsys' fixture the testcase function must specify as
+        an argument and pass to this functionhere.
+
+      hmc_creds (HmcCredentials): HMC credentials with CPC data.
+
+      fake_data (dict): Input data in case a mock environment needs to be set
+        up. The dict has the following keys:
+
+        * hmc_host (string): Hostname or IP address of the faked HMC.
+
+        * hmc_name (string): HMC name of the faked HMC.
+
+        * hmc_version (string): HMC version of the faked HMC.
+
+        * api_version (string): API version of the faked HMC.
+
+        * cpc_properties (dict): Properties for the faked CPC. 'name' must be
+          set.
+
+      rt_config (zhmcclient.RetryTimeoutConfig): Retry / timeout config
+        to override the default values. The default values used by this
+        function are the global defaults defined for the zhmcclient package,
+        whereby connection retries, connection timeout, operation timeout, and
+        status timeout have been shortened. The resulting default values should
+        be good for most function testcases.
+
+    Returns:
+
+      tuple: Tuple with the objects thathave been set up:
+
+        * cpc_name (string): Name of the CPC to be used (some fake name or
+          the real name that has been set up).
+
+        * session (zhmcclient.Session or zhmcclient_mock-FakedSession):
+          zhmcclient session object (faked or real) to be used for accessing
+          the HMC managing that CPC.
+
+        * client (zhmcclient.Client):
+          zhmcclient Client object to be used for accessing the HMC managing
+          that CPC.
+
+        * cpc (zhmcclient.Cpc): Cpc resource object representing the CPC to be
+          used (faked or real).
+
+        * faked_cpc (zhmcclient_mock.FakedCpc): FakedCpc object in case a
+          mock environment was set up (so the caller can add resources to it),
+          or otherwise `None`.
+    """
+
+    cpc_name = get_test_cpc()
+
+    if cpc_name is None:
+
+        # No test CPC defined in the environment -> use mock support and
+        # add a faked CPC.
+
+        cpc_properties = fake_data['cpc_properties']
+        cpc_name = cpc_properties['name']
+
+        info(capsys, "Testing with faked CPC %r (ZHMC_TEST_CPC env.var. "
+             "not set)", cpc_name)
+
+        session = zhmcclient_mock.FakedSession(
+            fake_data['hmc_host'], fake_data['hmc_name'],
+            fake_data['hmc_version'], fake_data['api_version'])
+
+        faked_cpc = session.hmc.cpcs.add(cpc_properties)
+
+    else:
+        # A test CPC is defined in the environment -> use it!
+
+        info(capsys, "Testing with CPC %r", cpc_name)
+
+        eff_rt_config = DEFAULT_RT_CONFIG
+        if rt_config:
+            eff_rt_config.override_with(rt_config)
+
+        cpc_item = hmc_creds.get_cpc_item(cpc_name)
+
+        assert cpc_item, "HMC credentials file not found: {!r}".\
+            format(hmc_creds.filepath)
+
+        session = zhmcclient.Session(
+            cpc_item['hmc_host'], cpc_item['hmc_userid'],
+            cpc_item['hmc_password'], retry_timeout_config=eff_rt_config)
+
+        faked_cpc = None
+
+    client = zhmcclient.Client(session)
+
+    cpc = client.cpcs.find(name=cpc_name)
+
+    return cpc_name, session, client, cpc, faked_cpc
+
+
+def print_logging():
+    """
+    Debug function that prints the relevant settings of all Python loggers
+    that are relevant for zhmcclient.
+    """
+    logger_names = LOGGER_NAMES.values()
+    for logger_name in logger_names:
+        logger = logging.getLogger(logger_name)
+        print_logger(logger)
+
+
+def print_logger(logger):
+    """
+    Debug function that prints the relevant settings of a Python logger.
+    """
+    print("Debug: Logger %r:" % logger.name)
+    print("Debug:   logger level: %s (%s)" %
+          (logger.level, logging.getLevelName(logger.level)))
+    if not logger.handlers:
+        print("Debug:   No handlers")
+    for handler in logger.handlers:
+        print("Debug:   Handler %s:" % type(handler))
+        print("Debug:     handler level: %s (%s)" %
+              (handler.level, logging.getLevelName(handler.level)))
+        format = getattr(handler.formatter, '_fmt', None)
+        print("Debug:     handler format: %r" % format)
+
+
+def setup_logging():
+    """
+    Set up logging for the zhmcclient, based on the value of the ZHMC_LOG
+    env. variable with the following value::
+
+        COMP=LEVEL[,COMP=LEVEL[,...]]
+
+    Where:
+
+      * ``COMP`` is one of: ``all``, ``api``, ``hmc``.
+      * ``LEVEL`` is one of: ``error``, ``warning``, ``info``, ``debug``.
+
+    If the variable is not set, this defaults to::
+
+        all=warning
+    """
+
+    log = os.environ.get('ZHMC_LOG', None)
+
+    if log is None:
+        log = DEFAULT_LOG
+
+    log_components = LOGGER_NAMES.keys()
+
+    for lc in log_components:
+        reset_logger(lc)
+
+    handler = logging.StreamHandler(stream=sys.stderr)
+    fs = '%(levelname)s %(name)s: %(message)s'
+    handler.setFormatter(logging.Formatter(fs))
+
+    log_specs = log.split(',')
+    for log_spec in log_specs:
+
+        # ignore extra ',' at begin, end or in between
+        if log_spec == '':
+            continue
+
+        try:
+            log_comp, log_level = log_spec.split('=', 1)
+        except ValueError:
+            raise ValueError("Missing '=' in COMP=LEVEL specification "
+                             "in ZHMC_LOG variable: {}".format(log_spec))
+
+        level = getattr(logging, log_level.upper(), None)
+        if level is None:
+            raise ValueError("Invalid level in COMP=LEVEL specification "
+                             "in ZHMC_LOG variable: {}".format(log_spec))
+
+        if log_comp not in log_components:
+            raise ValueError("Invalid component in COMP=LEVEL specification "
+                             "in ZHMC_LOG variable: {}".format(log_spec))
+
+        setup_logger(log_comp, handler, level)
+
+
+def reset_logger(log_comp):
+    """
+    Reset the logger for the specified log component (unless it is the root
+    logger) to add a NullHandler if it does not have any handlers. Having a
+    handler prevents a log request to be propagated to the parent logger.
+    """
+
+    name = LOGGER_NAMES[log_comp]
+    logger = logging.getLogger(name)
+
+    if name != '' and not logger.handlers:
+        logger.addHandler(logging.NullHandler())
+
+
+def setup_logger(log_comp, handler, level):
+    """
+    Setup the logger for the specified log component to add the specified
+    handler (removing a possibly present NullHandler) and to set it to the
+    specified log level. The handler is also set to the specified log level
+    because the default level of a handler is 0 which causes it to process all
+    levels.
+    """
+
+    name = LOGGER_NAMES[log_comp]
+    logger = logging.getLogger(name)
+
+    for h in logger.handlers:
+        if isinstance(h, logging.NullHandler):
+            logger.removeHandler(h)
+
+    handler.setLevel(level)
+    logger.addHandler(handler)
+    logger.setLevel(level)

--- a/tests/function/test_hmc_credentials_file.py
+++ b/tests/function/test_hmc_credentials_file.py
@@ -1,0 +1,98 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function tests for HMC credentials file.
+"""
+
+from __future__ import absolute_import, print_function
+
+import requests.packages.urllib3
+
+import zhmcclient
+from tests.common.utils import HmcCredentials, info
+
+requests.packages.urllib3.disable_warnings()
+
+
+class TestHMCCredentialsFile(object):
+    """
+    Test your HMC credentials file, if you have one at the default location.
+    """
+
+    def setup_method(self):
+        self.hmc_creds = HmcCredentials()
+
+    def test_1_format(self, capsys):
+        """Test the format of the HMC credentials file."""
+
+        cpc_items = self.hmc_creds.get_cpc_items()
+
+        if cpc_items is None:
+            info(capsys, "HMC credentials file not found: %r - Skipping "
+                 "format check of HMC credentials file",
+                 self.hmc_creds.filepath)
+            return
+
+        assert len(cpc_items) > 0
+
+    def test_2_hmcs(self, capsys):
+        """
+        Check out the HMCs specified in the HMC credentials file.
+        Skip HMCs that cannot be contacted.
+        """
+
+        cpc_items = self.hmc_creds.get_cpc_items()
+
+        if cpc_items is None:
+            info(capsys, "HMC credentials file not found: %r - Skipping the "
+                 "checking of HMCs", self.hmc_creds.filepath)
+            return
+
+        rt_config = zhmcclient.RetryTimeoutConfig(
+            connect_timeout=10,
+            connect_retries=1,
+        )
+
+        # Check HMCs and their CPCs
+        for cpc_name in cpc_items:
+
+            cpc_item = cpc_items[cpc_name]
+
+            hmc_host = cpc_item['hmc_host']
+
+            info(capsys, "Checking HMC %r for CPC %r", (hmc_host, cpc_name))
+
+            session = zhmcclient.Session(
+                hmc_host, cpc_item['hmc_userid'], cpc_item['hmc_password'],
+                retry_timeout_config=rt_config)
+
+            client = zhmcclient.Client(session)
+
+            try:
+                session.logon()
+            except zhmcclient.ConnectionError as exc:
+                info(capsys, "Skipping HMC %r for CPC %r: %s",
+                     (hmc_host, cpc_name, exc))
+                continue
+
+            cpcs = client.cpcs.list()
+            cpc_names = [cpc.name for cpc in cpcs]
+            if cpc_name not in cpc_names:
+                raise AssertionError(
+                    "CPC {!r} not found in HMC {!r}.\n"
+                    "Existing CPCs: {!r}".
+                    format(cpc_name, hmc_host, cpc_names))
+
+            session.logoff()

--- a/tests/function/test_partition_lifecycle.py
+++ b/tests/function/test_partition_lifecycle.py
@@ -1,0 +1,146 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function tests for partition lifecycle.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import requests.packages.urllib3
+
+import zhmcclient
+from tests.common.utils import HmcCredentials, info, setup_cpc, setup_logging
+
+requests.packages.urllib3.disable_warnings()
+
+
+class TestPartitionLifecycle(object):
+    """Test partition lifecycle."""
+
+    # Prefix for any names of HMC resources that are being created
+    NAME_PREFIX = 'zhmcclient.TestPartitionLifecycle.'
+
+    def setup_method(self):
+        """
+        Set up HMC data, Session to that HMC, Client, and Cpc object.
+        """
+        self.hmc_creds = HmcCredentials()
+        self.fake_data = dict(
+            hmc_host='fake-host', hmc_name='fake-hmc',
+            hmc_version='2.13.1', api_version='1.8',
+            cpc_properties={
+                'object-id': 'fake-cpc1-oid',
+                # object-uri is set up automatically
+                'parent': None,
+                'class': 'cpc',
+                'name': 'fake-cpc1',
+                'description': 'Fake CPC #1 (DPM mode)',
+                'status': 'active',
+                'dpm-enabled': True,
+                'is-ensemble-member': False,
+                'iml-mode': 'dpm',
+            })
+        setup_logging()
+
+    def test_crud(self, capsys):
+        """Create, read, update and delete a partition."""
+
+        cpc_name, session, client, cpc, faked_cpc = \
+            setup_cpc(capsys, self.hmc_creds, self.fake_data)
+
+        part_name = self.NAME_PREFIX + 'test_crud.part1'
+
+        # Ensure a clean starting point for this test
+        try:
+            part = cpc.partitions.find(name=part_name)
+        except zhmcclient.NotFound:
+            pass
+        else:
+            info(capsys, "Cleaning up partition from previous run: {!r}".
+                 format(part))
+            status = part.get_property('status')
+            if status != 'stopped':
+                part.stop()
+            part.delete()
+
+        # Test creating the partition
+
+        part_input_props = {
+            'name': part_name,
+            'description': 'Dummy partition description.',
+            'ifl-processors': 2,
+            'initial-memory': 1024,
+            'maximum-memory': 2048,
+            'processor-mode': 'shared',  # used for filtering
+            'type': 'linux',  # used for filtering
+        }
+        part_auto_props = {
+            'status': 'stopped',
+        }
+
+        part = cpc.partitions.create(part_input_props)
+
+        for pn in part_input_props:
+            exp_value = part_input_props[pn]
+            assert part.properties[pn] == exp_value, \
+                "Unexpected value for property {!r}".format(pn)
+        part.pull_full_properties()
+        for pn in part_input_props:
+            exp_value = part_input_props[pn]
+            assert part.properties[pn] == exp_value, \
+                "Unexpected value for property {!r}".format(pn)
+        for pn in part_auto_props:
+            exp_value = part_auto_props[pn]
+            assert part.properties[pn] == exp_value, \
+                "Unexpected value for property {!r}".format(pn)
+
+        # Test finding the partition based on its (cached) name
+
+        p = cpc.partitions.find(name=part_name)
+
+        assert p.name == part_name
+
+        # Test finding the partition based on a server-side filtered prop
+
+        parts = cpc.partitions.findall(type='linux')
+
+        assert part_name in [p.name for p in parts]  # noqa: F812
+
+        # Test finding the partition based on a client-side filtered prop
+
+        parts = cpc.partitions.findall(**{'processor-mode': 'shared'})
+
+        assert part_name in [p.name for p in parts]  # noqa: F812
+
+        # Test updating a property of the partition
+
+        new_desc = "Updated partition description."
+
+        part.update_properties(dict(description=new_desc))
+
+        assert part.properties['description'] == new_desc
+        part.pull_full_properties()
+        assert part.properties['description'] == new_desc
+
+        # Test deleting the partition
+
+        part.delete()
+
+        with pytest.raises(zhmcclient.NotFound):
+            cpc.partitions.find(name=part_name)
+
+        # Cleanup
+        session.logoff()

--- a/tests/unit/zhmcclient/test_logging.py
+++ b/tests/unit/zhmcclient/test_logging.py
@@ -291,25 +291,21 @@ class TestGetLogger(object):
     """All test cases for get_logger()."""
 
     def test_root_logger(self):
-        """Test that get_logger('') returns the Python root logger and has at
-        least one handler."""
+        """Test that get_logger('') returns the Python root logger."""
+
         py_logger = logging.getLogger()
 
         zhmc_logger = get_logger('')
 
-        assert isinstance(zhmc_logger, logging.Logger)
-        assert zhmc_logger == py_logger
-        assert len(zhmc_logger.handlers) >= 1, \
-            "Unexpected list of logging handlers: %r" % zhmc_logger.handlers
+        assert zhmc_logger is py_logger
 
     def test_foo_logger(self):
-        """Test that get_logger('foo') returns the Python logger 'foo'
-        and has at least one handler."""
-        py_logger = logging.getLogger('foo')
+        """Test that get_logger('zhmcclient.foo') returns the same-named
+        Python logger and has at least one handler."""
 
-        zhmc_logger = get_logger('foo')
+        py_logger = logging.getLogger('zhmcclient.foo')
 
-        assert isinstance(zhmc_logger, logging.Logger)
-        assert zhmc_logger == py_logger
-        assert len(zhmc_logger.handlers) >= 1, \
-            "Unexpected list of logging handlers: %r" % zhmc_logger.handlers
+        zhmc_logger = get_logger('zhmcclient.foo')
+
+        assert zhmc_logger is py_logger
+        assert len(zhmc_logger.handlers) >= 1

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -79,12 +79,12 @@ def get_logger(name):
     Return a :class:`~py:logging.Logger` object with the specified name.
 
     A :class:`~py:logging.NullHandler` handler is added to the logger if it
-    does not have any handlers yet. This prevents the propagation of log
-    requests up the Python logger hierarchy, and therefore causes this package
-    to be silent by default.
+    does not have any handlers yet and if it is not the Python root logger.
+    This prevents the propagation of log requests up the Python logger
+    hierarchy, and therefore causes this package to be silent by default.
     """
     logger = logging.getLogger(name)
-    if not logger.handlers:
+    if name != '' and not logger.handlers:
         logger.addHandler(logging.NullHandler())
     return logger
 


### PR DESCRIPTION
Ready for review and merge.

By default (e.g. in a CI), the function tests will either be skipped, or run against a faked/mocked environment. To set up testing against a real HMC/CPC, read the respective chapters in section "Development" in the docs.