### PR TITLE
Fixed incorrect list of managers in MetricsResourceNotFound when CPC not found

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,9 @@ Released: not yet
   only needed when performing end2end tests, or when using the example scripts.
   The extra can be installed with 'pip install zhmcclient[testutils]'.
 
+* Fixed incorrect list of managers in 'managers' attribute of zhmcclient
+  exception 'MetricsResourceNotFound' when a CPC was not found. (issue #1120)
+
 **Enhancements:**
 
 * Added missing test environments (Python >=3.6 on MacOS and Windows) to the

--- a/zhmcclient/_metrics.py
+++ b/zhmcclient/_metrics.py
@@ -877,7 +877,7 @@ class MetricObjectValues(object):
         resource_uri = self.resource_uri
 
         if resource_class == 'cpc':
-            cpc_managers = [self.client]
+            cpc_managers = [self.client.cpcs]
             filter_args = {'object-uri': resource_uri}
             try:
                 resource = self.client.cpcs.find(**filter_args)


### PR DESCRIPTION
For details, see the commit message.
Tested the bug fix with zhmc-prometheus-exporter.
No review needed.