### PR TITLE
Added server cert verification, security docs, trouble shooting docs

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,16 @@ Released: not yet
 
 **Enhancements:**
 
+* Added a 'verify_cert' init parameter to the 'zhmcclient.Session' class to
+  enable verificatin of the server certificate presented by the HMC during
+  SSL/TLS handshake.
+
+* Docs: Added a section "Security" to the documentation that describes security
+  related aspects in the communication between the zhmcclient and the HMC.
+
+* Docs: Added a section "Troubleshooting" to appendix of the documentation that
+  currently lists two cases of communication related issues.
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,5 +30,6 @@ zhmcclient - A pure Python client library for the IBM Z HMC Web Services API
    notifications.rst
    mocksupport.rst
    development.rst
+   security.rst
    appendix.rst
    changes.rst

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,0 +1,148 @@
+.. Copyright 2021 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _`Security`:
+
+Security
+========
+
+This section contains information about the security of the communication
+between the 'zhmcclient' client and the HMC.
+
+
+HMC Web Services API
+--------------------
+
+This section covers the communication between the 'zhmcclient' package
+and the HMC Web Services API on port 6794. The 'zhmcclient' package uses the
+`Python 'requests' package <https://pypi.org/project/requests/>`_
+for this purpose.
+
+SSL/TLS protocol version
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The HMC supports HTTPS at its Web Services API port, i.e. it requires the use
+of SSL/TLS-based sockets. The HMC can be configured to require TLS 1.2, or to
+tolerate the older SSLv3 protocol in addition. Since SSLv3 is considered
+insecure, it is highly recommended to configure the HMC to require TLS 1.2 and
+to disable SSLv3 and RC4. This can be configured in the HMC task
+"Customize Console Services". See also the :term:`HMC Security` book and
+Chapter 3 "Invoking API operations" in the :term:`HMC API` book.
+
+The 'zhmcclient' package uses the default settings of the 'requests' package
+regarding the SSL/TLS version, which causes the highest version supported by
+both client and HMC to be used. The highest supported SSL/TLS version used by
+the client is determined by the OpenSSL version used by Python on the client
+side. OpenSSL 1.0.1 or higher is required to support TLS 1.2.
+You can display the OpenSSL version used by Python using this command:
+
+.. code-block:: bash
+
+    $ python -c "import ssl; print(ssl.OPENSSL_VERSION)"
+    OpenSSL 1.1.1i  8 Dec 2020
+
+Server certificate
+^^^^^^^^^^^^^^^^^^
+
+By default, the HMC is configured with a self-signed certificate at its
+Web Services API. Self-signed certificates are rejected by the 'certifi' package.
+The HMC should be configured to use a proper CA-verifyable certificate. This
+can be done in the HMC task "Certificate Management".
+See also the :term:`HMC Security` book and Chapter 3 "Invoking API operations"
+in the :term:`HMC API` book.
+
+The 'zhmcclient' package provides a control knob for the verification of the
+server certificate presented by the HMC during SSL/TLS handshake via the
+``verify_cert`` init parameter of the :class:`zhmcclient.Session` class, which
+can be set to:
+
+* `False`: Do not verify the server certificate. Since that makes
+  the connection vulnerable to man-in-the-middle attacks, it should not be
+  used in production environments.
+
+* `True`: Verify the server certificate using the certificates provided by the
+  `Python 'certifi' package <https://pypi.org/project/certifi/>`_,
+  which are the certificates in the
+  `Mozilla Included CA Certificate List <https://wiki.mozilla.org/CA/Included_Certificates>`_.
+
+* :term:`string`: Path name of a CA_BUNDLE certificate file or directory to be
+  used for verifying the server certificate. For details, see
+  `SSL Cert Verification <https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification>`_.
+
+Cipher suites
+^^^^^^^^^^^^^
+
+During SSL/TLS handshake, the cipher suite to be used for various aspects in the
+communication is negotiated between the HMC and the 'zhmcclient' client.
+
+The set of cipher suites enabled for the HMC Web Services API can be configured
+in the HMC task "Certificate Management".
+See also the :term:`HMC Security` book for details.
+
+The 'zhmcclient' package uses the default cipher suites of the 'requests'
+package, which are the default cipher suites used by the standard Python 'ssl'
+module. By default, the CPython implementation uses OpenSSL.
+`Python PEP 644 <https://www.python.org/dev/peps/pep-0644/>`_ targeted for
+Python 3.10 contains information about which versions of Python support which
+versions of OpenSSL.
+
+As of Python 3.9, there is no function yet that lists the supported ciphers.
+
+You can display the OpenSSL version used by the Python on your system with
+this command:
+
+.. code-block:: bash
+
+    $ python -c "import ssl; print(ssl.OPENSSL_VERSION)"
+    OpenSSL 1.1.1i  8 Dec 2020
+
+The TLS 1.2 compatible ciphers that are supported by OpenSSL on your system can
+be listed with this command:
+
+.. code-block:: bash
+
+    $ openssl ciphers -tls1_2 -s -v | sort
+    AES128-GCM-SHA256  TLSv1.2  Kx=RSA  Au=RSA  Enc=AESGCM(128)  Mac=AEAD
+    AES128-SHA         SSLv3    Kx=RSA  Au=RSA  Enc=AES(128)     Mac=SHA1
+    AES128-SHA256      TLSv1.2  Kx=RSA  Au=RSA  Enc=AES(128)     Mac=SHA256
+    . . .
+
+The SSL/TLS version shown in the output is the *minimum* SSL/TLS protocol
+version needed to use the cipher, not the actual version that is used.
+
+Brief expansion of the output field names used by this command:
+
+* Kx = Key Exchange
+* Au = Authentication
+* Enc = Encryption
+* Mac = Message Authentication Code
+
+
+HMC Web Services API notifications
+----------------------------------
+
+The HMC Web Services API supports notifications that are sent from the HMC to
+a client. The HMC supports two protocols for this purpose:
+
+* STOMP (Streaming Text Oriented Messaging Protocol) on port 61612.
+* OpenWire on port 61617.
+
+These protocols can be enabled on the HMC task "Customize API Settings".
+See also the :term:`HMC Security` book for details.
+
+The 'zhmcclient' package supports the STOMP protocol for HMC notifications and
+uses the
+`Python 'stomp.py' package <https://pypi.org/project/stomp.py/>`_
+for this purpose.

