### PR TITLE
Upgrade mock files and their examples from z13 to z16

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -353,15 +353,15 @@ In that example HMC inventory file, the following nicknames of single HMCs are
 defined:
 
 * HMC1 - The HMC at 10.11.12.13.
-* MOCKED_Z13_CLASSIC - The mocked HMC defined in mock file
-  `examples/example_mocked_z13_classic.yaml <https://github.com/zhmcclient/python-zhmcclient/blob/master/examples/example_mocked_z13_classic.yaml>`_.
-* MOCKED_Z13_DPM - The mocked HMC defined in mock file
-  `examples/example_mocked_z13_dpm.yaml <https://github.com/zhmcclient/python-zhmcclient/blob/master/examples/example_mocked_z13_dpm.yaml>`_.
+* MOCKED_Z16_CLASSIC - The mocked HMC defined in mock file
+  `examples/example_mocked_z16_classic.yaml <https://github.com/zhmcclient/python-zhmcclient/blob/master/examples/example_mocked_z16_classic.yaml>`_.
+* MOCKED_Z16_DPM - The mocked HMC defined in mock file
+  `examples/example_mocked_z16_dpm.yaml <https://github.com/zhmcclient/python-zhmcclient/blob/master/examples/example_mocked_z16_dpm.yaml>`_.
 
 The following nicknames of HMC groups are defined:
 
-* all - All HMCs, i.e. HMC1, MOCKED_Z13_CLASSIC, and MOCKED_Z13_DPM.
-* default - The HMCs with nicknames MOCKED_Z13_CLASSIC and MOCKED_Z13_DPM.
+* all - All HMCs, i.e. HMC1, MOCKED_Z16_CLASSIC, and MOCKED_Z16_DPM.
+* default - The HMCs with nicknames MOCKED_Z16_CLASSIC and MOCKED_Z16_DPM.
 * dev - The HMC with nickname HMC1.
 
 The tests that use CPCs or resources within CPCs will be run against
@@ -369,8 +369,8 @@ only the subset of CPCs that are defined in the ``cpcs`` variables of the HMC
 entries. In that example HMC inventory file, those are:
 
 * For HMC1: Only the CPCs XYZ1 and XYZ2.
-* For MOCKED_Z13_CLASSIC: Only the CPC CPC1.
-* For MOCKED_Z13_DPM: Only the CPC CPC1.
+* For MOCKED_Z16_CLASSIC: Only the CPC CPC1.
+* For MOCKED_Z16_DPM: Only the CPC CPC1.
 
 Any variables defined for the HMCs are available to the test functions via an
 :class:`~zhmcclient.testutils.HMCDefinition` object. See pytest fixture

--- a/examples/example_hmc_inventory.yaml
+++ b/examples/example_hmc_inventory.yaml
@@ -25,27 +25,27 @@ all:
           dpm_enabled: true
 
     MOCKED_Z13_CLASSIC:
-      description: "Example mocked HMC with a z13 in classic mode"
-      mock_file: "example_mocked_z13_classic.yaml"
+      description: "Example mocked HMC with a z16 in classic mode"
+      mock_file: "example_mocked_z16_classic.yaml"
       cpcs:
         CPC1:
-          machine_type: "2964"
+          machine_type: "3906"
           dpm_enabled: false
 
     MOCKED_Z13_DPM:
-      description: "Example mocked HMC with a z13 in DPM mode"
-      mock_file: "example_mocked_z13_dpm.yaml"
+      description: "Example mocked HMC with a z16 in DPM mode"
+      mock_file: "example_mocked_z16_dpm.yaml"
       cpcs:
         CPC1:
-          machine_type: "2964"
+          machine_type: "3906"
           dpm_enabled: true
 
   children:
 
     default:
       hosts:
-        MOCKED_Z13_CLASSIC:
-        MOCKED_Z13_DPM:
+        MOCKED_Z16_CLASSIC:
+        MOCKED_Z16_DPM:
 
     dev:
       hosts:

--- a/examples/example_hmc_vault.yaml
+++ b/examples/example_hmc_vault.yaml
@@ -15,11 +15,11 @@ hmc_auth:
     password: password
     verify: false
 
-  MOCKED_Z13_CLASSIC:
+  MOCKED_Z16_CLASSIC:
     userid: dummy
     password: dummy
   
-  MOCKED_Z13_DPM:
+  MOCKED_Z16_DPM:
     userid: dummy
     password: dummy
   

--- a/examples/example_mocked_z16_classic.yaml
+++ b/examples/example_mocked_z16_classic.yaml
@@ -4,11 +4,11 @@
 
 hmc_definition:
   host: hmc1
-  api_version: '1.8'
+  api_version: '2.16.0'
   consoles:
   - properties:
       name: HMC 1
-      version: 2.13.1
+      version: 2.16.0
     users:
     - properties:
         object-id: user1
@@ -40,9 +40,9 @@ hmc_definition:
     - properties:
         object-id: cpc1
         name: "CPC1"
-        description: "Fake z13 (classic mode)"
-        machine-type: "2964"
-        machine-model: "NE1"
+        description: "Fake z16 (classic mode)"
+        machine-type: "3906"
+        machine-model: "MO1"
         status: "active"
         dpm-enabled: false
         is-ensemble-member: false

--- a/examples/example_mocked_z16_dpm.yaml
+++ b/examples/example_mocked_z16_dpm.yaml
@@ -4,12 +4,12 @@
 
 hmc_definition:
   host: hmc1
-  api_version: '1.8'
+  api_version: '2.16.0'
   consoles:
   - properties:
       name: HMC 1
-      version: 2.13.1
-      api-version: '1.8'
+      version: 2.16.0
+      api-version: '2.16.0'
     users:
     - properties:
         object-id: user1
@@ -55,9 +55,9 @@ hmc_definition:
     - properties:
         object-id: cpc1
         name: "CPC1"
-        description: "Faked CPC CPC1 (z13 in DPM mode)"
-        machine-type: "2964"
-        machine-model: "NE1"
+        description: "Faked CPC CPC1 (z16 in DPM mode)"
+        machine-type: "3906"
+        machine-model: "MO1"
         status: active
         dpm-enabled: true
         is-ensemble-member: false
@@ -73,8 +73,8 @@ hmc_definition:
             physical-channel-status: operating
             type: osd
             adapter-family: osa
-            detected-card-type: "osa-express-6s-1000base-t"
-            card-location: "A14B-D104J.01-D204J.01"
+            detected-card-type: "osa-express-7s-1000base-t"
+            card-location: "A23B-D107J.01-D207J.02"
             configured-capacity: 63
             maximum-total-capacity: 1920
           ports:
@@ -98,8 +98,8 @@ hmc_definition:
             physical-channel-status: operating
             type: fcp
             adapter-family: ficon
-            detected-card-type: "ficon-express-16s"
-            card-location: "A14B-D114J.01"
+            detected-card-type: "ficon-express-16s-plus"
+            card-location: "Z33B-D114-J.01"
             configured-capacity: 63
             maximum-total-capacity: 1920
           ports:


### PR DESCRIPTION
As mentioned in issue - https://github.com/zhmcclient/python-zhmcclient/issues/1133
Changed the mocked file for z13 to z16 configuration
Signed-off-by: Kavin Raj A M <rkavin78@gmail.com>