### PR TITLE
Mitigated that fIltering by adapter-id returns empty result for hex digits

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,10 @@ Released: not yet
 
 **Enhancements:**
 
+* Added a mitigation for a firmware defect that causes filtering of
+  adapters by adapter-id to return an empty result when the specified
+  adapter-id contains hex digits ('a' to 'f'). See issue #549.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -102,7 +102,16 @@ class AdapterManager(BaseManager):
         # for the version of the HMC this session is connected to.
         query_props = [
             'name',
-            'adapter-id',
+
+            # The adapter-id property is supported for filtering, but due to
+            # a firmware defect, adapters with a hex digit in their adapter-id
+            # property are not found. Disabling the property causes it to
+            # be handled via client-side filtering, so that mitigates the
+            # defect.
+            # TODO: Re-enable the property once the defect is fixed and the fix
+            # is rolled out broadly enough.
+            # 'adapter-id',
+
             'adapter-family',
             'type',
             'status',


### PR DESCRIPTION
Details:

* Added a mitigation for a firmware defect that causes filtering of
  adapters by adapter-id to return an empty result when the specified
  adapter-id contains hex digits ('a' to 'f'). See issue #549.

Signed-off-by: Andreas Maier <maiera@de.ibm.com>