### PR TITLE
Fixes #589: Added support for Storage Templates

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -298,6 +298,9 @@ Resources scoped to CPCs in DPM mode
      feature is enabled on the CPC.
      For details, see section :ref:`Storage Groups`.
 
+  Storage Group Template
+     A template for :term:`Storage Groups <Storage Group>`.
+
   Storage Port
      Short term for a :term:`Port` of a :term:`Storage Adapter`.
 
@@ -310,6 +313,9 @@ Resources scoped to CPCs in DPM mode
      Storage Volume objects exist only when the "dpm-storage-management"
      feature is enabled on the CPC.
      For details, see section :ref:`Storage Groups`.
+
+  Storage Volume Template
+     A template for :term:`Storage Volumes <Storage Volume>`.
 
   vHBA
      Synonym for :term:`HBA`. In this resource model, HBAs are always

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,8 @@ Released: not yet
     Lpar.psw_restart() (HMC: “PSW Restart”)
     Lpar.scsi_dump() (HMC: “SCSI Dump”)
 
+* Added support for Storage Template objects in DPM mode (see issue #589).
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -561,6 +561,38 @@ Virtual Storage Resources
    :special-members: __str__
 
 
+.. _`Storage Group Templates`:
+
+Storage Group Templates
+-----------------------
+
+.. automodule:: zhmcclient._storage_group_template
+
+.. autoclass:: zhmcclient.StorageGroupTemplateManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.StorageGroupTemplate
+   :members:
+   :special-members: __str__
+
+
+.. _`Storage Volume Templates`:
+
+Storage Volume Templates
+------------------------
+
+.. automodule:: zhmcclient._storage_volume_template
+
+.. autoclass:: zhmcclient.StorageVolumeTemplateManager
+   :members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.StorageVolumeTemplate
+   :members:
+   :special-members: __str__
+
+
 .. _`Console`:
 
 Console

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -54,3 +54,5 @@ from ._unmanaged_cpc import *          # noqa: F401
 from ._storage_group import *          # noqa: F401
 from ._storage_volume import *         # noqa: F401
 from ._virtual_storage_resource import *        # noqa: F401
+from ._storage_group_template import *          # noqa: F401
+from ._storage_volume_template import *         # noqa: F401

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -28,6 +28,7 @@ from ._resource import BaseResource
 from ._logging import logged_api_call
 from ._utils import timestamp_from_datetime
 from ._storage_group import StorageGroupManager
+from ._storage_group_template import StorageGroupTemplateManager
 from ._user import UserManager
 from ._user_role import UserRoleManager
 from ._user_pattern import UserPatternManager
@@ -186,6 +187,7 @@ class Console(BaseResource):
 
         # The manager objects for child resources (with lazy initialization):
         self._storage_groups = None
+        self._storage_group_templates = None
         self._users = None
         self._user_roles = None
         self._user_patterns = None
@@ -204,6 +206,18 @@ class Console(BaseResource):
         if not self._storage_groups:
             self._storage_groups = StorageGroupManager(self)
         return self._storage_groups
+
+    @property
+    def storage_group_templates(self):
+        """
+        :class:`~zhmcclient.StorageGroupTemplateManager`:
+          Manager object for the Storage Group Templates in scope of this
+          Console.
+        """
+        # We do here some lazy loading.
+        if not self._storage_group_templates:
+            self._storage_group_templates = StorageGroupTemplateManager(self)
+        return self._storage_group_templates
 
     @property
     def users(self):

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -216,9 +216,19 @@ class StorageGroupManager(BaseManager):
         return resource_obj_list
 
     @logged_api_call
-    def create(self, properties):
+    def create(self, properties=None, template=None):
         """
-        Create and configure a storage group.
+        Create and configure a storage group either from input properties or
+        from a :term:`storage group template`.
+
+        The input properties may specify initial storage volumes for the new
+        storage group via the `storage-volumes` property. Additional storage
+        volumes can be added with
+        :meth:`~zhmcclient.StorageGroup.update_properties`.
+
+        A storage group template can also specify initial storage volumes for
+        the new storage group. For details, see
+        :class:`~zhmcclient.StorageGroupTemplate`.
 
         The new storage group will be associated with the CPC identified by the
         `cpc-uri` input property.
@@ -239,6 +249,16 @@ class StorageGroupManager(BaseManager):
             storage group will be associated, and is required to be specified
             in this parameter.
 
+            The 'template-uri' property is not allowed. If you want to create
+            a storage group from a :term:`storage template`, specify the
+            `template` parameter.
+
+            The `properties` and `template` parameters are mutually exclusive.
+
+          template (:class:`~zhmcclient.StorageGroupTemplate`):
+            :term:`storage group template` defining the initial property values
+            for the storage group, including its initial storage volumes.
+
         Returns:
 
           :class:`~zhmcclient.StorageGroup`:
@@ -248,6 +268,7 @@ class StorageGroupManager(BaseManager):
 
         Raises:
 
+          :exc:`ValueError` - Property 'template-uri' is not permitted
           :exc:`~zhmcclient.HTTPError`
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
@@ -255,6 +276,15 @@ class StorageGroupManager(BaseManager):
         """
         if properties is None:
             properties = {}
+
+        if 'template-uri' in properties:
+            raise ValueError(
+                "Property 'template-uri' is not permitted - use the "
+                "'template' parameter to create storage groups from "
+                "templates.")
+
+        if template is not None:
+            properties['template-uri'] = template.uri
 
         result = self.session.post(self._base_uri, body=properties)
         # There should not be overlaps, but just in case there are, the

--- a/zhmcclient/_storage_group_template.py
+++ b/zhmcclient/_storage_group_template.py
@@ -1,0 +1,342 @@
+# Copyright 2019 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :class:`~zhmcclient.StorageGroupTemplate` object represents a
+:term:`storage group template` object and can be used to create
+:term:`storage group` objects with the properties of the template, including an
+initial set of storage volumes, using the
+:meth:`zhmcclient.StorageGroupTemplateManager.create` method.
+
+Storage group template objects can be created, updated and deleted.
+
+Storage group template objects can only be defined in CPCs that are in
+DPM mode and that have the "dpm-storage-management" feature enabled.
+"""
+
+from __future__ import absolute_import
+
+import copy
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._storage_volume_template import StorageVolumeTemplateManager
+from ._logging import logged_api_call
+
+__all__ = ['StorageGroupTemplateManager', 'StorageGroupTemplate']
+
+
+class StorageGroupTemplateManager(BaseManager):
+    """
+    Manager providing access to the
+    :term:`storage group templates <storage group template>` of the HMC.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable:
+
+    * :attr:`~zhmcclient.Console.storage_group_templates` of a
+      :class:`~zhmcclient.Console` object.
+    """
+
+    def __init__(self, console):
+        # This function should not go into the docs.
+        # Parameters:
+        #   console (:class:`~zhmcclient.Console`):
+        #     CPC or HMC defining the scope for this manager.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'cpc-uri',
+            'name',
+            'type',
+        ]
+
+        super(StorageGroupTemplateManager, self).__init__(
+            resource_class=StorageGroupTemplate,
+            class_name='storage-template',
+            session=console.manager.session,
+            parent=console,
+            base_uri='/api/storage-templates',
+            oid_prop='object-id',
+            uri_prop='object-uri',
+            name_prop='name',
+            query_props=query_props)
+        self._console = console
+
+    @property
+    def console(self):
+        """
+        :class:`~zhmcclient.Console`: The Console object representing the HMC.
+        """
+        return self._console
+
+    @logged_api_call
+    def list(self, full_properties=False, filter_args=None):
+        """
+        List the storage group templates defined in the HMC.
+
+        Storage group templates for which the authenticated user does not have
+        object-access permission are not included.
+
+        Authorization requirements:
+
+        * Object-access permission to any storage group templates to be
+          included in the result.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls that the full set of resource properties for each returned
+            storage group template is being retrieved, vs. only the following
+            short set: "object-uri", "cpc-uri", "name", and "type".
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.StorageGroupTemplate` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        resource_obj_list = []
+
+        if filter_args is None:
+            filter_args = {}
+
+        resource_obj = self._try_optimized_lookup(filter_args)
+        if resource_obj:
+            resource_obj_list.append(resource_obj)
+            # It already has full properties
+        else:
+            query_parms, client_filters = self._divide_filter_args(filter_args)
+            uri = '{}{}'.format(self._base_uri, query_parms)
+
+            result = self.session.get(uri)
+            if result:
+                props_list = result['storage-templates']
+                for props in props_list:
+
+                    resource_obj = self.resource_class(
+                        manager=self,
+                        uri=props[self._uri_prop],
+                        name=props.get(self._name_prop, None),
+                        properties=props)
+
+                    if self._matches_filters(resource_obj, client_filters):
+                        resource_obj_list.append(resource_obj)
+                        if full_properties:
+                            resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties):
+        """
+        Create a storage group template.
+
+        The new storage group will be associated with the CPC identified by the
+        `cpc-uri` input property.
+
+        Authorization requirements:
+
+        * Object-access permission to the CPC that will be associated with
+          the new storage group template.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): Initial property values.
+            Allowable properties are defined in section 'Request body contents'
+            in section 'Create Storage Template' in the :term:`HMC API` book.
+
+            The 'cpc-uri' property identifies the CPC to which the new
+            storage group template will be associated, and is required to be
+            specified in this parameter.
+
+        Returns:
+
+          :class:`~zhmcclient.StorageGroupTemplate`:
+            The resource object for the new storage group template.
+            The object will have its 'object-uri' property set as returned by
+            the HMC, and will also have the input properties set.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        if properties is None:
+            properties = {}
+
+        result = self.session.post(self._base_uri, body=properties)
+        # There should not be overlaps, but just in case there are, the
+        # returned props should overwrite the input props:
+        props = copy.deepcopy(properties)
+        props.update(result)
+        name = props.get(self._name_prop, None)
+        uri = props[self._uri_prop]
+        storage_group_template = StorageGroupTemplate(self, uri, name, props)
+        self._name_uri_cache.update(name, uri)
+        return storage_group_template
+
+
+class StorageGroupTemplate(BaseResource):
+    """
+    Representation of a :term:`storage group template`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.StorageGroupTemplateManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.StorageGroupTemplateManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, StorageGroupTemplateManager), \
+            "StorageGroupTemplate init: Expected manager type %s, got %s" % \
+            (StorageGroupTemplateManager, type(manager))
+        super(StorageGroupTemplate, self).__init__(
+            manager, uri, name, properties)
+        # The manager objects for child resources (with lazy initialization):
+        self._storage_volume_templates = None
+        self._cpc = None
+
+    @property
+    def storage_volume_templates(self):
+        """
+        :class:`~zhmcclient.StorageVolumeManager`: Access to the
+        :term:`storage volumes <storage volume>` in this storage group.
+        """
+        # We do here some lazy loading.
+        if not self._storage_volume_templates:
+            self._storage_volume_templates = StorageVolumeTemplateManager(self)
+        return self._storage_volume_templates
+
+    @property
+    def cpc(self):
+        """
+        :class:`~zhmcclient.Cpc`: The :term:`CPC` to which this storage group
+        template is associated.
+
+        The returned :class:`~zhmcclient.Cpc` has only a minimal set of
+        properties populated.
+        """
+        # We do here some lazy loading.
+        if not self._cpc:
+            cpc_uri = self.get_property('cpc-uri')
+            cpc_mgr = self.manager.console.manager.client.cpcs
+            self._cpc = cpc_mgr.resource_object(cpc_uri)
+        return self._cpc
+
+    @logged_api_call
+    def delete(self):
+        """
+        Delete this storage group template and its storage volume template
+        resources on the HMC.
+
+        Storage groups and their volumes that have been created from the
+        template that is deleted, are not affected.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group template.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        self.manager.session.delete(uri=self.uri)
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this storage group template.
+
+        This includes the `storage-template-volumes` property which contains
+        requests for creations, deletions and updates of
+        :class:`~zhmcclient.StorageVolumeTemplate` resources of this storage
+        group template.
+
+        As an alternative to this bulk approach for managing storage volume
+        templates, each :class:`~zhmcclient.StorageVolumeTemplate` resource
+        can individually be created, deleted and updated using the respective
+        methods on
+        :attr:`~zhmcclient.StorageGroupTemplate.storage_volume_templates`.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group template.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): New values for the properties to be updated.
+            Properties not to be updated are omitted.
+            Allowable properties are listed for operation
+            'Modify Storage Template Properties' in the :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        uri = '{}/operations/modify'.format(self.uri)
+        self.manager.session.post(uri, body=properties)
+        is_rename = self.manager._name_prop in properties
+        if is_rename:
+            # Delete the old name from the cache
+            self.manager._name_uri_cache.delete(self.name)
+        self.properties.update(copy.deepcopy(properties))
+        if is_rename:
+            # Add the new name to the cache
+            self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_storage_volume_template.py
+++ b/zhmcclient/_storage_volume_template.py
@@ -1,0 +1,354 @@
+# Copyright 2019 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A :class:`~zhmcclient.StorageVolumeTemplate` object represents a
+:term:`storage volume template` for FCP or FICON (ECKD) that is defined in a
+:term:`storage group template`.
+
+Storage volume template objects can be created, updated and deleted.
+
+Storage volume templates are contained in
+:term:`storage group templates <storage group template>`.
+
+You can create as many storage volume templates as you want in a storage group
+template. When creating a storage group from the storage group template, each
+storage volume template will cause a storage volume to be created in the new
+storage group.
+
+Storage group templates and storage volume templates only can be defined in
+CPCs that are in DPM mode and that have the "dpm-storage-management" feature
+enabled.
+"""
+
+from __future__ import absolute_import
+
+import copy
+# from requests.utils import quote
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import logged_api_call
+
+__all__ = ['StorageVolumeTemplateManager', 'StorageVolumeTemplate']
+
+
+class StorageVolumeTemplateManager(BaseManager):
+    """
+    Manager providing access to the
+    :term:`storage volume templates <storage volume template>`
+    in a particular :term:`storage group template`.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    accessible via the following instance variable of a
+    :class:`~zhmcclient.StorageGroupTemplate` object:
+
+    * :attr:`~zhmcclient.StorageGroupTemplate.storage_volume_templates`
+    """
+
+    def __init__(self, storage_group_template):
+        # This function should not go into the docs.
+        # Parameters:
+        #   storage_group_template (:class:`~zhmcclient.StorageGroupTemplate`):
+        #     Storage group template defining the scope for this manager.
+
+        # Resource properties that are supported as filter query parameters.
+        # If the support for a resource property changes within the set of HMC
+        # versions that support this type of resource, this list must be set up
+        # for the version of the HMC this session is connected to.
+        query_props = [
+            'name',
+            'maximum-size',
+            'minimum-size',
+            'usage',
+        ]
+
+        super(StorageVolumeTemplateManager, self).__init__(
+            resource_class=StorageVolumeTemplate,
+            class_name='storage-template-volume',
+            session=storage_group_template.manager.session,
+            parent=storage_group_template,
+            base_uri='{}/storage-template-volumes'.format(
+                storage_group_template.uri),
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            name_prop='name',
+            query_props=query_props)
+
+    @property
+    def storage_group_template(self):
+        """
+        :class:`~zhmcclient.StorageGroupTemplate`:
+        :term:`Storage group template` defining the scope for this manager.
+        """
+        return self._parent
+
+    @logged_api_call
+    def list(self, full_properties=False, filter_args=None):
+        """
+        List the storage volume templates in this storage group template.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group template.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls that the full set of resource properties for each returned
+            storage volume template is being retrieved, vs. only the following
+            short set: "element-uri", "name", "size", and "usage".
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned resources to
+            those that match the specified filter arguments. For details, see
+            :ref:`Filtering`.
+
+            `None` causes no filtering to happen, i.e. all resources are
+            returned.
+
+        Returns:
+
+          : A list of :class:`~zhmcclient.StorageVolumeTemplate` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        resource_obj_list = []
+
+        resource_obj = self._try_optimized_lookup(filter_args)
+        if resource_obj:
+            resource_obj_list.append(resource_obj)
+            # It already has full properties
+        else:
+            query_parms, client_filters = self._divide_filter_args(filter_args)
+
+            resources_name = 'storage-template-volumes'
+            uri = '{}/{}{}'.format(self.storage_group_template.uri,
+                                   resources_name, query_parms)
+
+            result = self.session.get(uri)
+            if result:
+                props_list = result[resources_name]
+                for props in props_list:
+
+                    resource_obj = self.resource_class(
+                        manager=self,
+                        uri=props[self._uri_prop],
+                        name=props.get(self._name_prop, None),
+                        properties=props)
+
+                    if self._matches_filters(resource_obj, client_filters):
+                        resource_obj_list.append(resource_obj)
+                        if full_properties:
+                            resource_obj.pull_full_properties()
+
+        self._name_uri_cache.update_from(resource_obj_list)
+        return resource_obj_list
+
+    @logged_api_call
+    def create(self, properties):
+        """
+        Create a :term:`storage volume template` in this storage group template
+        on the HMC.
+
+        This method performs the "Modify Storage Template Properties"
+        operation, requesting creation of the volume.
+
+        Authorization requirements:
+
+        * Object-access permission to this storage group template.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): Initial property values for the new volume
+            template.
+
+            Allowable properties are the fields defined in the
+            "storage-template-volume-request-info" nested object described for
+            operation "Modify Storage Template Properties" in the
+            :term:`HMC API` book.
+            The valid fields are those for the "create" operation. The
+            `operation` field must not be provided; it is set automatically
+            to the value "create".
+
+            The properties provided in this parameter will be copied and then
+            amended with the `operation="create"` field, and then used as a
+            single array item for the `storage-template-volumes` field in the
+            request body of the "Modify Storage Template Properties" operation.
+
+        Returns:
+
+          StorageVolumeTemplate:
+            The resource object for the new storage volume template.
+            The object will have the following properties set:
+
+            - 'element-uri' as returned by the HMC
+            - 'element-id' as determined from the 'element-uri' property
+            - 'class' and 'parent'
+            - additional properties as specified in the input properties
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+
+        Example::
+
+            stovol1 = fcp_stogrp.storage_volume_templates.create(
+                properties=dict(
+                    name='vol1',
+                    size=30,  # GiB
+            ))
+        """
+        volreq_obj = copy.deepcopy(properties)
+        volreq_obj['operation'] = 'create'
+        body = {
+            'storage-template-volumes': [volreq_obj],
+        }
+        result = self.session.post(
+            self.storage_group_template.uri + '/operations/modify',
+            body=body)
+        uri = result['element-uris'][0]
+        storage_volume_template = self.resource_object(uri, properties)
+        # The 'name' property is unique within the parent object. However, it
+        # is not returned by this operation, so we don't set the name-to-uri
+        # cache. It will be set lazily, upon first use.
+        return storage_volume_template
+
+
+class StorageVolumeTemplate(BaseResource):
+    """
+    Representation of a :term:`storage volume template`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from creation or list functions on their manager object
+    (in this case, :class:`~zhmcclient.StorageVolumeTemplateManager`).
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.StorageVolumeTemplateManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, StorageVolumeTemplateManager), \
+            "StorageVolumeTemplate init: Expected manager type %s, got %s" % \
+            (StorageVolumeTemplateManager, type(manager))
+        super(StorageVolumeTemplate, self).__init__(
+            manager, uri, name, properties)
+
+    @logged_api_call
+    def delete(self):
+        """
+        Delete this storage volume template on the HMC.
+
+        This method performs the "Modify Storage Template Properties"
+        operation, requesting deletion of the volume template.
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group template owning this
+          storage volume template.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        volreq_obj = {
+            'operation': 'delete',
+            'element-uri': self.uri,
+        }
+        body = {
+            'storage-volumes': [
+                volreq_obj
+            ],
+        }
+        self.manager.session.post(
+            self.manager.storage_group_template.uri + '/operations/modify',
+            body=body)
+
+        self.manager._name_uri_cache.delete(
+            self.properties.get(self.manager._name_prop, None))
+
+    @logged_api_call
+    def update_properties(self, properties):
+        """
+        Update writeable properties of this storage volume template on the HMC.
+
+        This method performs the "Modify Storage Template Properties"
+        operation, requesting modification of the volume.
+
+        Authorization requirements:
+
+        * Object-access permission to the storage group template owning this
+          storage volume template.
+        * Task permission to the "Configure Storage - System Programmer" task.
+
+        Parameters:
+
+          properties (dict): New property values for the volume.
+            Allowable properties are the fields defined in the
+            "storage-template-volume-request-info" nested object for the
+            "modify" operation. That nested object is described in operation
+            "Modify Storage Template Properties" in the :term:`HMC API` book.
+
+            The properties provided in this parameter will be copied and then
+            amended with the `operation="modify"` and `element-uri` properties,
+            and then used as a single array item for the
+            `storage-template-volumes` field in the request body of the
+            "Modify Storage Template Properties" operation.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+
+        volreq_obj = copy.deepcopy(properties)
+        volreq_obj['operation'] = 'modify'
+        volreq_obj['element-uri'] = self.uri
+        body = {
+            'storage-template-volumes': [volreq_obj],
+        }
+        self.manager.session.post(
+            self.manager.storage_group_template.uri + '/operations/modify',
+            body=body)
+        self.properties.update(copy.deepcopy(properties))


### PR DESCRIPTION
For details, see the commit message.

At this point, the support is completely implemented and documented and ready for trying it out, but tests or mock support is not implemented at this point.

To try it out, build the documentation from this branch using `make builddoc` and the starting points for reading are `Console.storage_group_templates` and `StorageGroupManager.create()`.