### PR TITLE
1.3: Made the 'JMS_LOGGER_NAME' symbol publicly available

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,9 @@ Released: not yet
 * Addressed issues discovered by Pylint 2.10 and higher (it was pinned to 2.7.0
   before).
 
+* Made the `JMS_LOGGER_NAME` symbol publicly available, in order for users
+  to have a symbol for the JMS logger name.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -34,6 +34,7 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'DEFAULT_STATUS_TIMEOUT',
            'DEFAULT_NAME_URI_CACHE_TIMETOLIVE',
            'HMC_LOGGER_NAME',
+           'JMS_LOGGER_NAME',
            'API_LOGGER_NAME',
            'HTML_REASON_WEB_SERVICES_DISABLED',
            'HTML_REASON_OTHER']


### PR DESCRIPTION
Rolls back PR #1009 into 1.3.1.