### PR TITLE
lpar: Fix body issue with STOP operation

### DIFF
--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -951,7 +951,7 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
             waiting for the desired LPAR status.
         """
-        body = {}
+        body = None
         result = self.manager.session.post(
             self.uri + '/operations/stop',
             body,

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -885,7 +885,7 @@ class Lpar(BaseResource):
         status has reached the desired value. If `wait_for_completion=True`,
         this method repeatedly checks the status of the LPAR after the HMC
         operation has completed, and waits until the status is in the desired
-        state "operating", or if `allow_status_exceptions` was
+        state "not-operating", or if `allow_status_exceptions` was
         set additionally in the state "exceptions".
 
         Authorization requirements:
@@ -903,7 +903,7 @@ class Lpar(BaseResource):
 
             * If `True`, this method will wait for completion of the
               asynchronous job performing the operation, and for the status
-              becoming "operating" (or in addition "exceptions", if
+              becoming "not-operating" (or in addition "exceptions", if
               `allow_status_exceptions` was set.
 
             * If `False`, this method will return immediately once the HMC has
@@ -958,7 +958,7 @@ class Lpar(BaseResource):
             wait_for_completion=wait_for_completion,
             operation_timeout=operation_timeout)
         if wait_for_completion:
-            statuses = ["operating"]
+            statuses = ["not-operating"]
             if allow_status_exceptions:
                 statuses.append("exceptions")
             self.wait_for_status(statuses, status_timeout)


### PR DESCRIPTION
This fixes the following problem:

$ zhmc -o json lpar stop --yes --allow-status-exceptions CPC LPAR
Error: HTTPError: 400,4: A content-length was specified but a body was not expected by this provider. [POST /api/logical-partitions/xxx/operations/stop]

According to the HMC REST API 2.15, the LPAR STOP operation doesn't expect
any body, not even an empty one.

See "Hardware Management Console Web Services API Version 2.15.0",
"Chapter 11. Core IBM Z resources", "Stop Logical Partition".

Signed-off-by: Alexander Egorenkov <egorenar@linux.ibm.com>