### PR TITLE
End2end test: Fixed volatility of CPC property 'last-energy-advice-time'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -53,6 +53,9 @@ Released: not yet
 * End2end test: Made user test tolerant against missing passweord rule 'Basic'.
   (issue #960)
 
+* End2end test: Added CPC property 'last-energy-advice-time' to the list of
+  volatile CPC properties in 'test_cpc_find_list()'.
+
 **Enhancements:**
 
 * End2end test: Changed the checking of the HMC definition files for end2end

--- a/tests/end2end/test_cpc.py
+++ b/tests/end2end/test_cpc.py
@@ -44,6 +44,7 @@ CPC_LIST_PROPS_Z15 = [
 
 # Properties whose values can change between retrievals
 CPC_VOLATILE_PROPS = [
+    'last-energy-advice-time',
     'zcpc-ambient-temperature',
     'zcpc-dew-point',
     'zcpc-exhaust-temperature',


### PR DESCRIPTION
No review needed.