### PR TITLE
Added z14-ZR1 and Rockhopper II support

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Docs: Added missing support statements for the LinuxOne Emperor II machine
+  generations to the documentation (The corresponding z14 was already listed).
+
 **Enhancements:**
 
 * Docs: Streamlined, improved and fixed the description how to release a version
@@ -42,6 +45,12 @@ Released: not yet
     officially declared on Pypi yet for this package).
   - `PyYAML` from 3.12 to 3.13 (see PyYAML issue
     https://github.com/yaml/pyyaml/issues/126).
+
+* Docs: Added support statements for the z14-ZR1 and LinuxONE Rockhopper II
+  machine generations to the documentation.
+
+* Added support for the z14-ZR1 and LinuxONE Rockhopper II machine generations
+  to the `Cpc.maximum_active_partitions()` method.
 
 **Known issues:**
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -78,18 +78,28 @@ The zhmcclient package is supported in these environments:
 * HMC versions: 2.11.1 and higher
 
 The following table shows for each HMC version the supported HMC API version
-and the supported IBM Z and LinuxONE machine generations:
+and the supported IBM Z machine generations. The corresponding LinuxONE
+machine generations are listed in the notes below the table:
 
-===========  ===============  ======================  ===============================================
+===========  ===============  ======================  =========================================
 HMC version  HMC API version  HMC API book            Machine generations
-===========  ===============  ======================  ===============================================
-2.11.1       1.1 / 1.2        :term:`HMC API 2.11.1`  z196 and z114
+===========  ===============  ======================  =========================================
+2.11.1       1.1 - 1.2        :term:`HMC API 2.11.1`  z196 and z114
 2.12.0       1.3              :term:`HMC API 2.12.0`  z196 to zEC12 and z114
-2.12.1       1.4 / 1.5        :term:`HMC API 2.12.1`  z196 to zEC12 and z114 to zBC12
-2.13.0       1.6              :term:`HMC API 2.13.0`  z196 to z13/Emperor and z114 to zBC12
-2.13.1       1.7 / 2.1 / 2.2  :term:`HMC API 2.13.1`  z196 to z13/Emperor and z114 to z13s/Rockhopper
-2.14.0       2.20             :term:`HMC API 2.14.0`  z196 to z14/Emperor and z114 to z13s/Rockhopper
-===========  ===============  ======================  ===============================================
+2.12.1       1.4 - 1.5        :term:`HMC API 2.12.1`  z196 to zEC12 and z114 to zBC12
+2.13.0       1.6              :term:`HMC API 2.13.0`  z196 to z13 (1) and z114 to zBC12
+2.13.1       1.7, 2.1 - 2.2   :term:`HMC API 2.13.1`  z196 to z13 (1) and z114 to z13s (2)
+2.14.0 (5)   2.20 - 2.24      :term:`HMC API 2.14.0`  z196 to z14 (3) and z114 to z14-ZR1 (4)
+===========  ===============  ======================  =========================================
+
+Notes:
+
+(1) Supported for z13 and LinuxONE Emperor
+(2) Supported for z13s and LinuxONE Rockhopper
+(3) Supported for z14 and LinuxONE Emperor II
+(4) Supported for z14-ZR1 and LinuxONE Rockhopper II
+(5) HMC version 2.14.0 supports both the first and second wave of
+    machines; there is no 2.14.1 numbered HMC version anymore.
 
 
 .. _`Installation`:

--- a/tools/cpcdata
+++ b/tools/cpcdata
@@ -46,7 +46,8 @@ MACH_TYPE_INFO = {
     '2817': ('z196', 60),
     '2827': ('zEC12', 60),
     '2964': ('z13', 85),  # Also LinuxONE Emperor
-    '3906': ('z14', 85),
+    '3906': ('z14', 85),  # Also LinuxONE Emperor II
+    '3907': ('z14-ZR1', 40),  # Also LinuxONE Rockhopper II
 
     '2066': ('z800', 15),
     '2086': ('z890', 30),

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -350,15 +350,25 @@ class Adapter(BaseResource):
         Integer: The maximum number of crypto domains on this crypto adapter.
 
         The following table shows the maximum number of crypto domains for
-        crypto adapters supported on machines in DPM mode:
+        crypto adapters supported on IBM Z machine generations in DPM mode. The
+        corresponding LinuxONE machine generations are listed in the notes
+        below the table:
 
-        =================  ===================  ===============
-        Adapter type       Machine generation   Maximum domains
-        =================  ===================  ===============
-        Crypto Express 5S  z14 / z13 / Emperor               85
-        Crypto Express 5S  z13s / Rockhopper                 40
-        Crypto Express 6S  z14                               85
-        =================  ===================  ===============
+        =================  =========================  ===============
+        Adapter type       Machine generations        Maximum domains
+        =================  =========================  ===============
+        Crypto Express 5S  z14 (3) / z13 (1)               85
+        Crypto Express 5S  z14-ZR1 (4) / z13s (2)          40
+        Crypto Express 6S  z14 (3)                         85
+        Crypto Express 6S  z14-ZR1 (4)                     40
+        =================  =========================  ===============
+
+        Notes:
+
+        (1) Supported for z13 and LinuxONE Emperor
+        (2) Supported for z13s and LinuxONE Rockhopper
+        (3) Supported for z14 and LinuxONE Emperor II
+        (4) Supported for z14-ZR1 and LinuxONE Rockhopper II
 
         If this adapter is not a crypto adapter, `None` is returned.
 

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -336,7 +336,13 @@ class Cpc(BaseResource):
         '2828': 30,  # zBC12
         '2964': 85,  # z13 / Emperor
         '2965': 40,  # z13s / Rockhopper
-        '3906': 85,  # z14
+        '3906': 85,  # z14 / Emperor II
+        '3907': 40,  # z14-ZR1 / Rockhopper II
+        # Note: From HMC API version 2.24 on, the Cpc object supports a
+        # 'maximum-partitions' property. Because that API version was
+        # introduced while model 3907 was already avbailable, the property is
+        # guaranteed to be available only on models after 3907.
+        # TODO: Exploit the new 'maximum-partitions' property.
     }
 
     @property
@@ -350,17 +356,18 @@ class Cpc(BaseResource):
         partitions or partitions by machine generations supported at the HMC
         API:
 
-        ==================  ==================
-        Machine generation  Maximum partitions
-        ==================  ==================
-        z196                                60
-        z114                                30
-        zEC12                               60
-        zBC12                               30
-        z13 / Emperor                       85
-        z13s / Rockhopper                   40
-        z14                                 85
-        ==================  ==================
+        =========================  ==================
+        Machine generation         Maximum partitions
+        =========================  ==================
+        z196                                      60
+        z114                                      30
+        zEC12                                     60
+        zBC12                                     30
+        z13 / Emperor                             85
+        z13s / Rockhopper                         40
+        z14 / Emperor II                          85
+        z14-ZR1 / Rockhopper II                   40
+        =========================  ==================
 
         Raises:
 


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge, except for this TODO:

* Clarify whether the use of HMC version 2.14.0 for the second wave of z14 machines is intentional (the zhmcclient docs make a statement about that).