### PR TITLE
1.10: Fixed zhmcclient_mock support for LDAP Server Definitions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,8 @@ Released: not yet
 
 * Fixed safety issues from 2023-08-27.
 
+* Fixed zhmcclient_mock support for LDAP Server Definitions.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/tests/unit/zhmcclient/test_ldap_server_definition.py
+++ b/tests/unit/zhmcclient/test_ldap_server_definition.py
@@ -145,7 +145,9 @@ class TestLdapServerDefinition(object):
              None,
              HTTPError({'http-status': 400, 'reason': 5})),
             ({'description': 'fake description X',
-              'name': 'a'},
+              'name': 'a',
+              'primary-hostname-ipaddr': '10.11.12.13',
+              'search-distinguished-name': 'test{0}'},
              ['element-uri', 'name', 'description'],
              None),
         ]
@@ -260,7 +262,8 @@ class TestLdapServerDefinition(object):
         sn_ldap_srv_def_props = {
             'name': ldap_srv_def_name,
             'description': 'LDAP Server Definition with same name',
-            'type': 'user-defined',
+            'primary-hostname-ipaddr': '10.11.12.13',
+            'search-distinguished-name': 'test{0}',
         }
 
         ldap_srv_def_mgr = self.console.ldap_server_definitions

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -3274,6 +3274,13 @@ class TestLdapServerDefinitionHandlers(object):
             'primary-hostname-ipaddr': '10.11.12.13',
             'connection-port': None,
             'use-ssl': False,
+            'backup-hostname-ipaddr': None,
+            'bind-distinguished-name': None,
+            'location-method': 'pattern',
+            'replication-overwrite-possible': False,
+            'search-filter': None,
+            'search-scope': None,
+            'tolerate-untrusted-certificates': None,
         }
         assert ldap_srv_def1 == exp_ldap_srv_def1
 
@@ -3285,6 +3292,8 @@ class TestLdapServerDefinitionHandlers(object):
         new_ldap_srv_def_input = {
             'name': 'ldap_srv_def_X',
             'description': 'LDAP Srv Def #X',
+            'primary-hostname-ipaddr': '10.11.12.13',
+            'search-distinguished-name': 'test{0}',
         }
 
         # the function to be tested:
@@ -3357,6 +3366,8 @@ class TestLdapServerDefinitionHandlers(object):
         new_ldap_srv_def_input = {
             'name': 'ldap_srv_def_X',
             'description': 'LDAP Srv Def #X',
+            'primary-hostname-ipaddr': '10.11.12.13',
+            'search-distinguished-name': 'test{0}',
         }
 
         # Create the LDAP Srv Def

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -1602,10 +1602,8 @@ class FakedLdapServerDefinitionManager(FakedBaseManager):
               if not specified.
             * 'class' will be auto-generated to 'ldap-server-definition',
               if not specified.
-            * 'connection-port' will be auto-generated to `None`,
-              if not specified.
-            * 'use-ssl' will be auto-generated to `False`,
-              if not specified.
+            * All of the other class-soecific resource properties will be set
+              to a default value consistent with the HMC data model.
 
         Returns:
           :class:`~zhmcclient_mock.FakedLdapServerDefinition`: The faked
@@ -1614,10 +1612,18 @@ class FakedLdapServerDefinitionManager(FakedBaseManager):
         new_lsd = super(FakedLdapServerDefinitionManager, self).add(properties)
 
         # Resource type specific default values
-        if 'connection-port' not in new_lsd.properties:
-            new_lsd.properties['connection-port'] = None
-        if 'use-ssl' not in new_lsd.properties:
-            new_lsd.properties['use-ssl'] = False
+        new_lsd.properties.setdefault('description', '')
+        new_lsd.properties.setdefault('connection-port', None)
+        new_lsd.properties.setdefault('backup-hostname-ipaddr', None)
+        new_lsd.properties.setdefault('use-ssl', False)
+        use_ssl = new_lsd.properties['use-ssl']
+        new_lsd.properties.setdefault('tolerate-untrusted-certificates',
+                                      False if use_ssl else None)
+        new_lsd.properties.setdefault('bind-distinguished-name', None)
+        new_lsd.properties.setdefault('location-method', 'pattern')
+        new_lsd.properties.setdefault('search-scope', None)
+        new_lsd.properties.setdefault('search-filter', None)
+        new_lsd.properties.setdefault('replication-overwrite-possible', False)
 
         return new_lsd
 

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -1444,7 +1444,9 @@ class LdapServerDefinitionsHandler(object):
             new_exc = InvalidResourceError(method, uri)
             new_exc.__cause__ = None
             raise new_exc  # zhmcclient_mock.InvalidResourceError
-        check_required_fields(method, uri, body, ['name'])
+        check_required_fields(method, uri, body,
+                              ['name', 'primary-hostname-ipaddr',
+                               'search-distinguished-name'])
         new_ldap_srv_def = console.ldap_server_definitions.add(body)
         return {'element-uri': new_ldap_srv_def.uri}
 
@@ -1474,6 +1476,7 @@ class LdapServerDefinitionHandler(GenericGetPropertiesHandler,
                 'primary-hostname-ipaddr',
                 'connection-port',
                 'backup-hostname-ipaddr',
+                'use-ssl',
                 'tolerate-untrusted-certificates',
                 'bind-distinguished-name',
                 'bind-password',
@@ -1481,6 +1484,7 @@ class LdapServerDefinitionHandler(GenericGetPropertiesHandler,
                 'search-distinguished-name',
                 'search-scope',
                 'search-filter',
+                'replication-overwrite-possible',
             ])
         lsd.update(body)
 


### PR DESCRIPTION
Rolls back PR #1235 into 1.10.1