### PR TITLE
Increase the minimum version of stomp.py to >= 4.1.21

### DIFF
--- a/examples/jms_notifications.py
+++ b/examples/jms_notifications.py
@@ -117,7 +117,6 @@ for topic in topics:
 
 conn = stomp.Connection([(session.host, amqport)], use_ssl="SSL")
 conn.set_listener('', MyListener())
-conn.start()
 conn.connect(userid, password, wait=True)
 
 sub_id = 42  # subscription ID

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -68,7 +68,7 @@ decorator==4.0.10
 pytz==2016.10
 requests==2.20.0
 six==1.10.0
-stomp.py==4.1.15
+stomp.py==4.1.21
 
 
 # Indirect dependencies for runtime (must be consistent with requirements.txt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ decorator>=4.0.10 # new BSD
 pytz>=2016.10 # MIT
 requests>=2.20.1 # Apache-2.0
 six>=1.10.0 # MIT
-stomp.py>=4.1.15 # Apache
-
+stomp.py>=4.1.21,<5.0.0; python_version == '2.7'  # Apache
+stomp.py>=4.1.21; python_version > '2.7'  # Apache
 
 # Indirect dependencies (commented out, only listed to document their license):
 

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -150,7 +150,6 @@ class NotificationReceiver(object):
         listener = _NotificationListener(self._handover_dict,
                                          self._handover_cond)
         self._conn.set_listener('', listener)
-        self._conn.start()
         self._conn.connect(self._userid, self._password, wait=True)
 
         for topic_name in self._topic_names:


### PR DESCRIPTION
"stomp.py" >= 5.0.0 is not compatible with our code, because in this
version the `start` method for STOMP connections has been removed (see
https://github.com/jasonrbriggs/stomp.py/commit/7648ef770b6ec4691fab552085461b96c728f487).
To fix this issue, increase the minimum version of "stomp.py" and drop
the `conn.start()` calls.

Signed-off-by: Marc Hartmayer <mhartmay@linux.ibm.com>