### PR TITLE
Added support for auto-updating of zhmcclient resource objects

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -52,6 +52,9 @@ Released: not yet
 * Made read and write access to the properties dictionary of zhmcclient resource
   objects thread-safe by adding a Python threading.RLock on each resource object.
 
+* Added support for auto-updating of resources. For details, see the new
+  section 'Concepts -> Auto-updating of resources'. (issue #762)
+
 **Cleanup:**
 
 * Removed old build tools that were needed on Travis and Appveyor

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -53,6 +53,20 @@ Retry / timeout configuration
    :special-members: __str__
 
 
+.. _`ResourceUpdater`:
+
+ResourceUpdater
+---------------
+
+.. automodule:: zhmcclient._resource_updater
+
+.. autoclass:: zhmcclient.ResourceUpdater
+  :members:
+  :autosummary:
+  :autosummary-inherited-members:
+  :special-members: __str__
+
+
 .. _`Client`:
 
 Client

--- a/examples/show_auto_update.py
+++ b/examples/show_auto_update.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+# Copyright 2021 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example that shows the auto-update of resource properties.
+"""
+
+import sys
+import logging
+import yaml
+import requests.packages.urllib3
+from time import sleep
+
+import zhmcclient
+
+# Print metadata for each OS message, before each message
+PRINT_METADATA = False
+
+requests.packages.urllib3.disable_warnings()
+
+if len(sys.argv) != 2:
+    print("Usage: %s hmccreds.yaml" % sys.argv[0])
+    sys.exit(2)
+hmccreds_file = sys.argv[1]
+
+with open(hmccreds_file, 'r') as fp:
+    hmccreds = yaml.safe_load(fp)
+
+examples = hmccreds.get("examples", None)
+if examples is None:
+    print("examples not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+show_auto_update = examples.get("show_auto_update", None)
+if show_auto_update is None:
+    print("show_auto_update not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+loglevel = show_auto_update.get("loglevel", None)
+if loglevel is not None:
+    level = getattr(logging, loglevel.upper(), None)
+    if level is None:
+        print("Invalid value for loglevel in credentials file %s: %s" % \
+              (hmccreds_file, loglevel))
+        sys.exit(1)
+    logmodule = show_auto_update.get("logmodule", None)
+    if logmodule is None:
+        logmodule = ''  # root logger
+    print("Logging for module %s with level %s" % (logmodule, loglevel))
+    handler = logging.StreamHandler()
+    format_string = '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
+    handler.setFormatter(logging.Formatter(format_string))
+    logger = logging.getLogger(logmodule)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+
+hmc = show_auto_update["hmc"]
+cpcname = show_auto_update["cpcname"]
+partname = show_auto_update["partname"]
+partprop = show_auto_update["partprop"]
+
+cred = hmccreds.get(hmc, None)
+if cred is None:
+    print("Credentials for HMC %s not found in credentials file %s" % \
+          (hmc, hmccreds_file))
+    sys.exit(1)
+
+userid = cred['userid']
+password = cred['password']
+
+print(__doc__)
+
+print("Using HMC %s with userid %s ..." % (hmc, userid))
+session = zhmcclient.Session(hmc, userid, password, verify_cert=False)
+cl = zhmcclient.Client(session)
+
+timestats = show_auto_update.get("timestats", False)
+if timestats:
+    session.time_stats_keeper.enable()
+
+session.logon()
+topic = session.object_topic
+if topic is None:
+    print("Error: Object notification topic is not set")
+    sys.exit(1)
+
+print("Object notification topic: %s" % topic)
+
+cpc = cl.cpcs.find(name=cpcname)
+
+# Two different zhmcclient.Partition objects representing the same partition
+# on the HMC
+partition1 = cpc.partitions.find(name=partname)
+partition2 = cpc.partitions.find(name=partname)
+
+print("Enabling auto-update for partition object 1 for partition {} (id={})".
+      format(partname, id(partition1)))
+sys.stdout.flush()
+partition1.enable_auto_update()
+
+print("Not enabling auto-update for partition object 2 for partition {} "
+      "(id={})".format(partname, id(partition2)))
+
+print("Entering loop that displays property '{}' of partition objects 1 and 2".
+      format(partprop))
+sys.stdout.flush()
+try:
+    while True:
+        value1 = partition1.prop(partprop)
+        value2 = partition2.prop(partprop)
+        print("Property '{}' on partition objects 1: {!r}, 2: {!r}".
+              format(partprop, value1, value2))
+        sys.stdout.flush()
+        sleep(1)
+except KeyboardInterrupt:
+    print("Keyboard interrupt - leaving loop")
+    sys.stdout.flush()
+finally:
+    print("Disabling auto-update for partition object 1")
+    sys.stdout.flush()
+    partition1.disable_auto_update()
+
+print("Logging off...")
+sys.stdout.flush()
+session.logoff()
+
+if timestats:
+    print(session.time_stats_keeper)
+
+print("Done.")

--- a/examples/show_object_notifications.py
+++ b/examples/show_object_notifications.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# Copyright 2021 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example that shows the object notification messages.
+"""
+
+import sys
+import logging
+import yaml
+import requests.packages.urllib3
+
+import zhmcclient
+
+# Print metadata for each OS message, before each message
+PRINT_METADATA = False
+
+requests.packages.urllib3.disable_warnings()
+
+if len(sys.argv) != 2:
+    print("Usage: %s hmccreds.yaml" % sys.argv[0])
+    sys.exit(2)
+hmccreds_file = sys.argv[1]
+
+with open(hmccreds_file, 'r') as fp:
+    hmccreds = yaml.safe_load(fp)
+
+examples = hmccreds.get("examples", None)
+if examples is None:
+    print("examples not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+show_object_notifications = examples.get("show_object_notifications", None)
+if show_object_notifications is None:
+    print("show_object_notifications not found in credentials file %s" % \
+          (hmccreds_file))
+    sys.exit(1)
+
+loglevel = show_object_notifications.get("loglevel", None)
+if loglevel is not None:
+    level = getattr(logging, loglevel.upper(), None)
+    if level is None:
+        print("Invalid value for loglevel in credentials file %s: %s" % \
+              (hmccreds_file, loglevel))
+        sys.exit(1)
+    logmodule = show_object_notifications.get("logmodule", None)
+    if logmodule is None:
+        logmodule = ''  # root logger
+    print("Logging for module %s with level %s" % (logmodule, loglevel))
+    handler = logging.StreamHandler()
+    format_string = '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
+    handler.setFormatter(logging.Formatter(format_string))
+    logger = logging.getLogger(logmodule)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+
+hmc = show_object_notifications["hmc"]
+cpcname = show_object_notifications["cpcname"]
+partname = show_object_notifications["partname"]
+
+cred = hmccreds.get(hmc, None)
+if cred is None:
+    print("Credentials for HMC %s not found in credentials file %s" % \
+          (hmc, hmccreds_file))
+    sys.exit(1)
+
+userid = cred['userid']
+password = cred['password']
+
+print(__doc__)
+
+print("Using HMC %s with userid %s ..." % (hmc, userid))
+session = zhmcclient.Session(hmc, userid, password, verify_cert=False)
+cl = zhmcclient.Client(session)
+
+timestats = show_object_notifications.get("timestats", False)
+if timestats:
+    session.time_stats_keeper.enable()
+
+session.logon()
+topic = session.object_topic
+if topic is None:
+    print("Error: Object notification topic is not set")
+    sys.exit(1)
+
+print("Object notification topic: %s" % topic)
+
+receiver = zhmcclient.NotificationReceiver(topic, hmc, userid, password)
+print("Showing object notifications ...")
+sys.stdout.flush()
+
+try:
+    for headers, message in receiver.notifications():
+        try:
+            uri = headers['object-uri']
+        except KeyError:
+            uri = headers['element-uri']
+        print("Object notification: type={}, uri={}, class={}, name={}".
+              format(headers['notification-type'], uri, headers['class'],
+                     headers['name']))
+        if headers['notification-type'] == 'property-change':
+            for prop_change in message['change-reports']:
+                print("  Property change: name: {}, new value: {}".
+                      format(prop_change['property-name'],
+                             prop_change['new-value']))
+except KeyboardInterrupt:
+    print("Keyboard interrupt - leaving receiver loop")
+    sys.stdout.flush()
+finally:
+    print("Closing receiver...")
+    sys.stdout.flush()
+    receiver.close()
+
+print("Logging off...")
+sys.stdout.flush()
+session.logoff()
+
+if timestats:
+    print(session.time_stats_keeper)
+
+print("Done.")

--- a/tests/unit/zhmcclient/test_notification.py
+++ b/tests/unit/zhmcclient/test_notification.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, print_function
 import json
 import threading
 from mock import patch
+import six
 
 from zhmcclient._notification import NotificationReceiver
 
@@ -80,11 +81,12 @@ class MockedStompConnection(object):
         self._sender_thread = None
         self._state_connected = False
 
-    def mock_add_message(self, headers, message_obj):
+    def mock_add_message(self, headers, message):
         """Adds a STOMP message to the queue."""
         assert self._sender_thread is None
-        message_str = json.dumps(message_obj)
-        self._queued_messages.append((headers, message_str))
+        if not isinstance(message, six.string_types):
+            message = json.dumps(message)
+        self._queued_messages.append((headers, message))
 
     def mock_start(self):
         """Start the STOMP message sender thread."""

--- a/tests/unit/zhmcclient/test_port.py
+++ b/tests/unit/zhmcclient/test_port.py
@@ -39,7 +39,12 @@ class TestPort(object):
         with requests_mock.mock() as m:
             # Because logon is deferred until needed, we perform it
             # explicitly in order to keep mocking in the actual test simple.
-            m.post('/api/sessions', json={'api-session': 'port-session-id'})
+            m.post(
+                '/api/sessions', json={
+                    'api-session': 'test-session-id',
+                    'notification-topic': 'test-obj-topic.1',
+                    'job-notification-topic': 'test-job-topic.1',
+                })
             self.session.logon()
 
         self.cpc_mgr = self.client.cpcs

--- a/tests/unit/zhmcclient/test_resource_updater.py
+++ b/tests/unit/zhmcclient/test_resource_updater.py
@@ -1,0 +1,391 @@
+# Copyright 2021 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _resource_updater module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import time
+import pytest
+from mock import patch
+
+from zhmcclient import BaseResource, BaseManager, Client
+from zhmcclient_mock import FakedSession
+
+from .test_notification import MockedStompConnection
+
+
+class MyResource(BaseResource):
+    """
+    A simple resource for testing the ResourceUpdater class.
+    """
+
+    # This init method is not part of the external API, so this testcase may
+    # need to be updated if the API changes.
+    def __init__(self, manager, uri, name, properties):
+        # pylint: disable=useless-super-delegation
+        super(MyResource, self).__init__(manager, uri, name, properties)
+
+
+class MyManager(BaseManager):
+    """
+    A simple resource manager for testing the ResourceUpdater class.
+
+    It is only needed because BaseResource needs it; it is not subject
+    of any test.
+    """
+
+    # This init method is not part of the external API, so this testcase may
+    # need to be updated if the API changes.
+    def __init__(self, session):
+        super(MyManager, self).__init__(
+            resource_class=MyResource,
+            class_name='myresource',
+            session=session,
+            parent=None,  # a top-level resource
+            base_uri='/api/myresources',
+            oid_prop='fake-oid-prop',
+            uri_prop='fake-uri-prop',
+            name_prop='fake-name-prop',
+            query_props=['qp1', 'qp2'])
+
+    def list(self, full_properties=False, filter_args=None):
+        # We have this method here just to avoid the warning about
+        # an unimplemented abstract method. It is not being used in this
+        # set of testcases.
+        raise NotImplementedError
+
+
+@pytest.fixture(params=[
+    (
+        # no object notifications
+    ),
+    (
+        # one property change notification on a CPC with one property
+        dict(
+            headers={
+                'notification-type': 'property-change',
+                'object-uri': '/api/cpcs/fake-cpc1',
+            },
+            message={
+                'change-reports': [
+                    {
+                        'property-name': 'description',
+                        'old-value': 'desc1',
+                        'new-value': 'desc_new',
+                    },
+                ]
+            },
+        ),
+    ),
+    (
+        # one property change notification on a CPC with two properties
+        dict(
+            headers={
+                'notification-type': 'property-change',
+                'object-uri': '/api/cpcs/fake-cpc1',
+            },
+            message={
+                'change-reports': [
+                    {
+                        'property-name': 'description',
+                        'old-value': 'desc1',
+                        'new-value': 'desc_new',
+                    },
+                    {
+                        'property-name': 'title',
+                        'old-value': 'title1',
+                        'new-value': 'title_new',
+                    },
+                ]
+            },
+        ),
+    ),
+    (
+        # one property change notification on a NIC with one property
+        # (for testing a resource that has element-uri instead of object-uri)
+        dict(
+            headers={
+                'notification-type': 'property-change',
+                'element-uri': '/api/partitions/fake-part1/nics/fake-nic1',
+            },
+            message={
+                'change-reports': [
+                    {
+                        'property-name': 'description',
+                        'old-value': 'desc1',
+                        'new-value': 'desc_new',
+                    },
+                ]
+            },
+        ),
+    ),
+    (
+        # one status change notification on a CPC
+        dict(
+            headers={
+                'notification-type': 'status-change',
+                'object-uri': '/api/cpcs/fake-cpc1',
+            },
+            message={
+                'change-reports': [
+                    {
+                        'old-status': 'status1',
+                        'old-additional-status': 'addstatus1',
+                        'new-status': 'status_new',
+                        'new-additional-status': 'addstatus_new',
+                        'has-unacceptable-status': True,
+                    },
+                ]
+            },
+        ),
+    ),
+    (
+        # one property change notification that misses both object-uri and
+        # element-uri (that would be an HMC error)
+        dict(
+            headers={
+                'notification-type': 'property-change',
+                'action': 'remove',
+            },
+            message={
+                'change-reports': [
+                    {
+                        'property-name': 'description',
+                        'old-value': 'desc1',
+                        'new-value': 'desc_new',
+                    },
+                ]
+            },
+        ),
+    ),
+    (
+        # one inventory change notification (will be ignored)
+        dict(
+            headers={
+                'notification-type': 'inventory-change',
+                'object-uri': '/api/cpcs/fake-cpc1',
+                'action': 'remove',
+            },
+            message=None,
+        ),
+    ),
+    (
+        # one property change notification with invalid JSON
+        dict(
+            headers={
+                'notification-type': 'property-change',
+                'object-uri': '/api/cpcs/fake-cpc1',
+                'action': 'remove',
+            },
+            message='{ prop: a}',
+        ),
+    ),
+], scope='module')
+def notifications(request):
+    """Fixture for test notifications for ResourceUpdater"""
+    return request.param
+
+
+@pytest.fixture(params=[
+    (
+        # no resources
+        {},
+        [],
+    ),
+    (
+        # one CPC resource with one partition that has one NIC
+        {
+            'cpcs': [
+                {
+                    'properties': {
+                        'object-uri': '/api/cpcs/fake-cpc1',
+                        'object-id': 'fake-cpc1',
+                        'name': 'fake-cpc1',
+                        'description': 'description1',
+                        'status': 'status1',
+                        'additional-status': 'addstatus1',
+                        'has-unacceptable-status': False,
+                    },
+                    'partitions': [
+                        {
+                            'properties': {
+                                'object-uri': '/api/partitions/fake-part1',
+                                'object-id': 'fake-part1',
+                                'name': 'fake-part1',
+                                'description': 'description1',
+                                'status': 'status1',
+                                'additional-status': 'addstatus1',
+                                'has-unacceptable-status': False,
+                            },
+                            'nics': [
+                                {
+                                    'properties': {
+                                        'element-uri':
+                                        '/api/partitions/fake-part1/'
+                                        'nics/fake-nic1',
+                                        'element-id': 'fake-nic1',
+                                        'name': 'fake-nic1',
+                                        'description': 'description1',
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        # resources enabled for auto-update
+        [
+            '/api/cpcs/fake-cpc1',
+            '/api/partitions/fake-part1',
+            '/api/partitions/fake-part1/nics/fake-nic1',
+        ],
+    ),
+], scope='module')
+def resources(request):
+    """
+    Fixture for test resources for ResourceUpdater,
+    in FakedHMC.add_resources() format.
+    """
+    return request.param
+
+
+class TestResourceUpdater(object):
+    """
+    Test the ResourceUpdater class.
+    """
+
+    def setup_method(self):
+        """
+        Setup that is called by pytest before each test method.
+        """
+        # pylint: disable=attribute-defined-outside-init
+
+        # The session has the ResourceUpdater object that is tested.
+        self.session = FakedSession(
+            'fake-hmc', 'fake-hmc', 'fake-version', 'fake-version')
+        self.mgr = MyManager(self.session)
+
+        # pylint: enable=attribute-defined-outside-init
+
+    @patch(target='stomp.Connection', new=MockedStompConnection)
+    def test_resource_updater(self, notifications, resources):
+        # pylint: disable=redefined-outer-name
+        """
+        Test function for all methods of ResourceUpdater.
+        """
+
+        faked_resources, enabled_uris = resources
+
+        # Build the faked resources.
+        # We need to set up faked resources because the enabling for auto-update
+        # will retrieve them. We set up all test resources as CPCs, since they
+        # are top-level objects and it does not really matter for this test.
+        self.session.hmc.add_resources(faked_resources)
+
+        # List the CPC resources from the faked session
+        client = Client(self.session)
+        cpcs = client.cpcs.list()
+        partitions = []
+        for cpc in cpcs:
+            partitions.extend(cpc.partitions.list())
+        nics = []
+        for partition in partitions:
+            nics.extend(partition.nics.list())
+        resource_objs = cpcs + partitions + nics
+
+        # Enable the resource objects for auto-update. This causes them to be
+        # registered with the resource updater.
+        enabled_resource_objs = [obj for obj in resource_objs
+                                 if obj.uri in enabled_uris]
+        for res_obj in enabled_resource_objs:
+            res_obj.enable_auto_update()
+            assert res_obj.auto_update_enabled()
+
+        # pylint: disable=protected-access
+        updater = self.session._resource_updater
+        if not enabled_uris:
+            assert updater is None
+            return
+
+        assert updater is not None
+        stomp_conn = updater._conn  # pylint: disable=protected-access
+
+        assert updater.has_objects()
+        assert self.session.auto_update_subscribed()
+
+        for res_obj in enabled_resource_objs:
+            registered_objs = list(updater.registered_objects(res_obj.uri))
+            assert res_obj in registered_objs
+
+        # Queue object notifications to be sent
+        for noti in notifications:
+            # pylint: disable=no-member
+            stomp_conn.mock_add_message(noti['headers'], noti['message'])
+
+        # Send the object notifications to the resource updater
+        stomp_conn.mock_start()  # pylint: disable=no-member
+
+        # Wait for notifications to be received and processed.
+        time.sleep(1)
+
+        # Build the expected changed resources from the notifications, for
+        # easier access by assertions
+        changed_resources = {}  # changed property dict by uri
+        for noti in notifications:
+            if not isinstance(noti['message'], dict):
+                continue
+            changed_props = {}
+            if noti['headers']['notification-type'] == 'property-change':
+                for cr in noti['message']['change-reports']:
+                    changed_props[cr['property-name']] = cr['new-value']
+            if noti['headers']['notification-type'] == 'status-change':
+                for cr in noti['message']['change-reports']:
+                    changed_props['status'] = cr['new-status']
+                    changed_props['additional-status'] = \
+                        cr['new-additional-status']
+                    changed_props['has-unacceptable-status'] = \
+                        cr['has-unacceptable-status']
+            if 'object-uri' in noti['headers']:
+                uri = noti['headers']['object-uri']
+            elif 'element-uri' in noti['headers']:
+                uri = noti['headers']['element-uri']
+            else:
+                uri = None
+            if uri:
+                changed_resources[uri] = changed_props
+
+        # Verify the updated resource objects
+        for res_obj in enabled_resource_objs:
+            for name, value in res_obj.properties.items():
+                try:
+                    exp_value = changed_resources[res_obj.uri][name]
+                except KeyError:  # for both
+                    exp_value = None
+                if exp_value is not None:
+                    assert value == exp_value, \
+                        "Unexpected value for property {} of resource {}". \
+                        format(name, res_obj.uri)
+
+        # Disable the resource objects for auto-update. This causes them to be
+        # unregistered from the resource updater.
+        for res_obj in enabled_resource_objs:
+            res_obj.disable_auto_update()
+            assert not res_obj.auto_update_enabled()
+
+        assert not updater.has_objects()
+        assert not self.session.auto_update_subscribed()

--- a/tests/unit/zhmcclient/test_session.py
+++ b/tests/unit/zhmcclient/test_session.py
@@ -43,7 +43,11 @@ def mock_server_1(m):
     logon and logoff.
     """
     m.register_uri('POST', '/api/sessions',
-                   json={'api-session': 'fake-session-id'},
+                   json={
+                       'api-session': 'test-session-id',
+                       'notification-topic': 'test-obj-topic.1',
+                       'job-notification-topic': 'test-job-topic.1',
+                   },
                    headers={'X-Request-Id': 'fake-request-id'})
     m.register_uri('DELETE', '/api/sessions/this-session',
                    headers={'X-Request-Id': 'fake-request-id'},
@@ -169,7 +173,7 @@ def test_session_logon(
             # The code to be tested:
             session.logon()
 
-            assert session.session_id == 'fake-session-id'
+            assert session.session_id == 'test-session-id'
             assert 'X-API-Session' in session.headers
             assert isinstance(session.session, requests.Session)
 
@@ -250,7 +254,7 @@ def test_session_logon_error_invalid_delim(*args):
     Logon with invalid JSON response that has an invalid delimiter.
     """
     m = args[0]
-    json_content = b'{\n"api-session"; "fake-session-id"\n}'
+    json_content = b'{\n"api-session"; "test-session-id"\n}'
     exp_msg_pattern = r"Expecting ':' delimiter: .*"
     exp_line = 2
     exp_col = 14
@@ -263,7 +267,7 @@ def test_session_logon_error_invalid_quotes(*args):
     Logon with invalid JSON response that incorrectly uses single quotes.
     """
     m = args[0]
-    json_content = b'{\'api-session\': \'fake-session-id\'}'
+    json_content = b'{\'api-session\': \'test-session-id\'}'
     exp_msg_pattern = r"Expecting property name enclosed in double " \
         "quotes: .*"
     exp_line = 1
@@ -277,7 +281,7 @@ def test_session_logon_error_extra_closing(*args):
     Logon with invalid JSON response that has an extra closing brace.
     """
     m = args[0]
-    json_content = b'{"api-session": "fake-session-id"}}'
+    json_content = b'{"api-session": "test-session-id"}}'
     exp_msg_pattern = r"Extra data: .*"
     exp_line = 1
     exp_col = 35
@@ -292,7 +296,12 @@ def test_session_get_notification_topics():
     with requests_mock.mock() as m:
         # Because logon is deferred until needed, we perform it
         # explicitly in order to keep mocking in the actual test simple.
-        m.post('/api/sessions', json={'api-session': 'fake-session-id'})
+        m.post(
+            '/api/sessions', json={
+                'api-session': 'test-session-id',
+                'notification-topic': 'test-obj-topic.1',
+                'job-notification-topic': 'test-job-topic.1',
+            })
         session.logon()
         gnt_uri = "/api/sessions/operations/get-notification-topics"
         gnt_result = {

--- a/tests/unit/zhmcclient/test_virtual_function.py
+++ b/tests/unit/zhmcclient/test_virtual_function.py
@@ -40,7 +40,12 @@ class TestVirtualFunction(object):
         with requests_mock.mock() as m:
             # Because logon is deferred until needed, we perform it
             # explicitly in order to keep mocking in the actual test simple.
-            m.post('/api/sessions', json={'api-session': 'test-session-id'})
+            m.post(
+                '/api/sessions', json={
+                    'api-session': 'test-session-id',
+                    'notification-topic': 'test-obj-topic.1',
+                    'job-notification-topic': 'test-job-topic.1',
+                })
             self.session.logon()
 
         self.cpc_mgr = self.client.cpcs

--- a/tests/unit/zhmcclient/test_virtual_switch.py
+++ b/tests/unit/zhmcclient/test_virtual_switch.py
@@ -40,7 +40,12 @@ class TestVirtualSwitch(object):
         with requests_mock.mock() as m:
             # Because logon is deferred until needed, we perform it
             # explicitly in order to keep mocking in the actual test simple.
-            m.post('/api/sessions', json={'api-session': 'vswitch-session-id'})
+            m.post(
+                '/api/sessions', json={
+                    'api-session': 'test-session-id',
+                    'notification-topic': 'test-obj-topic.1',
+                    'job-notification-topic': 'test-job-topic.1',
+                })
             self.session.logon()
 
         self.cpc_mgr = self.client.cpcs

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -28,6 +28,7 @@ from ._manager import *       # noqa: F401
 from ._resource import *      # noqa: F401
 from ._logging import *       # noqa: F401
 from ._session import *       # noqa: F401
+from ._resource_updater import *       # noqa: F401
 from ._timestats import *     # noqa: F401
 from ._client import *        # noqa: F401
 from ._cpc import *           # noqa: F401

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -118,6 +118,9 @@ HMC_LOGGER_NAME = 'zhmcclient.hmc'
 #: Name of the Python logger that logs zhmcclient API calls made by the user.
 API_LOGGER_NAME = 'zhmcclient.api'
 
+#: Name of the Python logger that logs JMS notifications.
+JMS_LOGGER_NAME = 'zhmcclient.jms'
+
 #: HTTP reason code: Web Services API is not enabled on the HMC.
 HTML_REASON_WEB_SERVICES_DISABLED = 900
 

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -20,8 +20,13 @@ names:
 * 'zhmcclient.api' for user-issued calls to zhmcclient API functions, at the
   debug level. Internal calls to API functions are not logged.
 
-* 'zhmcclient.hmc' for interactions between zhmcclient and the HMC, at the
+* 'zhmcclient.hmc' for operations from zhmcclient to the HMC, at the
   debug level.
+
+* 'zhmcclient.jms' for notifications from the HMC to zhmcclient, at the
+  debug, info, warning and error level. At this point, this logger is used only
+  for the :ref:`auto-update <Auto-updating of resources>` support, but not for
+  the :class:`~zhmcclient.NotificationReceiver` class.
 
 For HMC operations and API calls that contain the HMC password or HMC session
 tokens, the password is hidden in the log message by replacing it with a few

--- a/zhmcclient/_resource_updater.py
+++ b/zhmcclient/_resource_updater.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+# Copyright 2021 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Resource updater for
+:ref:`auto-updating of resources <Auto-updating of resources>`.
+"""
+
+import logging
+import json
+try:
+    from json import JSONDecodeError as _JSONDecodeError
+except ImportError:
+    _JSONDecodeError = ValueError
+
+from ._logging import logged_api_call
+from ._constants import DEFAULT_STOMP_PORT, JMS_LOGGER_NAME
+
+__all__ = ['ResourceUpdater']
+
+JMS_LOGGER = logging.getLogger(JMS_LOGGER_NAME)
+
+
+class ResourceUpdater(object):
+    """
+    A class that updates the properties of zhmcclient resource objects that are
+    enabled for auto-updating.
+
+    **Experimental:** This class is considered experimental at this point, and
+    its API may change incompatibly as long as it is experimental.
+
+    Note: The user should not create any objects of this class nor invoke any
+    methods of this class, because the objects are created automatically
+    when a :class:`~zhmcclient.Session` object is subscribed for
+    auto-update (via its :meth:`~zhmcclient.Session.subscribe_auto_update`
+    method).
+
+    Creating an object of this class establishes a JMS session with the HMC and
+    subscribes for the object notification topic of the session. This causes
+    the HMC to emit status notifications, property notifications, and inventory
+    notifications, which are processed by this class and cause the properties of
+    zhmcclient resource objects to be updated that are registered to this class
+    as a result of enabling auto-update for the resorce object
+    (via their :meth:`~zhmcclient.BaseResource.enable_auto_update` method).
+
+    Zhmcclient resource objects that are not enabled for auto-updating remain
+    unchanged.
+    """
+
+    def __init__(self, session):
+        """
+        Parameters:
+
+          session (:class:`~zhmcclient.Session`): Session for which the
+            resource updater should do its work. This defines the HMC host
+            and credentials that are used to establish the JMS session with
+            the HMC.
+        """
+
+        # Registered resource objects, as:
+        #   dict(key: uri, value: dict(key: id, value: object))
+        self._registered_objects = {}
+
+        # Subscription ID. We use some value that allows to identify on the
+        # HMC that this is the zhmcclient, but otherwise we are not using
+        # this value ourselves.
+        self._sub_id = 'zhmcclient.%s' % id(self)
+
+        # Lazy importing for stomp, because it is so slow (ca. 5 sec)
+        if 'Stomp_Connection' not in globals():
+            # pylint: disable=import-outside-toplevel
+            from stomp import Connection as Stomp_Connection
+
+        self._conn = Stomp_Connection(
+            [(session.host, DEFAULT_STOMP_PORT)], use_ssl="SSL")
+        listener = _UpdateListener(self, session)
+        self._conn.set_listener('', listener)
+        # pylint: disable=protected-access
+        self._conn.connect(session.userid, session._password, wait=True)
+
+        dest = "/topic/" + session.object_topic
+        self._conn.subscribe(destination=dest, id=self._sub_id, ack='auto')
+
+        JMS_LOGGER.info(
+            "JMS session for object notification topic '%s' has been "
+            "established", session.object_topic)
+
+    @logged_api_call
+    def close(self):
+        """
+        Disconnect and close the JMS session with the HMC.
+
+        This implicitly unsubscribes from the object notification topic this
+        updater was created for.
+        """
+        self._conn.disconnect()
+
+    def register_object(self, resource_obj):
+        """
+        Register a resource object to this resource updater.
+
+        If this resource object (by id) is already registered, nothing is done.
+        """
+        res_uri = resource_obj.uri
+        res_id = id(resource_obj)
+        if res_uri not in self._registered_objects:
+            self._registered_objects[res_uri] = {}
+        id_dict = self._registered_objects[res_uri]
+        if res_id not in id_dict:
+            id_dict[res_id] = resource_obj
+
+    def unregister_object(self, resource_obj):
+        """
+        Unregister a resource object from this resource updater.
+
+        If this resource object (by id) is already unregistered, nothing is
+        done.
+        """
+        res_uri = resource_obj.uri
+        res_id = id(resource_obj)
+        if res_uri in self._registered_objects:
+            id_dict = self._registered_objects[res_uri]
+            if res_id in id_dict:
+                del id_dict[res_id]
+            if not id_dict:
+                del self._registered_objects[res_uri]
+
+    def registered_objects(self, resource_uri):
+        """
+        Generator that yields the resource objects for the specified URI.
+        """
+        if resource_uri in self._registered_objects:
+            id_dict = self._registered_objects[resource_uri]
+            for res_obj in id_dict.values():
+                yield res_obj
+
+    def has_objects(self):
+        """
+        Return boolean indicating whether there are any resource objects
+        registered.
+        """
+        return bool(self._registered_objects)
+
+
+class _UpdateListener(object):
+    # pylint: disable=too-few-public-methods
+    """
+    A notification listener class for use by the Python `stomp` package.
+
+    This is an internal class that does not need to be accessed or created by
+    the user. An object of this class is automatically created by the
+    :class:`~zhmcclient.ResourceUpdater` class, for its notification
+    topic.
+
+    Note: In the stomp examples, this class inherits from
+    stomp.ConnectionListener. However, since that class defines only empty
+    methods and since we want to import the stomp module in a lazy manner,
+    we are not using that class, and stomp does not require us to.
+    """
+
+    def __init__(self, updater, session):
+        self._updater = updater
+        self._session = session
+
+    def on_message(self, headers, message):
+        """
+        Event method that gets called when this listener has received a JMS
+        message (representing an HMC notification).
+
+        Parameters:
+
+          headers (dict): JMS message headers, see HMC API book.
+
+          message (string): JMS message body as a string, which contains a
+            serialized JSON object, see HMC API book.
+        """
+
+        try:
+            msg_obj = json.loads(message)
+        except _JSONDecodeError:
+            JMS_LOGGER.error(
+                "JMS message for object notification topic '%s' "
+                "has a non-JSON message body (ignored): %r",
+                self._session.object_topic, message)
+            return
+
+        try:
+            uri = headers['object-uri']
+        except KeyError:
+            try:
+                uri = headers['element-uri']
+            except KeyError:
+                JMS_LOGGER.error(
+                    "JMS message for object notification topic '%s' "
+                    "has no URI field in its headers (ignored): %r",
+                    self._session.object_topic, headers)
+                return
+
+        noti_type = headers['notification-type']
+        if noti_type == 'property-change':
+            new_props = {}
+            for cr in msg_obj['change-reports']:
+                new_props[cr['property-name']] = cr['new-value']
+            JMS_LOGGER.debug(
+                "JMS message for property change notification for topic '%s' "
+                "for resource %s with properties: %r",
+                self._session.object_topic, uri, new_props)
+            for obj in self._updater.registered_objects(uri):
+                if obj.auto_update_enabled():
+                    obj.update_properties_local(new_props)
+        elif noti_type == 'status-change':
+            new_props = {}
+            for cr in msg_obj['change-reports']:
+                new_props['status'] = cr['new-status']
+                new_props['additional-status'] = cr['new-additional-status']
+                new_props['has-unacceptable-status'] = \
+                    cr['has-unacceptable-status']
+            JMS_LOGGER.debug(
+                "JMS message for status change notification for topic '%s' "
+                "for resource %s with properties: %r",
+                self._session.object_topic, uri, new_props)
+            for obj in self._updater.registered_objects(uri):
+                if obj.auto_update_enabled():
+                    obj.update_properties_local(new_props)
+        else:
+            JMS_LOGGER.warning(
+                "JMS message for notification of type %s for topic '%s' "
+                "for resource %s is ignored",
+                noti_type, self._session.object_topic, uri)
+
+    def on_error(self, headers, message):
+        # pylint: disable=unused-argument
+        """
+        Event method that gets called when this listener has received a JMS
+        error. This happens for example when the client registers for a
+        non-existing topic.
+
+        Parameters:
+
+          headers (dict): JMS message headers.
+
+          message (string): JMS message body as a string, which contains a
+            serialized JSON object.
+        """
+        JMS_LOGGER.error(
+            "JMS error message received for object notification topic '%s' "
+            "(ignored): %s",
+            self._session.object_topic, message)
+
+    def on_disconnected(self):
+        """
+        Event method that gets called when the JMS session has been
+        disconnected.
+        """
+        JMS_LOGGER.info(
+            "JMS session for object notification topic '%s' has been "
+            "disconnected",
+            self._session.object_topic)

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -71,6 +71,8 @@ class FakedSession(zhmcclient.Session):
         super(FakedSession, self).__init__(host)
         self._hmc = FakedHmc(hmc_name, hmc_version, api_version)
         self._urihandler = UriHandler(URIS)
+        self._object_topic = 'faked-notification-topic'
+        self._job_topic = 'faked-job-notification-topic'
 
     def __repr__(self):
         """


### PR DESCRIPTION
**Note: This PR is on top of PR #815 - review only the last commit**

See commit message for details.

Ready for review and for trying out, e.g. with the new `show_auto_update.py` example script.
No more open TODOs at this point.