### PR TITLE
Release 0.32.1

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,14 +19,10 @@ Change log
 ----------
 
 
-Version 0.32.1.dev1
-^^^^^^^^^^^^^^^^^^^
+Version 0.32.1
+^^^^^^^^^^^^^^
 
-Released: not yet
-
-**Incompatible changes:**
-
-**Deprecations:**
+Released: 2021-08-03
 
 **Bug fixes:**
 
@@ -34,16 +30,6 @@ Released: not yet
   'Console.list_permitted_lpars()' when run on HMC/SE version 2.14.0 failed
   when accessing the 'se-version' property of the partition unconditionally.
   That property was introduced only in HMC/SE version 2.14.1. (issue #816)
-
-**Enhancements:**
-
-**Cleanup:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
 
 
 Version 0.32.0

--- a/zhmcclient/_version.py
+++ b/zhmcclient/_version.py
@@ -27,7 +27,7 @@ __all__ = ['__version__']
 #:
 #: * "M.N.P.dev1": A not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '0.32.1.dev1'
+__version__ = '0.32.1'
 
 # Check supported Python versions
 # Keep these Python versions in sync with:


### PR DESCRIPTION
Please approve the release of zhmcclient 0.32.1.

Change log:

**Bug fixes:**

* Fixed a bug where 'Console.list_permitted_partitions()' and
  'Console.list_permitted_lpars()' when run on HMC/SE version 2.14.0 failed
  when accessing the 'se-version' property of the partition unconditionally.
  That property was introduced only in HMC/SE version 2.14.1. (issue #816)