### PR TITLE
timeout added to allow hmc to wait for partition to stop

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -186,6 +186,7 @@ Released: 2019-08-15
 
 **Enhancements:**
 
+* Added support for status timeout in partition stop that waits for partition stop to reach desired status.
 * Improved end2end test support for zhmcclient and its using projects.
   The zhmcclient.testutils package already provides some support for end2end
   tests by users of the zhmcclient package. It is also used by the end2end

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -450,7 +450,8 @@ class Partition(BaseResource):
         return result
 
     @logged_api_call
-    def stop(self, wait_for_completion=True, operation_timeout=None):
+    def stop(self, wait_for_completion=True, operation_timeout=None,
+             status_timeout=None):
         """
         Stop (deactivate) this Partition, using the HMC operation "Stop
         Partition".
@@ -480,6 +481,15 @@ class Partition(BaseResource):
             `wait_for_completion=True`, a
             :exc:`~zhmcclient.OperationTimeout` is raised.
 
+          status_timeout (:term:`number`):
+            Timeout in seconds, for waiting that the status of the partition
+            has reached the desired status, after the HMC operation has
+            completed.
+            The special value 0 means that no timeout is set. `None` means that
+            the default async operation timeout of the session is used.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.StatusTimeout` is raised.
+
         Returns:
 
           :class:`py:dict` or :class:`~zhmcclient.Job`:
@@ -499,11 +509,16 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
+          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
+            waiting for the desired partition status.
         """
         result = self.manager.session.post(
             self.uri + '/operations/stop',
             wait_for_completion=wait_for_completion,
             operation_timeout=operation_timeout)
+        if wait_for_completion:
+            statuses = ["stopped"]
+            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call


### PR DESCRIPTION
- Observed that the hmc api to stop partition does not update the status of the partition to stopped state despite the api returning a job 'complete' status.
- This additional waiting check is similar to the code in start() function which waits for the partition status to reflect to it's correct status.