### PR TITLE
Release 0.26.2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,14 +19,10 @@ Change log
 ----------
 
 
-Version 0.26.2.dev1
-^^^^^^^^^^^^^^^^^^^
+Version 0.26.2
+^^^^^^^^^^^^^^
 
-Released: not yet
-
-**Incompatible changes:**
-
-**Deprecations:**
+Released: 2020-08-12
 
 **Bug fixes:**
 
@@ -42,12 +38,6 @@ Released: not yet
 * Test: Added 'make installtest' to the Makefile to test installation of the
   package into an empty virtualenv using all supported installation methods.
   Added these install tests to the Travis CI tests. (related to issue #651)
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
 
 
 Version 0.26.1

--- a/zhmcclient/_version.py
+++ b/zhmcclient/_version.py
@@ -27,7 +27,7 @@ __all__ = ['__version__']
 #:
 #: * "M.N.P.dev1": A not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '0.26.2.dev1'
+__version__ = '0.26.2'
 
 # Check supported Python versions
 # Keep these Python versions in sync with:


### PR DESCRIPTION
Please approve the release of zhmcclient 0.26.2.
The main trigger for this release is the CNA fix.

For the changes in this version, see https://github.com/zhmcclient/python-zhmcclient/blob/release_0.26.2/docs/changes.rst