### PR TITLE
1.1: Mock support: Fixed error in repr() when FakedAdapter() raised InputError

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -68,6 +68,9 @@ Released: 2022-02-17
 * Mock support: Fixed that operations on activation profiles succeed with an
   empty result set in case the CPC is in DPM mode, instead of failing.
 
+* Mock support: Fixed a follow-on error in repr() when FakedAdapter() raised
+  InputError.
+
 **Cleanup:**
 
 * Removed the ability to build the Windows executable, triggered by the fact

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -1388,6 +1388,8 @@ class FakedAdapter(FakedBaseResource):
         super(FakedAdapter, self).__init__(
             manager=manager,
             properties=properties)
+        # Initial values to be prepared for raising InputError
+        self._ports = None
         # TODO: Maybe move this stuff into AdapterManager.add()?
         if 'adapter-family' in self._properties:
             family = self._properties['adapter-family']


### PR DESCRIPTION
Rolls back PR #927 into 1.1.2.