### PR TITLE
Fixes #596: Added support for Python 3.8 and increased several minimum package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,11 +94,27 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #      cache: pip
+#    - os: linux
+#      dist: xenial
+#      sudo: required
+#      language: python
+#      python: "3.7"
+#      env:
+#        - PACKAGE_LEVEL=latest
+#      cache: pip
+#    - os: linux
+#      dist: xenial
+#      sudo: required
+#      language: python
+#      python: "3.8"
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#      cache: pip
     - os: linux
       dist: xenial
       sudo: required
       language: python
-      python: "3.7"
+      python: "3.8"
       env:
         - PACKAGE_LEVEL=latest
       cache: pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,14 @@ environment:
 #      UNIX_PATH: none
 #      PYTHON_CMD: python
 
+#    - TOX_ENV: win64_py38_32
+#      UNIX_PATH: none
+#      PYTHON_CMD: python
+
+#    - TOX_ENV: win64_py38_64
+#      UNIX_PATH: none
+#      PYTHON_CMD: python
+
 # TODO: Disabled because python2.7 fails with segmentation fault
 #    - TOX_ENV: cygwin32_py27
 #      UNIX_PATH: C:\cygwin\bin
@@ -124,14 +132,14 @@ install:
   - if "%UNIX_PATH%"=="C:\cygwin64\bin" bash --noprofile --norc -c "set -e; %PYTHON_CMD% -m ensurepip; %PYTHON_CMD% -m pip install --upgrade pip setuptools wheel"
   - if "%UNIX_PATH%"=="C:\msys64\usr\bin" set MSYSTEM=MSYS & bash --noprofile --norc -c "set -e; %PYTHON_CMD% -m ensurepip; %PYTHON_CMD% -m pip install --upgrade pip setuptools wheel"
   # - if not "%UNIX_PATH%"=="none" bash --noprofile --norc -c "set -e; echo \"PIP_CMD=%PIP_CMD%\"; which -a %PIP_CMD%; %PIP_CMD% --version"
- 
+
   # Install Tox
   - if "%UNIX_PATH%"=="none" cmd /c "pip install tox"
   - if "%UNIX_PATH%"=="C:\cygwin\bin" bash --noprofile --norc -c "%PYTHON_CMD% -m pip install tox"
   - if "%UNIX_PATH%"=="C:\cygwin64\bin" bash --noprofile --norc -c "%PYTHON_CMD% -m pip install tox"
   - if "%UNIX_PATH%"=="C:\msys64\usr\bin" set MSYSTEM=MSYS & bash --noprofile --norc -c "%PIP_CMD% install tox"
   - if not "%UNIX_PATH%"=="none" bash --noprofile --norc -c "set -e; which -a tox; tox --version"
-  
+
 build: false
 
 before_test:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,13 +18,21 @@
 PyYAML>=3.13 # MIT
 
 # Tests (imports into testcases):
-pytest>=3.0.5 # MIT
+# pytest 5.0.0 has removed support for Python < 3.5
+# pytest 4.3.1 solves an issue on Python 3 with minimum package levels
+pytest>=4.3.1,<5.0.0; python_version < '3.5'
+pytest>=4.3.1; python_version >= '3.5'
 mock>=2.0.0 # BSD
-requests-mock>=1.2.0 # Apache-2.0
-testfixtures>=4.13.3 # Apache-2.0
+requests-mock>=1.6.0 # Apache-2.0
+testfixtures>=6.9.0 # Apache-2.0
 yamlordereddictloader>=0.4.0
 
 # Tests (no imports, invoked via py.test script):
+
+# Coverage reporting (no imports, invoked via coveralls script):
+# Make sure the Python version matches the one used in .travis.yml.
+coverage>=4.5.3; python_version == '3.8'
+python-coveralls>=2.9.2; python_version == '3.8'
 
 # TODO: Remove the pinning of the pytest-cov version again once issue
 #       https://github.com/z4r/python-coveralls/issues/66
@@ -34,9 +42,6 @@ yamlordereddictloader>=0.4.0
 #       >=4.4, which is in conflict with the version requirement
 #       defined by the python-coveralls package for coverage==4.0.3.
 pytest-cov>=2.4.0,<2.6 # BSD
-
-# Coverage reporting (no imports, invoked via coveralls script):
-python-coveralls>=2.9.0 # Apache-2.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx>=1.7.6,<2.0.0; python_version < '3.5'  # BSD

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,9 @@ Released: not yet
 * Promoted the development status of the zhmcclient package on Pypi from
   3 - Alpha to 4 - Beta.
 
