### PR TITLE
Support for saving and restoring faked resources to enable common tests 

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,11 +16,6 @@
 # PEP517 package builder, used in Makefile
 build>=0.5.0
 
-# PyYAML pulled in by zhmcclient examples and by python-coveralls
-# PyYAML 5.3 fixes narrow build error
-PyYAML>=5.1; python_version == '2.7'
-PyYAML>=5.1; python_version >= '3.5'
-
 
 # Unit test (imports into testcases):
 packaging>=19.0
@@ -52,7 +47,6 @@ virtualenv>=20.1.0
 pluggy>=0.7.1; python_version >= '2.7' and python_version <= '3.6'
 pluggy>=0.13.0; python_version >= '3.7'
 # decorator: covered in requirements.txt
-yamlloader>=0.5.5
 backports.statistics>=0.1.0; python_version == '2.7'
 # FormEncode is used for xml comparisons in unit test
 # FormEncode 1.3.1 has no python_requires and fails install on Python 3.10 due to incorrect
@@ -171,8 +165,6 @@ jupyter_core>=4.2.1
 nbconvert>=5.0.0
 nbformat>=4.2.0
 notebook>=4.3.1
-pyrsistent>=0.14.0,<0.16.0; python_version == '2.7'
-pyrsistent>=0.14.0; python_version >= '3.5'
 
 # Pywin32 is used (at least?) by jupyter.
 # Pywin32 version 222 is inconsistent in its 32-bit/64-bit support on py37

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,28 @@ Released: not yet
 * The installation of this package using `setup.py install` is no longer
   recommended. Use `pip install` instead.
 
+* The "timestamp" init parameter of "FakedMetricObjectValues" now gets
+  converted to a timezone-aware datetime object using the local timezone, if
+  provided as timezone-naive datetime object. This may be incompatible for
+  users of the zhmcclient mock support if the mock support is used in testcases
+  that have expected timestamps.
+
+* Mock support for metrics: The representation of metric group definitions has
+  been moved from the FakedMetricsContextManager class to the FakedHmc class,
+  where they are now predefined and no longer need to be added by the user of
+  the mock support. As a result, the add_metric_group_definition() method
+  has been dropped. The get_metric_group_definition() and
+  get_metric_group_definition_names() methods have also been dropped and
+  the predefined metric groups can now be accessed via a new property
+  FakedHmc.metric_groups that provides an immutable view.
+
+* Mock support for metrics: The representation of metric values has
+  been moved from the FakedMetricsContextManager class to the FakedHmc class.
+  The add_metric_values() method has been moved accordingly. The
+  get_metric_values() and get_metric_values_group_names() methods have been
+  dropped and the metric values can now be accessed via a new property
+  FakedHmc.metric_values that provides an immutable view.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -67,6 +89,10 @@ Released: not yet
 * Mock support: Fixed list of properties returned by the "List Adapters of CPC"
   operation.
 
+* Fixed that the "timestamp" init parameter of "FakedMetricObjectValues" gets
+  converted to a timezone-aware datetime object using the local timezone, if
+  provided as a timezone-naive datetime object.
+
 **Enhancements:**
 
 * Added support for Python 3.10. This required increasing the minimum version of
@@ -77,6 +103,15 @@ Released: not yet
 
 * Added support for activating and deactivating a CPC in classic mode, by
   adding Cpc.activate() and Cpc.deactivate().
+
+* Added support for saving real and faked HMCs to HMC definitions, via new
+  methods to_hmc_yaml_file(), to_hmc_yaml() and to_hmc_dict() on the 'Client'
+  class.
+  Added support for restoring faked HMCs from HMC definitions, via new methods
+  from_hmc_yaml_file(), from_hmc_yaml() and from_hmc_dict() on the
+  'FakedSession' class.
+  This required adding the following Python packages as dependencies:
+  PyYAML, yamlloader, jsonschema, dateutil.
 
 **Cleanup:**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -471,6 +471,7 @@ intersphinx_mapping = {
     'py2': ('https://docs.python.org/2', None), # specific to Python 2
     'py3': ('https://docs.python.org/3', None), # specific to Python 3
     'iv': ('https://immutable-views.readthedocs.io/en/latest/', None),
+    'dateutil': ('https://dateutil.readthedocs.io/en/stable/', None),
 }
 
 intersphinx_cache_limit = 5

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -155,6 +155,12 @@ Faked session
 .. autoclass:: zhmcclient_mock.FakedSession
    :members:
 
+.. autoclass:: zhmcclient_mock.HmcDefinitionYamlError
+   :members:
+
+.. autoclass:: zhmcclient_mock.HmcDefinitionSchemaError
+   :members:
+
 
 .. _`Faked HMC`:
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -97,10 +97,18 @@ requests==2.25.0; python_version >= '3.10'
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
 stomp.py==4.1.23
-
+python-dateutil==2.8.0
 immutable-views==0.6.0
-
 nocasedict==1.0.2
