### PR TITLE
0.26: Test: Fixed missing ffi.h file on CygWin when testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,8 +116,8 @@ install:
 
   # Install OS-level prerequisite packages for pyzmq Python package
   # Note. This installs them from 'outside' of the actual UNIX env, which works.
-  - if "%UNIX_PATH%"=="C:\cygwin\bin" C:\cygwin\setup-x86.exe -q -P libzmq-devel,python2-devel,python2-cython,python3-devel,python3-cython
-  - if "%UNIX_PATH%"=="C:\cygwin64\bin" C:\cygwin64\setup-x86_64.exe -q -P libzmq-devel,python2-devel,python2-cython,python3-devel,python3-cython
+  - if "%UNIX_PATH%"=="C:\cygwin\bin" C:\cygwin\setup-x86.exe -q -P libffi-devel,libzmq-devel,python2-devel,python2-cython,python3-devel,python3-cython
+  - if "%UNIX_PATH%"=="C:\cygwin64\bin" C:\cygwin64\setup-x86_64.exe -q -P libffi-devel,libzmq-devel,python2-devel,python2-cython,python3-devel,python3-cython
   - if "%UNIX_PATH%"=="C:\msys64\usr\bin" C:\msys64\usr\bin\pacman.exe --sync --noconfirm --needed mingw-w64-x86_64-zeromq
   - if "%UNIX_PATH%"=="C:\msys64\usr\bin" C:\msys64\usr\bin\pacman.exe --sync --noconfirm --needed libcrypt-devel
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Test: Fixed missing ffi.h file on CygWin when testing (See issue #655)
+
 **Enhancements:**
 
 **Known issues:**


### PR DESCRIPTION
Rolls back PR #656 into 0.26.2.