### PR TITLE
Inspection of firmware features

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -64,6 +64,13 @@ Released: not yet
 * Added a property `client` to class `CpcManager` for navigating from a `Cpc`
   object back to the `Client` object which is the top of the resource tree.
 
+* Added support for the new concept of firmware features to Cpcs and Partitions,
+  by adding methods `feature_enabled()` and `feature_info()` to classes `Cpc`
+  and `Partition` for inspection of firmware features. The firmware feature
+  concept was introduced starting with the z14-ZR1 and LinuxONE Rockhopper II
+  machine generation. The DPM storage management feature is the first of these
+  new firmware features.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -414,6 +414,89 @@ class Cpc(BaseResource):
         return max_parts
 
     @logged_api_call
+    def feature_enabled(self, feature_name):
+        """
+        Indicates whether the specified feature is enabled for this CPC.
+
+        The HMC must generally support features, and the specified feature must
+        be available for the CPC.
+
+        For a list of available features, see section "Features" in the
+        :term:`HMC API`, or use the :meth:`feature_info` method.
+
+        Authorization requirements:
+
+        * Object-access permission to this CPC.
+
+        Parameters:
+
+          feature_name (:term:`string`): The name of the feature.
+
+        Returns:
+
+          bool: `True` if the feature is enabled, or `False` if the feature is
+          disabled (but available).
+
+        Raises:
+
+          :exc:`ValueError`: Features are not supported on the HMC.
+          :exc:`ValueError`: The specified feature is not available for the
+            CPC.
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        feature_list = self.prop('available-features-list', None)
+        if feature_list is None:
+            raise ValueError("Firmware features are not supported on CPC %s" %
+                             self.name)
+        for feature in feature_list:
+            if feature['name'] == feature_name:
+                break
+        else:
+            raise ValueError("Firmware feature %s is not available on CPC %s" %
+                             (feature_name, self.name))
+        return feature['state']
+
+    @logged_api_call
+    def feature_info(self):
+        """
+        Returns information about the features available for this CPC.
+
+        Authorization requirements:
+
+        * Object-access permission to this CPC.
+
+        Returns:
+
+          :term:`iterable`:
+            An iterable where each item represents one feature that is
+            available for this CPC.
+
+            Each item is a dictionary with the following items:
+
+            * `name` (:term:`unicode string`): Name of the feature.
+            * `description` (:term:`unicode string`): Short description of
+              the feature.
+            * `state` (bool): Enablement state of the feature (`True` if the
+              enabled, `False` if disabled).
+
+        Raises:
+
+          :exc:`ValueError`: Features are not supported on the HMC.
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        feature_list = self.prop('available-features-list', None)
+        if feature_list is None:
+            raise ValueError("Firmware features are not supported on CPC %s" %
+                             self.name)
+        return feature_list
+
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this CPC.

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -275,6 +275,91 @@ class Partition(BaseResource):
         return self._virtual_functions
 
     @logged_api_call
+    def feature_enabled(self, feature_name):
+        """
+        Indicates whether the specified feature is enabled for the CPC of this
+        partition.
+
+        The HMC must generally support features, and the specified feature must
+        be available for the CPC.
+
+        For a list of available features, see section "Features" in the
+        :term:`HMC API`, or use the :meth:`feature_info` method.
+
+        Authorization requirements:
+
+        * Object-access permission to this partition.
+
+        Parameters:
+
+          feature_name (:term:`string`): The name of the feature.
+
+        Returns:
+
+          bool: `True` if the feature is enabled, or `False` if the feature is
+          disabled (but available).
+
+        Raises:
+
+          :exc:`ValueError`: Features are not supported on the HMC.
+          :exc:`ValueError`: The specified feature is not available for the
+            CPC.
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        feature_list = self.prop('available-features-list', None)
+        if feature_list is None:
+            raise ValueError("Firmware features are not supported on CPC %s" %
+                             self.manager.cpc.name)
+        for feature in feature_list:
+            if feature['name'] == feature_name:
+                break
+        else:
+            raise ValueError("Firmware feature %s is not available on CPC %s" %
+                             (feature_name, self.manager.cpc.name))
+        return feature['state']
+
+    @logged_api_call
+    def feature_info(self):
+        """
+        Returns information about the features available for the CPC of this
+        partition.
+
+        Authorization requirements:
+
+        * Object-access permission to this partition.
+
+        Returns:
+
+          :term:`iterable`:
+            An iterable where each item represents one feature that is
+            available for the CPC of this partition.
+
+            Each item is a dictionary with the following items:
+
+            * `name` (:term:`unicode string`): Name of the feature.
+            * `description` (:term:`unicode string`): Short description of
+              the feature.
+            * `state` (bool): Enablement state of the feature (`True` if the
+              enabled, `False` if disabled).
+
+        Raises:
+
+          :exc:`ValueError`: Features are not supported on the HMC.
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        feature_list = self.prop('available-features-list', None)
+        if feature_list is None:
+            raise ValueError("Firmware features are not supported on CPC %s" %
+                             self.manager.cpc.name)
+        return feature_list
+
+    @logged_api_call
     def start(self, wait_for_completion=True, operation_timeout=None,
               status_timeout=None):
         """


### PR DESCRIPTION
This PR will be used by the DPM storage group support.
For details, see the commit message.
Ready for review and merge.

**Important review point:**
* In case the feature is unknown or in case the CPC does not support features at all, should the `feature_enabled()` functions (1) raise `ValueError` as they do currently, or (2) return `False`? Returning `False`is more convenient, but does not allow distinguishing between feature available+disabled and feature unavailable (=unknown).