### PR TITLE
Fixed case insensitive names for users/roles/patterns/rules/ldap

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,12 @@ Released: not yet
 * Fixed the issue that 'StorageVolumeTemplate.delete()' provided an incorrect
   field in the request to the HMC. (issue #900)
 
+* Fixed the issue that resource types with case-insensitive names were matched
+  case-sensitively in find..() and list() methods. This affected resource
+  types User, UserRole, UserPattern, PasswordRule, and LDAPServerDefinition.
+  The mock support was also fixed accordingly. This required adding 'nocasedict'
+  as a new package dependency. (issue #894)
+
 **Enhancements:**
 
 * Added support for Python 3.10. This required increasing the minimum version of

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -100,6 +100,9 @@ stomp.py==4.1.23
 
 immutable-views==0.6.0
 
+nocasedict==1.0.2
+
+
 # Indirect dependencies for runtime (must be consistent with requirements.txt)
 
 certifi==2019.9.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,8 @@ stomp.py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version >= '3.6'  # Apache
 
 immutable-views>=0.6.0
 
+nocasedict>=1.0.2
+
 # Indirect dependencies (commented out, only listed to document their license):
 
 # certifi # ISC, from requests>=2.20

--- a/tests/unit/zhmcclient/test_ldap_server_definition.py
+++ b/tests/unit/zhmcclient/test_ldap_server_definition.py
@@ -115,6 +115,8 @@ class TestLdapServerDefinition(object):
              ['a', 'b']),
             ({'name': 'a'},
              ['a']),
+            ({'name': 'A'},  # LDAP user definitions have case-insensitive names
+             ['a']),
         ]
     )
     def test_ldap_srv_def_manager_list(

--- a/tests/unit/zhmcclient/test_manager.py
+++ b/tests/unit/zhmcclient/test_manager.py
@@ -520,7 +520,8 @@ class TestNameUriCache(object):
         self.manager._list_resources = [self.resource1, self.resource2]
 
         self.timetolive = 1.0  # seconds
-        self.cache = _NameUriCache(self.manager, self.timetolive)
+        self.cache = _NameUriCache(
+            self.manager, self.timetolive, case_insensitive_names=False)
         self.created = datetime.now()
 
     def test_initial(self):

--- a/tests/unit/zhmcclient/test_user.py
+++ b/tests/unit/zhmcclient/test_user.py
@@ -128,6 +128,8 @@ class TestUser(object):
              ['a', 'b']),
             ({'name': 'a'},
              ['a']),
+            ({'name': 'A'},  # users have case-insensitive names
+             ['a']),
         ]
     )
     def test_user_manager_list(

--- a/tests/unit/zhmcclient/test_user_pattern.py
+++ b/tests/unit/zhmcclient/test_user_pattern.py
@@ -131,6 +131,8 @@ class TestUserPattern(object):
              ['a', 'b']),
             ({'name': 'a'},
              ['a']),
+            ({'name': 'A'},  # user patterns have case-insensitive names
+             ['a']),
         ]
     )
     def test_upm_list(

--- a/tests/unit/zhmcclient/test_user_role.py
+++ b/tests/unit/zhmcclient/test_user_role.py
@@ -113,6 +113,8 @@ class TestUserRole(object):
              ['a', 'b']),
             ({'name': 'a'},
              ['a']),
+            ({'name': 'A'},  # user roles have case-insensitive names
+             ['a']),
         ]
     )
     def test_user_role_manager_list(

--- a/zhmcclient/_ldap_server_definition.py
+++ b/zhmcclient/_ldap_server_definition.py
@@ -56,6 +56,8 @@ class LdapServerDefinitionManager(BaseManager):
         # If the support for a resource property changes within the set of HMC
         # versions that support this type of resource, this list must be set up
         # for the version of the HMC this session is connected to.
+        # Because this resource has case-insensitive names, this list must
+        # contain the name property.
         query_props = [
             'name',
         ]
@@ -69,7 +71,8 @@ class LdapServerDefinitionManager(BaseManager):
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            case_insensitive_names=True)
 
     @property
     def console(self):

--- a/zhmcclient/_password_rule.py
+++ b/zhmcclient/_password_rule.py
@@ -55,6 +55,8 @@ class PasswordRuleManager(BaseManager):
         # If the support for a resource property changes within the set of HMC
         # versions that support this type of resource, this list must be set up
         # for the version of the HMC this session is connected to.
+        # Because this resource has case-insensitive names, this list must
+        # contain the name property.
         query_props = [
             'name',
             'type',
@@ -69,7 +71,8 @@ class PasswordRuleManager(BaseManager):
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            case_insensitive_names=True)
 
     @property
     def console(self):

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -52,6 +52,8 @@ class UserManager(BaseManager):
         # If the support for a resource property changes within the set of HMC
         # versions that support this type of resource, this list must be set up
         # for the version of the HMC this session is connected to.
+        # Because this resource has case-insensitive names, this list must
+        # contain the name property.
         query_props = [
             'name',
             'type',
@@ -66,7 +68,8 @@ class UserManager(BaseManager):
             oid_prop='object-id',
             uri_prop='object-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            case_insensitive_names=True)
 
     @property
     def console(self):

--- a/zhmcclient/_user_pattern.py
+++ b/zhmcclient/_user_pattern.py
@@ -66,6 +66,8 @@ class UserPatternManager(BaseManager):
         # If the support for a resource property changes within the set of HMC
         # versions that support this type of resource, this list must be set up
         # for the version of the HMC this session is connected to.
+        # Because this resource has case-insensitive names, this list must
+        # contain the name property.
         query_props = [
             'name',
             'type',
@@ -80,7 +82,8 @@ class UserPatternManager(BaseManager):
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            case_insensitive_names=True)
 
     @property
     def console(self):

--- a/zhmcclient/_user_role.py
+++ b/zhmcclient/_user_role.py
@@ -60,6 +60,8 @@ class UserRoleManager(BaseManager):
         # If the support for a resource property changes within the set of HMC
         # versions that support this type of resource, this list must be set up
         # for the version of the HMC this session is connected to.
+        # Because this resource has case-insensitive names, this list must
+        # contain the name property.
         query_props = [
             'name',
             'type',
@@ -74,7 +76,8 @@ class UserRoleManager(BaseManager):
             oid_prop='object-id',
             uri_prop='object-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            case_insensitive_names=True)
 
     @property
     def console(self):


### PR DESCRIPTION
For details, see commit message.

Even though this is a bug fix, it will not be rolled back to the stable release, because it adds a new package dependency (nocasedict package).