### PR TITLE
Added pull_properties() method

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -68,6 +68,13 @@ Released: not yet
   is used with filters that can be handled by the HMC, because in such cases
   the resource properties do not need to be retrieved.
 
+* Added a 'pull_properties()' method to zhmcclient resource classes, that
+  performs a "Get Properties" HMC operation with the 'properties' query
+  parameter defined. This can be used to speed up certain property retrieval
+  operations, for example on the Console or on CPCs. (issue #862)
+
+* Test: Added end2end testcases for property retrieval.
+
 **Cleanup:**
 
 **Known issues:**

--- a/tests/end2end/test_adapter.py
+++ b/tests/end2end/test_adapter.py
@@ -32,8 +32,8 @@ from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import pick_test_resources, runtest_find_list, TEST_PREFIX, \
-    skip_warn, standard_partition_props
+from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
+    standard_partition_props, runtest_find_list, runtest_get_properties
 
 urllib3.disable_warnings()
 
@@ -76,6 +76,39 @@ def test_adapter_find_list(dpm_mode_cpcs):  # noqa: F811
                 session, cpc.adapters, adapter.name, 'name', 'object-uri',
                 ADAPTER_VOLATILE_PROPS, ADAPTER_MINIMAL_PROPS,
                 ADAPTER_LIST_PROPS)
+
+
+def test_adapter_property(dpm_mode_cpcs):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test property related methods
+    """
+    if not dpm_mode_cpcs:
+        pytest.skip("HMC definition does not include any CPCs in DPM mode")
+
+    for cpc in dpm_mode_cpcs:
+        assert cpc.dpm_enabled
+
+        client = cpc.manager.client
+        session = cpc.manager.session
+        hd = session.hmc_definition
+
+        # Pick the adapters to test with
+        adapter_list = cpc.adapters.list()
+        if not adapter_list:
+            skip_warn("No adapters on CPC {c} managed by HMC {h}".
+                      format(c=cpc.name, h=hd.host))
+        adapter_list = pick_test_resources(adapter_list)
+
+        for adapter in adapter_list:
+            print("Testing on CPC {c} with adapter {a!r}".
+                  format(c=cpc.name, a=adapter.name))
+
+            # Select a property that is not returned by list()
+            non_list_prop = 'description'
+
+            runtest_get_properties(
+                client, adapter.manager, non_list_prop, None)
 
 
 def test_adapter_hs_crud(dpm_mode_cpcs):  # noqa: F811

--- a/tests/end2end/test_capacity_group.py
+++ b/tests/end2end/test_capacity_group.py
@@ -31,8 +31,8 @@ from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import pick_test_resources, runtest_find_list, TEST_PREFIX, \
-    skip_warn
+from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
+    runtest_find_list, runtest_get_properties
 
 urllib3.disable_warnings()
 
@@ -74,6 +74,39 @@ def test_capgrp_find_list(dpm_mode_cpcs):  # noqa: F811
                 session, cpc.capacity_groups, capgrp.name, 'name',
                 'element-uri', CAPGRP_VOLATILE_PROPS, CAPGRP_MINIMAL_PROPS,
                 CAPGRP_LIST_PROPS)
+
+
+def test_capgrp_property(dpm_mode_cpcs):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test property related methods
+    """
+    if not dpm_mode_cpcs:
+        pytest.skip("HMC definition does not include any CPCs in DPM mode")
+
+    for cpc in dpm_mode_cpcs:
+        assert cpc.dpm_enabled
+
+        client = cpc.manager.client
+        session = cpc.manager.session
+        hd = session.hmc_definition
+
+        # Pick the capacity groups to test with
+        capgrp_list = cpc.capacity_groups.list()
+        if not capgrp_list:
+            skip_warn("No capacity groups defined on CPC {c} managed by "
+                      "HMC {h}".format(c=cpc.name, h=hd.host))
+        capgrp_list = pick_test_resources(capgrp_list)
+
+        for capgrp in capgrp_list:
+            print("Testing on CPC {c} with capacity group {g!r}".
+                  format(c=cpc.name, g=capgrp.name))
+
+            # Select a property that is not returned by list()
+            non_list_prop = 'description'
+
+            runtest_get_properties(
+                client, capgrp.manager, non_list_prop, None)
 
 
 def test_capgrp_crud(dpm_mode_cpcs):  # noqa: F811

