### PR TITLE
Improved docs of HMC inventory & vault files and testutils module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,8 @@ doc_dependent_files := \
     $(wildcard $(doc_conf_dir)/*.rst) \
     $(wildcard $(doc_conf_dir)/notebooks/*.ipynb) \
     $(package_py_files) \
+    examples/example_hmc_inventory.yaml \
+    examples/example_hmc_vault.yaml \
 
 # Directory with test source files
 test_dir := tests

--- a/examples/example_hmc_inventory.yaml
+++ b/examples/example_hmc_inventory.yaml
@@ -1,41 +1,12 @@
 ---
-# HMC inventory file for zhmcclient.testutils
+# HMC inventory file for zhmcclient projects
 #
 # This file defines real HMCs and mocked HMCs (using the zhmcclient mock
-# support) for use by the zhmcclient.testutils module of the python-zhmcclient
-# project.
+# support) for use by the zhmcclient projects. Their credentials are defined
+# in a corresponding HMC vault file.
 #
-# The file must have the format defined in
-# zhmcclient/testutils/hmc_inventory_file.py of the python-zhmcclient project.
-#
-# HMC inventory files conform to the format of Ansible inventory files in YAML
-# format and define specific host attributes for HMCs.
-#
-# Brief description of the HMC inventory file format:
-#
-#   all:  # the top-level HMC group
-#     hosts:
-#       <hmc_name>:  # DNS hostname, IP address, or nickname of HMC
-#         description: <string>
-#         contact: <string>
-#         access_via: <string>
-#         ansible_host: <host>  # if real HMC and nickname is used
-#         mock_file: <path_name>  # if mocked HMC
-#         cpcs:  # expected CPCs managed by the HMC
-#           <cpc_name>:  # CPC name
-#             <prop_name>: <prop_value>  # expected CPC properties
-#         <var_name>: <var_value>  # additional variables for HMC
-#     vars:
-#       <var_name>: <var_value>  # additional variables for all HMCs in group
-#     children:
-#       <group_name>:  # a child HMC group
-#         hosts: ...  # variables are inherited from parent group
-#         vars: ...
-#         children: ...
-#
-# Notes for this example file:
-# * To use this example file, copy it to `~/.zhmc_inventory.yaml` which is the
-#   default path name used.
+# The format of HMC inventory files is described in
+# https://python-zhmcclient.readthedocs.io/en/latest/development.html#hmc-inventory-file
 
 all:
   hosts:

--- a/examples/example_hmc_vault.yaml
+++ b/examples/example_hmc_vault.yaml
@@ -1,28 +1,12 @@
 ---
-# HMC vault file for zhmcclient.testutils
+# HMC vault file for zhmcclient projects
 #
-# This file defines the credentials for real HMCs for use by the
-# zhmcclient.testutils module of the python-zhmcclient project.
+# This file defines the credentials for real HMCs for use by the zhmcclient
+# projects. Their HMC definitions are specified in a corresponding HMC inventory
+# file.
 #
-# The file must have the format defined in
-# zhmcclient/testutils/hmc_vault_file.py of the python-zhmcclient project.
-#
-# HMC vault files conform to the format of Ansible vault files in YAML
-# format and define specific variables for HMC authentication.
-#
-# Brief description of the file format:
-#
-#   hmc_auth:
-#     <hmc_name>:  # DNS hostname, IP address, or nickname of HMC
-#       userid: <userid>
-#       password: <password>
-#       verify: <verify>
-#       ca_certs: <ca_certs>
-#   <var_name>: <var_value>  # allowed but ignored
-#
-# Notes for this example file:
-# * To use this example file, copy it to `~/.zhmc_vault.yaml` which is the
-#   default path name used.
+# The format of HMC vault files is described in
+# https://python-zhmcclient.readthedocs.io/en/latest/development.html#hmc-vault-file
 
 hmc_auth:
 

--- a/zhmcclient/testutils/__init__.py
+++ b/zhmcclient/testutils/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-zhmcclient.testutils - Utilities for testing against (real or mocked) HMCs.
+zhmcclient.testutils - Utilities for testing against real or mocked HMCs.
 """
 
 from __future__ import absolute_import

--- a/zhmcclient/testutils/_cpc_fixtures.py
+++ b/zhmcclient/testutils/_cpc_fixtures.py
@@ -51,8 +51,11 @@ def fixtureid_cpcs(fixture_value):
 def all_cpcs(request, hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name,unused-argument
     """
-    Pytest fixture representing the set of all CPCs that are defined in the HMC
-    definition file for the selected HMC or HMC group.
+    Pytest fixture representing the set of all CPCs to test against, regardless
+    of their operational mode.
+
+    The CPCs to test against are defined in the ``cpcs`` variable for the
+    HMC entry in the :ref:`HMC inventory file`.
 
     A test function parameter using this fixture resolves to a list of
     :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
@@ -72,8 +75,11 @@ def all_cpcs(request, hmc_session):  # noqa: F811
 def dpm_mode_cpcs(request, hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name,unused-argument
     """
-    Pytest fixture representing the set of CPCs in DPM mode that are
-    defined in the HMC definition file for the selected HMC or HMC group.
+    Pytest fixture representing the set of CPCs in DPM mode to test against.
+
+    The CPCs to test against are defined in the ``cpcs`` variable in the
+    HMC entry in the :ref:`HMC inventory file` and have their ``dpm_enabled``
+    property set to ``true``.
 
     A test function parameter using this fixture resolves to a list of
     :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
@@ -93,8 +99,11 @@ def dpm_mode_cpcs(request, hmc_session):  # noqa: F811
 def classic_mode_cpcs(request, hmc_session):  # noqa: F811
     # pylint: disable=redefined-outer-name,unused-argument
     """
-    Pytest fixture representing the set of CPCs in classic mode that are
-    defined in the HMC definition file for the selected HMC or HMC group.
+    Pytest fixture representing the set of CPCs in classic mode to test against.
+
+    The CPCs to test against are defined in the ``cpcs`` variable in the
+    HMC entry in the :ref:`HMC inventory file` and have their ``dpm_enabled``
+    property set to ``false``.
 
     A test function parameter using this fixture resolves to a list of
     :class:`zhmcclient.Cpc` objects representing that set of CPCs. These

--- a/zhmcclient/testutils/_hmc_definition_fixtures.py
+++ b/zhmcclient/testutils/_hmc_definition_fixtures.py
@@ -70,8 +70,7 @@ def fixtureid_hmc_definition(fixture_value):
 )
 def hmc_definition(request):
     """
-    Fixture representing the set of HMC definitions to use for the end2end
-    tests.
+    Pytest fixture representing the set of HMC definitions to use for a test.
 
     A test function parameter using this fixture resolves to the
     :class:`~zhmcclient.testutils.HMCDefinition`
@@ -86,17 +85,21 @@ def hmc_definition(request):
 def hmc_session(request, hmc_definition):
     # pylint: disable=redefined-outer-name,unused-argument
     """
-    Pytest fixture representing the set of HMC sessions to use for the
-    end2end tests.
+    Pytest fixture representing the set of HMC sessions to run a test against.
+
+    A test function parameter using this fixture resolves to the
+    :class:`zhmcclient.Session` or :class:`zhmcclient_mock.FakedSession` object
+    for each HMC to test against.
+
+    The session is already logged on to the HMC.
+
+    The session object has an additional property named ``hmc_definition``
+    that is the :class:`~zhmcclient.testutils.HMCDefinition` object for the
+    corresponding HMC definition in the :ref:`HMC inventory file`.
 
     Because the `hmc_definition` parameter of this fixture is again a fixture,
     the :func:`zhmcclient.testutils.hmc_definition` function needs to be
     imported as well when this fixture is used.
-
-    A test function parameter using this fixture resolves to the
-    :class:`zhmcclient.Session` or :class:`zhmcclient_mock.FakedSession` object
-    for the HMC session to test against.
-    The session is already logged on to the HMC.
 
     Upon fixture teardown, the session is automatically logged off from the HMC.
     """
@@ -107,13 +110,13 @@ def hmc_session(request, hmc_definition):
 
 def setup_hmc_session(hd):
     """
-    Setup an HMC session and return a new zhmcclient.Session object for it.
+    Setup an HMC session and return a new session object for it.
 
     If the HMC definition represents a real HMC, log on to an HMC and return
-    a new zhmcclient.Session object.
+    a new :class:`zhmcclient.Session` object.
 
     If the HMC definition represents a mocked HMC, create a new mock environment
-    from that and return a zhmcclient_mock.FakedSession object.
+    from that and return a :class:`zhmcclient_mock.FakedSession` object.
     """
     # We use the cached skip reason from previous attempts
     skip_msg = getattr(hd, 'skip_msg', None)

--- a/zhmcclient/testutils/_hmc_definitions.py
+++ b/zhmcclient/testutils/_hmc_definitions.py
@@ -49,7 +49,9 @@ def hmc_definitions(load=True):
 
     Parameters:
 
-      load (bool): Load the HMC inventory and vault files.
+      load (bool): Load the HMC inventory and vault files. Otherwise, these
+        files are not loaded. This is used to avoid a dependency on these
+        files for normal zhmcclient users.
         If `None`, the 'TESTEND2END_LOAD' environment variable is used.
 
     Returns:
@@ -98,21 +100,22 @@ def _default(vars_tuple, key, default):
 
 class HMCNoVaultError(Exception):
     """
-    The HMC vault file does not have a corresponding entry for the HMC.
+    The :ref:`HMC vault file` does not have a corresponding entry for the HMC.
     """
     pass
 
 
 class HMCNotFound(Exception):
     """
-    The HMC group was not found in the HMC inventory file.
+    The HMC group was not found in the :ref:`HMC inventory file`.
     """
     pass
 
 
 class HMCDefinitions(object):
     """
-    The HMC definitions in the HMC inventory and vault files.
+    The HMC definitions in the :ref:`HMC inventory file` and their credentials
+    in the :ref:`HMC vault file`.
     """
 
     def __init__(self, inventory_file=None, vault_file=None, testhmc=None,
@@ -120,20 +123,24 @@ class HMCDefinitions(object):
         """
         Parameters:
 
-          inventory_file (string): Path name of HMC inventory file.
+          inventory_file (string): Path name of HMC inventory file`.
             If `None`, the file specified in the 'TESTINVENTORY' environment
-            variable, or the default file in the user's home directory is used.
+            variable or if not set, the default file ``~/.zhmc_inventory.yaml``
+            is used.
 
           vault_file (string): Path name of HMC vault file.
             If `None`, the file specified in the 'TESTVAULT' environment
-            variable, or the default file in the user's home directory is used.
+            variable or if not set, the default file ``~/.zhmc_vault.yaml``
+            is used.
 
-          testhmc (string): Group name or HMC nickname in HMC inventory file
+          testhmc (string): Group nickname or HMC nickname in HMC inventory file
             to test against.
-            If `None`, the file specified in the 'TESTHMC' environment
-            variable, or the default name is used.
+            If `None`, the nickname specified in the 'TESTHMC' environment
+            variable or if not set, the nickname "default" is used.
 
-          load (bool): Load the HMC inventory and vault files.
+          load (bool): Load the HMC inventory and vault files. Otherwise, these
+            files are not loaded. This is used to avoid a dependency on these
+            files for normal zhmcclient users.
             If `None`, the 'TESTEND2END_LOAD' environment variable is used.
 
         Raises:

--- a/zhmcclient/testutils/_hmc_inventory_file.py
+++ b/zhmcclient/testutils/_hmc_inventory_file.py
@@ -226,14 +226,14 @@ HMC_INVENTORY_FILE_SCHEMA = {
 
 class HMCInventoryFileError(Exception):
     """
-    An error in the HMC inventory file.
+    An error in the :ref:`HMC inventory file`.
     """
     pass
 
 
 class HMCInventoryFile(object):
     """
-    Encapsulation of an HMC inventory file in YAML format.
+    Encapsulation of an :ref:`HMC inventory file` in YAML format.
     """
 
     def __init__(self, filepath):
@@ -243,7 +243,7 @@ class HMCInventoryFile(object):
 
     def _load_file(self):
         """
-        Load and validate the HMC inventory file in YAML format.
+        Load and validate the :ref:`HMC inventory file` in YAML format.
         """
         try:
             # pylint: disable=unspecified-encoding
@@ -295,14 +295,16 @@ class HMCInventoryFile(object):
     @property
     def filepath(self):
         """
-        string: Path name of the HMC inventory file.
+        string: Path name of the :ref:`HMC inventory file`.
         """
         return self._filepath
 
     @property
     def data(self):
         """
-        OrderedDict: Content of the HMC inventory file, as nested OrderedDict
-        and list objects.
+        :class:`~py:collections.OrderedDict`: Content of the
+        :ref:`HMC inventory file`, as nested
+        :class:`~py:collections.OrderedDict` and
+        :class:`~py:list` objects.
         """
         return self._data

--- a/zhmcclient/testutils/_hmc_vault_file.py
+++ b/zhmcclient/testutils/_hmc_vault_file.py
@@ -130,14 +130,14 @@ HMC_VAULT_FILE_SCHEMA = {
 
 class HMCVaultFileError(Exception):
     """
-    An error in the HMC vault file.
+    An error in the :ref:`HMC vault file`.
     """
     pass
 
 
 class HMCVaultFile(object):
     """
-    Encapsulation of an HMC vault file in YAML format.
+    Encapsulation of an :ref:`HMC vault file` in YAML format.
     """
 
     def __init__(self, filepath):
@@ -147,7 +147,7 @@ class HMCVaultFile(object):
 
     def _load_file(self):
         """
-        Load and validate the HMC vault file in YAML format.
+        Load and validate the :ref:`HMC vault file` in YAML format.
         """
         try:
             # pylint: disable=unspecified-encoding
@@ -199,14 +199,16 @@ class HMCVaultFile(object):
     @property
     def filepath(self):
         """
-        string: Path name of the HMC vault file.
+        string: Path name of the :ref:`HMC vault file`.
         """
         return self._filepath
 
     @property
     def data(self):
         """
-        OrderedDict: Content of the HMC vault file, as nested OrderedDict
-        and list objects.
+        :class:`~py:collections.OrderedDict`: Content of the
+        :ref:`HMC vault file`, as nested
+        :class:`~py:collections.OrderedDict` and
+        :class:`~py:list` objects.
         """
         return self._data


### PR DESCRIPTION
To read the updated documentation, run `make builddoc` with this branch checked out and read these sections:
* "Development" -> "Testing" -> "HMC inventory file"
* "Development" -> "Testing" -> "HMC vault file"
* "Development" -> "Developing tests" (new section, content was moved up from under "Testing")