### PR TITLE
Mock support: Fixed error in repr() when FakedAdapter() raised InputError

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -61,6 +61,9 @@ Released: not yet
 * Mock support: Fixed that operations on activation profiles succeed with an
   empty result set in case the CPC is in DPM mode, instead of failing.
 
+* Mock support: Fixed a follow-on error in repr() when FakedAdapter() raised
+  InputError.
+
 **Enhancements:**
 
 * Added support for Python 3.10. This required increasing the minimum version of

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -1419,6 +1419,8 @@ class FakedAdapter(FakedBaseResource):
         super(FakedAdapter, self).__init__(
             manager=manager,
             properties=properties)
+        # Initial values to be prepared for raising InputError
+        self._ports = None
         # TODO: Maybe move this stuff into AdapterManager.add()?
         if 'adapter-family' in self._properties:
             family = self._properties['adapter-family']


### PR DESCRIPTION
No review needed.