### PR TITLE
Fixed install error of laxy-object-proxy on Python 3.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -87,20 +87,25 @@ autodocsumm>=0.1.13; python_version >= '3.5'
 # Pylint requires astroid
 # Pylint 1.x / astroid 1.x supports py27 and py34/35/36
 # Pylint 2.0 / astroid 2.0 removed py27, added py37
-# Workaround: lazy-object-proxy fails installing on macos/py35/minimum, because it uses
+# Pylint 2.4 / astroid 2.3 removed py34
+# Issue #2673: Pinning Pylint to <2.7.0 is a circumvention for Pylint issue
+#   https://github.com/PyCQA/pylint/issues/4120 that appears in Pylint 2.7.0.
+pylint>=1.6.4,<2.0.0; python_version == '2.7'
+pylint>=2.5.2,<2.7.0; python_version >= '3.6'
+astroid>=1.4.9,<2.0.0; python_version == '2.7'
+astroid>=2.4.0,<2.5.0; python_version >= '3.6'
+typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+# Workaround: lazy-object-proxy is used by astroid, and lazy-object-proxy 1.5.0
+#   dropped support for py34 but declared it as supported
+# Issue #2674: lazy-object-proxy fails installing on macos/py35/minimum, because it uses
 #   setuptools-scm for its setup and (up to 1.5.2) does not correctly pin setuptools-scm.
 #   Not clear why this does not happen on ubuntu/windows with py35 or on py34.
 #   See issue https://github.com/ionelmc/python-lazy-object-proxy/issues/51.
-#   Working around this by not installing pylint/astroid on py35.
-#   TODO: If lazy-object-proxy releases a correctly pinned 1.4.x version, this workaround
-#         can be removed again.
-pylint>=1.6.4,<2.0.0; python_version == '2.7'
-pylint>=2.5.0; python_version >= '3.5'
-astroid>=1.4.9,<2.0.0; python_version == '2.7'
-astroid>=2.4.0; python_version >= '3.5'
-# typed-ast is used by astroid on py34..py37
-typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version <= '3.7' and implementation_name=='cpython'
-lazy-object-proxy>=1.4.3
+#   This issue is circumvented by not installing pylint/astroid on py35.
+#   If and when lazy-object-proxy releases a correctly pinned 1.4.x version,
+#   this circumvention can be removed again.
+lazy-object-proxy>=1.4.3; python_version == '2.7'
+lazy-object-proxy>=1.4.3; python_version >= '3.6'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,12 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed an install error of laxy-object-proxy on Python 3.5 by no longer
+  installing pylint/astroid/typed-ast/laxy-object-proxy on Python 3.5. It
+  was already not invoked anymore on Python 3.5, but still installed.
+
+* Increased minimum version of Pylint to 2.5.2 on Python 3.6 and higher.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -163,15 +163,15 @@ Pygments==2.1.3
 sphinx-rtd-theme==0.5.0
 autodocsumm==0.1.13
 
-# PyLint (no imports, invoked via pylint script) - does not support py3:
+# PyLint (no imports, invoked via pylint script):
 pylint==1.6.4; python_version == '2.7'
-pylint==2.5.0; python_version >= '3.5'
+pylint==2.5.2; python_version >= '3.6'
 astroid==1.4.9; python_version == '2.7'
-astroid==2.4.0; python_version >= '3.5'
-# typed-ast is used by astroid on py34..py37
-typed-ast==1.4.0; python_version >= '3.5' and python_version <= '3.7' and implementation_name=='cpython'
+astroid==2.4.0; python_version >= '3.6'
+typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
 # Workaround: lazy-object-proxy is used by astroid
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.4.3; python_version == '2.7'
+lazy-object-proxy==1.4.3; python_version >= '3.6'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8==3.8.0


### PR DESCRIPTION
See commit message.