### PR TITLE
Dev: Excluded more-itertools 8.11.0 on Python 3.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -32,6 +32,9 @@ mock>=2.0.0 # BSD
 # requests: covered in direct deps for installation
 requests-mock>=1.6.0
 requests-toolbelt>=0.7.0
+# more-itertools 8.11.0 does not support py35 but incorrectly installs on it
+more-itertools>=4.0.0,!=8.11.0; python_version < '3.6'
+more-itertools>=4.0.0; python_version >= '3.6'
 # pytz: covered in requirements.txt
 
 # Virtualenv

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,6 +46,8 @@ Released: not yet
 
 * Docs: Fixed description of Client.get_inventory().
 
+* Dev: Excluded more-itertools 8.11.0 on Python 3.5.
+
 **Enhancements:**
 
 * Added support for the 'Set Auto-Start List' operation on CPCs by adding

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -120,6 +120,7 @@ colorama==0.3.9; python_version == '2.7'
 colorama==0.4.0; python_version >= '3.5'
 importlib-metadata==0.12; python_version <= '3.7'
 mock==2.0.0
+more-itertools==4.0.0
 # pytz: covered in direct deps for installation
 # requests: covered in direct deps for installation
 requests-mock==1.6.0


### PR DESCRIPTION
No review needed.