### PR TITLE
1.10: Fixed SubscriptionNotFound exception message

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,9 @@ Released: not yet
 
 * Fixed end2end testcases for adapters, auto-updating, and groups.
 
+* Fixed that SubscriptionNotFound exception message did not resolve its
+  format string.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -220,7 +220,8 @@ class NotificationReceiver(object):
             sub_id = self._sub_ids[topic_name]
         except KeyError:
             raise SubscriptionNotFound(
-                "Subscription topic {!r} is not currently subscribed for")
+                "Subscription topic {!r} is not currently subscribed for".
+                format(topic_name))
         id_value = self._id_value(sub_id)
         self._conn.unsubscribe(id=id_value)
 
@@ -255,7 +256,8 @@ class NotificationReceiver(object):
             sub_id = self._sub_ids[topic_name]
         except KeyError:
             raise SubscriptionNotFound(
-                "Subscription topic {!r} is not currently subscribed for")
+                "Subscription topic {!r} is not currently subscribed for".
+                format(topic_name))
         return self._id_value(sub_id)
 
     @logged_api_call


### PR DESCRIPTION
Rolls back PR #1242 into 1.10.2