### PR TITLE
1.8: Addressed safety issues from 6/2023

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -67,8 +67,7 @@ security:
         50886:
             reason: Fixed Pygments version requires Python>=3.5 and is used there
         51457:
-            reason: Py package is not yet fixed (latest version 1.11.0)
-            expires: 2023-06-30
+            reason: Py package is no longer being fixed (latest version 1.11.0)
         51499:
             reason: Fixed Wheel version requires Python>=3.7 and is used there; Risk is on Pypi side
         52322:
@@ -95,6 +94,8 @@ security:
             reason: Fixed notebook version 5.5.0 only works on Python>=3.6 and is used there
         54689:
             reason: Fixed notebook version 5.7.11 only works on Python>=3.6 and is used there
+        58755:
+            reason: Fixed requests version 2.31.0 requires Python>=3.7 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,9 @@ Released: not yet
 * Circumvented the removal of Python 2.7 from the Github Actions plugin
   setup-python, by using the Docker container python:2.7.18-buster instead.
 
+* Addressed safety issues from 6/2023, by increasing 'requests' to 2.31.0
+  on Python >=3.7.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -99,7 +99,8 @@ wheel==0.38.1; python_version >= '3.7'
 decorator==4.0.11
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
-requests==2.25.0
+requests==2.25.0; python_version <= '3.6'
+requests==2.31.0; python_version >= '3.7'
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
 stomp.py==4.1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ pytz>=2019.1; python_version >= '3.10'  # MIT
 
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six
-requests>=2.25.0  # Apache-2.0
+requests>=2.25.0; python_version <= '3.6'
+requests>=2.31.0; python_version >= '3.7'
 
 # six 1.16.0 removes the ImportWarning raised by Python 3.10
 six>=1.14.0; python_version <= '3.9'  # MIT


### PR DESCRIPTION
Rolls back PR #1193 into 1.8.2