### PR TITLE
Made testutils names importable from zhmcclient.testutils

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,7 @@ jobs:
     - name: Run builddoc
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
+        TESTHMCFILE_NOLOAD: True
       run: |
         make builddoc
     - name: Run check

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -66,6 +66,9 @@ Released: not yet
 * Docs: Improved and fixed the "Testing" section in the "Development" chapter.
   (issue #950)
 
+* Added a new function 'zhmcclient.testutils.hmc_definitions()' that
+  can be used by example scripts to access HMC definitions.
+
 **Cleanup:**
 
 * Made the handling of 'Lpar.list()' with filters that have no matching LPAR

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -255,34 +255,28 @@ It defines
 `pytest fixtures <https://docs.pytest.org/en/latest/explanation/fixtures.html>`_
 and encapsulates the access to the HMC definition file.
 
-.. automodule:: zhmcclient.testutils.hmc_definition_fixtures
+.. autofunction:: zhmcclient.testutils.hmc_definition
 
-.. autofunction:: zhmcclient.testutils.hmc_definition_fixtures.hmc_definition
+.. autofunction:: zhmcclient.testutils.hmc_session
 
-.. autofunction:: zhmcclient.testutils.hmc_definition_fixtures.hmc_session
+.. autofunction:: zhmcclient.testutils.one_cpc
 
-.. automodule:: zhmcclient.testutils.cpc_fixtures
+.. autofunction:: zhmcclient.testutils.all_cpcs
 
-.. autofunction:: zhmcclient.testutils.cpc_fixtures.one_cpc
+.. autofunction:: zhmcclient.testutils.dpm_mode_cpcs
 
-.. autofunction:: zhmcclient.testutils.cpc_fixtures.all_cpcs
+.. autofunction:: zhmcclient.testutils.classic_mode_cpcs
 
-.. autofunction:: zhmcclient.testutils.cpc_fixtures.dpm_mode_cpcs
-
-.. autofunction:: zhmcclient.testutils.cpc_fixtures.classic_mode_cpcs
-
-.. automodule:: zhmcclient.testutils.hmc_definitions
-
-.. autoclass:: zhmcclient.testutils.hmc_definitions.HMCDefinition
+.. autoclass:: zhmcclient.testutils.HMCDefinition
    :members:
    :autosummary:
    :special-members: __repr__
 
-.. autoclass:: zhmcclient.testutils.hmc_definitions.HMCDefinitionFile
+.. autoclass:: zhmcclient.testutils.HMCDefinitionFile
    :members:
    :autosummary:
 
-.. autoclass:: zhmcclient.testutils.hmc_definitions.HMCDefinitionFileError
+.. autoclass:: zhmcclient.testutils.HMCDefinitionFileError
    :members:
    :autosummary:
 

--- a/tests/end2end/test_activation_profile.py
+++ b/tests/end2end/test_activation_profile.py
@@ -26,8 +26,8 @@ import pytest
 from requests.packages import urllib3
 
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import classic_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, End2endTestWarning

--- a/tests/end2end/test_adapter.py
+++ b/tests/end2end/test_adapter.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning

--- a/tests/end2end/test_capacity_group.py
+++ b/tests/end2end/test_capacity_group.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning

--- a/tests/end2end/test_console.py
+++ b/tests/end2end/test_console.py
@@ -24,8 +24,8 @@ import pytest
 from requests.packages import urllib3
 
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import all_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list

--- a/tests/end2end/test_cpc.py
+++ b/tests/end2end/test_cpc.py
@@ -25,8 +25,8 @@ import pytest
 from requests.packages import urllib3
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import all_cpcs, classic_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import all_cpcs, classic_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, assert_res_prop, End2endTestWarning

--- a/tests/end2end/test_hba.py
+++ b/tests/end2end/test_hba.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, standard_partition_props, \

--- a/tests/end2end/test_hmc_definitions.py
+++ b/tests/end2end/test_hmc_definitions.py
@@ -23,7 +23,7 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 urllib3.disable_warnings()

--- a/tests/end2end/test_ldap_server_definition.py
+++ b/tests/end2end/test_ldap_server_definition.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import all_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning

--- a/tests/end2end/test_lpar.py
+++ b/tests/end2end/test_lpar.py
@@ -27,8 +27,8 @@ import pytest
 from requests.packages import urllib3
 
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import classic_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, End2endTestWarning

--- a/tests/end2end/test_nic.py
+++ b/tests/end2end/test_nic.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, standard_partition_props, \

--- a/tests/end2end/test_partition.py
+++ b/tests/end2end/test_partition.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, standard_partition_props, \

--- a/tests/end2end/test_password_rule.py
+++ b/tests/end2end/test_password_rule.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import all_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning

--- a/tests/end2end/test_port.py
+++ b/tests/end2end/test_port.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning

--- a/tests/end2end/test_storage_group.py
+++ b/tests/end2end/test_storage_group.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import skipif_no_storage_mgmt_feature, runtest_find_list, \

--- a/tests/end2end/test_storage_group_template.py
+++ b/tests/end2end/test_storage_group_template.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import skipif_no_storage_mgmt_feature, runtest_find_list, \

--- a/tests/end2end/test_storage_volume.py
+++ b/tests/end2end/test_storage_volume.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import skipif_no_storage_mgmt_feature, runtest_find_list, \

--- a/tests/end2end/test_storage_volume_template.py
+++ b/tests/end2end/test_storage_volume_template.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import skipif_no_storage_mgmt_feature, runtest_find_list, \

--- a/tests/end2end/test_task.py
+++ b/tests/end2end/test_task.py
@@ -25,8 +25,8 @@ import pytest
 from requests.packages import urllib3
 
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import all_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list

--- a/tests/end2end/test_user.py
+++ b/tests/end2end/test_user.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import all_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning

--- a/tests/end2end/test_user_pattern.py
+++ b/tests/end2end/test_user_pattern.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import all_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning

--- a/tests/end2end/test_user_role.py
+++ b/tests/end2end/test_user_role.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import all_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning

--- a/tests/end2end/test_virtual_function.py
+++ b/tests/end2end/test_virtual_function.py
@@ -28,8 +28,8 @@ from requests.packages import urllib3
 
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, standard_partition_props, \

--- a/tests/end2end/test_virtual_switch.py
+++ b/tests/end2end/test_virtual_switch.py
@@ -26,8 +26,8 @@ import pytest
 from requests.packages import urllib3
 
 # pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils.cpc_fixtures import dpm_mode_cpcs  # noqa: F401, E501
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, End2endTestWarning

--- a/zhmcclient/testutils/__init__.py
+++ b/zhmcclient/testutils/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2022 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+zhmcclient.testutils - Utilities for testing against (real or mocked) HMCs.
+"""
+
+from __future__ import absolute_import
+
+from ._hmc_definitions import *            # noqa: F401
+from ._hmc_definition_fixtures import *    # noqa: F401
+from ._cpc_fixtures import *               # noqa: F401

--- a/zhmcclient/testutils/_cpc_fixtures.py
+++ b/zhmcclient/testutils/_cpc_fixtures.py
@@ -22,8 +22,10 @@ import warnings
 import pytest
 import zhmcclient
 
-# pylint: disable=unused-import,line-too-long
-from .hmc_definition_fixtures import hmc_session, HMC_DEF_LIST  # noqa: F401, E501
+# pylint: disable=unused-import
+from ._hmc_definition_fixtures import hmc_session  # noqa: F401
+
+__all__ = ['one_cpc', 'all_cpcs', 'dpm_mode_cpcs', 'classic_mode_cpcs']
 
 
 def fixtureid_cpc(fixture_value):
@@ -65,7 +67,7 @@ def one_cpc(request, hmc_session):  # noqa: F811
     Pytest fixture representing a single, arbitrary CPC managed by the HMC.
 
     Because the `hmc_session` parameter of this fixture is again a fixture,
-    the :func:`zhmcclient.testutils.hmc_definition_fixtures.hmc_session`
+    the :func:`zhmcclient.testutils.hmc_session`
     function needs to be imported as well when this fixture is used.
 
     A test function parameter using this fixture resolves to a
@@ -79,30 +81,6 @@ def one_cpc(request, hmc_session):  # noqa: F811
     return cpc
 
 
-# TODO: The following is an attempt to define a parametrized CPC fixture
-# @pytest.mark.parametrize('hmc_definition', HMC_DEF_LIST)
-# @pytest.fixture(
-#     scope='module',
-#     ids=fixtureid_cpc
-# )
-# def any_mode_cpc(request, hmc_definition):  # noqa: F811
-#     # pylint: disable=redefined-outer-name,unused-argument
-#     """
-#     Pytest fixture representing the set of all CPCs defined in the
-#     HMC definition file (regardless of their classic/DPM mode).
-#
-#     Because the `hmc_session` parameter of this fixture is again a fixture,
-#     `hmc_session` needs to be imported as well when this fixture is used.
-#
-#     A test function parameter using this fixture resolves to a
-#     :class:`zhmcclient.Cpc` object from that set,
-#     that has the "short" set of properties (i.e. from list()).
-#     """
-#     session = setup_hmc_session(hmc_definition)
-#     yield defined_cpcs(session, 'any')  # don't know how to parametrize this
-#     teardown_hmc_session(session)
-
-
 @pytest.fixture(
     scope='module',
     ids=fixtureid_cpcs
@@ -114,7 +92,7 @@ def all_cpcs(request, hmc_session):  # noqa: F811
     HMC definition file (regardless of their classic/DPM mode).
 
     Because the `hmc_session` parameter of this fixture is again a fixture,
-    the :func:`zhmcclient.testutils.hmc_definition_fixtures.hmc_session`
+    the :func:`zhmcclient.testutils.hmc_session`
     function needs to be imported as well when this fixture is used.
 
     A test function parameter using this fixture resolves to a
@@ -135,7 +113,7 @@ def dpm_mode_cpcs(request, hmc_session):  # noqa: F811
     all CPCs defined in the HMC definition file.
 
     Because the `hmc_session` parameter of this fixture is again a fixture,
-    the :func:`zhmcclient.testutils.hmc_definition_fixtures.hmc_session`
+    the :func:`zhmcclient.testutils.hmc_session`
     function needs to be imported as well when this fixture is used.
 
     A test function parameter using this fixture resolves to a
@@ -156,7 +134,7 @@ def classic_mode_cpcs(request, hmc_session):  # noqa: F811
     all CPCs defined in the HMC definition file.
 
     Because the `hmc_session` parameter of this fixture is again a fixture,
-    the :func:`zhmcclient.testutils.hmc_definition_fixtures.hmc_session`
+    the :func:`zhmcclient.testutils.hmc_session`
     function needs to be imported as well when this fixture is used.
 
     A test function parameter using this fixture resolves to a
@@ -169,14 +147,23 @@ def classic_mode_cpcs(request, hmc_session):  # noqa: F811
 def defined_cpcs(session, mode):
     """
     Return a list of CPCs defined in the HMC definition file, that are managed
-    by the HMC, and that have the desired mode ('dpm', 'classic', 'any').
+    by the HMC, and that have the desired operational mode.
+
+    Parameters:
+
+      session (:class:`zhmcclient.Session`): The session with the HMC.
+
+      mode (string): The desired mode of the CPC ('dpm', 'classic', 'any').
+
+    Returns:
+      list of :class:`zhmcclient.Cpc`: The CPCs in the desired mode.
     """
     client = zhmcclient.Client(session)
-    all_cpcs = client.cpcs.list()
+    _all_cpcs = client.cpcs.list()
     hd = session.hmc_definition
     result_cpcs = []
     for cpc_name in hd.cpcs:
-        cpcs = [cpc for cpc in all_cpcs if cpc.name == cpc_name]
+        cpcs = [cpc for cpc in _all_cpcs if cpc.name == cpc_name]
         if not cpcs:
             warnings.warn(
                 "Cannot find CPC {c} defined in HMC definition file".

--- a/zhmcclient/testutils/_hmc_definitions.py
+++ b/zhmcclient/testutils/_hmc_definitions.py
@@ -29,6 +29,8 @@ import yaml
 import yamlloader
 import jsonschema
 
+__all__ = ['HMCDefinitionFileError', 'HMCDefinitionFile', 'HMCDefinition']
+
 THIS_DIR = os.path.dirname(__file__)
 
 EXAMPLE_HMC_FILE = os.path.join('tests', 'example_hmc_definitions.yaml')


### PR DESCRIPTION
See commit message for details.
No review needed.