### PR TITLE
1.4: Fixed a flake8 AttributeError by pinning importlib-metadata

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -27,6 +27,8 @@ pytest>=4.3.1; python_version >= '3.5' and python_version <= '3.6'
 pytest>=4.4.0; python_version >= '3.7' and python_version <= '3.9'
 pytest>=6.2.5; python_version >= '3.10'
 testfixtures>=6.9.0
+importlib-metadata>=0.22,<5.0.0; python_version <= '3.7'
+importlib-metadata>=1.1.0; python_version >= '3.8'
 mock>=2.0.0 # BSD
 # requests: covered in direct deps for installation
 requests-mock>=1.6.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed a flake8 AttributeError when using importlib-metadata 5.0.0 on
+  Python >=3.7, by pinning importlib-metadata to <5.0.0 on these Python versions.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -137,6 +137,7 @@ testfixtures==6.9.0
 colorama==0.3.9; python_version == '2.7'
 colorama==0.4.0; python_version >= '3.5'
 importlib-metadata==0.22; python_version <= '3.7'
+importlib-metadata==1.1.0; python_version >= '3.8'
 mock==2.0.0
 more-itertools==4.0.0
 # pytz: covered in direct deps for installation


### PR DESCRIPTION
Rolls back PR #1053 into 1.4.1.