### PR TITLE
Added OS-X for py2 to Travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,12 +71,12 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #        - PYTHON=2
-#    - os: osx
-#      language: generic
-#      python:
-#      env:
-#        - PACKAGE_LEVEL=latest
-#        - PYTHON=2
+    - os: osx
+      language: generic
+      python:
+      env:
+        - PACKAGE_LEVEL=latest
+        - PYTHON=2
 #    - os: osx
 #      language: generic
 #      python:


### PR DESCRIPTION
Because OS-X on Travis does not seem to have the huge backlogs it had, this change enables OS-X for python 2 and latest package level on Travis again.
This PR is on top of PR #474.
Ready for review and merge.