### PR TITLE
Added trouble shooting info for urllib3 2.0 ImportError requiring OpenSSL 1.1.1+

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -62,6 +62,9 @@ Released: not yet
 * Fixed RTD docs build ssue with OpenSSL version by providing a .readthedocs.yaml
   file that specifies Ubuntu 22.04 as the build OS.
 
+* Added trouble shooting info for urllib3 2.0 ImportError requiring
+  OpenSSL 1.1.1+.
+
 **Enhancements:**
 
 * Disabled the default retrieval of the full set of properties in list()


### PR DESCRIPTION
For details, see the commit message.

See also the discussions in https://github.com/urllib3/urllib3/issues/2168 and https://github.com/urllib3/urllib3/issues/3020