### PR TITLE
Fixed dumping of HMC definitions; Added dump_hmc_definition.py example

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,8 @@ Released: not yet
 
 **Incompatible changes:**
 
+* Mocked HMC definitions now require userid and password in the vault file.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -45,6 +47,10 @@ Released: not yet
 * Fixed an AttributeError on 'HMCDefinition.filepath' when using the testutils
   support for mocked environments. (issue #1001)
 
+* Fixed the 'dump()' method on the Client class and other resource classes
+  to accomodate for HBAs on z14 and later, unconfigured FICON adapters, and
+  presence of unmanaged CPCs.
+
 **Enhancements:**
 
 * Relative path names for mock files specified in the HMC inventory file are
@@ -55,6 +61,9 @@ Released: not yet
   'FakedSession.from_hmc_yaml_file()' method and to the methods it calls, in
   order to use a userid to log on to the mocked HMC, consistent with real HMCs.
   (part of issue #1001)
+
+* Added a dump_hmc_definition.py example script that dumps the resources of
+  an HMC to a HMC definition file for use as a mock definition.
 
 **Cleanup:**
 

--- a/examples/dump_hmc_definition.py
+++ b/examples/dump_hmc_definition.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Copyright 2022 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example that inspects an HMC and dumps it as a HMC definition file.
+"""
+
+import sys
+import requests.packages.urllib3
+
+import zhmcclient
+from zhmcclient.testutils import hmc_definitions
+
+requests.packages.urllib3.disable_warnings()
+
+# Get HMC info from HMC inventory and vault files
+hmc_def = hmc_definitions()[0]
+nickname = hmc_def.nickname
+host = hmc_def.host
+userid = hmc_def.userid
+password = hmc_def.password
+verify_cert = hmc_def.verify_cert
+
+hmc_yaml_file = 'hmc_definition.yaml'
+
+print(__doc__)
+
+print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+
+print("Creating a session with the HMC ...")
+try:
+    session = zhmcclient.Session(
+        host, userid, password, verify_cert=verify_cert)
+except zhmcclient.Error as exc:
+    print("Error: Cannot establish session with HMC {}: {}: {}".
+          format(host, exc.__class__.__name__, exc))
+    sys.exit(1)
+
+try:
+    client = zhmcclient.Client(session)
+
+    print("Dumping HMC resources as an HMC definition ...")
+    hmc_yaml_str = client.to_hmc_yaml()
+
+    print("Writing HMC definition to file: {}".format(hmc_yaml_file))
+    with open(hmc_yaml_file, 'w') as fp:
+        fp.write(hmc_yaml_str)
+
+finally:
+    print("Logging off ...")
+    session.logoff()

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -289,12 +289,7 @@ def assert_equal_hmc(hmc1, hmc2):
             lsd2 = lsds2[j]
             assert_equal_resource(lsd1, lsd2)
 
-        unmanaged_cpcs1 = console1.unmanaged_cpcs.list()
-        unmanaged_cpcs2 = console2.unmanaged_cpcs.list()
-        assert len(unmanaged_cpcs1) == len(unmanaged_cpcs2)
-        for j, unmanaged_cpc1 in enumerate(unmanaged_cpcs1):
-            unmanaged_cpc2 = unmanaged_cpcs2[j]
-            assert_equal_resource(unmanaged_cpc1, unmanaged_cpc2)
+        # Do not compare unmanaged CPCs, since they are not dumped.
 
         storage_groups1 = console1.storage_groups.list()
         storage_groups2 = console2.storage_groups.list()
@@ -338,12 +333,14 @@ def assert_equal_hmc(hmc1, hmc2):
                 nic2 = nics2[k]
                 assert_equal_resource(nic1, nic2)
 
-            hbas1 = partition1.hbas.list()
-            hbas2 = partition2.hbas.list()
-            assert len(hbas1) == len(hbas2)
-            for k, hba1 in enumerate(hbas1):
-                hba2 = hbas2[k]
-                assert_equal_resource(hba1, hba2)
+            if partition1.hbas is not None and partition2.hbas is not None:
+                # z14 and above do not have .hbas set
+                hbas1 = partition1.hbas.list()
+                hbas2 = partition2.hbas.list()
+                assert len(hbas1) == len(hbas2)
+                for k, hba1 in enumerate(hbas1):
+                    hba2 = hbas2[k]
+                    assert_equal_resource(hba1, hba2)
 
             vfs1 = partition1.virtual_functions.list()
             vfs2 = partition2.virtual_functions.list()
@@ -359,12 +356,14 @@ def assert_equal_hmc(hmc1, hmc2):
             adapter2 = adapters2[j]
             assert_equal_resource(adapter1, adapter2)
 
-            ports1 = adapter1.ports.list()
-            ports2 = adapter2.ports.list()
-            assert len(ports1) == len(ports2)
-            for k, port1 in enumerate(ports1):
-                port2 = ports2[k]
-                assert_equal_resource(port1, port2)
+            if adapter1.properties.get('type', None) != 'not-configured':
+                # Unconfigured FICON adapters cannot retrieve port properties
+                ports1 = adapter1.ports.list()
+                ports2 = adapter2.ports.list()
+                assert len(ports1) == len(ports2)
+                for k, port1 in enumerate(ports1):
+                    port2 = ports2[k]
+                    assert_equal_resource(port1, port2)
 
         vss1 = cpc1.virtual_switches.list()
         vss2 = cpc2.virtual_switches.list()

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -851,11 +851,11 @@ class Console(BaseResource):
         ldap_server_definitions = self.ldap_server_definitions.dump()
         if ldap_server_definitions:
             resource_dict['ldap_server_definitions'] = ldap_server_definitions
-        unmanaged_cpcs = self.unmanaged_cpcs.dump()
-        if unmanaged_cpcs:
-            resource_dict['unmanaged_cpcs'] = unmanaged_cpcs
         storage_groups = self.storage_groups.dump()
         if storage_groups:
             resource_dict['storage_groups'] = storage_groups
+
+        # Note: Unmanaged CPCs are not dumped, since their properties cannot
+        #       be retrieved.
 
         return resource_dict

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -1344,9 +1344,11 @@ class Partition(BaseResource):
         nics = self.nics.dump()
         if nics:
             resource_dict['nics'] = nics
-        hbas = self.hbas.dump()
-        if hbas:
-            resource_dict['hbas'] = hbas
+        if self.hbas is not None:
+            # Note: z14 and later do not have HBAs
+            hbas = self.hbas.dump()
+            if hbas:
+                resource_dict['hbas'] = hbas
         virtual_functions = self.virtual_functions.dump()
         if virtual_functions:
             resource_dict['virtual_functions'] = virtual_functions


### PR DESCRIPTION
For details, see the commit message.