### PR TITLE
Travis: Moved venv directory on OS-X out of work directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ install:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       $PIP_CMD install virtualenv;
-      virtualenv venv -p $PYTHON_CMD && source venv/bin/activate;
+      virtualenv ../venv -p $PYTHON_CMD && source ../venv/bin/activate;
     fi
   - make pyshow
   - $PIP_CMD list


### PR DESCRIPTION
This solves the issue that the doc build attempted to build the Python files
from the packages installed into the venv.