+
+# PyYAML pulled in by zhmcclient_mock (and zhmcclient examples, and python-coveralls)
+PyYAML==5.3
+
+# yamlloader pulled in by zhmcclient_mock
+yamlloader==0.5.5
+
+# jsonschema pulled in by zhmcclient_mock
+jsonschema==2.6.0
 
 
 # Indirect dependencies for runtime (must be consistent with requirements.txt)
@@ -111,17 +119,12 @@ docopt==0.6.2
 idna==2.5
 urllib3==1.25.9; python_version <= '3.9'
 urllib3==1.26.5; python_version >= '3.10'
-
+pyrsistent==0.15.0
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)
 
 # PEP517 package builder, used in Makefile
 build==0.5.0
-
-# PyYAML pulled in by zhmcclient examples and by python-coveralls
-PyYAML==5.3; python_version == '2.7'
-PyYAML==5.1; python_version >= '3.5' and python_version < '3.8'
-PyYAML==5.1.2; python_version >= '3.8'
 
 # Unit test (imports into testcases):
 packaging==19.0
@@ -148,7 +151,6 @@ virtualenv==20.1.0
 pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'
 pluggy==0.13.0; python_version >= '3.7'
 # decorator: covered in direct deps for installation
-yamlloader==0.5.5
 # FormEncode is used for xml comparisons in unit test
 FormEncode==1.3.1; python_version <= '3.9'
 FormEncode==2.0.0; python_version >= '3.10'
@@ -227,7 +229,6 @@ jupyter_core==4.2.1
 nbconvert==5.0.0
 nbformat==4.2.0
 notebook==4.3.1
-pyrsistent==0.14.0
 
 # Pywin32 is used (at least?) by jupyter.
 pywin32==222; sys_platform == 'win32' and python_version == '2.7'
@@ -267,7 +268,6 @@ imagesize==0.7.1
 isort==4.3.5
 Jinja2==2.8; python_version <= '3.9'
 Jinja2==2.10.2; python_version >= '3.10'
-jsonschema==2.5.1
 MarkupSafe==0.23; python_version <= '3.9'
 MarkupSafe==1.1.0; python_version >= '3.10'
 mistune==0.8.1
@@ -280,7 +280,6 @@ pkginfo==1.4.2
 ptyprocess==0.5.1
 py==1.5.1; python_version <= '3.9'
 py==1.8.2; python_version >= '3.10'
-python-dateutil==2.6.0
 qtconsole==4.2.1
 scandir==1.9.0
 simplegeneric==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,9 +35,22 @@ six>=1.16.0; python_version >= '3.10'  # MIT
 stomp.py>=4.1.23,<5.0.0; python_version <= '3.5'  # Apache
 stomp.py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version >= '3.6'  # Apache
 
+python-dateutil>=2.8.0
 immutable-views>=0.6.0
-
 nocasedict>=1.0.2
+
+# PyYAML pulled in by zhmcclient_mock (and zhmcclient examples, and python-coveralls)
+# PyYAML 5.3 fixes narrow build error
+# PyYAML 6.0 removed support for py27,35
+PyYAML>=5.3
+
+# yamlloader pulled in by zhmcclient_mock
+# yamlloader 1.0 removed support for py27,35
+yamlloader>=0.5.5
+
+# jsonschema pulled in by zhmcclient_mock
+# jsonschema 4.0 removed support for py27,35,36
+jsonschema>=2.6.0
 
 # Indirect dependencies (commented out, only listed to document their license):
 
@@ -46,3 +59,4 @@ nocasedict>=1.0.2
 # docopt # MIT, from stomp.py>=4.1
 # idna # BSD-like, from requests>=2.20
 # urllib3 # MIT, from requests>=2.20
+# pyrsistent # MIT, from jsonschema>=3.0

--- a/tests/faked_z13_classic.yaml
+++ b/tests/faked_z13_classic.yaml
@@ -2,13 +2,40 @@
 # Definition of a faked HMC for zhmcclient testing.
 # The faked HMC represents a single z13 CPC in classic mode.
 
-faked_client:
-  hmc_host: "fake-host"
-  hmc_name: "fake-hmc"
-  hmc_version: "2.13.1"
-  api_version: "1.8"
+hmc_definition:
+  hmc_host: hmc1
+  api_version: '1.8'
+  consoles:
+  - properties:
+      name: HMC 1
+      version: 2.13.1
+    users:
+    - properties:
+        object-id: user1
+        name: User 1
+    user_roles:
+    - properties:
+        object-id: userrole1
+        name: User role 1
+    user_patterns:
+    - properties:
+        element-id: userpattern1
+        name: User pattern 1
+    password_rules:
+    - properties:
+        element-id: passwordrule1
+        name: Password rule 1
+    tasks:
+    - properties:
+        element-id: task1
+        name: Task 1
+    ldap_server_definitions:
+    - properties:
+        element-id: lsd1
+        name: LDAP server definition 1
   cpcs:
     - properties:
+        object-id: cpc1
         name: "CPC1"
         description: "Fake z13 (classic mode)"
         machine-type: "2964"
@@ -18,6 +45,7 @@ faked_client:
         iml-mode: "lpar"
       lpars:
         - properties:
+            object-id: lpar1
             name: "LPAR1"
             partition-number: 0x41
             partition-identifier: 0x41
