### PR TITLE
1.1: Mock support: Fixed list of properties returned by "List Adapters of CPC"

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -71,6 +71,9 @@ Released: 2022-02-17
 * Mock support: Fixed a follow-on error in repr() when FakedAdapter() raised
   InputError.
 
+* Mock support: Fixed list of properties returned by the "List Adapters of CPC"
+  operation.
+
 **Cleanup:**
 
 * Removed the ability to build the Windows executable, triggered by the fact

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -4084,26 +4084,36 @@ class TestAdapterHandlers(object):
                     'object-uri': '/api/adapters/1',
                     'name': 'osa_1',
                     'status': 'active',
+                    'adapter-family': 'osa',
+                    'adapter-id': 'BEF',
                 },
                 {
                     'object-uri': '/api/adapters/2',
                     'name': 'fcp_2',
                     'status': 'active',
+                    'adapter-family': 'ficon',
+                    'adapter-id': 'CEF',
                 },
                 {
                     'object-uri': '/api/adapters/2a',
                     'name': 'fcp_2a',
                     'status': 'active',
+                    'adapter-family': 'ficon',
+                    'adapter-id': 'CEE',
                 },
                 {
                     'object-uri': '/api/adapters/3',
                     'name': 'roce_3',
                     'status': 'active',
+                    'adapter-family': 'roce',
+                    'adapter-id': 'DEF',
                 },
                 {
                     'object-uri': '/api/adapters/4',
                     'name': 'crypto_4',
                     'status': 'active',
+                    'adapter-family': 'crypto',
+                    'adapter-id': 'EEF',
                 },
             ]
         }

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -1805,7 +1805,8 @@ class AdaptersHandler(object):
             for adapter in cpc.adapters.list(filter_args):
                 result_adapter = {}
                 for prop in adapter.properties:
-                    if prop in ('object-uri', 'name', 'status'):
+                    if prop in ('object-uri', 'name', 'adapter-id',
+                                'adapter-family', 'type', 'status'):
                         result_adapter[prop] = adapter.properties[prop]
                 result_adapters.append(result_adapter)
         return {'adapters': result_adapters}


### PR DESCRIPTION
Rolls back PR #931 into 1.1.2.