### PR TITLE
Direct access to the one Console object

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -53,6 +53,14 @@ Released: not yet
 * Added support for the z14-ZR1 and LinuxONE Rockhopper II machine generations
   to the `Cpc.maximum_active_partitions()` method.
 
+* Provided direct access to the (one) `Console` object, from the
+  `ConsoleManager` and `CpcManager` objects, via a new `console` property.
+  This is for convenience and avoids having to code `find()` or `list()` calls.
+  The returned `Console` object is cached in the manager object.
+
+  Also, added a `console` property to the `FakedConsoleManager` class in the
+  mock support, for the same purpose.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -77,6 +77,7 @@ class ConsoleManager(BaseManager):
             query_props=None,
             list_has_name=False)
         self._client = client
+        self._console = None
 
     @property
     def client(self):
@@ -85,6 +86,28 @@ class ConsoleManager(BaseManager):
           The client defining the scope for this manager.
         """
         return self._client
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`:
+          The :term:`Console` representing the HMC this client is connected to.
+
+          The returned object is cached, so it is looked up only upon first
+          access to this property.
+
+          The returned object has only the following properties set:
+
+          * 'object-uri'
+
+          Use :meth:`~zhmcclient.BaseResource.get_property` or
+          :meth:`~zhmcclient.BaseResource.prop` to access any properties
+          regardless of whether they are already set or first need to be
+          retrieved.
+        """
+        if self._console is None:
+            self._console = self.list()[0]
+        return self._console
 
     @logged_api_call
     def list(self, full_properties=True, filter_args=None):

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -104,6 +104,26 @@ class CpcManager(BaseManager):
             name_prop='name',
             query_props=query_props)
 
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`:
+          The :term:`Console` representing the HMC this CPC is managed by.
+
+          The returned object is cached, so it is looked up only upon first
+          access to this property.
+
+          The returned object has only the following properties set:
+
+          * 'object-uri'
+
+          Use :meth:`~zhmcclient.BaseResource.get_property` or
+          :meth:`~zhmcclient.BaseResource.prop` to access any properties
+          regardless of whether they are already set or first need to be
+          retrieved.
+        """
+        return self.client.consoles.console
+
     @logged_api_call
     def list(self, full_properties=False, filter_args=None):
         """

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -714,6 +714,17 @@ class FakedConsoleManager(FakedBaseManager):
             oid_prop=None,  # Console does not have an object ID property
             uri_prop='object-uri',
             class_value='console')
+        self._console = None
+
+    @property
+    def console(self):
+        """
+        The faked Console representing the faked HMC (an object of
+        :class:`~zhmcclient_mock.FakedConsole`). The object is cached.
+        """
+        if self._console is None:
+            self._console = self.list()[0]
+        return self._console
 
     def add(self, properties):
         """


### PR DESCRIPTION
This PR will be used by the DPM storage group support.
For details, see the commit message.
Ready for review and merge.