### PR TITLE
Pinned Sphinx to below 2.0.0 also for py3.5+

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -39,7 +39,11 @@ pytest-cov>=2.4.0,<2.6 # BSD
 python-coveralls>=2.9.0 # Apache-2.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
-Sphinx>=1.7.6 # BSD
+Sphinx>=1.7.6,<2.0.0; python_version < '3.5'  # BSD
+Sphinx>=1.7.6,<2.0.0; python_version >= '3.5'  # BSD
+# TODO: On py3.5+, Sphinx currently fails, see issue
+#       https://github.com/sphinx-doc/sphinx/issues/6246. Therefore, Sphinx has
+#       been pinned to below 2.0.0 also for py3.5+.
 sphinx-git>=10.1.1 # GPL
 GitPython>=2.1.1 # BSD
 


### PR DESCRIPTION
For details, see the commit message.