### PR TITLE
Certificate verification, part 2

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -72,17 +72,16 @@ The root cause is that the HMC is set up to use a self-signed certificate
 and the client has used ``verify_cert=True`` in the :class:`zhmcclient.Session`
 initialization, which is the default. That causes the client to use the
 Python 'certifi' package for verification of the server certificate and the
-'certifi' package rejects self-signed certificates. The 'certifi' package
-uses the certificates from the
+'certifi' package provides the CA certificates from the
 `Mozilla Included CA Certificate List <https://wiki.mozilla.org/CA/Included_Certificates>`_
-for verifying the server certificate.
+which does not include the self-signed certificate.
 
 The issue can be temporarily circumvented by specifying ``verify_cert=False``,
 which disables the verification of the server certificate. Since that makes
 the connection vulnerable to man-in-the-middle attacks, it should be done
 only as a temporary circumvention.
 
-The solution is to have your HMC administrator obtain a proper CA-verifyable
+The solution is to have your HMC administrator obtain a CA-verifiable
 certificate and to install that in the HMC.
 
 See also the :ref:`Security` section.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,10 @@ Released: not yet
   are now raised as a new exception 'NotificationParseError'. Both new
   exceptions are based on a new base exception 'NotificationError'. (issue #770)
 
+* By default, the zhmcclient now verifies the HMC certificate using the
+  CA certificates in the Python 'certifi' package. This can be controlled with
+  a new 'verify_cert' init parameter to the 'zhmcclient.Session' class. (issue #779)
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -51,14 +55,17 @@ Released: not yet
 **Enhancements:**
 
 * Added a 'verify_cert' init parameter to the 'zhmcclient.Session' class to
-  enable verificatin of the server certificate presented by the HMC during
-  SSL/TLS handshake.
+  enable verification of the server certificate presented by the HMC during
+  SSL/TLS handshake. By default, the certificate is validated against
+  the CA certificates provided in the Python 'certifi' package. (issue #779)
 
 * Docs: Added a section "Security" to the documentation that describes security
   related aspects in the communication between the zhmcclient and the HMC.
+  (related to issue #779)
 
 * Docs: Added a section "Troubleshooting" to appendix of the documentation that
   currently lists two cases of communication related issues.
+  (related to issue #779)
 
 **Cleanup:**
 

--- a/tests/unit/zhmcclient/test_session.py
+++ b/tests/unit/zhmcclient/test_session.py
@@ -30,7 +30,7 @@ from zhmcclient import Session, ParseError, Job, HTTPError, OperationTimeout, \
     ClientAuthError, DEFAULT_HMC_PORT
 
 # Default value for the 'verify_cert' parameter of the Session class:
-DEFAULT_VERIFY_CERT = False
+DEFAULT_VERIFY_CERT = True
 
 
 # TODO: Test Session.get() in all variations (including errors)

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -274,7 +274,7 @@ class Session(object):
 
     def __init__(self, host, userid=None, password=None, session_id=None,
                  get_password=None, retry_timeout_config=None,
-                 port=DEFAULT_HMC_PORT, verify_cert=False):
+                 port=DEFAULT_HMC_PORT, verify_cert=True):
         # pylint: disable=line-too-long
         """
         Creating a session object will not immediately cause a logon to be
@@ -358,18 +358,28 @@ class Session(object):
             Controls whether and how the client verifies the server certificate
             presented by the HMC during SSL/TLS handshake:
 
-            * `False`: Do not verify the server certificate. Since that makes
-              the connection vulnerable to man-in-the-middle attacks, it should
-              not be used in production environments.
+            * `False`: Do not verify the HMC certificate. Not verifying the HMC
+              certificate means the zhmcclient will not detect hostname
+              mismatches, expired certificates, revoked certificates, or
+              otherwise invalid certificates. Since this mode makes the
+              connection vulnerable to man-in-the-middle attacks, it is insecure
+              and should not be used in production environments.
 
-            * `True`: Verify the server certificate using the certificates
-              in the
-              `Mozilla Included CA Certificate List <https://wiki.mozilla.org/CA/Included_Certificates>`_.
+            * `True`: Verify the HMC certificate using the CA certificates from
+              the first of these locations:
 
-            * :term:`string`: Path name of a CA_BUNDLE certificate file or
-              directory to be used for verifying the server certificate.
+              - The file or directory in the REQUESTS_CA_BUNDLE env.var, if set
+              - The file or directory in the CURL_CA_BUNDLE env.var, if set
+              - The Python 'certifi' package (which contains the
+                `Mozilla Included CA Certificate List <https://wiki.mozilla.org/CA/Included_Certificates>`_).
 
-            For details, see the :ref:`Security` section.
+            * :term:`string`: Path name of a certificate file or directory.
+              Verify the HMC certificate using the CA certificates in that file
+              or directory.
+
+            For details, see the :ref:`HMC certificate` section.
+
+            *Added in version 0.31*
         """  # noqa: E501
         # pylint: enable=line-too-long
 


### PR DESCRIPTION
**Note: This PR changes the default for the recently added `verify_cert` parameter of `zhmcclient.Session` to True, which is an incompatible change.**

The new default value of True will cause the HMC server certificate to be validated against the CA certificates in the 'certifi' package. If you run the HMC with self-signed certificates, or if its certificate has a certificate chain not covered by the 'certifi' package, communication with the HMC will fail. 

This PR should not be merged until we have extended all zhmcclient packages to support HMC certificate validation:
- zhmccli: DONE (PR https://github.com/zhmcclient/zhmccli/pull/178)
- zhmc-prometheus-exporter: DONE (PR https://github.com/zhmcclient/zhmc-prometheus-exporter/pull/144)
- zhmc-ansible-modules: DONE (PR https://github.com/zhmcclient/zhmc-ansible-modules/pull/405)

For details, see the commit message.