### PR TITLE
0.30: Fixed install error for "pywinpty" on py27/windows

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -206,3 +206,8 @@ pip-check-reqs>=2.0.4,<2.1.1; python_version == '2.7'
 pip-check-reqs>=2.0.4; python_version >= '3.4'
 
 # Indirect dependencies are not specified in this file unless constraints are needed.
+
+# The pywinpty package on Pypi does not have metadata for required python or
+# dependent packages. On py27/windows/, versions >=1.0 fail to install because
+# they pull in the "maturin" package which requires py>=35. See issue #772.
+pywinpty>=0.5,<1.0; os_name == "nt" and python_version == '2.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed a package dependency issue when setting up the development environment
+  with the "pywinpty" package on Python 2.7 and Windows. (issue #772)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -237,6 +237,8 @@ progressbar2==3.12.0
 pipdeptree==2.0.0
 pip-check-reqs==2.0.4
 
+pywinpty==0.5; os_name == "nt" and python_version == '2.7'
+
 # Indirect dependencies for develop (not in dev-requirements.txt)
 
 alabaster==0.7.9


### PR DESCRIPTION
Rolls back PR #773 into 0.30.2.