### PR TITLE
1.5: Fixed install error of pywin32-ctypes on Windows with py38+

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -153,6 +153,8 @@ twine>=1.8.1,<2.0.0; python_version <= '3.5'
 twine>=3.0.0; python_version >= '3.6'
 # readme-renderer 23.0 has made cmarkgfm part of extras (it fails on Cygwin)
 readme-renderer>=23.0
+# twine uses keyring, and keyring requires pywin32-ctypes!=0.1.0,0.1.1 but 0.2.0 is required on py38+
+pywin32-ctypes>=0.2.0; sys_platform=="win32"
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
 jupyter>=1.0.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,9 @@ Released: not yet
 
 * Accomodated use of Ubuntu 22.04 in Github Actions as the default ubuntu.
 
+* Fixed install error of twine -> keyring dependency pywin32-ctypes on Windows
+  with Python 3.8 and higher. (issue #1078)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -214,6 +214,7 @@ functools32==3.2.3.post2; python_version == '2.7'  # technically: python_version
 twine==1.8.1; python_version <= '3.5'
 twine==3.0.0; python_version >= '3.6'
 readme-renderer==23.0
+pywin32-ctypes==0.2.0; sys_platform=="win32"
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
 jupyter==1.0.0


### PR DESCRIPTION
Rolls back PR #1079 into 1.5.1.