### PR TITLE
Changed properties attribute to be immutable

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,12 @@ Released: not yet
   CA certificates in the Python 'certifi' package. This can be controlled with
   a new 'verify_cert' init parameter to the 'zhmcclient.Session' class. (issue #779)
 
+* The 'properties' attribute of the resource classes (e.g. 'Partition') now
+  is an immutable 'DictView' object in order to enforce the stated rule that
+  that callers must not modify the properties dictionary. If your code used to
+  make such modifications nevertheless, it will now get a 'TypeError' or
+  'AttributeError' exception, dependent on the nature of the modification.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -72,6 +78,11 @@ Released: not yet
 * Docs: Added a section "Troubleshooting" to appendix of the documentation that
   currently lists two cases of communication related issues.
   (related to issue #779)
+
+* The 'properties' attribute of the resource classes (e.g. 'Partition') now
+  is an immutable 'DictView' object provided by the 'immutable-views' package,
+  in order to enforce the stated rule that that callers must not modify the
+  properties dictionary of resource objects.
 
 **Cleanup:**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -470,6 +470,7 @@ intersphinx_mapping = {
     'py': ('https://docs.python.org/3/', None), # agnostic to Python version
     'py2': ('https://docs.python.org/2', None), # specific to Python 2
     'py3': ('https://docs.python.org/3', None), # specific to Python 3
+    'iv': ('https://immutable-views.readthedocs.io/en/latest/', None),
 }
 
 intersphinx_cache_limit = 5

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -92,6 +92,7 @@ requests==2.20.1
 six==1.14.0
 stomp.py==4.1.23
 
+immutable-views==0.6.0
 
 # Indirect dependencies for runtime (must be consistent with requirements.txt)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ six>=1.14.0 # MIT
 stomp.py>=4.1.23,<5.0.0; python_version <= '3.5'  # Apache
 stomp.py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version >= '3.6'  # Apache
 
+immutable-views>=0.6.0
+
 # Indirect dependencies (commented out, only listed to document their license):
 
 # certifi # ISC, from requests>=2.20

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -257,4 +257,4 @@ class ActivationProfile(BaseResource):
         # Attempts to change the 'name' property will be rejected by the HMC,
         # so we don't need to update the name-to-URI cache.
         assert self.manager._name_prop not in properties
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -428,7 +428,7 @@ class Adapter(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self.uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -461,7 +461,7 @@ class Adapter(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_capacity_group.py
+++ b/zhmcclient/_capacity_group.py
@@ -240,7 +240,7 @@ class CapacityGroup(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self._uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -273,7 +273,7 @@ class CapacityGroup(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -560,7 +560,7 @@ class Cpc(BaseResource):
         # Attempts to change the 'name' property will be rejected by the HMC,
         # so we don't need to update the name-to-URI cache.
         assert self.manager._name_prop not in properties
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
 
     @logged_api_call
     def start(self, wait_for_completion=True, operation_timeout=None):

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -260,7 +260,7 @@ class Hba(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self._uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -295,7 +295,7 @@ class Hba(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)
@@ -330,4 +330,4 @@ class Hba(BaseResource):
         self.manager.session.post(
             self._uri + '/operations/reassign-storage-adapter-port',
             body=body)
-        self.properties.update(body)
+        self._properties.update(body)

--- a/zhmcclient/_ldap_server_definition.py
+++ b/zhmcclient/_ldap_server_definition.py
@@ -230,7 +230,7 @@ class LdapServerDefinition(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self.uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -264,4 +264,4 @@ class LdapServerDefinition(BaseResource):
         # assert that here, because we omit the extra code for handling name
         # updates:
         assert self.manager._name_prop not in properties
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -214,7 +214,7 @@ class Lpar(BaseResource):
         # Attempts to change the 'name' property will be rejected by the HMC,
         # so we don't need to update the name-to-URI cache.
         assert self.manager._name_prop not in properties
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
 
     @logged_api_call
     def activate(self, wait_for_completion=True,

--- a/zhmcclient/_metrics.py
+++ b/zhmcclient/_metrics.py
@@ -282,7 +282,7 @@ class MetricsContext(BaseResource):
         """
         # Dictionary of MetricGroupDefinition objects, by metric group name
         metric_group_definitions = dict()
-        for mg_info in self.properties['metric-group-infos']:
+        for mg_info in self._properties['metric-group-infos']:
             mg_name = mg_info['group-name']
             mg_def = MetricGroupDefinition(
                 name=mg_name,

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -286,7 +286,7 @@ class Nic(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self._uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -320,7 +320,7 @@ class Nic(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -541,7 +541,7 @@ class Partition(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self.uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -574,7 +574,7 @@ class Partition(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_password_rule.py
+++ b/zhmcclient/_password_rule.py
@@ -232,7 +232,7 @@ class PasswordRule(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self.uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -268,4 +268,4 @@ class PasswordRule(BaseResource):
         # should cause HTTPError to be raised in the POST above, so we assert
         # that here, because we omit the extra code for handling name updates:
         assert self.manager._name_prop not in properties
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -221,4 +221,4 @@ class Port(BaseResource):
         # Attempts to change the 'name' property will be rejected by the HMC,
         # so we don't need to update the name-to-URI cache.
         assert self.manager._name_prop not in properties
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -21,6 +21,7 @@ by the HMC.
 
 from __future__ import absolute_import
 import time
+from immutable_views import DictView
 
 from ._logging import logged_api_call
 from ._utils import repr_dict, repr_timestamp
@@ -95,40 +96,42 @@ class BaseResource(object):
     @property
     def properties(self):
         """
-        dict:
-          The properties of this resource that are currently present in this
-          Python object.
-          Will not be `None`.
+        :class:`iv:immutable_views.DictView`: The properties of this resource
+        that are currently present in this Python object, as a dictionary.
 
           * Key: Name of the property.
           * Value: Value of the property.
 
-          See the respective 'Data model' sections in the :term:`HMC API` book
-          for a description of the resources along with their properties.
+        The returned :class:`iv:immutable_views.DictView` object is an immutable
+        dictionary view that behaves like a standard Python :class:`dict`
+        except that it prevents any modifications to the dictionary.
 
-          The dictionary contains either the full set of resource properties,
-          or a subset thereof, or can be empty in some cases.
+        See the respective 'Data model' sections in the :term:`HMC API` book
+        for a description of the resources along with their properties.
 
-          Because the presence of properties in this dictionary depends on the
-          situation, the purpose of this dictionary is only for iterating
-          through the resource properties that are currently present.
+        The dictionary contains either the full set of resource properties,
+        or a subset thereof, or can be empty in some cases.
 
-          Specific resource properties should be accessed via:
+        Because the presence of properties in this dictionary depends on the
+        situation, the purpose of this dictionary is only for iterating
+        through the resource properties that are currently present.
 
-          * The resource name, via the :attr:`~zhmcclient.BaseResource.name`
-            attribute.
-          * The resource URI, via the :attr:`~zhmcclient.BaseResource.uri`
-            attribute.
-          * Any resource property, via the
-            :meth:`~zhmcclient.BaseResource.get_property` or
-            :meth:`~zhmcclient.BaseResource.prop` methods.
+        Specific resource properties should be accessed via:
 
-        The properties in this dictionary are mutable. However, the properties
-        of the actual manageable resources may or may not be mutable.
-        Mutability for each resource property is indicated with the 'w'
-        qualifier in its data model in the :term:`HMC API` book.
+        * The resource name, via the :attr:`~zhmcclient.BaseResource.name`
+          attribute.
+        * The resource URI, via the :attr:`~zhmcclient.BaseResource.uri`
+          attribute.
+        * Any resource property, via the
+          :meth:`~zhmcclient.BaseResource.get_property` or
+          :meth:`~zhmcclient.BaseResource.prop` methods.
+
+        Updates to property values can be done via the ``update_properties()``
+        method of the resource class. Which properties can be updated
+        is indicated with the 'w' qualifier in the data model of the resource
+        in the :term:`HMC API` book.
         """
-        return self._properties
+        return DictView(self._properties)
 
     @property
     def uri(self):

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -495,7 +495,7 @@ class StorageGroup(BaseResource):
 
         # pylint: disable=protected-access
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -538,7 +538,7 @@ class StorageGroup(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_storage_group_template.py
+++ b/zhmcclient/_storage_group_template.py
@@ -294,7 +294,7 @@ class StorageGroupTemplate(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(uri=self.uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -338,7 +338,7 @@ class StorageGroupTemplate(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_storage_volume.py
+++ b/zhmcclient/_storage_volume.py
@@ -406,7 +406,7 @@ class StorageVolume(BaseResource):
 
         # pylint: disable=protected-access
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties, email_to_addresses=None,
@@ -491,7 +491,7 @@ class StorageVolume(BaseResource):
             self.manager.storage_group.uri + '/operations/modify',
             body=body)
 
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
 
     @logged_api_call
     def indicate_fulfillment_ficon(self, control_unit, unit_address):

--- a/zhmcclient/_storage_volume_template.py
+++ b/zhmcclient/_storage_volume_template.py
@@ -305,7 +305,7 @@ class StorageVolumeTemplate(BaseResource):
 
         # pylint: disable=protected-access
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -352,4 +352,4 @@ class StorageVolumeTemplate(BaseResource):
         self.manager.session.post(
             self.manager.storage_group_template.uri + '/operations/modify',
             body=body)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -228,7 +228,7 @@ class User(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self.uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -266,7 +266,7 @@ class User(BaseResource):
         # HTTPError to be raised in the POST above, so we assert that here,
         # because we omit the extra code for handling name updates:
         assert self.manager._name_prop not in properties
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
 
     @logged_api_call
     def add_user_role(self, user_role):

--- a/zhmcclient/_user_pattern.py
+++ b/zhmcclient/_user_pattern.py
@@ -272,7 +272,7 @@ class UserPattern(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self.uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -304,7 +304,7 @@ class UserPattern(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_user_role.py
+++ b/zhmcclient/_user_role.py
@@ -236,7 +236,7 @@ class UserRole(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self.uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -272,7 +272,7 @@ class UserRole(BaseResource):
         # cause HTTPError to be raised in the POST above, so we assert that
         # here, because we omit the extra code for handling name updates:
         assert self.manager._name_prop not in properties
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
 
     @logged_api_call
     def add_permission(self, permitted_object, include_members=False,

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -224,7 +224,7 @@ class VirtualFunction(BaseResource):
         # pylint: disable=protected-access
         self.manager.session.delete(self._uri)
         self.manager._name_uri_cache.delete(
-            self.properties.get(self.manager._name_prop, None))
+            self._properties.get(self.manager._name_prop, None))
 
     @logged_api_call
     def update_properties(self, properties):
@@ -259,7 +259,7 @@ class VirtualFunction(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_virtual_storage_resource.py
+++ b/zhmcclient/_virtual_storage_resource.py
@@ -313,7 +313,7 @@ class VirtualStorageResource(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -267,7 +267,7 @@ class VirtualSwitch(BaseResource):
         if is_rename:
             # Delete the old name from the cache
             self.manager._name_uri_cache.delete(self.name)
-        self.properties.update(copy.deepcopy(properties))
+        self._properties.update(copy.deepcopy(properties))
         if is_rename:
             # Add the new name to the cache
             self.manager._name_uri_cache.update(self.name, self.uri)

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -89,25 +89,25 @@ class FakedBaseResource(object):
             if self.manager.oid_prop is None:
                 self._oid = None
             else:
-                if self.manager.oid_prop not in self.properties:
+                if self.manager.oid_prop not in self._properties:
                     new_oid = self.manager._new_oid()
-                    self.properties[self.manager.oid_prop] = new_oid
-                self._oid = self.properties[self.manager.oid_prop]
+                    self._properties[self.manager.oid_prop] = new_oid
+                self._oid = self._properties[self.manager.oid_prop]
 
-            if self.manager.uri_prop not in self.properties:
+            if self.manager.uri_prop not in self._properties:
                 new_uri = self.manager.base_uri
                 if self.oid is not None:
                     new_uri += '/' + self.oid
-                self.properties[self.manager.uri_prop] = new_uri
-            self._uri = self.properties[self.manager.uri_prop]
+                self._properties[self.manager.uri_prop] = new_uri
+            self._uri = self._properties[self.manager.uri_prop]
 
             if self.manager.class_value:
-                if 'class' not in self.properties:
-                    self.properties['class'] = self.manager.class_value
+                if 'class' not in self._properties:
+                    self._properties['class'] = self.manager.class_value
 
             if self.manager.parent:
-                if 'parent' not in self.properties:
-                    self.properties['parent'] = self.manager.parent.uri
+                if 'parent' not in self._properties:
+                    self._properties['parent'] = self.manager.parent.uri
 
         else:
             self._oid = None
@@ -135,7 +135,7 @@ class FakedBaseResource(object):
                 _manager_id=id(self._manager),
                 _oid=self._oid,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
             ))
         return ret
 
@@ -190,7 +190,7 @@ class FakedBaseResource(object):
             Resource properties to be updated. Any other properties remain
             unchanged.
         """
-        self.properties.update(properties)
+        self._properties.update(properties)
 
     def add_resources(self, resources):
         """
@@ -812,7 +812,7 @@ class FakedConsole(FakedBaseResource):
                 manager_id=id(self._manager),
                 parent_uri=self._manager.parent.uri,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
                 _storage_groups=repr_manager(self.storage_groups, indent=2),
                 _users=repr_manager(self.users, indent=2),
                 _user_roles=repr_manager(self.user_roles, indent=2),
@@ -1389,35 +1389,35 @@ class FakedAdapter(FakedBaseResource):
             manager=manager,
             properties=properties)
         # TODO: Maybe move this stuff into AdapterManager.add()?
-        if 'adapter-family' in self.properties:
-            family = self.properties['adapter-family']
+        if 'adapter-family' in self._properties:
+            family = self._properties['adapter-family']
             if family in ('osa', 'roce', 'hipersockets'):
                 self._adapter_kind = 'network'
             elif family in ('ficon',):
                 self._adapter_kind = 'storage'
             else:
                 self._adapter_kind = 'other'
-        elif 'type' in self.properties:
+        elif 'type' in self._properties:
             # because 'type' is more specific than 'adapter-family', we can
             # auto-set 'adapter-family' from 'type'.
-            type_ = self.properties['type']
+            type_ = self._properties['type']
             if type_ in ('osd', 'osm'):
-                self.properties['adapter-family'] = 'osa'
+                self._properties['adapter-family'] = 'osa'
                 self._adapter_kind = 'network'
             elif type_ == 'roce':
-                self.properties['adapter-family'] = 'roce'
+                self._properties['adapter-family'] = 'roce'
                 self._adapter_kind = 'network'
             elif type_ == 'hipersockets':
-                self.properties['adapter-family'] = 'hipersockets'
+                self._properties['adapter-family'] = 'hipersockets'
                 self._adapter_kind = 'network'
             elif type_ in ('fcp', 'fc'):
-                self.properties['adapter-family'] = 'ficon'
+                self._properties['adapter-family'] = 'ficon'
                 self._adapter_kind = 'storage'
             elif type_ == 'crypto':
-                self.properties['adapter-family'] = 'crypto'
+                self._properties['adapter-family'] = 'crypto'
                 self._adapter_kind = 'other'
             elif type_ == 'zedc':
-                self.properties['adapter-family'] = 'accelerator'
+                self._properties['adapter-family'] = 'accelerator'
                 self._adapter_kind = 'other'
             else:
                 raise InputError("FakedAdapter with object-id=%s has an "
@@ -1428,17 +1428,17 @@ class FakedAdapter(FakedBaseResource):
                              "'adapter-family' or 'type' property specified." %
                              self.oid)
         if self.adapter_kind == 'network':
-            if 'network-port-uris' not in self.properties:
-                self.properties['network-port-uris'] = []
+            if 'network-port-uris' not in self._properties:
+                self._properties['network-port-uris'] = []
             self._ports = FakedPortManager(hmc=manager.hmc, adapter=self)
         elif self.adapter_kind == 'storage':
-            if 'storage-port-uris' not in self.properties:
-                self.properties['storage-port-uris'] = []
+            if 'storage-port-uris' not in self._properties:
+                self._properties['storage-port-uris'] = []
             self._ports = FakedPortManager(hmc=manager.hmc, adapter=self)
         else:
             self._ports = None
-        if 'status' not in self.properties:
-            self.properties['status'] = 'active'
+        if 'status' not in self._properties:
+            self._properties['status'] = 'active'
 
     def __repr__(self):
         """
@@ -1459,7 +1459,7 @@ class FakedAdapter(FakedBaseResource):
                 manager_id=id(self._manager),
                 parent_uri=self._manager.parent.uri,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
                 _ports=repr_manager(self.ports, indent=2),
             ))
         return ret
@@ -1565,15 +1565,15 @@ class FakedCpc(FakedBaseResource):
         self._load_activation_profiles = FakedActivationProfileManager(
             hmc=manager.hmc, cpc=self, profile_type='load')
 
-        if 'dpm-enabled' not in self.properties:
-            self.properties['dpm-enabled'] = False
-        if 'is-ensemble-member' not in self.properties:
-            self.properties['is-ensemble-member'] = False
-        if 'status' not in self.properties:
+        if 'dpm-enabled' not in self._properties:
+            self._properties['dpm-enabled'] = False
+        if 'is-ensemble-member' not in self._properties:
+            self._properties['is-ensemble-member'] = False
+        if 'status' not in self._properties:
             if self.dpm_enabled:
-                self.properties['status'] = 'active'
+                self._properties['status'] = 'active'
             else:
-                self.properties['status'] = 'operating'
+                self._properties['status'] = 'operating'
 
     def __repr__(self):
         """
@@ -1601,7 +1601,7 @@ class FakedCpc(FakedBaseResource):
                 manager_id=id(self._manager),
                 parent_uri=self._manager.parent.uri,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
                 _lpars=repr_manager(self.lpars, indent=2),
                 _partitions=repr_manager(self.partitions, indent=2),
                 _adapters=repr_manager(self.adapters, indent=2),
@@ -1625,7 +1625,7 @@ class FakedCpc(FakedBaseResource):
 
         This returns the value of the 'dpm-enabled' property.
         """
-        return self.properties['dpm-enabled']
+        return self._properties['dpm-enabled']
 
     @property
     def lpars(self):
@@ -1767,7 +1767,7 @@ class FakedUnmanagedCpc(FakedBaseResource):
                 manager_id=id(self._manager),
                 parent_uri=self._manager.parent.uri,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
             ))
         return ret
 
@@ -1944,8 +1944,8 @@ class FakedLpar(FakedBaseResource):
         super(FakedLpar, self).__init__(
             manager=manager,
             properties=properties)
-        if 'status' not in self.properties:
-            self.properties['status'] = 'not-activated'
+        if 'status' not in self._properties:
+            self._properties['status'] = 'not-activated'
 
 
 class FakedNicManager(FakedBaseManager):
@@ -2148,14 +2148,14 @@ class FakedPartition(FakedBaseResource):
         super(FakedPartition, self).__init__(
             manager=manager,
             properties=properties)
-        if 'hba-uris' not in self.properties:
-            self.properties['hba-uris'] = []
-        if 'nic-uris' not in self.properties:
-            self.properties['nic-uris'] = []
-        if 'virtual-function-uris' not in self.properties:
-            self.properties['virtual-function-uris'] = []
-        if 'status' not in self.properties:
-            self.properties['status'] = 'stopped'
+        if 'hba-uris' not in self._properties:
+            self._properties['hba-uris'] = []
+        if 'nic-uris' not in self._properties:
+            self._properties['nic-uris'] = []
+        if 'virtual-function-uris' not in self._properties:
+            self._properties['virtual-function-uris'] = []
+        if 'status' not in self._properties:
+            self._properties['status'] = 'stopped'
         self._nics = FakedNicManager(hmc=manager.hmc, partition=self)
         self._hbas = FakedHbaManager(hmc=manager.hmc, partition=self)
         self._virtual_functions = FakedVirtualFunctionManager(
@@ -2184,7 +2184,7 @@ class FakedPartition(FakedBaseResource):
                 manager_id=id(self._manager),
                 parent_uri=self._manager.parent.uri,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
                 _nics=repr_manager(self.nics, indent=2),
                 _hbas=repr_manager(self.hbas, indent=2),
                 _virtual_functions=repr_manager(
@@ -2563,8 +2563,8 @@ class FakedVirtualSwitch(FakedBaseResource):
         super(FakedVirtualSwitch, self).__init__(
             manager=manager,
             properties=properties)
-        if 'connected-vnic-uris' not in self.properties:
-            self.properties['connected-vnic-uris'] = []
+        if 'connected-vnic-uris' not in self._properties:
+            self._properties['connected-vnic-uris'] = []
 
 
 class FakedStorageGroupManager(FakedBaseManager):
@@ -2628,10 +2628,10 @@ class FakedStorageGroup(FakedBaseResource):
         super(FakedStorageGroup, self).__init__(
             manager=manager,
             properties=properties)
-        if 'storage-volume-uris' not in self.properties:
-            self.properties['storage-volume-uris'] = []
-        if 'shared' not in self.properties:
-            self.properties['shared'] = False
+        if 'storage-volume-uris' not in self._properties:
+            self._properties['storage-volume-uris'] = []
+        if 'shared' not in self._properties:
+            self._properties['shared'] = False
         self._storage_volumes = FakedStorageVolumeManager(
             hmc=manager.hmc, storage_group=self)
 
@@ -2654,7 +2654,7 @@ class FakedStorageGroup(FakedBaseResource):
                 manager_id=id(self._manager),
                 parent_uri=self._manager.parent.uri,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
                 _storage_volumes=repr_manager(self.storage_volumes, indent=2),
             ))
         return ret
@@ -2745,7 +2745,7 @@ class FakedStorageVolume(FakedBaseResource):
                 manager_id=id(self._manager),
                 parent_uri=self._manager.parent.uri,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
             ))
         return ret
 
@@ -2809,10 +2809,10 @@ class FakedCapacityGroup(FakedBaseResource):
         super(FakedCapacityGroup, self).__init__(
             manager=manager,
             properties=properties)
-        if 'capping-enabled' not in self.properties:
-            self.properties['capping-enabled'] = False
-        if 'partition-uris' not in self.properties:
-            self.properties['partition-uris'] = []
+        if 'capping-enabled' not in self._properties:
+            self._properties['capping-enabled'] = False
+        if 'partition-uris' not in self._properties:
+            self._properties['partition-uris'] = []
 
     def __repr__(self):
         """
@@ -2832,7 +2832,7 @@ class FakedCapacityGroup(FakedBaseResource):
                 manager_id=id(self._manager),
                 parent_uri=self._manager.parent.uri,
                 _uri=self._uri,
-                _properties=repr_dict(self.properties, indent=2),
+                _properties=repr_dict(self._properties, indent=2),
             ))
         return ret
 
@@ -3136,7 +3136,7 @@ class FakedMetricsContext(FakedBaseResource):
           iterable of :class:~zhmcclient.FakedMetricGroupDefinition`: The faked
             metric group definitions, in the order they had been added.
         """
-        group_names = self.properties.get('metric-groups', None)
+        group_names = self._properties.get('metric-groups', None)
         if not group_names:
             group_names = self.manager.get_metric_group_definition_names()
         mg_defs = []
@@ -3190,7 +3190,7 @@ class FakedMetricsContext(FakedBaseResource):
             values (:class:~zhmcclient.FakedMetricObjectValues`):
               The metric values for one resource at one point in time.
         """
-        group_names = self.properties.get('metric-groups', None)
+        group_names = self._properties.get('metric-groups', None)
         if not group_names:
             group_names = self.manager.get_metric_values_group_names()
         ret = []


### PR DESCRIPTION
See commit message.
This is a preparation for resource caching as proposed in issue #762, since it ensures that users cannot modify the properties dictionary.

**This is for review and discussion, not yet ready to merge.**