--- a/tests/unit/zhmcclient/test_session.py
+++ b/tests/unit/zhmcclient/test_session.py
@@ -29,6 +29,9 @@ import pytest
 from zhmcclient import Session, ParseError, Job, HTTPError, OperationTimeout, \
     ClientAuthError, DEFAULT_HMC_PORT
 
+# Default value for the 'verify_cert' parameter of the Session class:
+DEFAULT_VERIFY_CERT = False
+
 
 # TODO: Test Session.get() in all variations (including errors)
 # TODO: Test Session.post() in all variations (including errors)
@@ -55,6 +58,8 @@ def mock_server_1(m):
         ('fake-host', 'fake-userid', 'fake-pw', True, None, {}),
         ('fake-host', 'fake-userid', 'fake-pw', True, None,
          {'port': 1234}),
+        ('fake-host', 'fake-userid', 'fake-pw', True, None,
+         {'verify_cert': True}),
     ]
 )
 def test_session_init(
@@ -81,6 +86,7 @@ def test_session_init(
     assert session.session_id == session_id
     assert session.get_password == get_password
     assert session.port == kwargs.get('port', DEFAULT_HMC_PORT)
+    assert session.verify_cert == kwargs.get('verify_cert', DEFAULT_VERIFY_CERT)
 
     base_url = 'https://{}:{!s}'.format(session.host, session.port)
     assert session.base_url == base_url


### PR DESCRIPTION
See commit message.

Note that the new `verify_cert` parameter has a default of `False` in order to be backwards compatible. Thinking about that should be one review point.

Direct links for reviewers:

* New "Security" section: https://github.com/zhmcclient/python-zhmcclient/blob/andy/add-verify-cert/docs/security.rst
* New "Troublsshooting" section: https://github.com/zhmcclient/python-zhmcclient/blob/andy/add-verify-cert/docs/appendix.rst#troubleshooting
* New `verify_cert` init parameter: https://github.com/zhmcclient/python-zhmcclient/blob/andy/add-verify-cert/zhmcclient/_session.py#L357
 
Note that the rendered .RST files show some of the links in a strange way. The built documentation will have them right.