### PR TITLE
Added support for DPM storage groups for FCP

### DIFF
--- a/design/dpm-storage-model.rst
+++ b/design/dpm-storage-model.rst
@@ -1,0 +1,338 @@
+.. Copyright 2018 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+=======================================
+Design for DPM storage management model
+=======================================
+
+DPM introduces support for a new simplified way to manage the storage
+attached to a CPC.
+
+For simplicity, this design document uses the term "DPM storage management
+model" to mean all changes related to Storage Groups (part of LI1170), FICON
+Configuration (also part of LI1170), Feature List API (LI1421),
+and any other changes to existing WS-API functionality that is related to
+the new support.
+
+The DPM storage management model only applies to CPCs in DPM mode that have
+the "dpm-storage-management" feature enabled. Named features are also a newly
+introduced concept.
+
+The "dpm-storage-management" feature will be available for the z14 machine
+generation and onwards, and will not be rolled back to machine generations
+before z14. For the z14 machine generation (high end and mid range), the
+"dpm-storage-management" feature will roll out in the service stream for the
+machines. Once the service level containing support for it is applied to a
+CPC, that CPC will exhibit the new support. There is no means to enable or
+disable the "dpm-storage-management" feature for a CPC; it is always enabled
+once the service providing it has been applied. The service providing the
+"dpm-storage-management" feature is concurrent for the CPC but requires a
+reboot of SE and HMC.
+With the next machine generation after z14, the "dpm-storage-management"
+feature will be available from day 1.
+
+The DPM storage management model is incompatible for WS-API clients that used
+the storage related functionality so far. For example, HBA objects no longer
+exist.
+
+This design document describes at a high level how the zhmcclient API will
+expose the DPM storage management model.
+
+Resource model
+==============
+
+The zhmcclient API implements a concept of Python manager objects and Python
+resource objects to expose the HMC objects: A Python manager object is part of
+its parent resource object and mainly provides methods for listing its own
+resource objects, and for creating new resource objects. A Python resource
+object represents a corresponding HMC object.
+
+Because the DPM storage management model makes broad use of having resource URIs
+back and forth, the zhmcclient resource model at the Python API level
+distinguishes between child resources of a resource (over which lifecycle
+control is exercised), and other referenced resources (over which no lifecycle
+control is exercised).
+
+Navigation from a Python resource object to its child resource objects and to
+its referenced resources normally happens in the same way: A resource object
+has an attribute for each type of child resource and for each type of
+referenced resource. The attribute value is the Python manager object for the
+set of child resources or referenced resources, respectively.
+The difference is to which parent resource object the manager object of these
+resource objects point back via its "parent" attribute: The manager object of
+child resource objects always point back to their parent resource object (who
+manages the lifecycle of the child resource), while the manager object of
+referenced resource objects do not point back to their referencing resource,
+but to their true parent resource (to which the referenced resource is a child
+resource).
+
+The previous paragraph described how it works for child resources or referenced
+resources with a multiplicity of 0 or more (*). Some referenced resources have
+a multiplicity of 1. For those referenced resources, the Python object setup is
+simplified, in that there is no manager object. Instead, the attribute value if
+directly the referenced resource object.
+
+The following diagram shows the resource hierarchy that will be exposed by the
+zhmcclient API. The manager objects (for resources with a multiplicity of *)
+are not shown in the diagram, for simplicity. The names shown are the Python
+class names of the resource classes.
+In parenthesis follow the multiplicity, whether the resource object is a child
+resource or a referenced resource, and optionally the role of these resources
+within their parent or referencing resource.
+
+The diagram shows resource classes for storage groups (which are
+commonly used for FCP and FICON storage), the resource classes specific to the
+FICON configuration, and existing resource classes to the extent they are
+relevant for the DPM storage management model.
+
+It is important to understand that the storage groups and the FICON
+configuration are scoped to a single CPC, and represent that CPC’s view of a
+set of storage resources. A second CPC’s storage groups and FICON configuration
+may include resources that represent the same physical or logical entities, but
+they are represented at the WS-API and thus at the zhmcclient API as separate
+resource objects.
+
+.. code-block:: text
+
+    client
+      |
+      +-- CPC (*/child)
+      |     |
+      |     +-- Adapter (*/child, storage adapter, type: FCP or FICON)
+      |     |     |
+      |     |     +-- Port (*/child, storage port)
+      |     |           |
+      |     |           +-- StorageSwitch (1/ref, the switch connected to this port)
+      |     |           |
+      |     |           +-- StorageSubsystem (1/ref, the subsystem connected to this port)
+      |     |
+      |     +-- Partition (*/child)
+      |     |     |
+      |     |     +-- HBA (*/child readonly, future?)
+      |     |
+      |     +-- StorageGroup (*/child, type: FCP or FICON)
+      |           |
+      |           +-- StorageVolume (*/child)
+      |           |     |
+      |           |     +-- StorageControlUnit (*/ref, FICON SGs only)
+      |           |
+      |           +-- VirtualStorageResource (*/child)
+      |           |     |
+      |           |     +-- Partition (1/ref, partition to which this VSR is attached)
+      |           |     |
+      |           |     +-- Port (*/ref, actually used port, for FCP SGs)
+      |           |     |
+      |           |     +-- StorageVolume (*/ref, volume, for FICON SGs)
+      |           |
+      |           +-- Partition (*/ref, partitions to which this SG is attached)
+      |           |
+      |           +-- Port (*/ref, FCP SGs only, candidate ports to be used in this SG)
+      |
+      +-- StorageSite (1-2/child, FICON only)
+      |     |
+      |     +-- CPC (*/ref, the CPCs using this FICON configuration - currently always 1)
+      |     |
+      |     +-- StorageSubsystem (*/ref, the subsystems in this site)
+      |     |
+      |     +-- StorageSwitch (*/ref, the switches in this site)
+      |
+      +-- StorageFabric (*/child, FICON only)
+      |     |
+      |     +-- CPC (*/ref, the CPCs using this FICON configuration - currently always 1)
+      |     |
+      |     +-- StorageSwitch (*/ref, the switches in this fabric)
+      |
+      +-- StorageSwitch (*/child, FICON only, all switches)
+      |     |
+      |     +-- StorageSite (1/ref, the site this switch is in)
+      |     |
+      |     +-- StorageFabric (1/ref, the fabric this switch is in)
+      |
+      +-- StorageSubsystem (*/child, FICON only, all subsystems)
+            |
+            +-- StorageControlUnit (*/child, the logical control units of the subsystem)
+            |     |
+            |     +-- StoragePath (*/child, the paths that connect this control unit to a port on a switch and ultimately on an adapter of the CPC)
+            |           |
+            |           +-- StorageSwitch (0-1/ref, the exit switch for this path)
+            |           |
+            |           +-- Adapter (1/ref, the adapter for this path (its port is specified as a property)
+            |
+            +-- StorageSite (1/ref, the site this subsystem is in)
+            |
+            +-- StorageSwitch (*/ref, the connected switches)
+            |
+            +-- Adapter (*/ref, the connected adapters (their ports are specified as a property)
+
+Here are brief descriptions of the resource classes added by the DPM storage
+management model:
+
+Storage group support:
+
+* StorageGroup - A container for storage volumes (FCP or ECKD).
+
+  A particular storage group can be attached to zero or more partitions. In
+  case of more than one partition, the volumes in the group are being shared
+  between the partitions.
+
+  A particular partition may have multiple storage groups attached, which means
+  that all volumes in these storage groups are attached to the partition.
+
+* StorageVolume - A storage volume (FCP or ECKD) on a storage subsystem.
+
+  The storage volume resource objects can be created, but the act of actually
+  allocating the volume on the storage subsystem is not performed by the creation
+  operation and is instead performed separately. That act is termed "fulfillment".
+  Thus, a storage volume resource object has a fulfillment status.
+
+  When a storage group is attached to a partition, the group’s fulfilled storage
+  volumes are virtualized for that partition and the partition’s view of them is
+  represented by a set of virtual storage resource objects.
+
+* VirtualStorageResource - A storage volume (FCP or ECKD) that is attached to a
+  partition. If the same StorageVolume resource is attached to two partitions,
+  there is one VirtualStorageResource resource for each of thoser attachments.
+
+FICON configuration support:
+
+* StorageSite - A site housing storage subsystems and storage switches that are
+  accessible to a CPC (FICON only).
+
+  A storage site HMC object is a child resource of a CPC HMC object and
+  represents the view of the CPC on its storage. The same physical storage
+  subsystems and storage switches can be represented in multiple storage site
+  resources.
+
+  A primary storage site resource always exists by default for a CPC.
+  A secondary storage site resource for a CPC can optionally be defined.
+  Primary sites are typically local to the CPC. Secondary sites are typically
+  remote to the CPC, and are often used for redundancy.
+
+* StorageSwitch - A physical storage switch (FICON only).
+
+* StorageSubsystem - A physical storage subsystem (storage unit) (FICON only).
+
+  Storage subsystems are physically connected (cabled) to a set of storage
+  switches or directly to a set of storage adapters in the CPC.
+
+  Storage subsystems are subdivided into logical control units, which provide
+  access to a subset of a subsystem’s storage resources.
+
+* StorageControlUnit - A logical control unit within a storage subsystem (FICON
+  only).
+
+* StorageFabric - A logical construct that encompasses the set of all storage
+  switches that are interconnected (FICON only).
+
+  In a multi-site configuration, switches from both sites are interconnected,
+  therefore in such configurations, a fabric will span multiple sites.
+
+The other resource classes shown in the diagram already exist today in the
+zhmcclient API:
+
+* Adapter
+
+* Port
+
+* Partition
+
+* CPC
+
+TBD: Info on features.
+
+TBD: Info on storage resources and operations that are different or not
+available anymore (e.g. HBA).
+
+
+Mapping HMC operations to the zhmcclient API
+============================================
+
+In the following tables, "mgr" refers to the Python manager object for the
+resource, and "res" refers to the Python resource object for the resource.
+
+**Storage group support (FCP only)**
+
+Partition
+---------
+
+=====================================================  ==============================  ==========================================
+HMC Operation Name                                     zhmcclient API                  HTTP method and URI
+=====================================================  ==============================  ==========================================
+Attach Storage Group                                   res.attach_storage_group()      POST /api/partitions/{partition-id}/operations/attach-storage-group
+Detach Storage Group                                   res.detach_storage_group()      POST /api/partitions/{partition-id}/operations/detach-storage-group
+=====================================================  ==============================  ==========================================
+
+StorageGroup
+------------
+
+==========================  =============  ===================================
+Resource Attribute          kind           Python class      
+==========================  =============  ===================================
+storage_volumes             */child        StorageVolumeManager
+virtual_storage_resources   */child        VirtualStorageResourceManager
+==========================  =============  ===================================
+
+=====================================================  ==============================  ==========================================
+HMC Operation Name                                     zhmcclient API                  HTTP method and URI
+=====================================================  ==============================  ==========================================
+List Storage Groups                                    mgr.list()                      GET /api/cpcs/{cpc-id}/storage-groups
+Create Storage Group                                   mgr.create()                    POST /api/cpcs/{cpc-id}/storage-groups
+Delete Storage Group                                   res.delete()                    DELETE /api/storage-groups/{storage-group-id}
+Get Storage Group Properties                           res.properties                  GET /api/storage-groups/{storage-group-id}
+Modify Storage Group Properties                        res.update_properties()         POST /api/storage-groups/{storage-group-id}
+Add Candidate Adapter Ports to an FCP Sto.Grp.         res.add_candidate_ports()       POST /api/storage-groups/{storage-group-id}/operations/add-candidate-adapter-ports
+Remove Candidate Adapter Ports from an FCP Sto.Grp.    res.remove_candidate_ports()    POST /api/storage-groups/{storage-group-id}/operations/remove-candidate-adapter-ports
+Request Storage Group Fulfillment                      res.request_fulfillment()       POST /api/storage-groups/{storage-group-id}/operations/request-fulfillment
+Get Partitions for a Storage Group                     res.list_attached_partitions()  GET /api/storage-groups/{storage-group-id}/operations/get-partitions
+candidate-adapterport-uris property of storage group   res.list_candidate_ports()      
+=====================================================  ==============================  ==========================================
+
+StorageVolume
+-------------
+
+=====================================================  ==============================  ==========================================
+HMC Operation Name                                     zhmcclient API                  HTTP method and URI
+=====================================================  ==============================  ==========================================
+List Storage Volumes of a Storage Group                mgr.list()                      GET /api/storage-groups/{storage-group-id}/storage-volumes
+Modify Storage Group Properties (to create a volume)   mgr.create()
+Modify Storage Group Properties (to delete a volume)   mgr.delete()
+Get Storage Volume Properties                          res.properties                  GET /api/storage-groups/{storage-group-id}/storage-volumes/{storage-volume-id}
+Modify Storage Group Properties (to update a volume)   res.update_properties()
+Fulfill FICON Storage Volume                           res.fulfill_ficon()             POST /api/storage-groups/{storage-group-id}/storage-volumes/{storage-volume-id}/operations/fulfill-ficon-storage-volume
+Unfulfill FICON Storage Volume                         res.unfulfill_ficon()           POST /api/storage-groups/{storage-group-id}/storage-volumes/{storage-volume-id}/operations/unfulfill-ficon-storage-volume
+Fulfill FCP Storage Volume                             res.fulfill_fcp()               POST /api/storage-groups/{storage-group-id}/storage-volumes/{storage-volume-id}/operations/fulfill-fcp-storage-volume
+=====================================================  ==============================  ==========================================
+
+VirtualStorageResource
+----------------------
+
+==========================  =============  ===================================
+Resource Attribute          kind           Python class      
+==========================  =============  ===================================
+attached_partition          1/ref          Partition
+==========================  =============  ===================================
+
+=====================================================  ==============================  ==========================================
+HMC Operation Name                                     zhmcclient API                  HTTP method and URI
+=====================================================  ==============================  ==========================================
+List Virtual Storage Resources of a Storage Group      mgr.list()                      GET /api/storage-groups/{storage-group-id}/virtual-storage-resources
+Get Virtual Storage Resource Properties                res.properties                  GET /api/storage-groups/{storage-group-id}/virtual-storage-resources/{virtual-storage-resource-id}
+Update Virtual Storage Resource Properties             res.update_properties()         POST /api/storage-groups/{storage-group-id}/virtual-storage-resources/{virtual-storage-resource-id}
+adapter-port-uris property of VSR                      res.list_actual_adapter_ports()
+=====================================================  ==============================  ==========================================
+
+**FICON configuration support**
+
+TBD

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -60,6 +60,19 @@ This documentation uses a few special terms:
       The HMC gives each newly created session-id a lifetime of 10 hours, and
       expires it after that.
 
+   fulfillment
+      The act of satisfying requests for creation, modification, or deletion of
+      storage volumes in a storage subsystem (i.e. of the actual storage
+      backing a :term:`storage volume` object).
+
+      Storage volume objects have a fulfillment state indicating whether the
+      volume is fulfilled, which means that the request for creation or
+      modification has been carried out and the state of the backing volume is
+      now in sync with the storage volume object.
+
+      :term:`Storage group` objects also have a fulfillment state indicating
+      whether all of its storage volumes are fulfilled.
+
 
 .. _`Special type names`:
 
@@ -244,6 +257,9 @@ Resources scoped to CPCs in DPM mode
 
      For details, see section :ref:`HBAs`.
 
+     HBA resource objects only exist when the "dpm-storage-management" feature
+     is not enabled. See section :ref:`Storage Groups` for details.
+
   Network Adapter
      Short term for an :term:`Adapter` for attaching networks (e.g. OSA-Express
      adapter).
@@ -272,8 +288,28 @@ Resources scoped to CPCs in DPM mode
   Storage Adapter
      Short term for an :term:`Adapter` for attaching storage.
 
+  Storage Group
+     A grouping entity for a set of FCP or ECKD (=FICON)
+     :term:`storage volumes <storage volume>`. A storage group can be attached
+     to a :term:`partition` which will cause its storage volumes to be attached
+     to the partition.
+
+     Storage Group objects exist only when the "dpm-storage-management"
+     feature is enabled on the CPC.
+     For details, see section :ref:`Storage Groups`.
+
   Storage Port
      Short term for a :term:`Port` of a :term:`Storage Adapter`.
+
+  Storage Volume
+     An FCP or ECKD (=FICON) storage volume defined in context of a
+     :term:`storage group`. The life cycle of a storage volume includes being
+     defined but not :term:`fulfilled <fulfillment>`, being fulfilled but not
+     attached, and finally being attached to a :term:`partition`.
+
+     Storage Volume objects exist only when the "dpm-storage-management"
+     feature is enabled on the CPC.
+     For details, see section :ref:`Storage Groups`.
 
   vHBA
      Synonym for :term:`HBA`. In this resource model, HBAs are always
@@ -285,6 +321,18 @@ Resources scoped to CPCs in DPM mode
      :term:`Accelerator Adapter`.
 
      For details, see section :ref:`Virtual functions`.
+
+  Virtual Storage Resource
+     A representation of a storage-related z/Architecture device in a
+     :term:`partition`. For FCP type storage volumes, a Virtual Storage
+     Resource object represents an :term:`HBA` through which the attached
+     storage volume is accessed. For FICON (ECKD) type storage volumes, a
+     Virtual Storage Resource object represents the attached storage volume
+     itself.
+
+     Virtual Storage Resource objects exist only when the
+     "dpm-storage-management" feature is enabled on the CPC.
+     For details, see section :ref:`Storage Groups`.
 
   Virtual Switch
      A virtualized networking switch connecting :term:`NICs <NIC>` with a

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -71,6 +71,20 @@ Released: not yet
   machine generation. The DPM storage management feature is the first of these
   new firmware features.
 
+* Added support for the DPM storage management feature that is available starting
+  with the z14-ZR1 and LinuxONE Rockhopper II machine generation. This includes
+  new resources like Storage Groups, Storage Volumes, and Virtual Storage Resources.
+  It also includes new methods for managing storage group attachment to Partitions.
+  The new items in the documentation are:
+
+  - In 5.1. CPCs: `list_associated_storage_groups()`, `validate_lun_path()`.
+  - In 5.5. Partitions: `attach_storage_group()`, `detach_storage_group()`,
+    `list_attached_storage_groups()`.
+  - 5.12. Storage Groups
+  - 5.13. Storage Volumes
+  - 5.14. Virtual Storage Resources
+  - In 5.15 Console: `storage_groups`
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -513,6 +513,54 @@ Virtual Switches
    .. rubric:: Details
 
 
+.. _`Storage Groups`:
+
+Storage Groups
+-----------------
+
+.. automodule:: zhmcclient._storage_group
+
+.. autoclass:: zhmcclient.StorageGroupManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.StorageGroup
+   :members:
+   :special-members: __str__
+
+
+.. _`Storage Volumes`:
+
+Storage Volumes
+-----------------
+
+.. automodule:: zhmcclient._storage_volume
+
+.. autoclass:: zhmcclient.StorageVolumeManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.StorageVolume
+   :members:
+   :special-members: __str__
+
+
+.. _`Virtual Storage Resources`:
+
+Virtual Storage Resources
+-------------------------
+
+.. automodule:: zhmcclient._virtual_storage_resource
+
+.. autoclass:: zhmcclient.VirtualStorageResourceManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.VirtualStorageResource
+   :members:
+   :special-members: __str__
+
+
 .. _`Console`:
 
 Console

--- a/examples/example_hmccreds.yaml
+++ b/examples/example_hmccreds.yaml
@@ -85,6 +85,13 @@ examples:
         - "Crypto 0124 A13B-12"
       #loglevel: info
       #timestats: yes
+   list_storage_groups:
+      hmc: "192.168.111.5"
+      cpcname: DPMSE2
+      #sgname: BigOne
+      #loglevel: info
+      #logmodule: zhmcclient._session
+      #timestats: yes
 
 "192.168.111.5":
    userid: ensadmin

--- a/examples/list_storage_groups.py
+++ b/examples/list_storage_groups.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# Copyright 2018 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example that lists storage groups (DPM mode, z14).
+"""
+
+import sys
+import logging
+import yaml
+import requests.packages.urllib3
+
+import zhmcclient
+
+requests.packages.urllib3.disable_warnings()
+
+if len(sys.argv) != 2:
+    print("Usage: %s hmccreds.yaml" % sys.argv[0])
+    sys.exit(2)
+hmccreds_file = sys.argv[1]
+
+with open(hmccreds_file, 'r') as fp:
+    hmccreds = yaml.load(fp)
+
+examples = hmccreds.get("examples", None)
+if examples is None:
+    print("examples not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+list_storage_groups = examples.get("list_storage_groups", None)
+if list_storage_groups is None:
+    print("list_storage_groups not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+loglevel = list_storage_groups.get("loglevel", None)
+if loglevel is not None:
+    level = getattr(logging, loglevel.upper(), None)
+    if level is None:
+        print("Invalid value for loglevel in credentials file %s: %s" % \
+              (hmccreds_file, loglevel))
+        sys.exit(1)
+    logmodule = list_storage_groups.get("logmodule", None)
+    if logmodule is None:
+        logmodule = ''  # root logger
+    print("Logging for module %s with level %s" % (logmodule, loglevel))
+    handler = logging.StreamHandler()
+    format_string = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    handler.setFormatter(logging.Formatter(format_string))
+    logger = logging.getLogger(logmodule)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+
+hmc = list_storage_groups["hmc"]
+cpcname = list_storage_groups["cpcname"]
+
+cred = hmccreds.get(hmc, None)
+if cred is None:
+    print("Credentials for HMC %s not found in credentials file %s" % \
+          (hmc, hmccreds_file))
+    sys.exit(1)
+
+userid = cred['userid']
+password = cred['password']
+
+print(__doc__)
+
+print("Using HMC %s with userid %s ..." % (hmc, userid))
+session = zhmcclient.Session(hmc, userid, password)
+cl = zhmcclient.Client(session)
+
+timestats = list_storage_groups.get("timestats", False)
+if timestats:
+    session.time_stats_keeper.enable()
+
+print("Finding CPC %s ..." % cpcname)
+try:
+    cpc = cl.cpcs.find(name=cpcname)
+except zhmcclient.NotFound:
+    print("Could not find CPC %s on HMC %s" % (cpcname, hmc))
+    sys.exit(1)
+
+if False:
+    print("Checking CPC %s to be in DPM mode ..." % cpcname)
+    if not cpc.dpm_enabled:
+        print("Storage groups require DPM mode, but CPC %s is not in DPM mode" %
+              cpcname)
+        sys.exit(1)
+
+print("Storage Groups of CPC %s ..." % cpcname)
+storage_groups = cpc.storage_groups.list()
+
+sgname = list_storage_groups.get("sgname", None)
+
+for sg in storage_groups:
+
+    if sgname and sg.name != sgname:
+        print("  Skipping storage group: %s" % sg.name)
+        continue
+
+    part_names = [p.name for p in sg.list_attached_partitions()]
+    part_names_str = ', '.join(part_names) if part_names else "<none>"
+    print("  Storage Group: %s (type: %s, shared: %s, fulfillment: %s, "
+          "attached to partitions: %s)" %
+          (sg.name, sg.get_property('type'), sg.get_property('shared'),
+           sg.get_property('fulfillment-state'), part_names_str))
+
+    try:
+        volumes = sg.storage_volumes.list()
+    except zhmcclient.HTTPError as exc:
+        print("Error listing storage volumes of storage group %s:\n"
+              "HTTPError: %s" % (sg.name, exc))
+        volumes = []
+    for sv in volumes:
+        print("    Storage Volume: %s (oid: %s, uuid: %s, size: %s GiB, "
+              "fulfillment: %s)" %
+              (sv.name, sv.oid, sv.prop('uuid', 'N/A'),
+               sv.get_property('size'), sv.get_property('fulfillment-state')))
+
+    try:
+        vsrs = sg.virtual_storage_resources.list()
+    except zhmcclient.HTTPError as exc:
+        print("Error listing virtual storage resources of storage group %s:\n"
+              "HTTPError: %s" % (sg.name, exc))
+        vsrs = []
+    for vsr in vsrs:
+        port = vsr.adapter_port
+        adapter = port.manager.parent
+        print("    Virtual Storage Resource: %s (devno: %s, "
+              "adapter.port: %s.%s, attached to partition: %s)" %
+              (vsr.name, vsr.get_property('device-number'),
+               adapter.name, port.name, vsr.attached_partition.name))
+
+session.logoff()
+
+if timestats:
+    print(session.time_stats_keeper)

--- a/tests/end2end/test_storage_group.py
+++ b/tests/end2end/test_storage_group.py
@@ -1,0 +1,308 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function tests for storage groups and their child resources.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import requests.packages.urllib3
+
+import zhmcclient
+from tests.common.utils import HmcCredentials, info, setup_cpc
+
+requests.packages.urllib3.disable_warnings()
+
+
+@pytest.mark.skip('TODO: Enable and fix issues')
+class TestStorageGroups(object):
+    """Test storage groups and their child resources."""
+
+    # Prefix for any names of HMC resources that are being created
+    NAME_PREFIX = 'zhmcclient.TestStorageGroups.'
+
+    def setup_method(self):
+        """
+        Set up HMC data, Session to that HMC, Client, and Cpc object.
+        """
+        self.hmc_creds = HmcCredentials()
+        self.fake_data = dict(
+            hmc_host='fake-host', hmc_name='fake-hmc',
+            hmc_version='2.13.1', api_version='1.8',
+            cpc_properties={
+                'object-id': 'fake-cpc1-oid',
+                # object-uri is set up automatically
+                'parent': None,
+                'class': 'cpc',
+                'name': 'fake-cpc1',
+                'description': 'Fake CPC #1 (DPM mode)',
+                'status': 'active',
+                'dpm-enabled': True,
+                'is-ensemble-member': False,
+                'iml-mode': 'dpm',
+                'available-features-list': [
+                    dict(name='dpm-storage-management', state=True),
+                ],
+            })
+        # setup_logging()
+
+    @classmethod
+    def dpm_storage_management_enabled(self, cpc):
+        """
+        Return boolean indicating whether the "DPM Storage Management" feature
+        is enabled for the specified CPC.
+
+        If the machine is not even aware of firmware features, it is considered
+        disabled.
+        """
+        try:
+            dpm_sm = cpc.feature_enabled('dpm-storage-management')
+        except ValueError:
+            dpm_sm = False
+        return dpm_sm
+
+    def test_stogrp_crud(self, capsys):
+        """Create, read, update and delete a storage group."""
+
+        cpc_name, session, client, cpc, faked_cpc = \
+            setup_cpc(capsys, self.hmc_creds, self.fake_data)
+
+        if not self.dpm_storage_management_enabled(cpc):
+            info(capsys, "DPM Storage feature not enabled or not supported; "
+                 "Skipping test_stogrp_crud() test case")
+            return
+
+        console = client.consoles.console
+        stogrp_name = self.NAME_PREFIX + 'test_stogrp_crud.stogrp1'
+
+        # Ensure clean starting point
+        try:
+            stogrp = console.storage_groups.find(name=stogrp_name)
+        except zhmcclient.NotFound:
+            pass
+        else:
+            info(capsys, "Cleaning up storage group from previous run: {!r}".
+                 format(stogrp))
+            stogrp.delete()
+
+        # Test creating the storage group
+
+        stogrp_input_props = {
+            'name': stogrp_name,
+            'description': 'Dummy storage group description.',
+            'type': 'fcp',
+        }
+        stogrp_auto_props = {
+            'shared': False,
+            'active': False,
+            'fulfillment-state': 'creating',
+            'adapter-count': 1,
+        }
+
+        stogrp = console.storage_groups.create(stogrp_input_props)
+
+        for pn in stogrp_input_props:
+            exp_value = stogrp_input_props[pn]
+            assert stogrp.properties[pn] == exp_value, \
+                "Unexpected value for property {!r} of storage group:\n" \
+                "{!r}".format(pn, sorted(stogrp.properties))
+        stogrp.pull_full_properties()
+        for pn in stogrp_input_props:
+            exp_value = stogrp_input_props[pn]
+            assert stogrp.properties[pn] == exp_value, \
+                "Unexpected value for property {!r} of storage group:\n" \
+                "{!r}".format(pn, sorted(stogrp.properties))
+        if not faked_cpc:
+            for pn in stogrp_auto_props:
+                exp_value = stogrp_auto_props[pn]
+                assert stogrp.properties[pn] == exp_value, \
+                    "Unexpected value for property {!r} of storage group:\n" \
+                    "{!r}".format(pn, sorted(stogrp.properties))
+
+        # Test finding the storage group based on its (cached) name
+
+        sg = console.storage_groups.find(name=stogrp_name)
+
+        assert sg.name == stogrp_name
+
+        # Test finding the storage group based on a server-side filtered prop
+
+        stogrps = console.storage_groups.findall(type='fcp')
+
+        assert stogrp_name in [sg.name for sg in stogrps]  # noqa: F812
+
+        # Test finding the storage group based on a client-side filtered prop
+
+        stogrps = console.storage_groups.findall(active=False)
+
+        assert stogrp_name in [sg.name for sg in stogrps]
+
+        # Test updating a property of the storage group
+
+        new_desc = "Updated storage group description."
+
+        stogrp.update_properties(dict(description=new_desc))
+
+        assert stogrp.properties['description'] == new_desc
+        stogrp.pull_full_properties()
+        assert stogrp.properties['description'] == new_desc
+
+        # Test deleting the storage group
+
+        stogrp.delete()
+
+        with pytest.raises(zhmcclient.NotFound):
+            console.storage_groups.find(name=stogrp_name)
+
+        # Cleanup
+        session.logoff()
+
+    def test_stovol_crud(self, capsys):
+        """Create, read, update and delete a storage volume in a sto.grp."""
+
+        cpc_name, session, client, cpc, faked_cpc = \
+            setup_cpc(capsys, self.hmc_creds, self.fake_data)
+
+        if not self.dpm_storage_management_enabled(cpc):
+            info(capsys, "DPM Storage feature not enabled or not supported; "
+                 "Skipping test_stovol_crud() test case")
+            return
+
+        console = client.consoles.console
+
+        stogrp_name = self.NAME_PREFIX + 'test_stovol_crud.stogrp1'
+        stovol_name = self.NAME_PREFIX + 'test_stovol_crud.stovol1'
+
+        # Ensure clean starting point
+        try:
+            stogrp = console.storage_groups.find(name=stogrp_name)
+        except zhmcclient.NotFound:
+            pass
+        else:
+            info(capsys, "Cleaning up storage group from previous run: {!r}".
+                 format(stogrp))
+            stogrp.delete()
+
+        # Create a storage group for the volume
+        stogrp = console.storage_groups.create(
+            dict(name=stogrp_name, type='fcp'))
+
+        # Test creating a volume
+
+        stovol_input_props = {
+            'name': stovol_name,
+            'description': 'Dummy storage volume description.',
+            'size': 100,  # MB
+        }
+        stovol_auto_props = {
+            'fulfillment-state': 'creating',
+            'usage': 'data',
+        }
+
+        # TODO: Remove this tempfix when fixed:
+        if True:
+            info(capsys, "Tempfix: Volume does not support 'cpc-uri' "
+                 "property; Omitting it in Create Volume.")
+        else:
+            stovol_input_props['cpc-uri'] = cpc.uri
+
+        stovol = stogrp.storage_volumes.create(stovol_input_props)
+
+        for pn in stovol_input_props:
+            exp_value = stovol_input_props[pn]
+            assert stovol.properties[pn] == exp_value, \
+                "Unexpected value for property {!r} of storage volume:\n" \
+                "{!r}".format(pn, sorted(stovol.properties))
+        stovol.pull_full_properties()
+        for pn in stovol_input_props:
+            # TODO: Remove this tempfix when fixed:
+            if pn == 'name':
+                info(capsys, "Tempfix: Create Volume does not honor name; "
+                     "Skipping assertion of name:\n"
+                     "  provided name: %r\n"
+                     "  created name:  %r" %
+                     (stovol_input_props[pn], stovol.properties[pn]))
+                continue
+            exp_value = stovol_input_props[pn]
+            assert stovol.properties[pn] == exp_value, \
+                "Unexpected value for property {!r} of storage volume:\n" \
+                "{!r}".format(pn, sorted(stovol.properties))
+        if not faked_cpc:
+            for pn in stovol_auto_props:
+                exp_value = stovol_auto_props[pn]
+                assert stovol.properties[pn] == exp_value, \
+                    "Unexpected value for property {!r} of storage volume:\n" \
+                    "{!r}".format(pn, sorted(stovol.properties))
+
+        # Test finding the storage volume based on its (cached) name
+
+        sv = stogrp.storage_volumes.find(name=stovol_name)
+
+        assert sv.name == stovol_name
+
+        # Test finding the storage volume based on a server-side filtered prop
+
+        # TODO: Remove this tempfix when fixed:
+        try:
+            stovols = stogrp.storage_volumes.find(usage='data')
+        except zhmcclient.HTTPError as exc:
+            if exc.http_status == 500:
+                info(capsys, "Tempfix: List Volumes filtered by usage raises "
+                     "%s,%s %r; Skipping this test." %
+                     (exc.http_status, exc.reason, exc.message))
+        else:
+            assert stovol_name in [sv.name for sv in stovols]  # noqa: F812
+
+        # Test finding the storage group based on a client-side filtered prop
+
+        # TODO: Remove this tempfix when fixed:
+        try:
+            stovols = stogrp.storage_volumes.findall(active=False)
+        except zhmcclient.HTTPError as exc:
+            if exc.http_status == 500:
+                info(capsys, "Tempfix: List Volumes raises "
+                     "%s,%s %r; Skipping this test." %
+                     (exc.http_status, exc.reason, exc.message))
+        else:
+            assert stovol_name in [sv.name for sv in stovols]
+
+        # Test updating a property of the storage volume
+
+        new_desc = "Updated storage volume description."
+
+        stovol.update_properties(dict(description=new_desc))
+
+        assert stovol.properties['description'] == new_desc
+        stovol.pull_full_properties()
+        assert stovol.properties['description'] == new_desc
+
+        # Test deleting the storage volume
+
+        # TODO: Remove this tempfix when fixed:
+        try:
+            stovol.delete()
+        except zhmcclient.HTTPError as exc:
+            if exc.http_status == 500:
+                info(capsys, "Tempfix: Delete Volume raises "
+                     "%s,%s %r; Skipping this test." %
+                     (exc.http_status, exc.reason, exc.message))
+        else:
+            with pytest.raises(zhmcclient.NotFound):
+                stogrp.storage_volumes.find(name=stovol_name)
+
+        # Cleanup
+        stogrp.delete()
+        session.logoff()

--- a/tests/unit/zhmcclient/test_storage_group.py
+++ b/tests/unit/zhmcclient/test_storage_group.py
@@ -1,0 +1,572 @@
+# Copyright 2018 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _storage_group module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import re
+import copy
+
+from zhmcclient import Client, Cpc, StorageGroup, StorageGroupManager, \
+    StorageVolumeManager, VirtualStorageResourceManager, HTTPError, \
+    NotFound
+from zhmcclient_mock import FakedSession
+from tests.common.utils import assert_resources
+
+
+# Object IDs and names of our faked storage groups:
+CPC_OID = 'fake-cpc1-oid'
+CPC_URI = '/api/cpcs/%s' % CPC_OID
+SG1_OID = 'sg1-oid'
+SG1_NAME = 'sg 1'
+SG2_OID = 'sg2-oid'
+SG2_NAME = 'sg 2'
+
+
+class TestStorageGroup(object):
+    """All tests for the StorageGroup and StorageGroupManager classes."""
+
+    def setup_method(self):
+        """
+        Set up a faked session, and add a faked CPC in DPM mode without any
+        child resources.
+        """
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.14.1', '1.9')
+        self.client = Client(self.session)
+        self.faked_cpc = self.session.hmc.cpcs.add({
+            'object-id': CPC_OID,
+            # object-uri is set up automatically
+            'parent': None,
+            'class': 'cpc',
+            'name': 'fake-cpc1-name',
+            'description': 'CPC #1 (DPM mode, storage mgmt feature enabled)',
+            'status': 'active',
+            'dpm-enabled': True,
+            'is-ensemble-member': False,
+            'iml-mode': 'dpm',
+            'available-features-list': [
+                dict(name='dpm-storage-management', state=True),
+            ],
+        })
+        assert self.faked_cpc.uri == CPC_URI
+        self.cpc = self.client.cpcs.find(name='fake-cpc1-name')
+        self.faked_console = self.session.hmc.consoles.add({
+            # object-id is set up automatically
+            # object-uri is set up automatically
+            # parent will be automatically set
+            # class will be automatically set
+            'name': 'fake-console-name',
+            'description': 'The HMC',
+        })
+        self.console = self.client.consoles.console
+
+    def add_storage_group1(self):
+        """Add storage group 1 (type fcp)."""
+
+        faked_storage_group = self.faked_console.storage_groups.add({
+            'object-id': SG1_OID,
+            # object-uri will be automatically set
+            # parent will be automatically set
+            # class will be automatically set
+            'cpc-uri': CPC_URI,
+            'name': SG1_NAME,
+            'description': 'Storage Group #1',
+            'type': 'fcp',
+            'shared': False,
+            'fulfillment-state': 'complete',
+            'connectivity': 4,
+        })
+        return faked_storage_group
+
+    def add_storage_group2(self):
+        """Add storage group 2 (type fc)."""
+
+        faked_storage_group = self.faked_console.storage_groups.add({
+            'object-id': SG2_OID,
+            # object-uri will be automatically set
+            # parent will be automatically set
+            # class will be automatically set
+            'cpc-uri': CPC_URI,
+            'name': SG2_NAME,
+            'description': 'Storage Group #2',
+            'type': 'fc',
+            'shared': False,
+            'fulfillment-state': 'complete',
+            'connectivity': 4,
+        })
+        return faked_storage_group
+
+    def test_storagegroupmanager_initial_attrs(self):
+        """Test initial attributes of StorageGroupManager."""
+
+        storage_group_mgr = self.console.storage_groups
+
+        assert isinstance(storage_group_mgr, StorageGroupManager)
+
+        # Verify all public properties of the manager object
+        assert storage_group_mgr.resource_class == StorageGroup
+        assert storage_group_mgr.session == self.session
+        assert storage_group_mgr.parent == self.console
+        assert storage_group_mgr.console == self.console
+
+    # TODO: Test for StorageGroupManager.__repr__()
+
+    testcases_storagegroupmanager_list_full_properties = (
+        "full_properties_kwargs, prop_names", [
+            (dict(),
+             ['object-uri', 'cpc-uri', 'name', 'fulfillment-state', 'type']),
+            (dict(full_properties=False),
+             ['object-uri', 'cpc-uri', 'name', 'fulfillment-state', 'type']),
+            (dict(full_properties=True),
+             None),
+        ]
+    )
+
+    @pytest.mark.parametrize(
+        *testcases_storagegroupmanager_list_full_properties
+    )
+    def test_storagegroupmanager_list_full_properties(
+            self, full_properties_kwargs, prop_names):
+        """Test StorageGroupManager.list() with full_properties."""
+
+        # Add two faked storage groups
+        faked_storage_group1 = self.add_storage_group1()
+        faked_storage_group2 = self.add_storage_group2()
+
+        exp_faked_storage_groups = [faked_storage_group1, faked_storage_group2]
+        storage_group_mgr = self.console.storage_groups
+
+        # Execute the code to be tested
+        storage_groups = storage_group_mgr.list(**full_properties_kwargs)
+
+        assert_resources(storage_groups, exp_faked_storage_groups, prop_names)
+
+    testcases_storagegroupmanager_list_filter_args = (
+        "filter_args, exp_names", [
+            ({'object-id': SG1_OID},
+             [SG1_NAME]),
+            ({'object-id': SG2_OID},
+             [SG2_NAME]),
+            ({'object-id': [SG1_OID, SG2_OID]},
+             [SG1_NAME, SG2_NAME]),
+            ({'object-id': [SG1_OID, SG1_OID]},
+             [SG1_NAME]),
+            ({'object-id': SG1_OID + 'foo'},
+             []),
+            ({'object-id': [SG1_OID, SG2_OID + 'foo']},
+             [SG1_NAME]),
+            ({'object-id': [SG2_OID + 'foo', SG1_OID]},
+             [SG1_NAME]),
+            ({'name': SG1_NAME},
+             [SG1_NAME]),
+            ({'name': SG2_NAME},
+             [SG2_NAME]),
+            ({'name': [SG1_NAME, SG2_NAME]},
+             [SG1_NAME, SG2_NAME]),
+            ({'name': SG1_NAME + 'foo'},
+             []),
+            ({'name': [SG1_NAME, SG2_NAME + 'foo']},
+             [SG1_NAME]),
+            ({'name': [SG2_NAME + 'foo', SG1_NAME]},
+             [SG1_NAME]),
+            ({'name': [SG1_NAME, SG1_NAME]},
+             [SG1_NAME]),
+            ({'name': '.*sg 1'},
+             [SG1_NAME]),
+            ({'name': 'sg 1.*'},
+             [SG1_NAME]),
+            ({'name': 'sg .'},
+             [SG1_NAME, SG2_NAME]),
+            ({'name': '.g 1'},
+             [SG1_NAME]),
+            ({'name': '.+'},
+             [SG1_NAME, SG2_NAME]),
+            ({'name': 'sg 1.+'},
+             []),
+            ({'name': '.+sg 1'},
+             []),
+            ({'name': SG1_NAME,
+              'object-id': SG1_OID},
+             [SG1_NAME]),
+            ({'name': SG1_NAME,
+              'object-id': SG1_OID + 'foo'},
+             []),
+            ({'name': SG1_NAME + 'foo',
+              'object-id': SG1_OID},
+             []),
+            ({'name': SG1_NAME + 'foo',
+              'object-id': SG1_OID + 'foo'},
+             []),
+        ]
+    )
+
+    @pytest.mark.parametrize(
+        *testcases_storagegroupmanager_list_filter_args
+    )
+    def test_storagegroupmanager_list_filter_args(
+            self, filter_args, exp_names):
+        """Test StorageGroupManager.list() with filter_args."""
+
+        # Add two faked storage_groups
+        self.add_storage_group1()
+        self.add_storage_group2()
+
+        storage_group_mgr = self.console.storage_groups
+
+        # Execute the code to be tested
+        storage_groups = storage_group_mgr.list(filter_args=filter_args)
+
+        assert len(storage_groups) == len(exp_names)
+        if exp_names:
+            names = [p.properties['name'] for p in storage_groups]
+            assert set(names) == set(exp_names)
+
+    testcases_storagegroupmanager_create_no_volumes = (
+        "input_props, exp_prop_names, exp_exc", [
+            ({},
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'description': 'fake description X'},
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'name': 'fake-sg-x'},
+             None,
+             HTTPError({'http-status': 400, 'reason': 5})),
+            ({'name': 'fake-sg-x',
+              'cpc-uri': CPC_URI,
+              'type': 'fcp'},
+             ['object-uri', 'name', 'cpc-uri'],
+             None),
+        ]
+    )
+
+    @pytest.mark.parametrize(
+        *testcases_storagegroupmanager_create_no_volumes
+    )
+    def test_storagegroupmanager_create(
+            self, input_props, exp_prop_names, exp_exc):
+        """Test StorageGroupManager.create()."""
+
+        # TODO: Add logic and test cases for creating initial storage volumes
+
+        storage_group_mgr = self.console.storage_groups
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                storage_group = storage_group_mgr.create(
+                    properties=input_props)
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+        else:
+
+            # Execute the code to be tested.
+            # Note: the StorageGroup object returned by StorageGroup.create()
+            # has the input properties plus 'object-uri'.
+            storage_group = storage_group_mgr.create(properties=input_props)
+
+            # Check the resource for consistency within itself
+            assert isinstance(storage_group, StorageGroup)
+            storage_group_name = storage_group.name
+            exp_storage_group_name = storage_group.properties['name']
+            assert storage_group_name == exp_storage_group_name
+            storage_group_uri = storage_group.uri
+            exp_storage_group_uri = storage_group.properties['object-uri']
+            assert storage_group_uri == exp_storage_group_uri
+
+            # Check the properties against the expected names and values
+            for prop_name in exp_prop_names:
+                assert prop_name in storage_group.properties
+                if prop_name in input_props:
+                    value = storage_group.properties[prop_name]
+                    exp_value = input_props[prop_name]
+                    assert value == exp_value
+
+    def test_storagegroupmanager_resource_object(self):
+        """
+        Test StorageGroupManager.resource_object().
+
+        This test exists for historical reasons, and by now is covered by the
+        test for BaseManager.resource_object().
+        """
+
+        # Add a faked storage_group
+        faked_storage_group = self.add_storage_group1()
+        storage_group_oid = faked_storage_group.oid
+
+        storage_group_mgr = self.console.storage_groups
+
+        # Execute the code to be tested
+        storage_group = storage_group_mgr.resource_object(storage_group_oid)
+
+        storage_group_uri = "/api/storage-groups/" + storage_group_oid
+
+        sv_mgr = storage_group.storage_volumes
+        vsr_mgr = storage_group.virtual_storage_resources
+
+        assert isinstance(storage_group, StorageGroup)
+        assert isinstance(sv_mgr, StorageVolumeManager)
+        assert isinstance(vsr_mgr, VirtualStorageResourceManager)
+
+        sg_cpc = storage_group.cpc
+        assert isinstance(sg_cpc, Cpc)
+        assert sg_cpc.uri == storage_group.properties['cpc-uri']
+
+        # Note: Properties inherited from BaseResource are tested there,
+        # but we test them again:
+        assert storage_group.properties['object-uri'] == storage_group_uri
+        assert storage_group.properties['object-id'] == storage_group_oid
+        assert storage_group.properties['class'] == 'storage-group'
+        assert storage_group.properties['parent'] == self.console.uri
+
+    def test_storagegroup_repr(self):
+        """Test StorageGroup.__repr__()."""
+
+        # Add a faked storage_group
+        faked_storage_group = self.add_storage_group1()
+
+        storage_group_mgr = self.console.storage_groups
+        storage_group = storage_group_mgr.find(name=faked_storage_group.name)
+
+        # Execute the code to be tested
+        repr_str = repr(storage_group)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(r'^{classname}\s+at\s+0x{id:08x}\s+\(\\n.*'.
+                        format(classname=storage_group.__class__.__name__,
+                               id=id(storage_group)),
+                        repr_str)
+
+    def test_storagegroup_delete_non_associated(self):
+        """Test StorageGroup.delete() of non-associated storage group."""
+
+        # Add a faked storage group to be tested and another one
+        faked_storage_group = self.add_storage_group1()
+        self.add_storage_group2()
+
+        storage_group_mgr = self.console.storage_groups
+
+        storage_group = storage_group_mgr.find(name=faked_storage_group.name)
+
+        # Execute the code to be tested.
+        storage_group.delete()
+
+        # Check that the storage group no longer exists
+        with pytest.raises(NotFound):
+            storage_group_mgr.find(name=faked_storage_group.name)
+
+    def test_storagegroup_delete_create_same_name(self):
+        """Test StorageGroup.delete() followed by create() with same name."""
+
+        # Add a faked storage_group to be tested and another one
+        faked_storage_group = self.add_storage_group1()
+        storage_group_name = faked_storage_group.name
+        self.add_storage_group2()
+
+        # Construct the input properties for a third storage_group
+        sg3_props = copy.deepcopy(faked_storage_group.properties)
+        sg3_props['description'] = 'Third storage_group'
+
+        storage_group_mgr = self.console.storage_groups
+        storage_group = storage_group_mgr.find(name=storage_group_name)
+
+        # Execute the deletion code to be tested.
+        storage_group.delete()
+
+        # Check that the storage_group no longer exists
+        with pytest.raises(NotFound):
+            storage_group_mgr.find(name=storage_group_name)
+
+        # Execute the creation code to be tested.
+        storage_group_mgr.create(sg3_props)
+
+        # Check that the storage_group exists again under that name
+        storage_group3 = storage_group_mgr.find(name=storage_group_name)
+        description = storage_group3.get_property('description')
+        assert description == 'Third storage_group'
+
+    testcases_storagegroup_update_properties_sgs = (
+        "storage_group_name", [
+            SG1_NAME,
+            SG2_NAME,
+        ]
+    )
+
+    testcases_storagegroup_update_properties_props = (
+        "input_props", [
+            {},
+            {'description': 'New storage_group description'},
+            {'shared': True},
+            {'connectivity': 8},
+        ]
+    )
+
+    @pytest.mark.parametrize(
+        *testcases_storagegroup_update_properties_sgs
+    )
+    @pytest.mark.parametrize(
+        *testcases_storagegroup_update_properties_props
+    )
+    def test_storagegroup_update_properties(
+            self, input_props, storage_group_name):
+        """Test StorageGroup.update_properties()."""
+
+        # Add faked storage_groups
+        self.add_storage_group1()
+        self.add_storage_group2()
+
+        storage_group_mgr = self.console.storage_groups
+        storage_group = storage_group_mgr.find(name=storage_group_name)
+
+        storage_group.pull_full_properties()
+        saved_properties = copy.deepcopy(storage_group.properties)
+
+        # Execute the code to be tested
+        storage_group.update_properties(properties=input_props)
+
+        # Verify that the resource object already reflects the property
+        # updates.
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in storage_group.properties
+            prop_value = storage_group.properties[prop_name]
+            assert prop_value == exp_prop_value
+
+        # Refresh the resource object and verify that the resource object
+        # still reflects the property updates.
+        storage_group.pull_full_properties()
+        for prop_name in saved_properties:
+            if prop_name in input_props:
+                exp_prop_value = input_props[prop_name]
+            else:
+                exp_prop_value = saved_properties[prop_name]
+            assert prop_name in storage_group.properties
+            prop_value = storage_group.properties[prop_name]
+            assert prop_value == exp_prop_value
+
+    def test_storagegroup_update_name(self):
+        """
+        Test StorageGroup.update_properties() with 'name' property.
+        """
+
+        # Add a faked storage_group
+        faked_storage_group = self.add_storage_group1()
+        storage_group_name = faked_storage_group.name
+
+        storage_group_mgr = self.console.storage_groups
+        storage_group = storage_group_mgr.find(name=storage_group_name)
+
+        new_storage_group_name = "new-" + storage_group_name
+
+        # Execute the code to be tested
+        storage_group.update_properties(
+            properties={'name': new_storage_group_name})
+
+        # Verify that the resource is no longer found by its old name, using
+        # list() (this does not use the name-to-URI cache).
+        storage_groups_list = storage_group_mgr.list(
+            filter_args=dict(name=storage_group_name))
+        assert len(storage_groups_list) == 0
+
+        # Verify that the resource is no longer found by its old name, using
+        # find() (this uses the name-to-URI cache).
+        with pytest.raises(NotFound):
+            storage_group_mgr.find(name=storage_group_name)
+
+        # Verify that the resource object already reflects the update, even
+        # though it has not been refreshed yet.
+        assert storage_group.properties['name'] == new_storage_group_name
+
+        # Refresh the resource object and verify that it still reflects the
+        # update.
+        storage_group.pull_full_properties()
+        assert storage_group.properties['name'] == new_storage_group_name
+
+        # Verify that the resource can be found by its new name, using find()
+        new_storage_group_find = storage_group_mgr.find(
+            name=new_storage_group_name)
+        assert new_storage_group_find.properties['name'] == \
+            new_storage_group_name
+
+        # Verify that the resource can be found by its new name, using list()
+        new_storage_groups_list = storage_group_mgr.list(
+            filter_args=dict(name=new_storage_group_name))
+        assert len(new_storage_groups_list) == 1
+        new_storage_group_list = new_storage_groups_list[0]
+        assert new_storage_group_list.properties['name'] == \
+            new_storage_group_name
+
+    # TODO: Adjust to invoke a SG method
+    @pytest.mark.parametrize(
+        "initial_status, exp_exc", [
+            ('stopped', None),
+            ('terminated', HTTPError({'http-status': 409, 'reason': 1})),
+            ('starting', HTTPError({'http-status': 409, 'reason': 1})),
+            ('active', HTTPError({'http-status': 409, 'reason': 1})),
+            ('stopping', HTTPError({'http-status': 409, 'reason': 1})),
+            ('degraded', HTTPError({'http-status': 409, 'reason': 1})),
+            ('reservation-error',
+             HTTPError({'http-status': 409, 'reason': 1})),
+            ('paused', HTTPError({'http-status': 409, 'reason': 1})),
+        ]
+    )
+    def xtest_storagegroup_start(self, initial_status, exp_exc):
+        """Test StorageGroup.start()."""
+
+        # Add a faked storage_group
+        faked_storage_group = self.add_storage_group1()
+
+        # Set the initial status of the faked storage_group
+        faked_storage_group.properties['status'] = initial_status
+
+        storage_group_mgr = self.console.storage_groups
+        storage_group = storage_group_mgr.find(name=faked_storage_group.name)
+
+        if exp_exc is not None:
+
+            with pytest.raises(exp_exc.__class__) as exc_info:
+
+                # Execute the code to be tested
+                storage_group.start()
+
+            exc = exc_info.value
+            if isinstance(exp_exc, HTTPError):
+                assert exc.http_status == exp_exc.http_status
+                assert exc.reason == exp_exc.reason
+
+        else:
+
+            # Execute the code to be tested.
+            ret = storage_group.start()
+
+            assert ret == {}
+
+            storage_group.pull_full_properties()
+            status = storage_group.get_property('status')
+            assert status == 'active'

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -51,3 +51,6 @@ from ._password_rule import *          # noqa: F401
 from ._task import *          # noqa: F401
 from ._ldap_server_definition import *         # noqa: F401
 from ._unmanaged_cpc import *          # noqa: F401
+from ._storage_group import *          # noqa: F401
+from ._storage_volume import *         # noqa: F401
+from ._virtual_storage_resource import *        # noqa: F401

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -27,6 +27,7 @@ from ._manager import BaseManager
 from ._resource import BaseResource
 from ._logging import get_logger, logged_api_call
 from ._utils import timestamp_from_datetime
+from ._storage_group import StorageGroupManager
 from ._user import UserManager
 from ._user_role import UserRoleManager
 from ._user_pattern import UserPatternManager
@@ -186,6 +187,7 @@ class Console(BaseResource):
         super(Console, self).__init__(manager, uri, name, properties)
 
         # The manager objects for child resources (with lazy initialization):
+        self._storage_groups = None
         self._users = None
         self._user_roles = None
         self._user_patterns = None
@@ -193,6 +195,17 @@ class Console(BaseResource):
         self._tasks = None
         self._ldap_server_definitions = None
         self._unmanaged_cpcs = None
+
+    @property
+    def storage_groups(self):
+        """
+        :class:`~zhmcclient.StorageGroupManager`:
+          Manager object for the Storage Groups in scope of this Console.
+        """
+        # We do here some lazy loading.
+        if not self._storage_groups:
+            self._storage_groups = StorageGroupManager(self)
+        return self._storage_groups
 
     @property
     def users(self):

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -20,7 +20,11 @@ an :term:`FCP Adapter`. More specifically, an HBA connects a Partition with an
 
 HBA resources are contained in Partition resources.
 
-HBAs only exist in :term:`CPCs <CPC>` that are in DPM mode.
+HBA resources only exist in :term:`CPCs <CPC>` that are in DPM mode and when
+the "dpm-storage-management" feature is not enabled. See section
+:ref:`Storage Groups` for details. When the "dpm-storage-management" feature is
+enabled, :term:`virtual HBAs <HBA>` are represented as
+:term:`Virtual Storage Resource` resources.
 """
 
 from __future__ import absolute_import

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -1,0 +1,657 @@
+# Copyright 2018 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Starting with the z14-ZR1 and LinuxONE Rockhopper II machine generations, the
+"dpm-storage-management" firmware feature has been introduced to support a
+simpler management of FCP and FICON (=ECKD) storage for DPM mode. If machines
+of these generations are in DPM mode, the feature is always enabled and cannot
+be disabled.
+
+When the "dpm-storage-management" feature is enabled, :term:`storage group`
+and :term:`storage volume` resources can be defined on the HMC, and can cause
+fulfillment requests to be sent via email to storage administrators.
+Once these requests are satisfied on the actual storage subsystem and possibly
+SAN switches, the changes are automatically discovered by DPM and reflected
+in the state of these resources. Thus, the allocation of actual storage volumes
+on the storage subsystem is not performed by DPM.
+
+The sending of email is optional, and if the changes are done by some
+automation tool, they will also be discovered automatically. That way, the
+whole process of allocating and attaching volumes can be fully automated, if
+so desired.
+
+The top level resource objects are :term:`storage groups <storage group>`.
+Storage groups are defined globally at the HMC level, and are associated with a
+CPC. They can only be associated with one CPC at a time. In the zhmcclient, the
+:class:`~zhmcclient.StorageGroup` objects are accessible via the
+:attr:`~zhmcclient.ConsoleManager.storage_groups` property.
+
+Storage groups are a grouping mechanism for
+:term:`storage volumes <storage volume>`. An FCP-type storage
+group can contain only FCP type storage volumes, and a FICON-type storage
+group can contain only FICON/ECKD type storage volumes.
+
+Attachment and detachment of volumes to a partition happens at the level of
+storage groups, and always applies to all volumes defined in the storage group.
+
+The storage-related z/Architecture devices that are visible to a partition are
+different for the two storage architectures: For FCP, the virtualized HBA is
+visible as a device, and the storage volumes (LUNs) are not represented as
+devices. For FICON, each ECKD volume is visible as a device, but the
+virtualized FICON adapter port is not represented as a device. When the
+"dpm-storage-management" feature is enabled, each storage-related
+z/Architecture device that is visible to a partition is represented as a
+:term:`virtual storage resource` object. The virtual storage resource objects
+are instantiated automatically when a storage group is attached to a partition.
+The :term:`HBA` resource objects known from DPM mode before the introduction of
+the "dpm-storage-management" feature are not exposed anymore (their equivalent
+are now the :term:`virtual storage resource` objects).
+
+Single storage volumes cannot be attached to partitions, only entire storage
+groups can be. In fact, storage volume objects do not even exist outside the
+scope of storage groups.
+A particular storage volume can be contained in only one storage group.
+
+Storage groups can be listed, created, deleted, and updated, and their storage
+volumes can also be listed, created, deleted, and updated.
+
+Storage groups can be attached to zero or more partitions. Attachment to
+multiple partitions at the same time is possible for storage groups that are
+defined to be shareable. In case of multiple attachments of a storage group, it
+contains the storage volume objects only once for all attachments, but the
+virtual storage resource objects are instantiated separately for each
+attachment.
+
+Storage groups can only be associated with CPCs that have the
+"dpm-storage-management" feature enabled.
+"""
+
+from __future__ import absolute_import
+
+import copy
+import re
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._storage_volume import StorageVolumeManager
+from ._virtual_storage_resource import VirtualStorageResourceManager
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['StorageGroupManager', 'StorageGroup']
+
+LOG = get_logger(__name__)
+
+
+class StorageGroupManager(BaseManager):
+    """
+    Manager providing access to the :term:`storage groups <storage group>` of
+    the HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable:
+
+    * :attr:`~zhmcclient.Console.storage_groups` of a
+      :class:`~zhmcclient.Console` object.
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #     CPC or HMC defining the scope for this manager.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'cpc-uri',
+            'name',
+            'type',
+            'fulfillment-state',
+        ]
+
+        super(StorageGroupManager, self).__init__(
+            resource_class=StorageGroup,
+            class_name='storage-group',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/storage-groups',
+            oid_prop='object-id',
+            uri_prop='object-uri',
+            name_prop='name',
+            query_props=query_props)
+        self._console = console
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: The Console object representing the HMC.
+        """
+        return self._console
+
+    @logged_api_call
+    def list(self, full_properties=False, filter_args=None):
+        """
+        List the storage groups defined in the HMC.
+
+        Storage groups for which the authenticated user does not have
+        object-access permission are not included.
+
+        Authorization requirements:
+
+        * Object-access permission to any storage groups to be included in the
+          result.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls that the full set of resource properties for each returned
+            storage volume is being retrieved, vs. only the following short
+            set: "object-uri", "cpc-uri", "name", "fulfillment-state", and
+            "type".
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.StorageGroup` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        resource_obj_list = []
+
+        if filter_args is None:
+            filter_args = {}
+
+        resource_obj = self._try_optimized_lookup(filter_args)
+        if resource_obj:
+            resource_obj_list.append(resource_obj)
+            # It already has full properties
+        else:
+            query_parms, client_filters = self._divide_filter_args(filter_args)
+            uri = '{}{}'.format(self._base_uri, query_parms)
+
+            result = self.session.get(uri)
+            if result:
+                props_list = result['storage-groups']
+                for props in props_list:
+
+                    resource_obj = self.resource_class(
+                        manager=self,
+                        uri=props[self._uri_prop],
+                        name=props.get(self._name_prop, None),
+                        properties=props)
+
+                    if self._matches_filters(resource_obj, client_filters):
+                        resource_obj_list.append(resource_obj)
+                        if full_properties:
+                            resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties):
+        """
+        Create and configure a storage group.
+
+        The new storage group will be associated with the CPC identified by the
+        `cpc-uri` input property.
+
+        Authorization requirements:
+
+        * Object-access permission to the CPC that will be associated with
+          the new storage group.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create Storage Group' in the :term:`HMC API` book.
+
+            The 'cpc-uri' property identifies the CPC to which the new
+            storage group will be associated, and is required to be specified
+            in this parameter.
+
+        Returns:
+
+          :class:`~zhmcclient.StorageGroup`:
+            The resource object for the new storage group.
+            The object will have its 'object-uri' property set as returned by
+            the HMC, and will also have the input properties set.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        if properties is None:
+            properties = {}
+
+        result = self.session.post(self._base_uri, body=properties)
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = copy.deepcopy(properties)
+        props.update(result)
+        name = props.get(self._name_prop, None)
+        uri = props[self._uri_prop]
+        storage_group = StorageGroup(self, uri, name, props)
+        self._name_uri_cache.update(name, uri)
+        return storage_group
+
+
+class StorageGroup(BaseResource):
+    """
+    Representation of a :term:`storage group`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.StorageGroupManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.StorageGroupManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, StorageGroupManager), \
+            "StorageGroup init: Expected manager type %s, got %s" % \
+            (StorageGroupManager, type(manager))
+        super(StorageGroup, self).__init__(manager, uri, name, properties)
+        # The manager objects for child resources (with lazy initialization):
+        self._storage_volumes = None
+        self._virtual_storage_resources = None
+        self._cpc = None
+
+    @property
+    def storage_volumes(self):
+        """
+        :class:`~zhmcclient.StorageVolumeManager`: Access to the
+        :term:`storage volumes <storage volume>` in this storage group.
+        """
+        # We do here some lazy loading.
+        if not self._storage_volumes:
+            self._storage_volumes = StorageVolumeManager(self)
+        return self._storage_volumes
+
+    @property
+    def virtual_storage_resources(self):
+        """
+        :class:`~zhmcclient.VirtualStorageResourceManager`: Access to the
+        :term:`virtual storage resources <Virtual Storage Resource>` in this
+        storage group.
+        """
+        # We do here some lazy loading.
+        if not self._virtual_storage_resources:
+            self._virtual_storage_resources = \
+                VirtualStorageResourceManager(self)
+        return self._virtual_storage_resources
+
+    @property
+    def cpc(self):
+        """
+        :class:`~zhmcclient.Cpc`: The :term:`CPC` to which this storage group
+        is associated.
+
+        The returned :class:`~zhmcclient.Cpc` has only a minimal set of
+        properties populated.
+        """
+        # We do here some lazy loading.
+        if not self._cpc:
+            cpc_uri = self.get_property('cpc-uri')
+            cpc_mgr = self.manager.console.manager.client.cpcs
+            self._cpc = cpc_mgr.resource_object(cpc_uri)
+        return self._cpc
+
+    @logged_api_call
+    def list_attached_partitions(self, name=None, status=None):
+        """
+        Return the partitions to which this storage group is currently
+        attached, optionally filtered by partition name and status.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          name (:term:`string`): Filter pattern (regular expression) to limit
+            returned partitions to those that have a matching name. If `None`,
+            no filtering for the partition name takes place.
+
+          status (:term:`string`): Filter string to limit returned partitions
+            to those  that have a matching status. The value must be a valid
+            partition status property value. If `None`, no filtering for the
+            partition status takes place.
+
+        Returns:
+
+          List of :class:`~zhmcclient.Partition` objects representing the
+          partitions to whivch this storage group is currently attached,
+          with a minimal set of properties ('object-id', 'name', 'status').
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        query_parms = []
+        if name is not None:
+            self.manager._append_query_parms(query_parms, 'name', name)
+        if status is not None:
+            self.manager._append_query_parms(query_parms, 'status', status)
+        query_parms_str = '&'.join(query_parms)
+        if query_parms_str:
+            query_parms_str = '?{}'.format(query_parms_str)
+
+        uri = '{}/operations/get-partitions{}'.format(
+            self.uri, query_parms_str)
+
+        sg_cpc = self.cpc
+        part_mgr = sg_cpc.partitions
+
+        result = self.manager.session.get(uri)
+        props_list = result['partitions']
+        part_list = []
+        for props in props_list:
+            part = part_mgr.resource_object(props['object-uri'], props)
+            part_list.append(part)
+        return part_list
+
+    @logged_api_call
+    def delete(self, email_to_addresses=None, email_cc_addresses=None,
+               email_insert=None):
+        """
+        Delete this storage group and its storage volume resources on the HMC,
+        and optionally send emails to storage administrators requesting
+        deletion of the storage volumes on the storage subsystem and cleanup of
+        any resources related to the storage group (e.g. zones on a SAN switch,
+        or host objects on a storage subsystem).
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          email_to_addresses (:term:`iterable` of :term:`string`): Email
+            addresses of one or more storage administrator to be notified.
+            If `None` or empty, no email will be sent.
+
+          email_cc_addresses (:term:`iterable` of :term:`string`): Email
+            addresses of one or more storage administrator to be copied
+            on the notification email.
+            If `None` or empty, nobody will be copied on the email.
+            Must be `None` or empty if `email_to_addresses` is `None` or empty.
+
+          email_insert (:term:`string`): Additional text to be inserted in the
+            notification email.
+            The text can include HTML formatting tags.
+            If `None`, no additional text will be inserted.
+            Must be `None` or empty if `email_to_addresses` is `None` or empty.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+          :exc:`ValueError`: Incorrect input arguments
+        """
+
+        body = {}
+
+        if email_to_addresses:
+            body['email-to-addresses'] = email_to_addresses
+            if email_cc_addresses:
+                body['email-cc-addresses'] = email_cc_addresses
+            if email_insert:
+                body['email-insert'] = email_insert
+        else:
+            if email_cc_addresses:
+                raise ValueError("email_cc_addresses must not be specified if "
+                                 "there is no email_to_addresses: %r" %
+                                 email_cc_addresses)
+            if email_insert:
+                raise ValueError("email_insert must not be specified if "
+                                 "there is no email_to_addresses: %r" %
+                                 email_insert)
+
+        self.manager.session.post(
+            uri=self.uri + '/operations/delete', body=body)
+
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this storage group.
+
+        This includes the `storage-volumes` property which contains requests
+        for creations, deletions and updates of
+        :class:`~zhmcclient.StorageVolume` resources of this storage group.
+        As an alternative to this bulk approach for managing storage volumes,
+        each :class:`~zhmcclient.StorageVolume` resource can individually be
+        created, deleted and updated using the respective methods on
+        :attr:`~zhmcclient.StorageGroup.storage_volumes`.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are listed for operation
+            'Modify Storage Group Properties' in section 'Storage Group object'
+            in the :term:`HMC API` book. This includes the email addresses
+            of the storage administrators.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        uri = '{}/operations/modify'.format(self.uri)
+        self.manager.session.post(uri, body=properties)
+        is_rename = self.manager._name_prop in properties
+        if is_rename:
+            # Delete the old name from the cache
+            self.manager._name_uri_cache.delete(self.name)
+        self.properties.update(copy.deepcopy(properties))
+        if is_rename:
+            # Add the new name to the cache
+            self.manager._name_uri_cache.update(self.name, self.uri)
+
+    @logged_api_call
+    def add_candidate_adapter_ports(self, ports):
+        """
+        Add a list of storage adapter ports to this storage group's candidate
+        adapter ports list.
+
+        This operation only applies to storage groups of type "fcp".
+
+        These adapter ports become candidates for use as backing adapters when
+        creating virtual storage resources when the storage group is attached
+        to a partition. The adapter ports should have connectivity to the
+        storage area network (SAN).
+
+        Candidate adapter ports may only be added before the CPC discovers a
+        working communications path, indicated by a "verified" status on at
+        least one of this storage group's WWPNs. After that point, all
+        adapter ports in the storage group are automatically detected and
+        manually adding them is no longer possible.
+
+        Because the CPC discovers working communications paths automatically,
+        candidate adapter ports do not need to be added by the user. Any
+        ports that are added, are validated by the CPC during discovery,
+        and may or may not actually be used.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group.
+        * Object-access permission to the adapter of each specified port.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          ports (:class:`py:list`): List of :class:`~zhmcclient.Port` objects
+            representing the ports to be added. All specified ports must not
+            already be members of this storage group's candidate adapter ports
+            list.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {
+            'adapter-port-uris': [p.uri for p in ports],
+        }
+        self.manager.session.post(
+            self.uri + '/operations/add-candidate-adapter-ports',
+            body=body)
+
+    @logged_api_call
+    def remove_candidate_adapter_ports(self, ports):
+        """
+        Remove a list of storage adapter ports from this storage group's
+        candidate adapter ports list.
+
+        This operation only applies to storage groups of type "fcp".
+
+        Because the CPC discovers working communications paths automatically,
+        candidate adapter ports do not need to be managed by the user. Any
+        ports that are removed using this function, might actually be added
+        again by the CPC dependent on the results of discovery.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group.
+        * Object-access permission to the adapter of each specified port.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          ports (:class:`py:list`): List of :class:`~zhmcclient.Port` objects
+            representing the ports to be removed. All specified ports must
+            currently be members of this storage group's candidate adapter
+            ports list and must not be referenced by any of the group's virtual
+            storage resources.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {
+            'adapter-port-uris': [p.uri for p in ports],
+        }
+        self.manager.session.post(
+            self.uri + '/operations/remove-candidate-adapter-ports',
+            body=body)
+
+    @logged_api_call
+    def list_candidate_adapter_ports(self, full_properties=False):
+        """
+        Return the current candidate storage adapter port list of this storage
+        group.
+
+        The result reflects the actual list of ports used by the CPC, including
+        any changes that have been made during discovery. The source for this
+        information is the 'candidate-adapter-port-uris' property of the
+        storage group object.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls that the full set of resource properties for each returned
+            candidate storage adapter port is being retrieved, vs. only the
+            following short set: "element-uri", "element-id", "class",
+            "parent".
+
+            TODO: Verify short list of properties.
+
+        Returns:
+
+          List of :class:`~zhmcclient.Port` objects representing the
+          current candidate storage adapter ports of this storage group.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        sg_cpc = self.cpc
+        adapter_mgr = sg_cpc.adapters
+        port_list = []
+        port_uris = self.get_property('candidate-adapter-port-uris')
+        if port_uris:
+            for port_uri in port_uris:
+                m = re.match(r'^(/api/adapters/[^/]*)/.*', port_uri)
+
+                adapter_uri = m.group(1)
+                adapter = adapter_mgr.resource_object(adapter_uri)
+
+                port_mgr = adapter.ports
+                port = port_mgr.resource_object(port_uri)
+                port_list.append(port)
+                if full_properties:
+                    port.pull_full_properties()
+
+        return port_list

--- a/zhmcclient/_storage_volume.py
+++ b/zhmcclient/_storage_volume.py
@@ -1,0 +1,625 @@
+# Copyright 2018 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :class:`~zhmcclient.StorageVolume` object represents an FCP or FICON (ECKD)
+:term:`storage volume` that is defined in a :term:`storage group`.
+
+Storage volume objects can be created, but what is created is the definition
+of a storage volume in the HMC and CPC. This does not include the act of
+actually allocating the volume on a storage subsystem. That is performed by a
+storage administrator who :term:`fulfills <fulfillment>` the volumes.
+
+In order to represent that, storage volume objects have a fulfillment state
+that is available in their 'fulfillment-state' property.
+
+When a storage group is attached to a :term:`partition`, the group's
+storage volumes are attached to the partition and any :term:`virtual storage
+resource` objects are instantiated.
+
+Storage volumes are contained in :term:`storage groups <storage group>`.
+
+You can create as many storage volumes as you want in a storage group.
+
+Storage groups and storage volumes only can be defined in CPCs that are in
+DPM mode and that have the "dpm-storage-management" feature enabled.
+"""
+
+from __future__ import absolute_import
+
+import re
+import copy
+# from requests.utils import quote
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['StorageVolumeManager', 'StorageVolume']
+
+LOG = get_logger(__name__)
+
+
+class StorageVolumeManager(BaseManager):
+    """
+    Manager providing access to the :term:`storage volumes <storage volume>`
+    in a particular :term:`storage group`.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.StorageGroup` object:
+
+    * :attr:`~zhmcclient.StorageGroup.storage_volumes`
+    """
+
+    def __init__(self, storage_group):
+        # This function should not go into the docs.
+        # Parameters:
+        #   storage_group (:class:`~zhmcclient.StorageGroup`):
+        #     Storage group defining the scope for this manager.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+            'fulfillment-state',
+            'maximum-size',
+            'minimum-size',
+            'usage',
+        ]
+
+        super(StorageVolumeManager, self).__init__(
+            resource_class=StorageVolume,
+            class_name='storage_volume',
+            session=storage_group.manager.session,
+            parent=storage_group,
+            base_uri='{}/storage-volumes'.format(storage_group.uri),
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def storage_group(self):
+        """
+        :class:`~zhmcclient.StorageGroup`: :term:`Storage group` defining the
+        scope for this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=False, filter_args=None):
+        """
+        List the storage volumes in this storage group.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls that the full set of resource properties for each returned
+            storage volume is being retrieved, vs. only the following short
+            set: "element-uri", "name", "fulfillment-state", "size", and
+            "usage".
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.StorageVolume` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        resource_obj_list = []
+
+        resource_obj = self._try_optimized_lookup(filter_args)
+        if resource_obj:
+            resource_obj_list.append(resource_obj)
+            # It already has full properties
+        else:
+            query_parms, client_filters = self._divide_filter_args(filter_args)
+
+            resources_name = 'storage-volumes'
+            uri = '{}/{}{}'.format(self.storage_group.uri, resources_name,
+                                   query_parms)
+
+            result = self.session.get(uri)
+            if result:
+                props_list = result[resources_name]
+                for props in props_list:
+
+                    resource_obj = self.resource_class(
+                        manager=self,
+                        uri=props[self._uri_prop],
+                        name=props.get(self._name_prop, None),
+                        properties=props)
+
+                    if self._matches_filters(resource_obj, client_filters):
+                        resource_obj_list.append(resource_obj)
+                        if full_properties:
+                            resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties, email_to_addresses=None,
+               email_cc_addresses=None, email_insert=None):
+        """
+        Create a :term:`storage volume` in this storage group on the HMC, and
+        optionally send emails to storage administrators requesting creation of
+        the storage volume on the storage subsystem and setup of any resources
+        related to the storage volume (e.g. LUN mask definition on the storage
+        subsystem).
+
+        This method performs the "Modify Storage Group Properties" operation,
+        requesting creation of the volume.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): Initial property values for the new volume.
+
+            Allowable properties are the fields defined in the
+            "storage-volume-request-info" nested object described for
+            operation "Modify Storage Group Properties" in the
+            :term:`HMC API` book.
+            The valid fields are those for the "create" operation. The
+            `operation` field must not be provided; it is set automatically
+            to the value "create".
+
+            The properties provided in this parameter will be copied and then
+            amended with the `operation="create"` field, and then used as a
+            single array item for the `storage-volumes` field in the request
+            body of the "Modify Storage Group Properties" operation.
+
+            Note that for storage volumes, the HMC does auto-generate a value
+            for the "name" property, but that auto-generated name is not unique
+            within the parent storage group. If you depend on a unique name,
+            you need to specify a "name" property accordingly.
+
+          email_to_addresses (:term:`iterable` of :term:`string`): Email
+            addresses of one or more storage administrator to be notified.
+            If `None` or empty, no email will be sent.
+
+          email_cc_addresses (:term:`iterable` of :term:`string`): Email
+            addresses of one or more storage administrator to be copied
+            on the notification email.
+            If `None` or empty, nobody will be copied on the email.
+            Must be `None` or empty if `email_to_addresses` is `None` or empty.
+
+          email_insert (:term:`string`): Additional text to be inserted in the
+            notification email.
+            The text can include HTML formatting tags.
+            If `None`, no additional text will be inserted.
+            Must be `None` or empty if `email_to_addresses` is `None` or empty.
+
+        Returns:
+
+          StorageVolume:
+            The resource object for the new storage volume.
+            The object will have the following properties set:
+
+            - 'element-uri' as returned by the HMC
+            - 'element-id' as determined from the 'element-uri' property
+            - 'class' and 'parent'
+            - additional properties as specified in the input properties
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+
+        Example::
+
+            stovol1 = fcp_stogrp.storage_volumes.create(
+                properties=dict(
+                    name='vol1',
+                    size=30,  # GiB
+            ))
+        """
+
+        sv_properties = copy.deepcopy(properties)
+        sv_properties['operation'] = 'create'
+        body = {
+            'storage-volumes': [sv_properties],
+        }
+        if email_to_addresses:
+            body['email-to-addresses'] = email_to_addresses
+            if email_cc_addresses:
+                body['email-cc-addresses'] = email_cc_addresses
+            if email_insert:
+                body['email-insert'] = email_insert
+        else:
+            if email_cc_addresses:
+                raise ValueError("email_cc_addresses must not be specified if "
+                                 "there is no email_to_addresses: %r" %
+                                 email_cc_addresses)
+            if email_insert:
+                raise ValueError("email_insert must not be specified if "
+                                 "there is no email_to_addresses: %r" %
+                                 email_insert)
+
+        result = self.session.post(
+            self.storage_group.uri + '/operations/modify',
+            body=body)
+        uri = result['element-uris'][0]
+
+        storage_volume = self.resource_object(uri, properties)
+
+        # The name is not guaranteed to be unique, so we don't maintain
+        # a name-to-uri cache for storage volumes.
+
+        return storage_volume
+
+
+class StorageVolume(BaseResource):
+    """
+    Representation of a :term:`storage volume`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.StorageVolumeManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.StorageVolumeManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, StorageVolumeManager), \
+            "StorageVolume init: Expected manager type %s, got %s" % \
+            (StorageVolumeManager, type(manager))
+        super(StorageVolume, self).__init__(manager, uri, name, properties)
+
+    @property
+    def oid(self):
+        """
+        :term `unicode string`: The object ID of this storage volume.
+        The object ID is unique within the parent storage group.
+
+        Note that for storage volumes, the 'name' property is not unique and
+        therefore cannot be used to identify a storage volume. Therefore,
+        storage volumes provide easy access to the object ID, as a means to
+        identify the storage volume in CLIs and other string-based tooling.
+        """
+        m = re.match(r'^/api/storage-groups/[^/]*/storage-volumes/([^/]*)$',
+                     self.uri)
+        oid = m.group(1)
+        return oid
+
+    @logged_api_call
+    def delete(self, email_to_addresses=None, email_cc_addresses=None,
+               email_insert=None):
+        """
+        Delete this storage volume on the HMC, and optionally send emails to
+        storage administrators requesting deletion of the storage volume on the
+        storage subsystem and cleanup of any resources related to the storage
+        volume (e.g. LUN mask definitions on a storage subsystem).
+
+        This method performs the "Modify Storage Group Properties" operation,
+        requesting deletion of the volume.
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group owning this storage
+          volume.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          email_to_addresses (:term:`iterable` of :term:`string`): Email
+            addresses of one or more storage administrator to be notified.
+            If `None` or empty, no email will be sent.
+
+          email_cc_addresses (:term:`iterable` of :term:`string`): Email
+            addresses of one or more storage administrator to be copied
+            on the notification email.
+            If `None` or empty, nobody will be copied on the email.
+            Must be `None` or empty if `email_to_addresses` is `None` or empty.
+
+          email_insert (:term:`string`): Additional text to be inserted in the
+            notification email.
+            The text can include HTML formatting tags.
+            If `None`, no additional text will be inserted.
+            Must be `None` or empty if `email_to_addresses` is `None` or empty.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        req_properties = {
+            'operation': 'delete',
+            'element-uri': self.uri,
+        }
+        body = {
+            'storage-volumes': req_properties,
+        }
+        if email_to_addresses:
+            body['email-to-addresses'] = email_to_addresses
+            if email_cc_addresses:
+                body['email-cc-addresses'] = email_cc_addresses
+            if email_insert:
+                body['email-insert'] = email_insert
+        else:
+            if email_cc_addresses:
+                raise ValueError("email_cc_addresses must not be specified if "
+                                 "there is no email_to_addresses: %r" %
+                                 email_cc_addresses)
+            if email_insert:
+                raise ValueError("email_insert must not be specified if "
+                                 "there is no email_to_addresses: %r" %
+                                 email_insert)
+
+        self.session.post(
+            self.storage_group.uri + '/operations/modify',
+            body=body)
+
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties, email_to_addresses=None,
+                          email_cc_addresses=None, email_insert=None):
+        """
+        Update writeable properties of this storage volume on the HMC, and
+        optionally send emails to storage administrators requesting
+        modification of the storage volume on the storage subsystem and of any
+        resources related to the storage volume.
+
+        This method performs the "Modify Storage Group Properties" operation,
+        requesting modification of the volume.
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group owning this storage
+          volume.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): New property values for the volume.
+            Allowable properties are the fields defined in the
+            "storage-volume-request-info" nested object for the "modify"
+            operation. That nested object is described in section "Request body
+            contents" for operation "Modify Storage Group Properties" in the
+            :term:`HMC API` book.
+
+            The properties provided in this parameter will be copied and then
+            amended with the `operation="modify"` and `element-uri` properties,
+            and then used as a single array item for the `storage-volumes`
+            field in the request body of the "Modify Storage Group Properties"
+            operation.
+
+          email_to_addresses (:term:`iterable` of :term:`string`): Email
+            addresses of one or more storage administrator to be notified.
+            If `None` or empty, no email will be sent.
+
+          email_cc_addresses (:term:`iterable` of :term:`string`): Email
+            addresses of one or more storage administrator to be copied
+            on the notification email.
+            If `None` or empty, nobody will be copied on the email.
+            Must be `None` or empty if `email_to_addresses` is `None` or empty.
+
+          email_insert (:term:`string`): Additional text to be inserted in the
+            notification email.
+            The text can include HTML formatting tags.
+            If `None`, no additional text will be inserted.
+            Must be `None` or empty if `email_to_addresses` is `None` or empty.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        req_properties = copy.deepcopy(properties)
+        req_properties['operation'] = 'modify'
+        req_properties['element-uri'] = self.uri
+        body = {
+            'storage-volumes': req_properties,
+        }
+        if email_to_addresses:
+            body['email-to-addresses'] = email_to_addresses
+            if email_cc_addresses:
+                body['email-cc-addresses'] = email_cc_addresses
+            if email_insert:
+                body['email-insert'] = email_insert
+        else:
+            if email_cc_addresses:
+                raise ValueError("email_cc_addresses must not be specified if "
+                                 "there is no email_to_addresses: %r" %
+                                 email_cc_addresses)
+            if email_insert:
+                raise ValueError("email_insert must not be specified if "
+                                 "there is no email_to_addresses: %r" %
+                                 email_insert)
+
+        self.session.post(
+            self.storage_group.uri + '/operations/modify',
+            body=body)
+
+        self.properties.update(copy.deepcopy(properties))
+
+    @logged_api_call
+    def indicate_fulfillment_ficon(self, control_unit, unit_address):
+        """
+        TODO: Add ControlUnit objects etc for FICON support.
+
+        Indicate completion of :term:`fulfillment` for this ECKD (=FICON)
+        storage volume and provide identifying information (control unit
+        and unit address) about the actual storage volume on the storage
+        subsystem.
+
+        Manually indicating fulfillment is required for all ECKD volumes,
+        because they are not auto-discovered by the CPC.
+
+        This method performs the "Fulfill FICON Storage Volume" HMC operation.
+
+        Upon successful completion of this operation, the "fulfillment-state"
+        property of this storage volume object will have been set to
+        "complete". That is necessary for the CPC to be able to address and
+        connect to the volume.
+
+        If the "fulfillment-state" properties of all storage volumes in the
+        owning storage group are "complete", the owning storage group's
+        "fulfillment-state" property will also be set to "complete".
+
+        Parameters:
+
+          control_unit (:class:`~zhmcclient.ControlUnit`):
+            Logical control unit (LCU) in which the backing ECKD volume is
+            defined.
+
+          unit_address (:term:`string`):
+            Unit address of the backing ECKD volume within its logical control
+            unit,
+            as a hexadecimal number of up to 2 characters in any lexical case.
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group owning this storage
+          volume.
+        * Task permission to the "Configure Storage - Storage Administrator"
+          task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        # The operation requires exactly 2 characters in lower case
+        unit_address_2 = format(int(unit_address, 16), '02x')
+
+        body = {
+            'control-unit-uri': control_unit.uri,
+            'unit-address': unit_address_2,
+        }
+        self.manager.session.post(
+            self.uri + '/operations/fulfill-ficon-storage-volume',
+            body=body)
+
+    @logged_api_call
+    def indicate_fulfillment_fcp(self, wwpn, lun, host_port):
+        """
+        Indicate completion of :term:`fulfillment` for this FCP storage volume
+        and provide identifying information (WWPN and LUN) about the actual
+        storage volume on the storage subsystem.
+
+        Manually indicating fulfillment is required for storage volumes that
+        will be used as boot devices for a partition. The specified host
+        port will be used to access the storage volume during boot of the
+        partition.
+
+        Because the CPC discovers storage volumes automatically, the
+        fulfillment of non-boot volumes does not need to be manually indicated
+        using this function (it may be indicated though before the CPC
+        discovers a working communications path to the volume, but the role
+        of the specified host port is not clear in this case).
+
+        This method performs the "Fulfill FCP Storage Volume" HMC operation.
+
+        Upon successful completion of this operation, the "fulfillment-state"
+        property of this storage volume object will have been set to
+        "complete". That is necessary for the CPC to be able to address and
+        connect to the volume.
+
+        If the "fulfillment-state" properties of all storage volumes in the
+        owning storage group are "complete", the owning storage group's
+        "fulfillment-state" property will also be set to "complete".
+
+        Parameters:
+
+          wwpn (:term:`string`):
+            World wide port name (WWPN) of the FCP storage subsystem containing
+            the storage volume,
+            as a hexadecimal number of up to 16 characters in any lexical case.
+
+          lun (:term:`string`):
+            Logical Unit Number (LUN) of the storage volume within its FCP
+            storage subsystem,
+            as a hexadecimal number of up to 16 characters in any lexical case.
+
+          host_port (:class:`~zhmcclient.Port`):
+            Storage port on the CPC that will be used to boot from.
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group owning this storage
+          volume.
+        * Task permission to the "Configure Storage - Storage Administrator"
+          task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        # The operation requires exactly 16 characters in lower case
+        wwpn_16 = format(int(wwpn, 16), '016x')
+        lun_16 = format(int(lun, 16), '016x')
+
+        body = {
+            'world-wide-port-name': wwpn_16,
+            'logical-unit-number': lun_16,
+            'adapter-port-uri': host_port.uri,
+        }
+        self.manager.session.post(
+            self.uri + '/operations/fulfill-fcp-storage-volume',
+            body=body)