--- a/tests/end2end/test_console.py
+++ b/tests/end2end/test_console.py
@@ -27,7 +27,7 @@ import zhmcclient
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import runtest_find_list
+from .utils import runtest_find_list, runtest_get_properties
 
 urllib3.disable_warnings()
 
@@ -55,3 +55,16 @@ def test_console_find_list(hmc_session):  # noqa: F811
         hmc_session, client.consoles, console.name, 'name',
         'object-uri', CONSOLE_VOLATILE_PROPS, CONSOLE_MINIMAL_PROPS,
         CONSOLE_LIST_PROPS)
+
+
+def test_console_property(hmc_session):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test property related methods
+    """
+    client = zhmcclient.Client(hmc_session)
+
+    # Select a property that is not returned by list()
+    non_list_prop = 'description'
+
+    runtest_get_properties(client, client.consoles, non_list_prop, (2, 15))

--- a/tests/end2end/test_cpc.py
+++ b/tests/end2end/test_cpc.py
@@ -28,7 +28,8 @@ from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 from zhmcclient.testutils import all_cpcs, classic_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import runtest_find_list, assert_res_prop, skip_warn
+from .utils import skip_warn, assert_res_prop, runtest_find_list, \
+    runtest_get_properties
 
 urllib3.disable_warnings()
 
@@ -105,6 +106,25 @@ def test_cpc_find_list(hmc_session):  # noqa: F811
         runtest_find_list(
             hmc_session, client.cpcs, cpc_name, 'name', 'status',
             CPC_VOLATILE_PROPS, CPC_MINIMAL_PROPS, cpc_list_props)
+
+
+def test_cpc_property(all_cpcs):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test property related methods
+    """
+    if not all_cpcs:
+        pytest.skip("HMC definition does not include any CPCs")
+
+    for cpc in all_cpcs:
+        print("Testing with CPC {c}".format(c=cpc.name))
+
+        client = cpc.manager.client
+
+        # Select a property that is not returned by list()
+        non_list_prop = 'description'
+
+        runtest_get_properties(client, cpc.manager, non_list_prop, (2, 14))
 
 
 def test_cpc_features(all_cpcs):  # noqa: F811

--- a/tests/end2end/test_password_rule.py
+++ b/tests/end2end/test_password_rule.py
@@ -30,8 +30,8 @@ import zhmcclient
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import pick_test_resources, runtest_find_list, TEST_PREFIX, \
-    skip_warn
+from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
+    runtest_find_list, runtest_get_properties
 
 urllib3.disable_warnings()
 
@@ -73,6 +73,37 @@ def test_pwrule_find_list(hmc_session):  # noqa: F811
             hmc_session, console.password_rules, pwrule.name, 'name',
             'element-uri', PWRULE_VOLATILE_PROPS, PWRULE_MINIMAL_PROPS,
             PWRULE_LIST_PROPS)
