### PR TITLE
Extended auto-update support to cover resources that no longer exist

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,11 @@ Released: not yet
 
 * Mocked HMC definitions now require userid and password in the vault file.
 
+* Auto-updated resources now auto-detect if the corresponding HMC resource no
+  longer exists and accessing the zhmcclient resource in that case with certain
+  attributes and methods causes a new `zhmcclient.CeasedExistence` exception to
+  be raised. The documentation shows which attributes and methods do that.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -66,6 +71,13 @@ Released: not yet
   an HMC to a HMC definition file for use as a mock definition.
 
 * Improved mock support for password rules by creating default properties.
+
+* Auto-updated resources now auto-detect if the corresponding HMC resource no
+  longer exists. This can be tested with a new `ceased_existence` attribute on
+  the resources. Accessing the zhmcclient resource in that case with certain
+  attributes and methods causes a new `zhmcclient.CeasedExistence` exception to
+  be raised. The documentation shows which attributes and methods do that.
+  (Issue #996)
 
 **Cleanup:**
 

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -256,6 +256,12 @@ Exceptions
    :autosummary-inherited-members:
    :special-members: __str__
 
+.. autoclass:: zhmcclient.CeasedExistence
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
 
 .. _`Constants`:
 

--- a/examples/show_auto_update.py
+++ b/examples/show_auto_update.py
@@ -100,11 +100,18 @@ try:
 
         print("Entering loop that displays property '{}' of partition objects "
               "1 and 2".format(part_prop))
-        print("\n==> Update property '{}' of partition '{}' on CPC '{}' from "
-              "another session\n".format(part_prop, part_name, cpc.name))
+        print("")
+        print("==> Update property '{}' of partition '{}' on CPC '{}' from "
+              "another session".format(part_prop, part_name, cpc.name))
+        print("==> Delete partition '{}' on CPC '{}' from another "
+              "session".format(part_name, cpc.name))
+        print("")
         try:
             while True:
-                value1 = partition1.prop(part_prop)
+                try:
+                    value1 = partition1.prop(part_prop)
+                except zhmcclient.CeasedExistence:
+                    value1 = 'N/A'
                 value2 = partition2.prop(part_prop)
                 print("Property '{}' on partition objects 1: {!r}, 2: {!r}".
                       format(part_prop, value1, value2))

--- a/tests/end2end/test_resource_auto_update.py
+++ b/tests/end2end/test_resource_auto_update.py
@@ -1,0 +1,201 @@
+# Copyright 2022 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for auto-updated resources (on CPCs in DPM mode).
+
+These tests use partitions to test the auto-updating of resources. They do not
+change any existing partitions, but create, modify and delete test partitions.
+"""
+
+from __future__ import absolute_import, print_function
+
+import uuid
+from time import sleep
+import pytest
+from requests.packages import urllib3
+
+import zhmcclient
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from .utils import TEST_PREFIX, standard_partition_props
+
+urllib3.disable_warnings()
+
+
+def test_autoupdate_prop(dpm_mode_cpcs):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test auto-updated partitions when updating a property.
+    """
+    if not dpm_mode_cpcs:
+        pytest.skip("HMC definition does not include any CPCs in DPM mode")
+
+    for cpc in dpm_mode_cpcs:
+        assert cpc.dpm_enabled
+
+        print("Testing on CPC {c}".format(c=cpc.name))
+
+        part_name = "{}_{}".format(TEST_PREFIX, uuid.uuid4().hex)
+
+        # Create the partition
+        part_input_props = standard_partition_props(cpc, part_name)
+        part = cpc.partitions.create(part_input_props)
+
+        try:
+
+            # Get a second zhmcclient object for the same partition, which will
+            # be auto-updated
+            part_auto = cpc.partitions.find(name=part_name)
+
+            # Enable auto-update for the second partition
+            part_auto.enable_auto_update()
+
+            # Save some properties
+            org_desc = part_auto.get_property('description')
+            org_name = part_auto.name
+            org_uri = part_auto.uri
+
+            # Change the 'description' property through the first partition
+            # object
+            new_desc = org_desc + ' new'
+            part.update_properties({'description': new_desc})
+
+            # Test that the property change auto-updates the second partition
+            # object.
+            # We allow for some delay here, but in actual tests, the JMS message
+            # about the change arrived faster than the operation response:
+            #   07:20:59,817 Request Update Partition Properties
+            #   07:21:00,529 JMS message for property change notification
+            #   07:21:00,530 Response Update Partition Properties
+            attempts = 20
+            delay = 0.1  # seconds
+            for _ in range(attempts):
+                desc_auto = part_auto.properties['description']
+                if desc_auto == new_desc:
+                    break
+                sleep(delay)
+            assert desc_auto == new_desc, \
+                "Property did not auto-update after {} seconds". \
+                format(attempts * delay)
+
+            # Delete the partition through the first partition object
+            part.delete()
+
+            # Test that the second partition object is in ceased-existence
+            # state.
+            # We allow for some delay here, but in actual tests, the JMS message
+            # about the change arrived faster than the operation response:
+            #   07:21:00,532 Request Delete Partition
+            #   07:21:02,735 JMS message for inventory change notification
+            #   07:21:02,809 Response Delete Partition
+            attempts = 20
+            delay = 0.1  # seconds
+            for _ in range(attempts):
+                ceased = part_auto.ceased_existence
+                if ceased:
+                    break
+                sleep(delay)
+            assert ceased, \
+                "Ceased-existence state did not auto-update after {} seconds". \
+                format(attempts * delay)
+
+            # Test that accessing certain properties/methods on the
+            # second (auto-updated) partition raises CeasedExistence
+
+            with pytest.raises(zhmcclient.CeasedExistence) as exc_info:
+                _ = part_auto.get_property('description')
+            exc = exc_info.value
+            assert exc.resource_uri == part.uri
+
+            with pytest.raises(zhmcclient.CeasedExistence) as exc_info:
+                _ = part_auto.prop('description')
+            exc = exc_info.value
+            assert exc.resource_uri == part.uri
+
+            with pytest.raises(zhmcclient.CeasedExistence) as exc_info:
+                part_auto.pull_full_properties()
+            exc = exc_info.value
+            assert exc.resource_uri == part.uri
+
+            with pytest.raises(zhmcclient.CeasedExistence) as exc_info:
+                _ = part_auto.dump()
+            exc = exc_info.value
+            assert exc.resource_uri == part.uri
+
+            # Test that accessing certain properties/methods on the
+            # second (auto-updated) partition does not raise CeasedExistence
+
+            uri = part_auto.uri
+            assert uri == org_uri
+
+            name = part_auto.name
+            assert name == org_name
+
+            desc = part_auto.properties['description']
+            assert desc == new_desc
+
+            _ = part_auto.manager
+
+            _ = part_auto.full_properties
+
+            _ = part_auto.properties_timestamp
+
+            ce = part_auto.ceased_existence
+            assert ce is True
+
+            _ = str(part_auto)
+
+            _ = repr(part_auto)
+
+            # Test that accessing properties of the first partition does not
+            # raise CeasedExistence
+
+            desc = part.get_property('description')
+            assert desc == new_desc
+
+            desc = part.prop('description')
+            assert desc == new_desc
+
+            ce = part.ceased_existence
+            assert ce is False
+
+            # Test that using methods of the first partition that need to
+            # use the partition on the HMC raise HTTP 404.1
+
+            with pytest.raises(zhmcclient.HTTPError) as exc_info:
+                part.pull_full_properties()
+            exc = exc_info.value
+            assert exc.http_status == 404 and exc.reason == 1
+
+            with pytest.raises(zhmcclient.HTTPError) as exc_info:
+                _ = part.dump()
+            exc = exc_info.value
+            assert exc.http_status == 404 and exc.reason == 1
+
+        finally:
+            # We want to make sure the test partition gets cleaned up after
+            # the test, e.g. if the test is interrupted with Ctrl-C.
+            try:
+                part.delete()
+            except zhmcclient.HTTPError as exc:
+                # Since it normally will have been deleted already, we need to
+                # allow for "not found".
+                if exc.http_status == 404 and exc.reason == 1:
+                    pass
+                else:
+                    raise

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -24,7 +24,8 @@ __all__ = ['Error', 'ConnectionError', 'ConnectTimeout', 'ReadTimeout',
            'ServerAuthError', 'ParseError', 'VersionError', 'HTTPError',
            'OperationTimeout', 'StatusTimeout', 'NoUniqueMatch', 'NotFound',
            'MetricsResourceNotFound', 'NotificationError',
-           'NotificationJMSError', 'NotificationParseError', 'ConsistencyError']
+           'NotificationJMSError', 'NotificationParseError', 'ConsistencyError',
+           'CeasedExistence']
 
 
 class Error(Exception):
