### PR TITLE
End2end test: Removed CPC scope from test functions for HMC-based resources

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -97,6 +97,9 @@ Released: not yet
 * Transitioned test code for the old format for defining HMCs to the new
   format, and removed some test code. (issue #966)
 
+* End2end test: Removed CPC scope from test functions for HMC-based resources
+  (e.g. users)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/tests/end2end/test_console.py
+++ b/tests/end2end/test_console.py
@@ -20,12 +20,11 @@ These tests do not change the console object.
 
 from __future__ import absolute_import, print_function
 
-import pytest
 from requests.packages import urllib3
 
+import zhmcclient
 # pylint: disable=line-too-long,unused-import
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list
@@ -42,24 +41,17 @@ CONSOLE_LIST_PROPS = ['object-uri', 'name', 'type']
 CONSOLE_VOLATILE_PROPS = []
 
 
-def test_pwrule_find_list(all_cpcs):  # noqa: F811
+def test_console_find_list(hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test list(), find(), findall().
     """
-    if not all_cpcs:
-        pytest.skip("No CPCs provided")
+    client = zhmcclient.Client(hmc_session)
 
-    for cpc in all_cpcs:
-        session = cpc.manager.session
-        client = cpc.manager.client
+    # Pick the single console
+    console = client.consoles.console
 
-        # Pick the single console
-        console = client.consoles.console
-
-        print("Testing on CPC {}".format(cpc.name))
-
-        runtest_find_list(
-            session, client.consoles, console.name, 'name',
-            'object-uri', CONSOLE_VOLATILE_PROPS, CONSOLE_MINIMAL_PROPS,
-            CONSOLE_LIST_PROPS)
+    runtest_find_list(
+        hmc_session, client.consoles, console.name, 'name',
+        'object-uri', CONSOLE_VOLATILE_PROPS, CONSOLE_MINIMAL_PROPS,
+        CONSOLE_LIST_PROPS)

--- a/tests/end2end/test_cpc.py
+++ b/tests/end2end/test_cpc.py
@@ -114,7 +114,7 @@ def test_cpc_features(all_cpcs):  # noqa: F811
     - feature_info()
     """
     if not all_cpcs:
-        pytest.skip("No CPCs provided")
+        pytest.skip("HMC does not manage any CPCs")
 
     for cpc in all_cpcs:
         print("Testing with CPC {}".format(cpc.name))

--- a/tests/end2end/test_password_rule.py
+++ b/tests/end2end/test_password_rule.py
@@ -29,7 +29,6 @@ from requests.packages import urllib3
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning
@@ -46,146 +45,131 @@ PWRULE_LIST_PROPS = ['element-uri', 'name', 'type']
 PWRULE_VOLATILE_PROPS = []
 
 
-def test_pwrule_find_list(all_cpcs):  # noqa: F811
+def test_pwrule_find_list(hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test list(), find(), findall().
     """
-    if not all_cpcs:
-        pytest.skip("No CPCs provided")
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
 
-    for cpc in all_cpcs:
-        session = cpc.manager.session
-        console = cpc.manager.client.consoles.console
-        client = console.manager.client
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        pytest.skip("HMC {hv} does not yet support password rules".
+                    format(hv=hmc_version))
 
-        api_version = client.query_api_version()
-        hmc_version = api_version['hmc-version']
-        hmc_version_info = tuple(map(int, hmc_version.split('.')))
-        if hmc_version_info < (2, 13, 0):
-            pytest.skip("HMC {hv} does not yet support password rules".
-                        format(hv=hmc_version))
+    # Pick a random password rule
+    pwrule_list = console.password_rules.list()
+    if not pwrule_list:
+        msg_txt = "No password rules defined on HMC"
+        warnings.warn(msg_txt, End2endTestWarning)
+        pytest.skip(msg_txt)
+    pwrule = random.choice(pwrule_list)
 
-        # Pick a random password rule
-        pwrule_list = console.password_rules.list()
-        if not pwrule_list:
-            msg_txt = "No password rules defined on CPC {}". \
-                format(cpc.name)
-            warnings.warn(msg_txt, End2endTestWarning)
-            pytest.skip(msg_txt)
-        pwrule = random.choice(pwrule_list)
-
-        print("Testing on CPC {}".format(cpc.name))
-
-        runtest_find_list(
-            session, console.password_rules, pwrule.name, 'name',
-            'element-uri', PWRULE_VOLATILE_PROPS, PWRULE_MINIMAL_PROPS,
-            PWRULE_LIST_PROPS)
+    print("Testing with password rule {}".format(pwrule.name))
+    runtest_find_list(
+        hmc_session, console.password_rules, pwrule.name, 'name',
+        'element-uri', PWRULE_VOLATILE_PROPS, PWRULE_MINIMAL_PROPS,
+        PWRULE_LIST_PROPS)
 
 
-def test_pwrule_crud(all_cpcs):  # noqa: F811
+def test_pwrule_crud(hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test create, read, update and delete a password rule.
     """
-    if not all_cpcs:
-        pytest.skip("No CPCs provided")
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+    hd = hmc_session.hmc_definition
 
-    for cpc in all_cpcs:
-        print("Testing on CPC {}".format(cpc.name))
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        pytest.skip("HMC {hv} does not yet support password rules".
+                    format(hv=hmc_version))
 
-        session = cpc.manager.session
-        console = cpc.manager.client.consoles.console
-        client = console.manager.client
-        hd = session.hmc_definition
+    pwrule_name = TEST_PREFIX + ' test_pwrule_crud pwrule1'
+    pwrule_name_new = pwrule_name + ' new'
 
-        api_version = client.query_api_version()
-        hmc_version = api_version['hmc-version']
-        hmc_version_info = tuple(map(int, hmc_version.split('.')))
-        if hmc_version_info < (2, 13, 0):
-            pytest.skip("HMC {hv} does not yet support password rules".
-                        format(hv=hmc_version))
-
-        pwrule_name = TEST_PREFIX + ' test_pwrule_crud pwrule1'
-        pwrule_name_new = pwrule_name + ' new'
-
-        # Ensure a clean starting point for this test
-        try:
-            pwrule = console.password_rules.find(name=pwrule_name)
-        except zhmcclient.NotFound:
-            pass
-        else:
-            warnings.warn(
-                "Deleting test password rule from previous run: '{p}' "
-                "on CPC '{c}'".
-                format(p=pwrule_name, c=cpc.name), UserWarning)
-            pwrule.delete()
-
-        # Test creating the password rule
-
-        pwrule_input_props = {
-            'name': pwrule_name,
-            'description': 'Test password rule for zhmcclient end2end tests',
-            'expiration': 90,
-        }
-        pwrule_auto_props = {
-            'min-length': 8,
-            'max-length': 256,
-        }
-
-        # The code to be tested
-        try:
-            pwrule = console.password_rules.create(
-                pwrule_input_props)
-        except zhmcclient.HTTPError as exc:
-            if exc.http_status == 403 and exc.reason == 1:
-                msg_txt = "HMC userid '{u}' is not authorized for the " \
-                    "'Manage Password Rules' task on HMC {h}". \
-                    format(u=hd.hmc_userid, h=hd.hmc_host)
-                warnings.warn(msg_txt, End2endTestWarning)
-                pytest.skip(msg_txt)
-            else:
-                raise
-
-        for pn, exp_value in pwrule_input_props.items():
-            assert pwrule.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-        pwrule.pull_full_properties()
-        for pn, exp_value in pwrule_input_props.items():
-            assert pwrule.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-        for pn, exp_value in pwrule_auto_props.items():
-            assert pwrule.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-
-        # Test updating a property of the password rule
-
-        new_desc = "Updated password rule description."
-
-        # The code to be tested
-        pwrule.update_properties(dict(description=new_desc))
-
-        assert pwrule.properties['description'] == new_desc
-        pwrule.pull_full_properties()
-        assert pwrule.properties['description'] == new_desc
-
-        # Test that password rules cannot be renamed
-
-        with pytest.raises(zhmcclient.HTTPError) as exc_info:
-
-            # The code to be tested
-            pwrule.update_properties(dict(name=pwrule_name_new))
-
-        exc = exc_info.value
-        assert exc.http_status == 400
-        assert exc.reason == 6
-        with pytest.raises(zhmcclient.NotFound):
-            console.password_rules.find(name=pwrule_name_new)
-
-        # Test deleting the password rule
-
-        # The code to be tested
+    # Ensure a clean starting point for this test
+    try:
+        pwrule = console.password_rules.find(name=pwrule_name)
+    except zhmcclient.NotFound:
+        pass
+    else:
+        warnings.warn(
+            "Deleting test password rule from previous run: '{p}'".
+            format(p=pwrule_name), UserWarning)
         pwrule.delete()
 
-        with pytest.raises(zhmcclient.NotFound):
-            console.password_rules.find(name=pwrule_name)
+    # Test creating the password rule
+
+    pwrule_input_props = {
+        'name': pwrule_name,
+        'description': 'Test password rule for zhmcclient end2end tests',
+        'expiration': 90,
+    }
+    pwrule_auto_props = {
+        'min-length': 8,
+        'max-length': 256,
+    }
+
+    # The code to be tested
+    try:
+        pwrule = console.password_rules.create(
+            pwrule_input_props)
+    except zhmcclient.HTTPError as exc:
+        if exc.http_status == 403 and exc.reason == 1:
+            msg_txt = "HMC userid '{u}' is not authorized for the " \
+                "'Manage Password Rules' task on HMC {h}". \
+                format(u=hd.hmc_userid, h=hd.hmc_host)
+            warnings.warn(msg_txt, End2endTestWarning)
+            pytest.skip(msg_txt)
+        else:
+            raise
+
+    for pn, exp_value in pwrule_input_props.items():
+        assert pwrule.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+    pwrule.pull_full_properties()
+    for pn, exp_value in pwrule_input_props.items():
+        assert pwrule.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+    for pn, exp_value in pwrule_auto_props.items():
+        assert pwrule.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+
+    # Test updating a property of the password rule
+
+    new_desc = "Updated password rule description."
+
+    # The code to be tested
+    pwrule.update_properties(dict(description=new_desc))
+
+    assert pwrule.properties['description'] == new_desc
+    pwrule.pull_full_properties()
+    assert pwrule.properties['description'] == new_desc
+
+    # Test that password rules cannot be renamed
+
+    with pytest.raises(zhmcclient.HTTPError) as exc_info:
+
+        # The code to be tested
+        pwrule.update_properties(dict(name=pwrule_name_new))
+
+    exc = exc_info.value
+    assert exc.http_status == 400
+    assert exc.reason == 6
+    with pytest.raises(zhmcclient.NotFound):
+        console.password_rules.find(name=pwrule_name_new)
+
+    # Test deleting the password rule
+
+    # The code to be tested
+    pwrule.delete()
+
+    with pytest.raises(zhmcclient.NotFound):
+        console.password_rules.find(name=pwrule_name)

--- a/tests/end2end/test_task.py
+++ b/tests/end2end/test_task.py
@@ -24,9 +24,9 @@ import random
 import pytest
 from requests.packages import urllib3
 
+import zhmcclient
 # pylint: disable=line-too-long,unused-import
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list
@@ -43,33 +43,27 @@ TASK_LIST_PROPS = ['element-uri', 'name']
 TASK_VOLATILE_PROPS = []
 
 
-def test_task_find_list(all_cpcs):  # noqa: F811
+def test_task_find_list(hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test list(), find(), findall().
     """
-    if not all_cpcs:
-        pytest.skip("No CPCs provided")
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
 
-    for cpc in all_cpcs:
-        session = cpc.manager.session
-        console = cpc.manager.client.consoles.console
-        client = console.manager.client
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        pytest.skip("HMC {hv} does not yet support tasks".
+                    format(hv=hmc_version))
 
-        api_version = client.query_api_version()
-        hmc_version = api_version['hmc-version']
-        hmc_version_info = tuple(map(int, hmc_version.split('.')))
-        if hmc_version_info < (2, 13, 0):
-            pytest.skip("HMC {hv} does not yet support tasks".
-                        format(hv=hmc_version))
+    # Pick a random task
+    task_list = console.tasks.list()
+    assert task_list  # system-defined and therefore never empty
+    task = random.choice(task_list)
 
-        # Pick a random task
-        task_list = console.tasks.list()
-        assert task_list  # system-defined and therefore never empty
-        task = random.choice(task_list)
-
-        print("Testing on CPC {}".format(cpc.name))
-
-        runtest_find_list(
-            session, console.tasks, task.name, 'name', 'element-uri',
-            TASK_VOLATILE_PROPS, TASK_MINIMAL_PROPS, TASK_LIST_PROPS)
+    print("Testing with task {}".format(task.name))
+    runtest_find_list(
+        hmc_session, console.tasks, task.name, 'name', 'element-uri',
+        TASK_VOLATILE_PROPS, TASK_MINIMAL_PROPS, TASK_LIST_PROPS)

--- a/tests/end2end/test_user_pattern.py
+++ b/tests/end2end/test_user_pattern.py
@@ -29,7 +29,6 @@ from requests.packages import urllib3
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning
@@ -46,151 +45,136 @@ UPATT_LIST_PROPS = ['element-uri', 'name', 'type']
 UPATT_VOLATILE_PROPS = []
 
 
-def test_upatt_find_list(all_cpcs):  # noqa: F811
+def test_upatt_find_list(hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test list(), find(), findall().
     """
-    if not all_cpcs:
-        pytest.skip("No CPCs provided")
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
 
-    for cpc in all_cpcs:
-        session = cpc.manager.session
-        console = cpc.manager.client.consoles.console
-        client = console.manager.client
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        pytest.skip("HMC {hv} does not yet support user patterns".
+                    format(hv=hmc_version))
 
-        api_version = client.query_api_version()
-        hmc_version = api_version['hmc-version']
-        hmc_version_info = tuple(map(int, hmc_version.split('.')))
-        if hmc_version_info < (2, 13, 0):
-            pytest.skip("HMC {hv} does not yet support user patterns".
-                        format(hv=hmc_version))
+    # Pick a random user pattern
+    upatt_list = console.user_patterns.list()
+    if not upatt_list:
+        msg_txt = "No user patterns defined on HMC"
+        warnings.warn(msg_txt, End2endTestWarning)
+        pytest.skip(msg_txt)
+    upatt = random.choice(upatt_list)
 
-        # Pick a random user pattern
-        upatt_list = console.user_patterns.list()
-        if not upatt_list:
-            msg_txt = "No user patterns defined on CPC {}". \
-                format(cpc.name)
-            warnings.warn(msg_txt, End2endTestWarning)
-            pytest.skip(msg_txt)
-        upatt = random.choice(upatt_list)
-
-        print("Testing on CPC {}".format(cpc.name))
-
-        runtest_find_list(
-            session, console.user_patterns, upatt.name, 'name',
-            'element-uri', UPATT_VOLATILE_PROPS, UPATT_MINIMAL_PROPS,
-            UPATT_LIST_PROPS)
+    print("Testing with user pattern {}".format(upatt.name))
+    runtest_find_list(
+        hmc_session, console.user_patterns, upatt.name, 'name',
+        'element-uri', UPATT_VOLATILE_PROPS, UPATT_MINIMAL_PROPS,
+        UPATT_LIST_PROPS)
 
 
-def test_upatt_crud(all_cpcs):  # noqa: F811
+def test_upatt_crud(hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test create, read, update and delete a user pattern.
     """
-    if not all_cpcs:
-        pytest.skip("No CPCs provided")
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+    hd = hmc_session.hmc_definition
 
-    for cpc in all_cpcs:
-        print("Testing on CPC {}".format(cpc.name))
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        pytest.skip("HMC {hv} does not yet support user patterns".
+                    format(hv=hmc_version))
 
-        session = cpc.manager.session
-        console = cpc.manager.client.consoles.console
-        client = console.manager.client
-        hd = session.hmc_definition
+    upatt_name = TEST_PREFIX + ' test_upatt_crud upatt1'
+    upatt_name_new = upatt_name + ' new'
 
-        api_version = client.query_api_version()
-        hmc_version = api_version['hmc-version']
-        hmc_version_info = tuple(map(int, hmc_version.split('.')))
-        if hmc_version_info < (2, 13, 0):
-            pytest.skip("HMC {hv} does not yet support user patterns".
-                        format(hv=hmc_version))
-
-        upatt_name = TEST_PREFIX + ' test_upatt_crud upatt1'
-        upatt_name_new = upatt_name + ' new'
-
-        # Ensure a clean starting point for this test
-        try:
-            upatt = console.user_patterns.find(name=upatt_name)
-        except zhmcclient.NotFound:
-            pass
-        else:
-            warnings.warn(
-                "Deleting test user pattern from previous run: '{p}' "
-                "on CPC '{c}'".
-                format(p=upatt_name, c=cpc.name), UserWarning)
-            upatt.delete()
-
-        # Pick a template user to be the template user for the user pattern
-        template_users = console.users.findall(type='template')
-        if not template_users:
-            msg_txt = "No template users on HMC {h}".format(h=hd.hmc_host)
-            warnings.warn(msg_txt, End2endTestWarning)
-            pytest.skip(msg_txt)
-        template_user = template_users[0]
-
-        # Test creating the user pattern
-
-        upatt_input_props = {
-            'name': upatt_name,
-            'description': 'Test user pattern for zhmcclient end2end tests',
-            'pattern': TEST_PREFIX + ' test_upatt_crud .+',
-            'type': 'regular-expression',
-            'retention-time': 180,
-            'user-template-uri': template_user.uri,  # required until z13
-        }
-        upatt_auto_props = {}
-
-        # The code to be tested
-        try:
-            upatt = console.user_patterns.create(upatt_input_props)
-        except zhmcclient.HTTPError as exc:
-            if exc.http_status == 403 and exc.reason == 1:
-                msg_txt = "HMC userid '{u}' is not authorized for the " \
-                    "'Manage User Patterns' task on HMC {h}". \
-                    format(u=hd.hmc_userid, h=hd.hmc_host)
-                warnings.warn(msg_txt, End2endTestWarning)
-                pytest.skip(msg_txt)
-            else:
-                raise
-
-        for pn, exp_value in upatt_input_props.items():
-            assert upatt.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-        upatt.pull_full_properties()
-        for pn, exp_value in upatt_input_props.items():
-            assert upatt.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-        for pn, exp_value in upatt_auto_props.items():
-            assert upatt.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-
-        # Test updating a property of the user pattern
-
-        new_desc = "Updated user pattern description."
-
-        # The code to be tested
-        upatt.update_properties(dict(description=new_desc))
-
-        assert upatt.properties['description'] == new_desc
-        upatt.pull_full_properties()
-        assert upatt.properties['description'] == new_desc
-
-        # Test renaming the user pattern
-
-        # The code to be tested
-        upatt.update_properties(dict(name=upatt_name_new))
-
-        assert upatt.properties['name'] == upatt_name_new
-        upatt.pull_full_properties()
-        assert upatt.properties['name'] == upatt_name_new
-        with pytest.raises(zhmcclient.NotFound):
-            console.user_patterns.find(name=upatt_name)
-
-        # Test deleting the user pattern
-
-        # The code to be tested
+    # Ensure a clean starting point for this test
+    try:
+        upatt = console.user_patterns.find(name=upatt_name)
+    except zhmcclient.NotFound:
+        pass
+    else:
+        warnings.warn(
+            "Deleting test user pattern from previous run: '{p}'".
+            format(p=upatt_name), UserWarning)
         upatt.delete()
 
-        with pytest.raises(zhmcclient.NotFound):
-            console.user_patterns.find(name=upatt_name_new)
+    # Pick a template user to be the template user for the user pattern
+    template_users = console.users.findall(type='template')
+    if not template_users:
+        msg_txt = "No template users on HMC {h}".format(h=hd.hmc_host)
+        warnings.warn(msg_txt, End2endTestWarning)
+        pytest.skip(msg_txt)
+    template_user = template_users[0]
+
+    # Test creating the user pattern
+
+    upatt_input_props = {
+        'name': upatt_name,
+        'description': 'Test user pattern for zhmcclient end2end tests',
+        'pattern': TEST_PREFIX + ' test_upatt_crud .+',
+        'type': 'regular-expression',
+        'retention-time': 180,
+        'user-template-uri': template_user.uri,  # required until z13
+    }
+    upatt_auto_props = {}
+
+    # The code to be tested
+    try:
+        upatt = console.user_patterns.create(upatt_input_props)
+    except zhmcclient.HTTPError as exc:
+        if exc.http_status == 403 and exc.reason == 1:
+            msg_txt = "HMC userid '{u}' is not authorized for the " \
+                "'Manage User Patterns' task on HMC {h}". \
+                format(u=hd.hmc_userid, h=hd.hmc_host)
+            warnings.warn(msg_txt, End2endTestWarning)
+            pytest.skip(msg_txt)
+        else:
+            raise
+
+    for pn, exp_value in upatt_input_props.items():
+        assert upatt.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+    upatt.pull_full_properties()
+    for pn, exp_value in upatt_input_props.items():
+        assert upatt.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+    for pn, exp_value in upatt_auto_props.items():
+        assert upatt.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+
+    # Test updating a property of the user pattern
+
+    new_desc = "Updated user pattern description."
+
+    # The code to be tested
+    upatt.update_properties(dict(description=new_desc))
+
+    assert upatt.properties['description'] == new_desc
+    upatt.pull_full_properties()
+    assert upatt.properties['description'] == new_desc
+
+    # Test renaming the user pattern
+
+    # The code to be tested
+    upatt.update_properties(dict(name=upatt_name_new))
+
+    assert upatt.properties['name'] == upatt_name_new
+    upatt.pull_full_properties()
+    assert upatt.properties['name'] == upatt_name_new
+    with pytest.raises(zhmcclient.NotFound):
+        console.user_patterns.find(name=upatt_name)
+
+    # Test deleting the user pattern
+
+    # The code to be tested
+    upatt.delete()
+
+    with pytest.raises(zhmcclient.NotFound):
+        console.user_patterns.find(name=upatt_name_new)

--- a/tests/end2end/test_user_role.py
+++ b/tests/end2end/test_user_role.py
@@ -29,7 +29,6 @@ from requests.packages import urllib3
 import zhmcclient
 # pylint: disable=line-too-long,unused-import
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, TEST_PREFIX, End2endTestWarning
@@ -46,145 +45,130 @@ UROLE_LIST_PROPS = ['object-uri', 'name', 'type']
 UROLE_VOLATILE_PROPS = []
 
 
-def test_urole_find_list(all_cpcs):  # noqa: F811
+def test_urole_find_list(hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test list(), find(), findall().
     """
-    if not all_cpcs:
-        pytest.skip("No CPCs provided")
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
 
-    for cpc in all_cpcs:
-        session = cpc.manager.session
-        console = cpc.manager.client.consoles.console
-        client = console.manager.client
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        pytest.skip("HMC {hv} does not yet support user roles".
+                    format(hv=hmc_version))
 
-        api_version = client.query_api_version()
-        hmc_version = api_version['hmc-version']
-        hmc_version_info = tuple(map(int, hmc_version.split('.')))
-        if hmc_version_info < (2, 13, 0):
-            pytest.skip("HMC {hv} does not yet support user roles".
-                        format(hv=hmc_version))
+    # Pick a random user role
+    urole_list = console.user_roles.list()
+    if not urole_list:
+        msg_txt = "No user roles defined on HMC"
+        warnings.warn(msg_txt, End2endTestWarning)
+        pytest.skip(msg_txt)
+    urole = random.choice(urole_list)
 
-        # Pick a random user role
-        urole_list = console.user_roles.list()
-        if not urole_list:
-            msg_txt = "No user roles defined on CPC {}". \
-                format(cpc.name)
-            warnings.warn(msg_txt, End2endTestWarning)
-            pytest.skip(msg_txt)
-        urole = random.choice(urole_list)
-
-        print("Testing on CPC {}".format(cpc.name))
-
-        runtest_find_list(
-            session, console.user_roles, urole.name, 'name',
-            'object-uri', UROLE_VOLATILE_PROPS, UROLE_MINIMAL_PROPS,
-            UROLE_LIST_PROPS)
+    print("Testing with user role {}".format(urole.name))
+    runtest_find_list(
+        hmc_session, console.user_roles, urole.name, 'name',
+        'object-uri', UROLE_VOLATILE_PROPS, UROLE_MINIMAL_PROPS,
+        UROLE_LIST_PROPS)
 
 
-def test_urole_crud(all_cpcs):  # noqa: F811
+def test_urole_crud(hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test create, read, update and delete a user role.
     """
-    if not all_cpcs:
-        pytest.skip("No CPCs provided")
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+    hd = hmc_session.hmc_definition
 
-    for cpc in all_cpcs:
-        print("Testing on CPC {}".format(cpc.name))
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        pytest.skip("HMC {hv} does not yet support user roles".
+                    format(hv=hmc_version))
 
-        session = cpc.manager.session
-        console = cpc.manager.client.consoles.console
-        client = console.manager.client
-        hd = session.hmc_definition
+    urole_name = TEST_PREFIX + ' test_urole_crud urole1'
+    urole_name_new = urole_name + ' new'
 
-        api_version = client.query_api_version()
-        hmc_version = api_version['hmc-version']
-        hmc_version_info = tuple(map(int, hmc_version.split('.')))
-        if hmc_version_info < (2, 13, 0):
-            pytest.skip("HMC {hv} does not yet support user roles".
-                        format(hv=hmc_version))
-
-        urole_name = TEST_PREFIX + ' test_urole_crud urole1'
-        urole_name_new = urole_name + ' new'
-
-        # Ensure a clean starting point for this test
-        try:
-            urole = console.user_roles.find(name=urole_name)
-        except zhmcclient.NotFound:
-            pass
-        else:
-            warnings.warn(
-                "Deleting test user role from previous run: '{p}' "
-                "on CPC '{c}'".
-                format(p=urole_name, c=cpc.name), UserWarning)
-            urole.delete()
-
-        # Test creating the user role
-
-        urole_input_props = {
-            'name': urole_name,
-            'description': 'Test user role for zhmcclient end2end tests',
-        }
-        urole_auto_props = {
-            'type': 'user-defined',
-            'is-inheritance-enabled': False,
-        }
-
-        # The code to be tested
-        try:
-            urole = console.user_roles.create(
-                urole_input_props)
-        except zhmcclient.HTTPError as exc:
-            if exc.http_status == 403 and exc.reason == 1:
-                msg_txt = "HMC userid '{u}' is not authorized for the " \
-                    "'Manage User Roles' task on HMC {h}". \
-                    format(u=hd.hmc_userid, h=hd.hmc_host)
-                warnings.warn(msg_txt, End2endTestWarning)
-                pytest.skip(msg_txt)
-            else:
-                raise
-
-        for pn, exp_value in urole_input_props.items():
-            assert urole.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-        urole.pull_full_properties()
-        for pn, exp_value in urole_input_props.items():
-            assert urole.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-        for pn, exp_value in urole_auto_props.items():
-            assert urole.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
-
-        # Test updating a property of the user role
-
-        new_desc = "Updated user role description."
-
-        # The code to be tested
-        urole.update_properties(dict(description=new_desc))
-
-        assert urole.properties['description'] == new_desc
-        urole.pull_full_properties()
-        assert urole.properties['description'] == new_desc
-
-        # Test that user roles cannot be renamed
-
-        with pytest.raises(zhmcclient.HTTPError) as exc_info:
-
-            # The code to be tested
-            urole.update_properties(dict(name=urole_name_new))
-
-        exc = exc_info.value
-        assert exc.http_status == 400
-        assert exc.reason == 6
-        with pytest.raises(zhmcclient.NotFound):
-            console.user_roles.find(name=urole_name_new)
-
-        # Test deleting the user role
-
-        # The code to be tested
+    # Ensure a clean starting point for this test
+    try:
+        urole = console.user_roles.find(name=urole_name)
+    except zhmcclient.NotFound:
+        pass
+    else:
+        warnings.warn(
+            "Deleting test user role from previous run: '{p}'".
+            format(p=urole_name), UserWarning)
         urole.delete()
 
-        with pytest.raises(zhmcclient.NotFound):
-            console.user_roles.find(name=urole_name)
+    # Test creating the user role
+
+    urole_input_props = {
+        'name': urole_name,
+        'description': 'Test user role for zhmcclient end2end tests',
+    }
+    urole_auto_props = {
+        'type': 'user-defined',
+        'is-inheritance-enabled': False,
+    }
+
+    # The code to be tested
+    try:
+        urole = console.user_roles.create(
+            urole_input_props)
+    except zhmcclient.HTTPError as exc:
+        if exc.http_status == 403 and exc.reason == 1:
+            msg_txt = "HMC userid '{u}' is not authorized for the " \
+                "'Manage User Roles' task on HMC {h}". \
+                format(u=hd.hmc_userid, h=hd.hmc_host)
+            warnings.warn(msg_txt, End2endTestWarning)
+            pytest.skip(msg_txt)
+        else:
+            raise
+
+    for pn, exp_value in urole_input_props.items():
+        assert urole.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+    urole.pull_full_properties()
+    for pn, exp_value in urole_input_props.items():
+        assert urole.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+    for pn, exp_value in urole_auto_props.items():
+        assert urole.properties[pn] == exp_value, \
+            "Unexpected value for property {!r}".format(pn)
+
+    # Test updating a property of the user role
+
+    new_desc = "Updated user role description."
+
+    # The code to be tested
+    urole.update_properties(dict(description=new_desc))
+
+    assert urole.properties['description'] == new_desc
+    urole.pull_full_properties()
+    assert urole.properties['description'] == new_desc
+
+    # Test that user roles cannot be renamed
+
+    with pytest.raises(zhmcclient.HTTPError) as exc_info:
+
+        # The code to be tested
+        urole.update_properties(dict(name=urole_name_new))
+
+    exc = exc_info.value
+    assert exc.http_status == 400
+    assert exc.reason == 6
+    with pytest.raises(zhmcclient.NotFound):
+        console.user_roles.find(name=urole_name_new)
+
+    # Test deleting the user role
+
+    # The code to be tested
+    urole.delete()
+
+    with pytest.raises(zhmcclient.NotFound):
+        console.user_roles.find(name=urole_name)


### PR DESCRIPTION
No review needed.