@@ -26,6 +54,7 @@ faked_client:
             next-activation-profile-name: "LPAR1"
             last-used-activation-profile: "LPAR1"
         - properties:
+            object-id: lpar2
             name: "LPAR2"
             partition-number: 0x42
             partition-identifier: 0x42
@@ -39,11 +68,11 @@ faked_client:
             iocds-name: "ABC"
       load_activation_profiles:
         - properties:
-            name: "LPAR1"
+            name: "STANDARDLOAD"
             ipl-type: "ipltype-standard"
             ipl-address: "189AB"
         - properties:
-            name: "LPAR2"
+            name: "SCSILOAD"
             ipl-type: "ipltype-scsi"
             worldwide-port-name: "1234"
             logical-unit-number: "1234"

--- a/tests/faked_z13_dpm.yaml
+++ b/tests/faked_z13_dpm.yaml
@@ -2,13 +2,55 @@
 # Definition of a faked HMC for zhmcclient testing.
 # The faked HMC represents a single z13 CPC in DPM mode.
 
-faked_client:
-  hmc_host: "fake-host"
-  hmc_name: "fake-hmc"
-  hmc_version: "2.13.1"
-  api_version: "1.8"
+hmc_definition:
+  hmc_host: hmc1
+  api_version: '1.8'
+  consoles:
+  - properties:
+      name: HMC 1
+      version: 2.13.1
+      api-version: '1.8'
+    users:
+    - properties:
+        object-id: user1
+        name: User 1
+    user_roles:
+    - properties:
+        object-id: userrole1
+        name: User role 1
+    user_patterns:
+    - properties:
+        element-id: userpattern1
+        name: User pattern 1
+    password_rules:
+    - properties:
+        element-id: passwordrule1
+        name: Password rule 1
+    tasks:
+    - properties:
+        element-id: task1
+        name: Task 1
+    ldap_server_definitions:
+    - properties:
+        element-id: lsd1
+        name: LDAP server definition 1
+    storage_groups:
+    - properties:
+        object-id: sg1
+        name: Storage group 1
+        shared: false
+        type: fcp
+        fulfillment-state: complete
+      storage_volumes:
+      - properties:
+          element-id: sv1
+          name: Storage volume 1
+          fulfillment-state: complete
+          site: 10.0
+          usage: boot
   cpcs:
     - properties:
+        object-id: cpc1
         name: "CPC1"
         description: "Faked CPC CPC1 (z13 in DPM mode)"
         machine-type: "2964"
@@ -16,24 +58,9 @@ faked_client:
         dpm-enabled: true
         is-ensemble-member: false
         iml-mode: dpm
-      partitions:
-        - properties:
-            name: "PART1"
-            description: "Faked partition PART1 on CPC1"
-            autogenerate-partition-id: true
-            partition-id: 0x41
-            type: linux
-            status: active
-            auto-start: true
-            processor-mode: shared
-            ifl-processors: 2
-            initial-ifl-processing-weight: 20
-            initial-memory: 4096
-            maximum-memory: 4096
-            boot-device: network-adapter
-            boot-network-device: null  # Should be resource URI
       adapters:
         - properties:
+            object-id: osa1
             name: "OSA1"
             description: "Faked OSA adapter OSA1 in CPC1"
             adapter-id: "108"
@@ -48,10 +75,43 @@ faked_client:
             maximum-total-capacity: 1920
           ports:
             - properties:
+                element-id: port0
                 name: "Port 0"
                 description: "Faked port 0 of OSA adapter OSA1 in CPC1"
                 index: 0
             - properties:
+                element-id: port1
                 name: "Port 1"
                 description: "Faked port 1 of OSA adapter OSA1 in CPC1"
                 index: 1
+      virtual_switches:
+        - properties:
+            object-id: vs-osa1
+            name: "Virtual Switch for OSA1"
+            description: "Faked Virtual Switch for OSA adapter OSA1 in CPC1"
+            backing-adapter-uri: /api/adapters/osa1
+            port: 0
+      partitions:
+        - properties:
+            object-id: part1
+            name: "PART1"
+            description: "Faked partition PART1 on CPC1"
+            autogenerate-partition-id: true
+            partition-id: 0x41
+            type: linux
+            status: active
+            auto-start: true
+            processor-mode: shared
+            ifl-processors: 2
+            initial-ifl-processing-weight: 20
+            initial-memory: 4096
+            maximum-memory: 4096
+            boot-device: network-adapter
+            boot-network-device: null  # Should be resource URI
+          nics:
+            - properties:
+                element-id: nic1
+                name: "OSA1-NIC1"
+                description: "NIC1 backed by OSA1"
+                device-number: '0010'
+                virtual-switch-uri: /api/virtual-switches/vs-osa1

--- a/tests/unit/zhmcclient/test_metrics.py
+++ b/tests/unit/zhmcclient/test_metrics.py
@@ -22,7 +22,7 @@ import re
 import pytest
 
 from zhmcclient import Client, MetricsContext, HTTPError, NotFound
