### PR TITLE
Release 1.7.1

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,14 +20,10 @@ Change log
 ----------
 
 
-Version 1.7.1.dev1
-^^^^^^^^^^^^^^^^^^
+Version 1.7.1
+^^^^^^^^^^^^^
 
-Released: not yet
-
-**Incompatible changes:**
-
-**Deprecations:**
+Released: 2023-05-06
 
 **Bug fixes:**
 
@@ -38,16 +34,6 @@ Released: not yet
   The old method was deprecated in urllib3 1.26.0 and removed in 2.0.0.
   Related to that, incrased the minimum versions of urllib3 to 1.26.5 and of
   requests to 2.25.0. (issue #1145)
-
-**Enhancements:**
-
-**Cleanup:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
 
 
 Version 1.7.0

--- a/zhmcclient/_version.py
+++ b/zhmcclient/_version.py
@@ -27,7 +27,7 @@ __all__ = ['__version__']
 #:
 #: * "M.N.P.dev1": A not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '1.7.1.dev1'
+__version__ = '1.7.1'
 
 # Check supported Python versions
 # Keep these Python versions in sync with:


### PR DESCRIPTION
Nothing relevant for users, just releasing it because 1.8.0 is ready for release soon.
No review needed.