### PR TITLE
Fixed docs issues & missing datetime_from_timestamp/timestamp_from_datetime

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -208,7 +208,7 @@ Released: 2022-05-17
   (issues #950, #986)
 
 * Renamed the properties of the 'zhmcclient.testutils.HMCDefinition' to remove
-  the 'hmc_' prefix, e.g. 'hmc_userid' became 'userid', etc. (part of issue #986)
+  the 'hmc&nbsp;_' prefix, e.g. 'hmc_userid' became 'userid', etc. (part of issue #986)
 
 **Bug fixes:**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ sys.stdout.flush()
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -518,7 +518,7 @@ intersphinx_cache_limit = 5
 
 extlinks = {
     'nbview': ('http://nbviewer.jupyter.org/github/zhmcclient/'
-               'python-zhmcclient/blob/master/docs/notebooks/%s', ''),
+               'python-zhmcclient/blob/master/docs/notebooks/%s', None),
     'nbdown': ('https://github.com/zhmcclient/python-zhmcclient/'
-               'raw/master/docs/notebooks/%s', '')
+               'raw/master/docs/notebooks/%s', None)
 }

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -31,7 +31,7 @@ import six
 import pytz
 from requests.utils import quote
 
-__all__ = []
+__all__ = ['datetime_from_timestamp', 'timestamp_from_datetime']
 
 
 _EPOCH_DT = datetime(1970, 1, 1, 0, 0, 0, 0, pytz.utc)


### PR DESCRIPTION
For details, see the commit message.
This fixes the recent weekend build issue on Python 3.10