-from zhmcclient_mock import FakedSession, FakedMetricGroupDefinition
+from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
@@ -30,9 +30,9 @@ from tests.common.utils import assert_resources
 MC1_OID = 'mc1-oid'
 MC2_OID = 'mc2-oid'
 
-# Names of our faked metric groups:
-MG1_NAME = 'mg1-name'
-MG2_NAME = 'mg2-name'
+# Names of our metric groups:
+MG1_NAME = 'partition-usage'
+MG2_NAME = 'dpm-system-usage-overview'
 
 # Base URI for metrics contexts (Object ID will be added to get URI):
 MC_BASE_URI = '/api/services/metrics/context/'
@@ -52,33 +52,6 @@ class TestMetricsContext(object):
 
         self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
         self.client = Client(self.session)
-
-    def add_metricgroupdefinition1(self):
-        """Add metric group definition 1."""
-
-        faked_metricgroupdefinition = FakedMetricGroupDefinition(
-            name=MG1_NAME,
-            types=[
-                ('faked-metric11', 'integer-metric'),
-                ('faked-metric12', 'string-metric'),
-            ]
-        )
-        self.session.hmc.metrics_contexts.add_metric_group_definition(
-            faked_metricgroupdefinition)
-        return faked_metricgroupdefinition
-
-    def add_metricgroupdefinition2(self):
-        """Add metric group definition 2."""
-
-        faked_metricgroupdefinition = FakedMetricGroupDefinition(
-            name=MG2_NAME,
-            types=[
-                ('faked-metric21', 'boolean-metric'),
-            ]
-        )
-        self.session.hmc.metrics_contexts.add_metric_group_definition(
-            faked_metricgroupdefinition)
-        return faked_metricgroupdefinition
 
     def add_metricscontext1(self):
         """Add faked metrics context 1."""
@@ -146,10 +119,6 @@ class TestMetricsContext(object):
     def test_mcm_list_full_properties(
             self, full_properties_kwargs, prop_names):
         """Test MetricsContextManager.list() with full_properties."""
-
-        # Add faked metric groups
-        self.add_metricgroupdefinition1()
-        self.add_metricgroupdefinition2()
 
         # Create (non-faked) metrics contexts (list() will only return those)
         metricscontext1 = self.create_metricscontext1()
@@ -225,10 +194,6 @@ class TestMetricsContext(object):
     def test_mcm_list_filter_args(
             self, filter_args, exp_names):
         """Test MetricsContextManager.list() with filter_args."""
-
-        # Add faked metric groups
-        self.add_metricgroupdefinition1()
-        self.add_metricgroupdefinition2()
 
         # Create (non-faked) metrics contexts (list() will only return those)
         self.create_metricscontext1()

--- a/tests/unit/zhmcclient/test_utils.py
+++ b/tests/unit/zhmcclient/test_utils.py
@@ -25,7 +25,8 @@ import time
 import pytz
 import pytest
 
-from zhmcclient._utils import datetime_from_timestamp, timestamp_from_datetime
+from zhmcclient._utils import datetime_from_timestamp, \
+    timestamp_from_datetime, datetime_to_isoformat, datetime_from_isoformat
 
 
 # The Unix epoch
@@ -317,3 +318,95 @@ def test_datetime_max():
 
     # The test is that it does not raise an exception:
     timestamp_from_datetime(datetime.max)