+
+
+def test_pwrule_property(hmc_session):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test property related methods
+    """
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+    hd = hmc_session.hmc_definition
+
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        skip_warn("HMC {h} of version {v} does not yet support password rules".
+                  format(h=hd.host, v=hmc_version))
+
+    # Pick the password rules to test with
+    pwrule_list = console.password_rules.list()
+    if not pwrule_list:
+        skip_warn("No password rules defined on HMC {h}".format(h=hd.host))
+    pwrule_list = pick_test_resources(pwrule_list)
+
+    for pwrule in pwrule_list:
+        print("Testing with password rule {r!r}".format(r=pwrule.name))
+
+        # Select a property that is not returned by list()
+        non_list_prop = 'description'
+
+        runtest_get_properties(client, pwrule.manager, non_list_prop, None)
 
 
 def test_pwrule_crud(hmc_session):  # noqa: F811

--- a/tests/end2end/test_user.py
+++ b/tests/end2end/test_user.py
@@ -30,8 +30,8 @@ import zhmcclient
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import pick_test_resources, runtest_find_list, TEST_PREFIX, \
-    skip_warn
+from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
+    runtest_find_list, runtest_get_properties
 
 urllib3.disable_warnings()
 
@@ -73,6 +73,37 @@ def test_user_find_list(hmc_session):  # noqa: F811
             hmc_session, console.users, user.name, 'name',
             'object-uri', USER_VOLATILE_PROPS, USER_MINIMAL_PROPS,
             USER_LIST_PROPS)
+
+
+def test_user_property(hmc_session):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test property related methods
+    """
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+    hd = hmc_session.hmc_definition
+
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        skip_warn("HMC {h} of version {v} does not yet support users".
+                  format(h=hd.host, v=hmc_version))
+
+    # Pick the users to test with
+    user_list = console.users.list()
+    if not user_list:
+        skip_warn("No users defined on HMC {h}".format(h=hd.host))
+    user_list = pick_test_resources(user_list)
+
+    for user in user_list:
+        print("Testing with user {u!r}".format(u=user.name))
+
+        # Select a property that is not returned by list()
+        non_list_prop = 'description'
+
+        runtest_get_properties(client, user.manager, non_list_prop, None)
 
 
 def test_user_crud(hmc_session):  # noqa: F811

--- a/tests/end2end/test_user_pattern.py
+++ b/tests/end2end/test_user_pattern.py
@@ -30,8 +30,8 @@ import zhmcclient
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import pick_test_resources, runtest_find_list, TEST_PREFIX, \
-    skip_warn
+from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
+    runtest_find_list, runtest_get_properties
 
 urllib3.disable_warnings()
 
@@ -73,6 +73,37 @@ def test_upatt_find_list(hmc_session):  # noqa: F811
             hmc_session, console.user_patterns, upatt.name, 'name',
             'element-uri', UPATT_VOLATILE_PROPS, UPATT_MINIMAL_PROPS,
             UPATT_LIST_PROPS)
+
+
+def test_upatt_property(hmc_session):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test property related methods
+    """
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+    hd = hmc_session.hmc_definition
+
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        skip_warn("HMC {h} of version {v} does not yet support user patterns".
+                  format(h=hd.host, v=hmc_version))
+
+    # Pick the user patterns to test with
+    upatt_list = console.user_patterns.list()
+    if not upatt_list:
+        skip_warn("No user patterns defined on HMC {h}".format(h=hd.host))
+    upatt_list = pick_test_resources(upatt_list)
+
+    for upatt in upatt_list:
+        print("Testing with user pattern {p!r}".format(p=upatt.name))
+
+        # Select a property that is not returned by list()
+        non_list_prop = 'description'
+
+        runtest_get_properties(client, upatt.manager, non_list_prop, None)
 
 
 def test_upatt_crud(hmc_session):  # noqa: F811

--- a/tests/end2end/test_user_role.py
+++ b/tests/end2end/test_user_role.py
@@ -30,8 +30,8 @@ import zhmcclient
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
-from .utils import pick_test_resources, runtest_find_list, TEST_PREFIX, \
-    skip_warn
+from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
+    runtest_find_list, runtest_get_properties
 
 urllib3.disable_warnings()
 
@@ -73,6 +73,37 @@ def test_urole_find_list(hmc_session):  # noqa: F811
             hmc_session, console.user_roles, urole.name, 'name',
             'object-uri', UROLE_VOLATILE_PROPS, UROLE_MINIMAL_PROPS,
             UROLE_LIST_PROPS)
+
+
+def test_urole_property(hmc_session):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test property related methods
+    """
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+    hd = hmc_session.hmc_definition
+
+    api_version = client.query_api_version()
+    hmc_version = api_version['hmc-version']
+    hmc_version_info = tuple(map(int, hmc_version.split('.')))
+    if hmc_version_info < (2, 13, 0):
+        skip_warn("HMC {h} of version {v} does not yet support user roles".
+                  format(h=hd.host, v=hmc_version))
+
+    # Pick the user roles to test with
+    urole_list = console.user_roles.list()
+    if not urole_list:
+        skip_warn("No user roles defined on HMC {h}".format(h=hd.host))
+    urole_list = pick_test_resources(urole_list)
+
+    for urole in urole_list:
+        print("Testing with user role {r!r}".format(r=urole.name))
+
+        # Select a property that is not returned by list()
+        non_list_prop = 'description'
+
+        runtest_get_properties(client, urole.manager, non_list_prop, None)
 
 
 def test_urole_crud(hmc_session):  # noqa: F811

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -123,7 +123,8 @@ class ActivationProfileManager(BaseManager):
             oid_prop='name',  # This is an exception!
             uri_prop='element-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            supports_properties=True)
 
         self._profile_type = profile_type
 

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -75,7 +75,8 @@ class ConsoleManager(BaseManager):
             uri_prop='object-uri',
             name_prop='name',
             query_props=None,
