### PR TITLE
0.30: Circumvented a missing argument in 'NotificationListener.on_message()'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed a missing argument in 'NotificationListener.on_message()' by pinning
+  stomp.py such that 6.1.0 and 6.1.1 are excluded. (issue #763)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,10 @@ requests>=2.20.1,<2.22.0; python_version == '3.4'  # Apache-2.0
 requests>=2.20.1; python_version >= '3.5'  # Apache-2.0
 six>=1.14.0 # MIT
 # stomp.py 5.0.0 (now deleted) and 6.0.0 removed support for Python 2.7, 3.4 and 3.5
+# stomp.py 6.1.0 on Pypi contained older code than v6.1.0 in the repo -> will be yanked on Pypi
+# stomp.py 6.1.1 broke compatibility -> will be yanked on Pypi and re-released as 7.0.0
 stomp.py>=4.1.23,<5.0.0; python_version <= '3.5'  # Apache
-stomp.py>=4.1.23; python_version >= '3.6'  # Apache
+stomp.py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version >= '3.6'  # Apache
 
 # Indirect dependencies (commented out, only listed to document their license):
 


### PR DESCRIPTION
Rolls back PR #764 into 0.30.1.