### PR TITLE
Made fixtureid functions tolerant against pytest NotSetType

### DIFF
--- a/zhmcclient/testutils/_cpc_fixtures.py
+++ b/zhmcclient/testutils/_cpc_fixtures.py
@@ -37,8 +37,9 @@ def fixtureid_cpcs(fixture_value):
 
       * fixture_value (list of zhmcclient.Cpc): The list of CPCs.
     """
+    if not isinstance(fixture_value, list):
+        return None  # Use pytest auto-generated ID
     cpc_list = fixture_value
-    assert isinstance(cpc_list, list)
     cpcs_str = ','.join([cpc.name for cpc in cpc_list])
     return "CPCs={}".format(cpcs_str)
 

--- a/zhmcclient/testutils/_hmc_definition_fixtures.py
+++ b/zhmcclient/testutils/_hmc_definition_fixtures.py
@@ -48,8 +48,9 @@ def fixtureid_hmc_definition(fixture_value):
       * fixture_value (HMCDefinition): The HMC definition of the HMC the test
         runs against.
     """
+    if not isinstance(fixture_value, HMCDefinition):
+        return None  # Use pytest auto-generated ID
     hd = fixture_value
-    assert isinstance(hd, HMCDefinition)
     show_hmc = False  # Enable to show HMC/userid or mock file in tests
     if not show_hmc:
         hmc_str = ""


### PR DESCRIPTION
For details, see the commit message.
No review needed.