### PR TITLE
Update requests package to 2.20.0 in requirements.txt

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Update Requests package to 2.20.0 to fix follwing vulnerability of
+  the National Vulnerability Database:
+  https://nvd.nist.gov/vuln/detail/CVE-2018-18074
+
 **Enhancements:**
 
 **Known issues:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -47,7 +47,7 @@ wheel==0.29.0
 decorator==4.0.10
 pbr==1.10.0
 pytz==2016.10
-requests==2.12.4
+requests==2.20.0
 six==1.10.0
 stomp.py==4.1.15
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,14 @@
 decorator>=4.0.10 # new BSD
 pbr>=1.10.0 # Apache-2.0
 pytz>=2016.10 # MIT
-requests>=2.12.4,!=2.17.1,!=2.17.2 # Apache-2.0
+requests>=2.20.0 # Apache-2.0
 six>=1.10.0 # MIT
 stomp.py>=4.1.15 # Apache
 
 
 # Indirect dependencies (commented out, only listed to document their license):
 
-# certifi # ISC, from requests>=2.16
-# chardet # LGPL, from requests>=2.16
-# idna # BSD-like, from requests>=2.16
-# urllib3 # MIT, from requests>=2.16
+# certifi # ISC, from requests>=2.20
+# chardet # LGPL, from requests>=2.20
+# idna # BSD-like, from requests>=2.20
+# urllib3 # MIT, from requests>=2.20


### PR DESCRIPTION
The Requests package through 2.19.1 before 2018-09-14
for Python sends an HTTP Authorization header to
an http URI upon receiving a same-hostname
https-to-http redirect, which makes it easier
for remote attackers to discover credentials
by sniffing the network.

Link to vulnerability in National Vulnerability
Database:
https://nvd.nist.gov/vuln/detail/CVE-2018-18074

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>