### PR TITLE
Excluded .DS_Store file (on OS-X) from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /AUTHORS
 /ChangeLog
 /.pytest_cache/
+.DS_Store
 .ipynb_checkpoints/
 .coverage
 .venv


### PR DESCRIPTION
Fast path.