### PR TITLE
Travis for OS-X: Fixed changed Python install and added py2 run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,12 +71,12 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #        - PYTHON=2
-#    - os: osx
-#      language: generic
-#      python:
-#      env:
-#        - PACKAGE_LEVEL=latest
-#        - PYTHON=2
+    - os: osx
+      language: generic
+      python:
+      env:
+        - PACKAGE_LEVEL=latest
+        - PYTHON=2
 #    - os: osx
 #      language: generic
 #      python:
@@ -120,9 +120,9 @@ install:
     echo "PIP_CMD=$PIP_CMD"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "${PYTHON:0:1}" == "2" ]]; then
-        OSX_PYTHON_PKG=python;
+        OSX_PYTHON_PKG=python@2;
       else
-        OSX_PYTHON_PKG=python3;
+        OSX_PYTHON_PKG=python@3;
       fi;
       echo "OSX_PYTHON_PKG=$OSX_PYTHON_PKG";
     fi
@@ -130,7 +130,10 @@ install:
       brew update;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew ls --versions $OSX_PYTHON_PKG && brew upgrade $OSX_PYTHON_PKG || brew install $OSX_PYTHON_PKG;
+      brew ls --versions $OSX_PYTHON_PKG && brew upgrade $OSX_PYTHON_PKG || brew install $OSX_PYTHON_PKG || brew link --overwrite $OSX_PYTHON_PKG;
+      echo "Checking Python command: $PYTHON_CMD";
+      which $PYTHON_CMD;
+      $PYTHON_CMD --version;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       virtualenv venv -p $PYTHON_CMD && source venv/bin/activate;


### PR DESCRIPTION
Details:

- Because OS-X on Travis does not seem to have the huge backlogs it
  had, this change enables OS-X for Python 2 and for the latest
  package level again.

- The Python command for py2 and py3 on OS-X in Travis failed with:
    /usr/local/opt/python/bin/python2.7: bad interpreter: No such
    file or directory
  This change attempts to fix that by issuing:
    brew link --overwrite python
  This change also adds 'which python' and 'python --version'
  to double check that it is available.

Signed-off-by: Andreas Maier <maiera@de.ibm.com>