### PR TITLE
1.1: Fixes in mock support for "Update LPAR Properties"

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,9 @@ Released: not yet
 * Fixed issues in the zhmcclient_mock support for the "Update LPAR Properties"
   operation. (issue #909)
 
+* Fixed issues in the zhmcclient_mock support for the "Update LPAR Properties"
+  operation. (issue #909)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -3332,7 +3332,7 @@ class LparHandler(GenericGetPropertiesHandler):
             raise CpcInDpmError(method, uri, cpc)
         check_valid_cpc_status(method, uri, cpc)
         status = lpar.properties.get('status', None)
-        if status not in ('operating', 'exceptions'):
+        if status not in ('not-operating', 'operating', 'exceptions'):
             # LPAR permits property updates only when a active
             new_exc = ConflictError(
                 method, uri, 1,


### PR DESCRIPTION
Rolls back PR #910 into 1.1.1.