+* Added support for Python 3.8 to the package metadata and to the Travis and
+  Appveyor and Tox environments. (See issue #596)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -36,10 +36,33 @@
 #   setuptools  33.1.1    2017-01-16
 #   wheel       0.29.0    2016-02-06
 #   pbr         1.10.0    2016-05-23
+# * Ubuntu 18.04:
+#   Python      2.7.15
+#   Python3     3.6.5
+#   pip         9.0.1     (py2+py3)
+#   setuptools  39.0.1    (py2+py3)
+#   wheel       0.30.0    (py2+py3)
+# * Ubuntu 19.04:
+#   Python      2.7.16
+#   Python3     3.7.3
+#   pip         18.1      (py2+py3)
+#   setuptools  40.8.0    (py2+py3)
+#   wheel       0.32.3    (py2+py3)
+# * Versions installed on Python 3.8 on Appveyor
+#   Python38    3.8.0
+#   pip         19.3.1
+#   setuptools  41.6.0
+#   wheel       0.33.6
 
-pip==9.0.1
-setuptools==33.1.1
-wheel==0.29.0
+# For Python up to Python 3.7, we use the versions from Ubuntu 17.04:
+pip==9.0.1; python_version <= '3.7'
+setuptools==33.1.1; python_version <= '3.7'
+wheel==0.29.0; python_version <= '3.7'
+
+# For Python 3.8 and above, we use the versions from Python 3.8.0:
+pip==19.3.1; python_version >= '3.8'
+setuptools==41.6.0; python_version >= '3.8'
+wheel==0.33.6; python_version >= '3.8'
 
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
@@ -66,17 +89,18 @@ urllib3==1.21.1
 PyYAML==3.13
 
 # Tests (imports into testcases):
-pytest==3.0.5
+pytest==4.3.1
 mock==2.0.0
 requests-mock==1.2.0
 testfixtures==4.13.3
 yamlordereddictloader==0.4.0
 
+# Coverage reporting (no imports, invoked via coveralls script):
+python-coveralls==2.9.2
+coverage==4.5.3
+
 # Tests (no imports, invoked via py.test script):
 pytest-cov==2.4.0
-
-# Coverage reporting (no imports, invoked via coveralls script):
-python-coveralls==2.9.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==1.7.6
@@ -113,7 +137,7 @@ backports-abc==0.5
 backports.functools-lru-cache==1.3
 backports.shutil-get-terminal-size==1.0.0
 backports.ssl-match-hostname==3.5.0.1
-bleach==1.5.0
+bleach==2.1.4
 clint==0.5.1
 configparser==3.5.0
 coverage==4.0.3
@@ -123,7 +147,7 @@ enum34==1.1.6
 funcsigs==1.0.2 #; python_version < '3.3'
 functools32==3.2.3.post2 #; python_version == '2.7'
 gitdb2==2.0.0
-html5lib==0.9999999
+html5lib==0.999999999
 imagesize==0.7.1
 ipykernel==4.5.2
 ipython==5.1.0
@@ -138,17 +162,17 @@ jupyter_core==4.2.1
 lazy-object-proxy==1.2.2
 MarkupSafe==0.23
 mccabe==0.5.3
-mistune==0.7.3
+mistune==0.8.1
 nbconvert==5.0.0
 nbformat==4.2.0
 notebook==4.3.1
 pandocfilters==1.4.1
-pathlib2==2.1.0
+pathlib2==2.2.0
 pexpect==4.2.1
 pickleshare==0.7.4
 pkginfo==1.4.1
 ptyprocess==0.5.1
-py==1.4.32
+py==1.5.1
 pycodestyle==2.2.0
 pyflakes==1.3.0
 Pygments==2.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@
 decorator>=4.0.10 # new BSD
 pbr>=1.10.0 # Apache-2.0
 pytz>=2016.10 # MIT
-requests>=2.20.0 # Apache-2.0
+requests>=2.20.1 # Apache-2.0
 six>=1.10.0 # MIT
 stomp.py>=4.1.15 # Apache
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifier =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ envlist =
     py35
     py36
     py37
+    py38
     win64_py27_32
     win64_py27_64
     win64_py34_32
@@ -24,6 +25,8 @@ envlist =
     win64_py36_64
     win64_py37_32
     win64_py37_64
+    win64_py38_32
+    win64_py38_64
     cygwin32_py27
     cygwin64_py27
     cygwin64_py36
@@ -80,6 +83,10 @@ basepython = python3.6
 [testenv:py37]
 platform = linux2|darwin
 basepython = python3.7
+
+[testenv:py38]
+platform = linux2|darwin
+basepython = python3.8
 
 [testenv:win64_py27_32]
 platform = win32
@@ -140,6 +147,18 @@ platform = win32
 basepython = python
 setenv =
     PATH = C:\Python37-x64;{env:PATH}
+
+[testenv:win64_py38_32]
+platform = win32
+basepython = python
+setenv =
+    PATH = C:\Python38;{env:PATH}
+
+[testenv:win64_py38_64]
+platform = win32
+basepython = python
+setenv =
+    PATH = C:\Python38-x64;{env:PATH}
 
 [testenv:cygwin32_py27]
 platform = cygwin


### PR DESCRIPTION
Ready for review and merge.

See the manual-ci-run branch for a test on all Python versions, that one should pass before merging this PR.