### PR TITLE
Increased stomp.py to 4.1.23 to address hang in NotificationReceiver.close()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,9 @@ Released: not yet
 * Pinned version of PyYAML to <5.3 for Python 3.4 because 5.3 removed support
   for Python 3.4
 
+* Increased minimum version of stomp.py to 4.1.23 to pick up a fix for
+  hangs during NotificationReceiver.close(). (See issue #572)
+
 **Enhancements:**
 
 * Promoted the development status of the zhmcclient package on Pypi from

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -68,7 +68,7 @@ decorator==4.0.10
 pytz==2016.10
 requests==2.20.0
 six==1.10.0
-stomp.py==4.1.21
+stomp.py==4.1.23
 
 
 # Indirect dependencies for runtime (must be consistent with requirements.txt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ decorator>=4.0.10 # new BSD
 pytz>=2016.10 # MIT
 requests>=2.20.1 # Apache-2.0
 six>=1.10.0 # MIT
-stomp.py>=4.1.21,<5.0.0; python_version == '2.7'  # Apache
-stomp.py>=4.1.21; python_version > '2.7'  # Apache
+stomp.py>=4.1.23,<5.0.0; python_version == '2.7'  # Apache
+stomp.py>=4.1.23; python_version > '2.7'  # Apache
 
 # Indirect dependencies (commented out, only listed to document their license):
 


### PR DESCRIPTION
See commit message.