### PR TITLE
0.26: Fixed empty port list returned by PortManager.list() for CNA adapters

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,8 @@ Released: not yet
 
 * Test: Fixed missing ffi.h file on CygWin when testing (See issue #655)
 
+* Fixed empty port list returned by PortManager.list() for CNA adapters.
+
 **Enhancements:**
 
 **Known issues:**

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -263,6 +263,8 @@ class Adapter(BaseResource):
         'osa': 'network-port-uris',
         'roce': 'network-port-uris',
         'hipersockets': 'network-port-uris',
+        'cna': 'network-port-uris',
+        'cloud-network': 'network-port-uris',  # for preliminary driver
     }
 
     # URI segment for port URIs, dependent on adapter family
@@ -271,6 +273,8 @@ class Adapter(BaseResource):
         'osa': 'network-ports',
         'roce': 'network-ports',
         'hipersockets': 'network-ports',
+        'cna': 'network-ports',
+        'cloud-network': 'network-ports',  # for preliminary driver
     }
 
     # Port type, dependent on adapter family
@@ -279,6 +283,8 @@ class Adapter(BaseResource):
         'osa': 'network',
         'roce': 'network',
         'hipersockets': 'network',
+        'cna': 'network',
+        'cloud-network': 'network',  # for preliminary driver
     }
 
     def __init__(self, manager, uri, name=None, properties=None):


### PR DESCRIPTION
Rolls back PR #664 into 0.26.2.