### PR TITLE
Timeout added to allow hmc to wait for partition to stop

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,9 @@ Released: not yet
 * Added support for operations for managing temporary processor capacity:
   `Cpc.add_temporary_capacity()` and `Cpc.remove_temporary_capacity()`.
 
+* Added support for status timeout in `Partition.stop()` that waits for partition
+  stop to reach desired status.
+
 * Test: Resolved remaining Pylint issues and enforcing no issues from now on
   (issue #661).
 

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -450,7 +450,8 @@ class Partition(BaseResource):
         return result
 
     @logged_api_call
-    def stop(self, wait_for_completion=True, operation_timeout=None):
+    def stop(self, wait_for_completion=True, operation_timeout=None,
+             status_timeout=None):
         """
         Stop (deactivate) this Partition, using the HMC operation "Stop
         Partition".
@@ -480,6 +481,15 @@ class Partition(BaseResource):
             `wait_for_completion=True`, a
             :exc:`~zhmcclient.OperationTimeout` is raised.
 
+          status_timeout (:term:`number`):
+            Timeout in seconds, for waiting that the status of the partition
+            has reached the desired status, after the HMC operation has
+            completed.
+            The special value 0 means that no timeout is set. `None` means that
+            the default async operation timeout of the session is used.
+            If the timeout expires when `wait_for_completion=True`, a
+            :exc:`~zhmcclient.StatusTimeout` is raised.
+
         Returns:
 
           :class:`py:dict` or :class:`~zhmcclient.Job`:
@@ -499,11 +509,16 @@ class Partition(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
+          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
+            waiting for the desired partition status.
         """
         result = self.manager.session.post(
             self.uri + '/operations/stop',
             wait_for_completion=wait_for_completion,
             operation_timeout=operation_timeout)
+        if wait_for_completion:
+            statuses = ["stopped"]
+            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call


### PR DESCRIPTION
See commit message.
This PR integrates PR #685, with the following changes on top:
- moves the change log entry to the correct version 0.28.0 and made editorial changes to it.