--- a/zhmcclient/_virtual_storage_resource.py
+++ b/zhmcclient/_virtual_storage_resource.py
@@ -1,0 +1,320 @@
+# Copyright 2018 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :term:`virtual storage resource` object represents a storage-related
+z/Architecture device that is visible to a partition and that provides access
+for that partition to a :term:`storage volume`.
+
+The storage-related z/Architecture devices that are visible to a partition are
+different for the two storage architectures: For FCP, the virtualized HBA is
+visible as a device, and the storage volumes (LUNs) are not represented as
+devices. For FICON, each ECKD volume is visible as a device, but the
+virtualized FICON adapter port is not represented as a device.
+
+What the virtual storage resource objects represent, therefore depends on
+the storage architecture of the storage volume they are used for:
+
+* For FCP, a virtual storage resource object represents the virtualized HBA
+  in the partition that is used to access the LUN. However, each usage of
+  the virtual HBA in context of a storage group has its own virtual storage
+  resource object.
+* For FICON, a virtual storage resource object represents the ECKD volume.
+
+Virtual storage resource objects are instantiated automatically when a storage
+group is attached to a partition, and are removed automatically upon
+detachment.
+
+The :term:`HBA` resource objects known from DPM mode before introduction of the
+"dpm-storage-management" feature are no longer exposed.
+
+Virtual storage resource objects are contained in :term:`storage group`
+objects.
+
+Storage groups and storage volumes only can be defined in CPCs that are in
+DPM mode and that have the "dpm-storage-management" feature enabled.
+"""
+
+from __future__ import absolute_import
+
+import re
+import copy
+# from requests.utils import quote
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import get_logger, logged_api_call
+
+__all__ = ['VirtualStorageResourceManager', 'VirtualStorageResource']
+
+LOG = get_logger(__name__)
+
+
+class VirtualStorageResourceManager(BaseManager):
+    """
+    Manager providing access to the :term:`virtual storage resources
+    <Virtual Storage Resource>` in a particular :term:`storage group`.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.StorageGroup` object:
+
+    * :attr:`~zhmcclient.StorageGroup.virtual_storage_resources`
+    """
+
+    def __init__(self, storage_group):
+        # This function should not go into the docs.
+        # Parameters:
+        #   storage_group (:class:`~zhmcclient.StorageGroup`):
+        #     Storage group defining the scope for this manager.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+            'device-number',
+            'adapter-port-uri',
+            'partition-uri',
+        ]
+
+        super(VirtualStorageResourceManager, self).__init__(
+            resource_class=VirtualStorageResource,
+            class_name='virtual-storage-resource',
+            session=storage_group.manager.session,
+            parent=storage_group,
+            base_uri='{}/virtual-storage-resources'.format(storage_group.uri),
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def storage_group(self):
+        """
+        :class:`~zhmcclient.StorageGroup`: :term:`Storage group` defining the
+        scope for this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=False, filter_args=None):
+        """
+        List the virtual storage resources in this storage group.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls that the full set of resource properties for each returned
+            storage volume is being retrieved, vs. only the following short
+            set: "element-uri", "name", "device-number", "adapter-port-uri",
+            and "partition-uri".
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.VirtualStorageResource` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        resource_obj_list = []
+
+        resource_obj = self._try_optimized_lookup(filter_args)
+        if resource_obj:
+            resource_obj_list.append(resource_obj)
+            # It already has full properties
+        else:
+            query_parms, client_filters = self._divide_filter_args(filter_args)
+
+            resources_name = 'virtual-storage-resources'
+            uri = '{}/{}{}'.format(self.storage_group.uri, resources_name,
+                                   query_parms)
+
+            result = self.session.get(uri)
+            if result:
+                props_list = result[resources_name]
+                for props in props_list:
+
+                    resource_obj = self.resource_class(
+                        manager=self,
+                        uri=props[self._uri_prop],
+                        name=props.get(self._name_prop, None),
+                        properties=props)
+
+                    if self._matches_filters(resource_obj, client_filters):
+                        resource_obj_list.append(resource_obj)
+                        if full_properties:
+                            resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+
+class VirtualStorageResource(BaseResource):
+    """
+    Representation of a :term:`virtual storage resource`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.VirtualStorageResourceManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.VirtualStorageResourceManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, VirtualStorageResourceManager), \
+            "VirtualStorageResource init: Expected manager type %s, got %s" % \
+            (VirtualStorageResourceManager, type(manager))
+        super(VirtualStorageResource, self).__init__(
+            manager, uri, name, properties)
+        self._attached_partition = None
+        self._adapter_port = None
+        self._storage_volume = None
+
+    @property
+    def attached_partition(self):
+        """
+        :class:`~zhmcclient.Partition`: The partition to which this virtual
+        storage resource is attached.
+
+        The returned partition object has only a minimal set of properties set
+        ('object-id', 'object-uri', 'class', 'parent').
+
+        Note that a virtual storage resource is always attached to a partition,
+        as long as it exists.
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group owning this
+          virtual storage resource.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        if self._attached_partition is None:
+            part_mgr = self.manager.storage_group.manager.cpc.partitions
+            part = part_mgr.resource_object(self.get_property('partition-uri'))
+            self._attached_partition = part
+        return self._attached_partition
+
+    @property
+    def adapter_port(self):
+        """
+        :class:`~zhmcclient.Port`: The storage adapter port associated with
+        this virtual storage resource, once discovery has determined which
+        port to use for this virtual storage resource.
+
+        This applies to both, FCP and FICON/ECKD typed storage groups.
+
+        The returned adapter port object has only a minimal set of properties
+        set ('object-id', 'object-uri', 'class', 'parent').
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group owning this
+          virtual storage resource.
+        * Object-access permission to the CPC of the storage adapter.
+        * Object-access permission to the storage adapter.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        if self._adapter_port is None:
+            port_uri = self.get_property('adapter-port-uri')
+            assert port_uri is not None
+            m = re.match(r'^(/api/adapters/[^/]+)/.*', port_uri)
+            adapter_uri = m.group(1)
+            adapter_mgr = self.manager.storage_group.manager.cpc.adapters
+            filter_args = {'object-uri': adapter_uri}
+            adapter = adapter_mgr.find(**filter_args)
+            port_mgr = adapter.ports
+            port = port_mgr.resource_object(port_uri)
+            self._adapter_port = port
+        return self._adapter_port
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this virtual storage resource.
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group owning this
+          virtual storage resource.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are the properties with qualifier (w) in
+            section 'Data model' in section 'Virtual Storage Resource object'
+            in the :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.post(self.uri, body=properties)
+        is_rename = self.manager._name_prop in properties
+        if is_rename:
+            # Delete the old name from the cache
+            self.manager._name_uri_cache.delete(self.name)
+        self.properties.update(copy.deepcopy(properties))
+        if is_rename:
+            # Add the new name to the cache
+            self.manager._name_uri_cache.update(self.name, self.uri)


### PR DESCRIPTION
**Note: This PR is on top of PRs #526, #527, #528, #529.**

This PR provides support for DPM storage groups for FCP. The implementation is complete, but test cases and mock support are incomplete at this point and are left for a future PR.

For details, see the commit message.
Ready for review and merge.