### PR TITLE
1.10: Fixed end2end testcases for adapters, auto-updating, and groups

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed end2end testcases for adapters, auto-updating, and groups.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,8 @@ Released: not yet
 
 * Fixed end2end testcases for adapters, auto-updating, and groups.
 
+* Fixed end2end testcases for adapters, auto-updating, and groups.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/tests/end2end/test_adapter.py
+++ b/tests/end2end/test_adapter.py
@@ -363,6 +363,9 @@ def test_adapter_list_assigned_part(dpm_mode_cpcs):  # noqa: F811
                         for part in before_parts:
                             sgroups = part.list_attached_storage_groups()
                             for sg in sgroups:
+                                if sg.get_property('type') != 'fcp':
+                                    # This test works only for FCP stogrps
+                                    continue
                                 vsrs = sg.virtual_storage_resources.list()
                                 for vsr in vsrs:
                                     port = vsr.adapter_port

--- a/tests/end2end/test_auto_update.py
+++ b/tests/end2end/test_auto_update.py
@@ -22,7 +22,6 @@ change any existing partitions, but create, modify and delete test partitions.
 from __future__ import absolute_import, print_function
 
 import uuid
-import warnings
 from time import sleep
 import pytest
 from requests.packages import urllib3
@@ -247,7 +246,7 @@ def test_autoupdate_list(dpm_mode_cpcs):  # noqa: F811
             part_names = set([p.name for p in part_list])
             assert part_names == initial_part_names
 
-            # Disable auto-updating on partition manager and check partition list
+            # Disable auto-updating on partition manager and check part. list
             cpc.partitions.disable_auto_update()
             part_list = cpc.partitions.list()
             part_names = set([p.name for p in part_list])

--- a/tests/end2end/test_group.py
+++ b/tests/end2end/test_group.py
@@ -81,6 +81,10 @@ def test_group_crud(hmc_session):  # noqa: F811
 
     skipif_no_group_support(client)
 
+    # TODO: Get group issue on T224 HMC resolved.
+    if hd.host == '9.114.87.7':
+        skip_warn("Issues with group support on HMC {h}".format(h=hd.host))
+
     group_name = TEST_PREFIX + ' test_group_crud group'
 
     # Ensure a clean starting point for this test

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -471,8 +471,7 @@ def validate_list_features(api_version, all_features, regex_reduced_features):
     if len(all_features) > 0:
         # But when there are some available API features, there are a few that
         # are always present.
-        expected_features = ['cpc-delete-retrieved-internal-code',
-                             'cpc-install-and-activate']
+        expected_features = ['cpc-install-and-activate']
         for feature in expected_features:
             assert feature in all_features, \
                 '{} missing from {}'.format(feature, all_features)


### PR DESCRIPTION
Rolls back PR #1239 into 1.10.2.