### PR TITLE
Fixed coveralls issues with KeyError and HTTP 422 Unprocessable Entity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,6 +277,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true
         COVERALLS_FLAG_NAME: "${{ matrix.os }},${{ matrix.python-version }},${{ matrix.package_level }}"
+        COVERALLS_SERVICE_NAME: github
+        COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
+        COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
       run: |
         coveralls
     - name: Run installtest
@@ -301,5 +304,6 @@ jobs:
     - name: Send coverage finish to coveralls.io
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
       run: |
         coveralls --finish

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -64,8 +64,7 @@ coverage>=5.0
 pytest-cov>=2.7.0
 # coveralls 2.0 has removed support for Python 2.7
 git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-# TODO: Remove coveralls pinning to <3.0.0 once fixed (TheKevJames/coveralls-python#252)
-coveralls>=2.1.2,<3.0.0; python_version >= '3.5'
+coveralls>=3.3.0; python_version >= '3.5'
 # PyYAML: covered in direct deps for development
 
 # Safety CI by pyup.io

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -172,7 +172,7 @@ pluggy==0.13.0; python_version >= '3.7'
 coverage==5.0
 pytest-cov==2.7.0
 # handled by dev-requirements.txt: git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls==2.1.2; python_version >= '3.5'
+coveralls==3.3.0; python_version >= '3.5'
 
 # Safety CI by pyup.io
 # Safety is run only on Python >=3.6


### PR DESCRIPTION
After initially disabling coveralls reporting, I found a solution that seems to work reliably.
It required an update to the Python 2.7 version of coveralls-python on https://github.com/andy-maier/coveralls-python/tree/andy/add-py27.
This PR is ready for merge. No review needed.