### PR TITLE
Support for TESTOPTS containing blanks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ check_py_files := \
     $(wildcard docs/notebooks/*.py) \
 
 ifdef TESTCASES
-  pytest_opts := $(TESTOPTS) -k $(TESTCASES)
+  pytest_opts := $(TESTOPTS) -k "$(TESTCASES)"
 else
   pytest_opts := $(TESTOPTS)
 endif


### PR DESCRIPTION
No review needed