### PR TITLE
Release 1.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ on:
     - # cron (in UTC): minute hour day_of_month month day_of_week
       cron: '00 04 * * SUN'
   push:
-    branches: [ master, stable_0.32 ]
+    branches: [ master, stable_1.0 ]
   pull_request:
-    branches: [ master, stable_0.32 ]
+    branches: [ master, stable_1.0 ]
 
 jobs:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,12 +19,12 @@ Change log
 ----------
 
 
-Version 1.0.0.dev1
-^^^^^^^^^^^^^^^^^^
+Version 1.0.0
+^^^^^^^^^^^^^
 
-This version contains all fixes up to version 0.32.x.
+This version contains all fixes up to version 0.32.1.
 
-Released: not yet
+Released: 2021-08-05
 
 **Incompatible changes:**
 
@@ -32,12 +32,10 @@ Released: not yet
   on March 18, 2019 and has officially reached its end of life as of that date.
   Current Linux distributions no longer support Python 3.4. (issue #792)
 
-**Deprecations:**
-
 **Bug fixes:**
 
-* Fixed an install error of laxy-object-proxy on Python 3.5 by no longer
-  installing pylint/astroid/typed-ast/laxy-object-proxy on Python 3.5. It
+* Fixed an install error of lazy-object-proxy on Python 3.5 by no longer
+  installing pylint/astroid/typed-ast/lazy-object-proxy on Python 3.5. It
   was already not invoked anymore on Python 3.5, but still installed.
 
 * Increased minimum version of Pylint to 2.5.2 on Python 3.6 and higher.
@@ -59,12 +57,6 @@ Released: not yet
 
 * Removed old build tools that were needed on Travis and Appveyor
   (remove_duplicate_setuptools.py and retry.bat) (issue #809)
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
 
 
 Version 0.32.0

--- a/zhmcclient/_version.py
+++ b/zhmcclient/_version.py
@@ -27,7 +27,7 @@ __all__ = ['__version__']
 #:
 #: * "M.N.P.dev1": A not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '1.0.0.dev1'
+__version__ = '1.0.0'
 
 # Check supported Python versions
 # Keep these Python versions in sync with:


### PR DESCRIPTION
Please approve the release of zhmcclient 1.0.0.

Change history: https://github.com/zhmcclient/python-zhmcclient/blob/release_1.0.0/docs/changes.rst#version-100