@@ -1382,3 +1383,56 @@ class ConsistencyError(Error):
     Derived from :exc:`~zhmcclient.Error`.
     """
     pass
+
+
+class CeasedExistence(Error):
+    # pylint: disable=abstract-method
+    """
+    This exception indicates that the corresponding HMC resource for an
+    auto-updated zhmcclient resource no longer exists.
+
+    This exception will only be raised for zhmcclient resources that are
+    enabled for :ref:`auto-update <Auto-updating of resources>`.
+
+    Derived from :exc:`~zhmcclient.Error`.
+    """
+
+    def __init__(self, resource_uri):
+        """
+        Parameters:
+
+          resource_uri (:term:`string`):
+            URI of the resource that no longer exists.
+
+        ``args[0]`` will be set to a default message.
+        """
+        msg = "Resource no longer exists: {}".format(resource_uri)
+        super(CeasedExistence, self).__init__(msg)
+        self._resource_uri = resource_uri
+
+    @property
+    def resource_uri(self):
+        """
+        :term:`string`: The URI of the resource that no longer exists.
+        """
+        return self._resource_uri
+
+    def __repr__(self):
+        """
+        Return a string with the state of this exception object, for debug
+        purposes.
+        """
+        return "{}(message={!r}, resource_uri={!r})". \
+            format(self.__class__.__name__, self.args[0], self.resource_uri)
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; message={}; resource_uri={}
+        """
+        return "classname={!r}; message={!r}; resource_uri={!r}". \
+            format(self.__class__.__name__, self.args[0], self.resource_uri)

--- a/zhmcclient/testutils/_hmc_definition_fixtures.py
+++ b/zhmcclient/testutils/_hmc_definition_fixtures.py
@@ -146,6 +146,11 @@ def setup_hmc_session(hd):
                 logger.addHandler(LOG_HANDLER)
             logger.setLevel(logging.DEBUG)
 
+            logger = logging.getLogger('zhmcclient.jms')
+            if LOG_HANDLER not in logger.handlers:
+                logger.addHandler(LOG_HANDLER)
+            logger.setLevel(logging.DEBUG)
+
         rt_config = zhmcclient.RetryTimeoutConfig(
             read_timeout=300,
         )


### PR DESCRIPTION
For details, see the commit message.

Particular review points:
* Behavior when using properties or methods of auto-updated resources that no longer exist on the HMC. Which ones should raise the `CeasedExistence` exception?