### PR TITLE
Travis: Removed workarounds, changed matrix to jobs, added blank lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,37 +5,10 @@
 notifications:
   email: false
 
-# We define the job matrix explicitly, in order to minimize the
-# combinations.
-# For OS-X, using an explicit matrix is required, because Travis at
-# this point only has half-baked support for Python on OS-X that does
-# not work. Also, on OS-X, it needs to be invoked with language=generic
-# and an empty 'python' variable in order to prevent that Travis attempts
-# to install Python.
-# TODO: Figure out how specific versions of Python 3.x can be used with OS-X
-
-# When defining the job matrix explicitly, there are Travis environments
-# that produce an additional default job. See these Travis issues:
-#   https://github.com/travis-ci/travis-ci/issues/1228
-#   https://github.com/travis-ci/travis-ci/issues/4681
-#   https://github.com/travis-ci/travis-ci/issues/9843
-# The public Travis does not seem to have this issue anymore,
-# but Travis@IBM does have this issue (as of 9/2018). The workaround for
-# this issue is to define variables globally and to exclude this same
-# variable value in the matrix definition. Experiments have shown that
-# not all variable combinations work. Using a combination of 'language'
-# and 'os' set to the default values works.
-
-# See note about explicit job matrix, above.
-language: ruby
-os: linux
-
-matrix:
-
-  # See note about explicit job matrix, above.
-  exclude:
-    - language: ruby
-    - os: linux
+# We define the job matrix explicitly, in order to have a minimum number of
+# useful combinations. The disabled combinations will be enabled in a specific
+# branch that does not run for every change.
+jobs:
 
   include:
 
@@ -185,21 +158,6 @@ matrix:
 
 before_install:
   - env | sort
-
-  # The following statement is a workaround to leave an OS-X job
-  # when running on Linux. That happens on Travis@IBM which does not
-  # have OS-X support but still runs os=osx on Linux.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$_system_type" == "Linux" ]]; then
-      echo "Exiting from OS-X job running on Linux";
-      exit;
-    fi
-
-  # The following statement is a safety net in case the matrix exclusion
-  # does not work for some reason.
-  - if [[ "$TRAVIS_LANGUAGE" == "ruby" ]]; then
-      echo "Exiting from unwanted default Ruby job";
-      exit;
-    fi
 
   - if [[ "$TRAVIS_BRANCH" == "manual-ci-run" ]]; then
       export _NEED_REBASE=true;

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,54 +38,63 @@ matrix:
     - os: linux
 
   include:
+
     - os: linux
       language: python
       python: "2.7"
       env:
         - PACKAGE_LEVEL=minimum
       cache: pip
+
     - os: linux
       language: python
       python: "2.7"
       env:
         - PACKAGE_LEVEL=latest
       cache: pip
+
 #    - os: linux
 #      language: python
 #      python: "3.4"
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #      cache: pip
+
     - os: linux
       language: python
       python: "3.4"
       env:
         - PACKAGE_LEVEL=latest
       cache: pip
+
 #    - os: linux
 #      language: python
 #      python: "3.5"
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #      cache: pip
+
 #    - os: linux
 #      language: python
 #      python: "3.5"
 #      env:
 #        - PACKAGE_LEVEL=latest
 #      cache: pip
+
 #    - os: linux
 #      language: python
 #      python: "3.6"
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #      cache: pip
+
 #    - os: linux
 #      language: python
 #      python: "3.6"
 #      env:
 #        - PACKAGE_LEVEL=latest
 #      cache: pip
+
 #    - os: linux
 #      dist: xenial
 #      language: python
@@ -93,6 +102,7 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=minimum
 #      cache: pip
+
 #    - os: linux
 #      dist: xenial
 #      language: python
@@ -100,6 +110,7 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=latest
 #      cache: pip
+
     - os: linux
       dist: xenial
       language: python
@@ -107,6 +118,7 @@ matrix:
       env:
         - PACKAGE_LEVEL=minimum
       cache: pip
+
     - os: linux
       dist: xenial
       language: python
@@ -114,26 +126,31 @@ matrix:
       env:
         - PACKAGE_LEVEL=latest
       cache: pip
+
 #    - os: linux
 #      language: python
 #      python: "pypy"  # currently Python 2.7.13, PyPy 7.1.1
 #      env:
 #        - PACKAGE_LEVEL=minimum
+
 #    - os: linux
 #      language: python
 #      python: "pypy"  # currently Python 2.7.13, PyPy 7.1.1
 #      env:
 #        - PACKAGE_LEVEL=latest
+
 #    - os: linux
 #      language: python
 #      python: "pypy3"  # currently Python 3.6.1, PyPy 7.1.1-beta0
 #      env:
 #        - PACKAGE_LEVEL=minimum
+
 #    - os: linux
 #      language: python
 #      python: "pypy3"  # currently Python 3.6.1, PyPy 7.1.1-beta0
 #      env:
 #        - PACKAGE_LEVEL=latest
+
 #    - os: osx
 #      language: generic
 #      python:
@@ -141,6 +158,7 @@ matrix:
 #        - PACKAGE_LEVEL=minimum
 #        - PYTHON=2
 #      cache: pip
+
 #    - os: osx
 #      language: generic
 #      python:
@@ -148,6 +166,7 @@ matrix:
 #        - PACKAGE_LEVEL=latest
 #        - PYTHON=2
 #      cache: pip
+
 #    - os: osx
 #      language: generic
 #      python:
@@ -155,6 +174,7 @@ matrix:
 #        - PACKAGE_LEVEL=minimum
 #        - PYTHON=3
 #      cache: pip
+
 #    - os: osx
 #      language: generic
 #      python:


### PR DESCRIPTION
Note that Python 3.4 fails currently, but that is unrelated to this PR and will be fixed later.