-            list_has_name=False)
+            list_has_name=False,
+            supports_properties=True)
         self._client = client
         self._console = None
 

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -113,7 +113,8 @@ class CpcManager(BaseManager):
             oid_prop='object-id',
             uri_prop='object-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            supports_properties=True)
         self._client = client
 
     @property

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -77,7 +77,8 @@ class LparManager(BaseManager):
             oid_prop='object-id',
             uri_prop='object-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            supports_properties=True)
 
     @property
     def cpc(self):

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -192,7 +192,8 @@ class BaseManager(object):
 
     def __init__(self, resource_class, class_name, session, parent, base_uri,
                  oid_prop, uri_prop, name_prop, query_props,
-                 list_has_name=True, case_insensitive_names=False):
+                 list_has_name=True, case_insensitive_names=False,
+                 supports_properties=False):
         # This method intentionally has no docstring, because it is internal.
         #
         # Parameters:
@@ -243,6 +244,10 @@ class BaseManager(object):
         #   case_insensitive_names (bool):
         #     Indicates whether the name of the resource is treated case
         #     insensitively.
+        #   supports_properties (bool):
+        #     Indicates whether the Get Properties operation for this type of
+        #     resource supports the 'properties' query parameter in the latest
+        #     released version of the HMC.
 
         # We want to surface precondition violations as early as possible,
         # so we test those that are not surfaced through the init code:
@@ -265,6 +270,7 @@ class BaseManager(object):
         self._query_props = query_props
         self._list_has_name = list_has_name
         self._case_insensitive_names = case_insensitive_names
+        self._supports_properties = supports_properties
 
         self._name_uri_cache = _NameUriCache(
             self, session.retry_timeout_config.name_uri_cache_timetolive,
@@ -288,6 +294,7 @@ class BaseManager(object):
             "  _query_props={_query_props},\n"
             "  _list_has_name={_list_has_name!r},\n"
             "  _case_insensitive_names={_case_insensitive_names!r},\n"
+            "  _supports_properties={_supports_properties!r},\n"
             "  _name_uri_cache={_name_uri_cache!r}\n"
             ")".format(
                 classname=self.__class__.__name__,
@@ -305,6 +312,7 @@ class BaseManager(object):
                 _query_props=repr_list(self._query_props, indent=2),
                 _list_has_name=self._list_has_name,
                 _case_insensitive_names=self._case_insensitive_names,
+                _supports_properties=self._supports_properties,
                 _name_uri_cache=self._name_uri_cache,
             ))
         return ret
@@ -439,6 +447,16 @@ class BaseManager(object):
           insensitively.
         """
         return self._case_insensitive_names
+
+    @property
+    def supports_properties(self):
+        """
+        :class:`py:bool`:
+          Indicates whether the "Get Properties" operation for this type of
+          resource supports the 'properties' query parameter in the latest
+          released version of the HMC.
+        """
+        return self._supports_properties
 
     def resource_object(self, uri_or_oid, props=None):
         """

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -86,7 +86,8 @@ class PartitionManager(BaseManager):
             oid_prop='object-id',
             uri_prop='object-uri',
             name_prop='name',
-            query_props=query_props)
+            query_props=query_props,
+            supports_properties=True)
 
     @property
     def cpc(self):


### PR DESCRIPTION
For details, see the commit message.

Note that this PR picked options from the description in issue #862 - please keep that in mind when reviewing. These options can be changed, based on your review feedback.

The new end2end property testcases have been run against T224, S208B, M12.