+
+
+# Test cases for datetime_to_isoformat()
+TESTCASES_DATETIME_TO_ISOFORMAT = [
+    # dt, exp_dt_str
+    (
+        datetime(2017, 9, 5, 12, 13, 10, 0),
+        '2017-09-05 12:13:10'
+    ),
+    (
+        datetime(2017, 9, 5, 12, 13, 10, 123456),
+        '2017-09-05 12:13:10.123456'
+    ),
+    (
+        datetime(2017, 9, 5, 12, 13, 10, 0, pytz.utc),
+        '2017-09-05 12:13:10+00:00'
+    ),
+    (
+        datetime(2017, 9, 5, 12, 13, 10, 0, pytz.timezone('CET')),
+        '2017-09-05 12:13:10+01:00'
+    ),
+    (
+        datetime(2017, 9, 5, 12, 13, 10, 0, pytz.timezone('EST')),
+        '2017-09-05 12:13:10-05:00'
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "dt, exp_dt_str",
+    TESTCASES_DATETIME_TO_ISOFORMAT)
+def test_datetime_to_isoformat(dt, exp_dt_str):
+    """
+    Test function for datetime_to_isoformat().
+    """
+
+    # The function to be tested
+    dt_str = datetime_to_isoformat(dt)
+
+    assert dt_str == exp_dt_str
+
+
+# Test cases for datetime_from_isoformat()
+TESTCASES_DATETIME_FROM_ISOFORMAT = [
+    # dt_str, exp_dt
+    (
+        '2017-09-05 12:13:10',
+        datetime(2017, 9, 5, 12, 13, 10, 0)  # timezone-naive
+    ),
+    (
+        '2017-09-05T12:13:10',
+        datetime(2017, 9, 5, 12, 13, 10, 0)  # timezone-naive
+    ),
+    (
+        '2017-09-05 12:13:10.123456',
+        datetime(2017, 9, 5, 12, 13, 10, 123456)  # timezone-naive
+    ),
+    (
+        '2017-09-05 12:13:10+00:00',
+        datetime(2017, 9, 5, 12, 13, 10, 0, pytz.utc)
+    ),
+    (
+        '2017-09-05 12:13:10+0000',
+        datetime(2017, 9, 5, 12, 13, 10, 0, pytz.utc)
+    ),
+    (
+        '2017-09-05 12:13:10+01:00',
+        datetime(2017, 9, 5, 12, 13, 10, 0, pytz.timezone('CET'))
+    ),
+    (
+        '2017-09-05 12:13:10+0100',
+        datetime(2017, 9, 5, 12, 13, 10, 0, pytz.timezone('CET'))
+    ),
+    (
+        '2017-09-05 12:13:10-05:00',
+        datetime(2017, 9, 5, 12, 13, 10, 0, pytz.timezone('EST'))
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "dt_str, exp_dt",
+    TESTCASES_DATETIME_FROM_ISOFORMAT)
+def test_datetime_from_isoformat(dt_str, exp_dt):
+    """
+    Test function for datetime_from_isoformat().
+    """
+
+    # The function to be tested
+    dt = datetime_from_isoformat(dt_str)
+
+    assert dt == exp_dt

--- a/tests/unit/zhmcclient_mock/test_session.py
+++ b/tests/unit/zhmcclient_mock/test_session.py
@@ -1,0 +1,319 @@
+# Copyright 2022 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=protected-access,attribute-defined-outside-init
+
+"""
+Unit tests for _session module of the zhmcclient_mock package.
+"""
+
+from __future__ import absolute_import, print_function
+
+from datetime import datetime
+
+from zhmcclient import Client
+from zhmcclient_mock import FakedSession
+
+from zhmcclient_mock._hmc import \
+    FakedMetricGroupDefinition, FakedMetricObjectValues
+
+from tests.common.utils import assert_equal_hmc
+
+
+# The resource input for the test_hmc_dump_load() test function.
+# Each type of resource should appear in this resource input.
+HMC1_RESOURCES = {
+    'consoles': [
+        {
+            'properties': {
+                'name': 'hmc1',
+                'version': '2.14.1',
+            },
+            'users': [
+                {
+                    'properties': {
+                        'object-id': 'user1',
+                        'name': 'User 1',
+                    },
+                },
+            ],
+            'user_roles': [
+                {
+                    'properties': {
+                        'object-id': 'userrole1',
+                        'name': 'User role 1',
+                    },
+                },
+            ],
+            'user_patterns': [
+                {
+                    'properties': {
+                        'element-id': 'userpattern1',
+                        'name': 'User pattern 1',
+                    },
+                },
+            ],
+            'password_rules': [
+                {
+                    'properties': {
+                        'element-id': 'passwordrule1',
+                        'name': 'Password rule 1',
+                    },
+                },
+            ],
+            'tasks': [
+                {
+                    'properties': {
+                        'element-id': 'task1',
+                        'name': 'Task 1',
+                    },
+                },
+            ],
+            'ldap_server_definitions': [
+                {
+                    'properties': {
+                        'element-id': 'lsd1',
+                        'name': 'LDAP server definition 1',
+                    },
+                },
+            ],
+            'unmanaged_cpcs': [
+                {
+                    'properties': {
+                        'object-id': 'cpc3',
+                        'name': 'Unmanaged CPC 3',
+                    },
+                },
+            ],
+            'storage_groups': [
+                {
+                    'properties': {
+                        'object-id': 'sg1',
+                        'name': 'Storage group 1',
+                    },
+                    'storage_volumes': [
+                        {
+                            'properties': {
+                                'element-id': 'sv1',
+                                'name': 'Storage volume 1',
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    'cpcs': [
+        {
+            'properties': {
+                'object-id': 'cpc1',
+                'name': 'CPC 1 (DPM mode)',
+                'dpm-enabled': True,
+                'se-version': '2.13',
+                'status': 'operating',
+            },
+            'capacity_groups': [
+                {
+                    'properties': {
+                        'object-id': 'cg1',
+                        'name': 'Capacity group 1',
+                    },
+                },
+            ],
+            'partitions': [
+                {
+                    'properties': {
+                        'object-id': 'part1',
+                        'name': 'Partition 1',
+                    },
+                    'nics': [
+                        {
+                            'properties': {
+                                'element-id': 'nic1',
+                                'name': 'NIC 1',
+                                'device-number': '0010',
+                            },
+                        },
+                    ],
+                    'hbas': [
+                        {
+                            'properties': {
+                                'element-id': 'hba1',
+                                'name': 'HBA 1',
+                                'device-number': '0018',
+                            },
+                        },
+                    ],
+                    'virtual_functions': [
+                        {
+                            'properties': {
+                                'element-id': 'vf1',
+                                'name': 'Virtual function 1',
+                                'device-number': '0020',
+                            },
+                        },
+                    ],
+                },
+            ],
+            'adapters': [
+                {
+                    'properties': {
+                        'object-id': 'ad1',
+                        'name': 'Adapter 1',
+                        'adapter-family': 'hipersockets',
+                    },
+                    'ports': [
+                        {
+                            'properties': {
+                                'element-id': '1',
+                                'name': 'Port 1',
+                            },
+                        },
+                    ],
+                },
+            ],
+            'virtual_switches': [
+                {
+                    'properties': {
+                        'object-id': 'vs1',
+                        'name': 'Virtual switch 1',
+                    },
+                },
+            ],
+        },
+        {
+            'properties': {
+                'object-id': 'cpc2',
+                'name': 'CPC 2 (classic mode)',
+                'dpm-enabled': False,
+                'se-version': '2.13',
+                'status': 'active',
+            },
+            'capacity_groups': [
+                {
+                    'properties': {
+                        'object-id': 'cg1',
+                        'name': 'Capacity group 1',
+                    },
+                },
+            ],
+            'lpars': [
+                {
+                    'properties': {
+                        'object-id': 'lpar1',
+                        'name': 'LPAR1',
+                    },
+                },
+            ],
+            'reset_activation_profiles': [
+                {
+                    'properties': {
+                        'object-id': 'rap1',
+                        'name': 'RAP1',
+                    },
+                },
+            ],
+            'image_activation_profiles': [
+                {
+                    'properties': {
+                        'object-id': 'lpar1',
+                        'name': 'LPAR1',
+                    },
+                },
+            ],
+            'load_activation_profiles': [
+                {
+                    'properties': {
+                        'object-id': 'specialload',
+                        'name': 'SPECIALLOAD',
+                    },
+                },
+            ],
+        },
+    ]
+}
+
+# The metroc group definitions for the test_hmc_dump_load() test function.
+HMC_DUMP_LOAD_METRIC_GROUP_DEFS = [
+    FakedMetricGroupDefinition(
+        name='partition-usage',
+        types=[
+            ('processor-usage', 'integer-metric'),
+            ('network-usage', 'integer-metric'),
+            ('storage-usage', 'integer-metric'),
+            ('accelerator-usage', 'integer-metric'),
+            ('crypto-usage', 'integer-metric'),
+        ]
+    ),
+]
+
+
+def test_session_to_from_yaml():
+    """Test FakedSession.to_yaml() and from_yaml()"""
+
+    debug_yamlfile = False  # Enable to get the HMC dump file created
+
+    # Set up the faked session
+    console_props = HMC1_RESOURCES['consoles'][0]['properties']
+    hmc_host = 'testhmc'
+    api_version = '2.20'
+    hmc_name = console_props['name']
+    hmc_version = console_props['version']
+
+    session = FakedSession(hmc_host, hmc_name, hmc_version, api_version)
+    client = Client(session)
+
+    session.hmc.add_resources(HMC1_RESOURCES)
+
+    cpc1 = session.hmc.cpcs.list(filter_args={'object-id': 'cpc1'})[0]
+    part1 = cpc1.partitions.list(filter_args={'object-id': 'part1'})[0]
+    session.hmc.add_metric_values(
+        FakedMetricObjectValues(
+            group_name='partition-usage',
+            resource_uri=part1.uri,
+            timestamp=datetime.now(),
+            values=[
+                ('processor-usage', 15),
+                ('network-usage', 0),
+                ('storage-usage', 1),
+                ('accelerator-usage', 0),
+                ('crypto-usage', 0),
+            ]))
+    session.hmc.add_metric_values(
+        FakedMetricObjectValues(
+            group_name='partition-usage',
+            resource_uri=part1.uri,
+            timestamp=datetime.now(),
+            values=[
+                ('processor-usage', 17),
+                ('network-usage', 5),
+                ('storage-usage', 2),
+                ('accelerator-usage', 0),
+                ('crypto-usage', 0),
+            ]))
+
+    # The function to be tested:
+    hmc_yaml = client.to_hmc_yaml()
+
+    if debug_yamlfile:
+        filename = 'tmp_hmcdef.yaml'
+        print("Creating file with faked HMC definition: {}".
+              format(filename))
+        with open(filename, 'w') as fp:
+            fp.write(hmc_yaml)
+
+    # The function to be tested:
+    new_session = FakedSession.from_hmc_yaml(hmc_yaml)
+
+    assert_equal_hmc(new_session.hmc, session.hmc)

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -581,3 +581,32 @@ class Adapter(BaseResource):
         body = {'type': adapter_type}
         self.manager.session.post(
             self.uri + '/operations/change-adapter-type', body)
+
+    def dump(self):
+        """
+        Dump this Adapter resource with its properties and child resources
+        (recursively) as a resource definition.
+
+        The returned resource definition has the following format::
+
+            {
+                # Resource properties:
+                "properties": {...},
+
+                # Child resources:
+                "ports": [...],
+            }
+
+        Returns:
+          dict: Resource definition of this resource.
+        """
+
+        # Dump the resource properties
+        resource_dict = super(Adapter, self).dump()
+
+        # Dump the child resources
+        ports = self.ports.dump()
+        if ports:
+            resource_dict['ports'] = ports
+
+        return resource_dict

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -802,3 +802,60 @@ class Console(BaseResource):
                         lpar_obj.pull_full_properties()
 
         return lpar_objs
+
+    def dump(self):
+        """
+        Dump this Console resource with its properties and child resources
+        (recursively) as a resource definition.
+
+        The returned resource definition has the following format::
+
+            {
+                # Resource properties:
+                "properties": {...},
+
+                # Child resources:
+                "users": [...],
+                "user_roles": [...],
+                "user_patterns": [...],
+                "password_rules": [...],
+                "tasks": [...],
+                "ldap_server_definitions": [...],
+                "unmanaged_cpcs": [...],
+                "storage_groups": [...],
+            }
+
+        Returns:
+          dict: Resource definition of this resource.
+        """
+
+        # Dump the resource properties
+        resource_dict = super(Console, self).dump()
+
+        # Dump the child resources
+        users = self.users.dump()
+        if users:
+            resource_dict['users'] = users
+        user_roles = self.user_roles.dump()
+        if user_roles:
+            resource_dict['user_roles'] = user_roles
+        user_patterns = self.user_patterns.dump()
+        if user_patterns:
+            resource_dict['user_patterns'] = user_patterns
+        password_rules = self.password_rules.dump()
+        if password_rules:
+            resource_dict['password_rules'] = password_rules
+        tasks = self.tasks.dump()
+        if tasks:
+            resource_dict['tasks'] = tasks
+        ldap_server_definitions = self.ldap_server_definitions.dump()
+        if ldap_server_definitions:
+            resource_dict['ldap_server_definitions'] = ldap_server_definitions
+        unmanaged_cpcs = self.unmanaged_cpcs.dump()
+        if unmanaged_cpcs:
+            resource_dict['unmanaged_cpcs'] = unmanaged_cpcs
+        storage_groups = self.storage_groups.dump()
+        if storage_groups:
+            resource_dict['storage_groups'] = storage_groups
+
+        return resource_dict

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -461,6 +461,67 @@ class Cpc(BaseResource):
             new_exc.__cause__ = None
             raise new_exc  # ValueError
 
+    def dump(self):
+        """
+        Dump this Cpc resource with its properties and child resources
+        (recursively) as a resource definition.
+
+        The returned resource definition has the following format::
+
+            {
+                # Resource properties:
+                "properties": {...},
+
+                # Child resources for any CPC mode:
+                "capacity_groups": [...],
+
+                # Child resources for DPM mode:
+                "partitions": [...],
+                "adapters": [...],
+                "virtual_switches": [...],
+
+                # Child resources for classic mode:
+                "lpars": [...],  # Faked Lpar children
+                "reset_activation_profiles": [...],
+                "image_activation_profiles": [...],
+                "load_activation_profiles": [...],
+            }
+
+        Returns:
+          dict: Resource definition of this resource.
+        """
+
+        # Dump the resource properties
+        resource_dict = super(Cpc, self).dump()
+
+        # Dump the child resources
+        capacity_groups = self.capacity_groups.dump()
+        if capacity_groups:
+            resource_dict['capacity_groups'] = capacity_groups
+        partitions = self.partitions.dump()
+        if partitions:
+            resource_dict['partitions'] = partitions
+        adapters = self.adapters.dump()
+        if adapters:
+            resource_dict['adapters'] = adapters
+        virtual_switches = self.virtual_switches.dump()
+        if virtual_switches:
+            resource_dict['virtual_switches'] = virtual_switches
+        lpars = self.lpars.dump()
+        if lpars:
+            resource_dict['lpars'] = lpars
+        reset_act_profiles = self.reset_activation_profiles.dump()
+        if reset_act_profiles:
+            resource_dict['reset_activation_profiles'] = reset_act_profiles
+        image_act_profiles = self.image_activation_profiles.dump()
+        if image_act_profiles:
+            resource_dict['image_activation_profiles'] = image_act_profiles
+        load_act_profiles = self.load_activation_profiles.dump()
+        if load_act_profiles:
+            resource_dict['load_activation_profiles'] = load_act_profiles
+
+        return resource_dict
+
     @logged_api_call
     def feature_enabled(self, feature_name):
         """

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -830,3 +830,28 @@ class BaseManager(object):
             "Use of flush() on zhmcclient manager objects is deprecated; "
             "use invalidate_cache() instead", DeprecationWarning)
         self.invalidate_cache()
+
+    def dump(self):
+        """
+        Dump the resources of this resource manager as a resource definition.
+
+        This is the default implementation for the case where the resource
+        manager has no internal state that needs to be saved.
+        If the resource manager does have internal state, this method needs to
+        be overridden in the resource manager subclass.
+
+        The returned resource definition of this implementation has the
+        following format::
+
+            [
+                {...},  # resource definition
+                ...
+            ]
+
+        Returns:
+          list: Resource definitions of the resources of this resource manager.
+        """
+        res_list = []
+        for res in self.list():
+            res_list.append(res.dump())
+        return res_list

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -1315,3 +1315,40 @@ class Partition(BaseResource):
                 if full_properties:
                     sg.pull_full_properties()
         return sg_list
+
+    def dump(self):
+        """
+        Dump this Partition resource with its properties and child resources
+        (recursively) as a resource definition.
+
+        The returned resource definition has the following format::
+
+            {
+                # Resource properties:
+                "properties": {...},
+
+                # Child resources:
+                "nics": [...],
+                "hbas": [...],
+                "virtual_functions": [...],
+            }
+
+        Returns:
+          dict: Resource definition of this resource.
+        """
+
+        # Dump the resource properties
+        resource_dict = super(Partition, self).dump()
+
+        # Dump the child resources
+        nics = self.nics.dump()
+        if nics:
+            resource_dict['nics'] = nics
+        hbas = self.hbas.dump()
+        if hbas:
+            resource_dict['hbas'] = hbas
+        virtual_functions = self.virtual_functions.dump()
+        if virtual_functions:
+            resource_dict['virtual_functions'] = virtual_functions
+
+        return resource_dict

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -22,6 +22,10 @@ by the HMC.
 from __future__ import absolute_import
 import time
 import threading
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 # import contextlib
 from immutable_views import DictView
 
@@ -490,3 +494,28 @@ class BaseResource(object):
             session.resource_updater.unregister_object(self)
             if not session.resource_updater.has_objects():
                 session.unsubscribe_auto_update()
+
+    def dump(self):
+        """
+        Dump this resource with its properties and child resources
+        (recursively) as a resource definition.
+
+        This is the default implementation for the case where the resource has
+        no child resources. If the resource does have child resources, this
+        method needs to be overridden in the resource subclass.
+
+        The returned resource definition of this implementation has the
+        following format::
+
+            {
+                "properties": {...},
+            }
+
+        Returns:
+          dict: Resource definition of this resource.
+        """
+        resource_dict = OrderedDict()
+        self.pull_full_properties()
+        resource_dict['properties'] = OrderedDict(self._properties)
+        # No child resources
+        return resource_dict

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -822,3 +822,32 @@ class StorageGroup(BaseResource):
     # TODO: Add support for "Reject Mismatched FCP Storage Volumes" operation
 
     # TODO: Add support for "Get Storage Group Histories" operation
+
+    def dump(self):
+        """
+        Dump this StorageGroup resource with its properties and child
+        resources (recursively) as a resource definition.
+
+        The returned resource definition has the following format::
+
+            {
+                # Resource properties:
+                "properties": {...},
+
+                # Child resources:
+                "storage_volumes": [...],
+            }
+
+        Returns:
+          dict: Resource definition of this resource.
+        """
+
+        # Dump the resource properties
+        resource_dict = super(StorageGroup, self).dump()
+
+        # Dump the child resources
+        storage_volumes = self.storage_volumes.dump()
+        if storage_volumes:
+            resource_dict['storage_volumes'] = storage_volumes
+
+        return resource_dict

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -26,11 +26,13 @@ except ImportError:
     # pylint: disable=deprecated-class
     from collections import Mapping, MutableSequence, Iterable
 from datetime import datetime
+from dateutil import parser
 import six
 import pytz
 from requests.utils import quote
 
-__all__ = ['datetime_from_timestamp', 'timestamp_from_datetime']
+__all__ = ['datetime_from_timestamp', 'timestamp_from_datetime',
+           'datetime_from_isoformat', 'datetime_to_isoformat']
 
 
 _EPOCH_DT = datetime(1970, 1, 1, 0, 0, 0, 0, pytz.utc)
@@ -488,3 +490,46 @@ def matches_prop(obj, prop_name, prop_match):
             if prop_value == prop_match:
                 return True
     return False
+
+
+def datetime_from_isoformat(dt_str):
+    """
+    Return a datetime object representing the date time string in ISO8601
+    format.
+
+    This function is used to parse timestamp strings from the externalized
+    HMC definition.
+
+    The date time strings are parsed using dateutil.parse.isoparse(), which
+    supports the ISO8601 formats. The separator between the date portion and
+    the time portion can be ' ' or 'T', and the optional timezone portion can
+    be specified as 'shhmm' or 'shh:mm'.
+
+    If the date time string specifies a timezone, the returned datetime object
+    is timezone-aware. Otherwise, it is timezone-naive.
+    """
+    dt = parser.isoparse(dt_str)
+    return dt
+
+
+def datetime_to_isoformat(dt):
+    """
+    Return a date time string in ISO8601 format representing the datetime
+    object.
+
+    This function is used to create timestamp strings for the externalized
+    HMC definition.
+
+    The generated date time string has this format:
+
+        YYYY-MM-DD HH:MM:SS[.ssssss][shh:mm]
+
+    Where:
+      * .ssssss - is an optional part specifying microseconds. It is not created
+        when the datetime microsecond value is 0.
+      * shh:mm - is an optional part specifying the timezone offset with sign,
+        hours hh and minutes mm. It is not created when the datetime is
+        timezone-naive.
+    """
+    dt_str = dt.isoformat(sep=' ')
+    return dt_str


### PR DESCRIPTION
See commit message for details.

This is a first step towards consolidating end2end testing and mock environment testing, so that we can write testcases that run against both real and mocked environments.

Ready for review and merge.