### PR TITLE
Fixed HMC field error in StorageVolumeTemplate.delete()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,9 @@ Released: not yet
   storage volumes, storage template volumes) did not update the uris list in
   the local properties of its parent object.
 
+* Fixed the issue that 'StorageVolumeTemplate.delete()' provided an incorrect
+  field in the request to the HMC. (issue #900)
+
 **Enhancements:**
 
 * Added support for Python 3.10. This required increasing the minimum version of

--- a/zhmcclient/_storage_volume_template.py
+++ b/zhmcclient/_storage_volume_template.py
@@ -298,7 +298,7 @@ class StorageVolumeTemplate(BaseResource):
             'element-uri': self.uri,
         }
         body = {
-            'storage-volumes': [
+            'storage-template-volumes': [
                 volreq_obj
             ],
         }


### PR DESCRIPTION
See commit message.
No review needed.