### PR TITLE
End2end tests: Took TestWarning away from pytest by renaming to End2endTestWarning

### DIFF
--- a/tests/end2end/test_ldap_server_definition.py
+++ b/tests/end2end/test_ldap_server_definition.py
@@ -31,7 +31,7 @@ from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_ses
 from zhmcclient.testutils.cpc_fixtures import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import runtest_find_list, TEST_PREFIX, TestWarning
+from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning
 
 urllib3.disable_warnings()
 
@@ -62,7 +62,7 @@ def test_ldapsrvdef_find_list(all_cpcs):  # noqa: F811
         if not ldapsrvdef_list:
             msg_txt = "No LPAR Server Definitions defined on CPC {}". \
                 format(cpc.name)
-            warnings.warn(msg_txt, TestWarning)
+            warnings.warn(msg_txt, End2endTestWarning)
             pytest.skip(msg_txt)
 
         ldapsrvdef = ldapsrvdef_list[-1]  # Pick the last one returned
@@ -133,7 +133,7 @@ def test_ldapsrvdef_crud(all_cpcs):  # noqa: F811
                 msg_txt = "HMC userid '{u}' is not authorized for 'Manage " \
                     "LDAP Server Definitions' task on HMC {h}". \
                     format(u=hd.hmc_userid, h=hd.hmc_host)
-                warnings.warn(msg_txt, TestWarning)
+                warnings.warn(msg_txt, End2endTestWarning)
                 pytest.skip(msg_txt)
 
         for pn, exp_value in ldapsrvdef_input_props.items():

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -18,13 +18,14 @@ Utility functions for end2end tests.
 
 from __future__ import absolute_import, print_function
 
+import warnings
 import pytest
 
 # Prefix used for names of resources that are created during tests
 TEST_PREFIX = 'zhmcclient_tests_end2end'
 
 
-class TestWarning(UserWarning):
+class End2endTestWarning(UserWarning):
     """
     Python warning indicating an issue with an end2end test.
     """
@@ -278,12 +279,14 @@ def standard_partition_props(cpc, part_name):
     elif cpc.get_property('processor-count-general-purpose') > 0:
         part_input_props['cp-processors'] = 2
     else:
+        part_input_props['cp-processors'] = 1
         pc_names = filter(lambda p: p.startswith('processor-count-'),
                           cpc.properties.keys())
         pc_list = ["{}={}".format(n, cpc.properties[n]) for n in pc_names]
-        raise AssertionError(
-            "CPC '{c}' has neither IFL nor CP processors. Processor-count "
-            "properties are: {p}".
-            format(c=cpc.name, p=', '.join(pc_list)))
+        warnings.warn(
+            "CPC '{c}' shows neither IFL nor CP processors, specifying 1 CP "
+            "for partition creation. "
+            "CPC processor-count properties are: {p}".
+            format(c=cpc.name, p=', '.join(pc_list)), End2endTestWarning)
 
     return part_input_props


### PR DESCRIPTION
No review needed.