### PR TITLE
Changed import of stomp module to be lazy for zhmcclient import speed

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -66,6 +66,12 @@ Released: not yet
 
 * Blanked out the session ID value in the log record for logging off.
 
+* Changed import of 'stomp' module used for notifications from the HMC, to be
+  lazy, in order to speed up the import of 'zhmcclient' for its users.
+  The 'stomp' module is now imported when the first
+  `zhmcclient.NotificationReceiver` object is created. Also, only the class
+  needed is imported now, instead of the entire module.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -66,7 +66,6 @@ messages issued by the operating system. The following commands use the
 """
 
 import threading
-import stomp
 import json
 
 from ._logging import logged_api_call
@@ -138,7 +137,11 @@ class NotificationReceiver(object):
         self._handover_dict = {}
         self._handover_cond = threading.Condition()
 
-        self._conn = stomp.Connection(
+        # Lazy importing for stomp, because it is so slow (ca. 5 sec)
+        if 'Stomp_Connection' not in globals():
+            from stomp import Connection as Stomp_Connection
+
+        self._conn = Stomp_Connection(
             [(self._host, self._port)], use_ssl="SSL")
         listener = _NotificationListener(self._handover_dict,
                                          self._handover_cond)


### PR DESCRIPTION
For details, see the commit message.
Ready for review.