### PR TITLE
Fixed end2end testcase errors in test_hba.py and test_console.py

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -87,6 +87,13 @@ Released: not yet
 
 **Cleanup:**
 
+* So far, the `Partition.hbas` property was set to `None` for CPCs that have the
+  "dpm-storage-management" feature enabled (i.e. starting with z14), because
+  HBAs are then represented as Virtual Storage Resource objects. For
+  consistency, this property was changed to provide an `HbaManager` object.
+  Since that property uses lazy initialization, there is no change at runtime
+  unless the property is actually accessed.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/tests/end2end/test_console.py
+++ b/tests/end2end/test_console.py
@@ -32,10 +32,10 @@ from .utils import runtest_find_list, runtest_get_properties
 urllib3.disable_warnings()
 
 # Properties in minimalistic Console objects (e.g. find_by_name())
-CONSOLE_MINIMAL_PROPS = ['object-uri', 'name']
+CONSOLE_MINIMAL_PROPS = ['object-uri']
 
 # Properties in Console objects returned by list() without full props
-CONSOLE_LIST_PROPS = ['object-uri', 'name', 'type']
+CONSOLE_LIST_PROPS = ['object-uri']
 
 # Properties whose values can change between retrievals of Console objects
 CONSOLE_VOLATILE_PROPS = []

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -259,17 +259,14 @@ class Partition(BaseResource):
         :class:`~zhmcclient.HbaManager`: Access to the :term:`HBAs <HBA>` in
         this Partition.
 
-        If the "dpm-storage-management" feature is enabled, this property is
-        `None`.
+        If the "dpm-storage-management" feature is enabled (i.e. starting with
+        z14), the CPC will not have any HBA objects anymore (they are now
+        Virtual Storage Resources), but this property still provides a manager
+        object for consistency.
         """
         # We do here some lazy loading.
         if not self._hbas:
-            try:
-                dpm_sm = self.feature_enabled('dpm-storage-management')
-            except ValueError:
-                dpm_sm = False
-            if not dpm_sm:
-                self._hbas = HbaManager(self)
+            self._hbas = HbaManager(self)
         return self._hbas
 
     @property


### PR DESCRIPTION
For details, see the commit message.

No need to roll back to 1.7, since the one error was introduced only in 1.8.0 and the other error did not surface due to missing testcases.

Particular review points:
* The Partition.hbas property is now unconditionally set to a HbaManager object, even when on z14 or later.