### PR TITLE
Added support for faked HMCs to end2end tests

### DIFF
--- a/tests/example_hmc_definitions.yaml
+++ b/tests/example_hmc_definitions.yaml
@@ -1,7 +1,8 @@
 ---
 # HMC definition file for zhmcclient end2end tests
 #
-# This file has the following format:
+# This file can define real HMCs and faked HMCs (using the zhmcclient mock
+# support) and has the following format:
 #
 # hmcs:                          # Dict of HMC definitions.
 #   NICKNAME1:                   # Nickname of the HMC.
@@ -11,20 +12,19 @@
 #                                # Optional, default: empty.
 #     access_via: TEXT           # Preconditions to reach the network of the HMC.
 #                                # Optional, default: empty.
-#     hmc_host: TEXT             # IP address or hostname of the HMC.
-#                                # Mandatory.
-#     hmc_userid: TEXT           # Userid for logging on to the HMC.
-#                                # Mandatory.
-#     hmc_password: TEXT         # Password for logging on to the HMC.
-#                                # Mandatory.
-#
+#     hmc_host: TEXT             # For real HMC: IP address or hostname of the
+#                                # HMC. Mandatory (if real HMC).
+#     hmc_userid: TEXT           # For real HMC: Userid for logging on to the
+#                                # HMC. Mandatory (if real HMC).
+#     hmc_password: TEXT         # For real HMC: Password for logging on to the
+#                                # HMC. Mandatory (if real HMC).
+#     faked_hmc_file: TEXT       # For faked HMC: Path name of fake HMC file,
+#                                # relative to this file.
+#                                # Mandatory (if faked HMC).
 # hmc_groups:                    # Dict of HMC groups (optional).
 #   NICKNAME42:                  # Nickname of HMC group.
 #     - NICKNAME1                # Nicknames of HMCs or HMC groups in that grp.
 #     - NICKNAME2
-
-# Note: This is an example file that should be copied to
-#       hmc_definitions.yaml and modified as needed.
 
 hmcs:
 
@@ -37,10 +37,18 @@ hmcs:
     hmc_password: password
     cpcs:
       XYZ1:
-        brand_model: z13
+        machine_type: "2964"
         dpm: true
       XYZ2:
-        brand_model: z14
+        machine_type: "3906"
+        dpm: true
+
+  FAKED_ABC:
+    description: "an example faked HMC"
+    faked_hmc_file: "faked_abc.yaml"
+    cpcs:
+      ABC1:
+        machine_type: "2964"
         dpm: true
 
   # additional HMCs ...

--- a/tests/faked_hmc1.yaml
+++ b/tests/faked_hmc1.yaml
@@ -1,0 +1,62 @@
+---
+# Definition of a faked HMC for zhmcclient testing.
+# The faked HMC represents a single z13 CPC in classic mode.
+
+faked_client:
+  hmc_host: "fake-host"
+  hmc_name: "fake-hmc"
+  hmc_version: "2.13.1"
+  api_version: "1.8"
+  cpcs:
+    - properties:
+        object-id: "fake-cpc1-oid"
+        # object-uri is set up automatically
+        parent: null
+        class: "cpc"
+        name: "CPC1"
+        description: "Fake z13 (classic mode)"
+        machine-type: "2964"
+        status: "active"
+        dpm-enabled: false
+        is-ensemble-member: false
+        iml-mode: "lpar"
+      lpars:
+        - properties:
+            partition-number: 0x41
+            partition-identifier: 0x41
+            name: "LPAR1"
+            status: "operating"
+            activation-mode: "linux"
+            next-activation-profile-name: "LPAR1"
+            last-used-activation-profile: "LPAR1"
+        - properties:
+            partition-number: 0x42
+            partition-identifier: 0x42
+            name: "LPAR2"
+            status: "not-activated"
+            activation-mode: "not-set"
+            next-activation-profile-name: "LPAR2"
+            last-used-activation-profile: "LPAR2"
+      reset_activation_profiles:
+        - properties:
+            name: "CPC1"
+            iocds-name: "ABC"
+      load_activation_profiles:
+        - properties:
+            name: "LPAR1"
+            ipl-type: "ipltype-standard"
+            ipl-address: "189AB"
+        - properties:
+            name: "LPAR2"
+            ipl-type: "ipltype-scsi"
+            worldwide-port-name: "1234"
+            logical-unit-number: "1234"
+            boot-record-lba: "1234"
+            disk-partition-id: 0
+      image_activation_profiles:
+        - properties:
+            name: "LPAR1"
+            # TODO: Add more properties
+        - properties:
+            name: "LPAR2"
+            # TODO: Add more properties


### PR DESCRIPTION
**Note:** This PR is on top of PR #556 - review only the last commit.
For details, see the commit message.