### PR TITLE
1.7: Changed urllib3.Retry.method_whitelist to allowed_methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,11 @@ Released: not yet
 * Addressed safety issues by increasing minimum versions of packages, where
   possible.
 
+* Changed use of 'method_whitelist' in urllib3.Retry to 'allowed_methods'.
+  The old method was deprecated in urllib3 1.26.0 and removed in 2.0.0.
+  Related to that, incrased the minimum versions of urllib3 to 1.26.5 and of
+  requests to 2.25.0. (issue #1145)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -99,8 +99,7 @@ wheel==0.38.1; python_version >= '3.7'
 decorator==4.0.11
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
-requests==2.22.0; python_version <= '3.9'
-requests==2.25.0; python_version >= '3.10'
+requests==2.25.0
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
 stomp.py==4.1.23
@@ -128,8 +127,7 @@ chardet==3.0.3
 docopt==0.6.2
 idna==2.5
 # urllib3 1.26.5 fixes safety issue 43975
-urllib3==1.25.9; python_version <= '3.9'
-urllib3==1.26.5; python_version >= '3.10'
+urllib3==1.26.5
 pyrsistent==0.15.0
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,12 +18,9 @@ decorator>=4.0.11; python_version >= '3.5'  # new BSD
 pytz>=2016.10; python_version <= '3.9'  # MIT
 pytz>=2019.1; python_version >= '3.10'  # MIT
 
-# requests 2.22.0 removes the pinning of urllib3 to <1.25.0, and urllib 1.25.9
-#   is required to address safety issues
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six
-requests>=2.22.0; python_version <= '3.9'  # Apache-2.0
-requests>=2.25.0; python_version >= '3.10'  # Apache-2.0
+requests>=2.25.0  # Apache-2.0
 
 # six 1.16.0 removes the ImportWarning raised by Python 3.10
 six>=1.14.0; python_version <= '3.9'  # MIT

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -206,12 +206,12 @@ class RetryTimeoutConfig(object):
         self.name_uri_cache_timetolive = name_uri_cache_timetolive
 
         # Read retries only for these HTTP methods:
-        self.method_whitelist = {'GET'}
+        self.allowed_methods = {'GET'}
 
     _attrs = ('connect_timeout', 'connect_retries', 'read_timeout',
               'read_retries', 'max_redirects', 'operation_timeout',
               'status_timeout', 'name_uri_cache_timetolive',
-              'method_whitelist')
+              'allowed_methods')
 
     def override_with(self, override_config):
         """
@@ -726,7 +726,7 @@ class Session(object):
             total=retry_timeout_config.connect_retries,
             connect=retry_timeout_config.connect_retries,
             read=retry_timeout_config.read_retries,
-            method_whitelist=retry_timeout_config.method_whitelist,
+            allowed_methods=retry_timeout_config.allowed_methods,
             redirect=retry_timeout_config.max_redirects)
         session = requests.Session()
         session.mount('https://',


### PR DESCRIPTION
Rolls back PR #1147 into 1.7.1.