### PR TITLE
1.1: Fixed HMC field error in StorageVolumeTemplate.delete()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,9 @@ Released: not yet
   storage volumes, storage template volumes) did not update the uris list in
   the local properties of its parent object.
 
+* Fixed the issue that 'StorageVolumeTemplate.delete()' provided an incorrect
+  field in the request to the HMC. (issue #900)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient/_storage_volume_template.py
+++ b/zhmcclient/_storage_volume_template.py
@@ -298,7 +298,7 @@ class StorageVolumeTemplate(BaseResource):
             'element-uri': self.uri,
         }
         body = {
-            'storage-volumes': [
+            'storage-template-volumes': [
                 volreq_obj
             ],
         }


### PR DESCRIPTION
Rolls back PR #901 into 1.1.1