### PR TITLE
1.0: lpar: Fix completion statuses for STOP operation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed an issue in 'Lpar.stop()' where incorrectly an empty body was sent, and
+  an incorrect status has been waited for.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -885,7 +885,7 @@ class Lpar(BaseResource):
         status has reached the desired value. If `wait_for_completion=True`,
         this method repeatedly checks the status of the LPAR after the HMC
         operation has completed, and waits until the status is in the desired
-        state "operating", or if `allow_status_exceptions` was
+        state "not-operating", or if `allow_status_exceptions` was
         set additionally in the state "exceptions".
 
         Authorization requirements:
@@ -903,7 +903,7 @@ class Lpar(BaseResource):
 
             * If `True`, this method will wait for completion of the
               asynchronous job performing the operation, and for the status
-              becoming "operating" (or in addition "exceptions", if
+              becoming "not-operating" (or in addition "exceptions", if
               `allow_status_exceptions` was set.
 
             * If `False`, this method will return immediately once the HMC has
@@ -958,7 +958,7 @@ class Lpar(BaseResource):
             wait_for_completion=wait_for_completion,
             operation_timeout=operation_timeout)
         if wait_for_completion:
-            statuses = ["operating"]
+            statuses = ["not-operating"]
             if allow_status_exceptions:
                 statuses.append("exceptions")
             self.wait_for_status(statuses, status_timeout)


### PR DESCRIPTION
Rolls back PRs #828 and #831 into 1.0.2.