### PR TITLE
Docs: Improved documentation for developing tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,8 @@ Released: not yet
 
 **Enhancements:**
 
+* Docs: Improved documentation for developing tests.
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -457,10 +457,21 @@ that run against real HMCs or mocked HMCs defined with the :ref:`mock support`.
 These HMCs are defined in an :ref:`HMC inventory file`, and their credentials
 are defined in an :ref:`HMC vault file`.
 
+
+zhmcclient.testutils module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: zhmcclient.testutils
+
 This module defines
 `pytest fixtures <https://docs.pytest.org/en/latest/explanation/fixtures.html>`_
 for use by the test functions and encapsulates the access to the HMC inventory
 and vault files.
+
+Look at the existing test functions in
+https://github.com/zhmcclient/python-zhmcclient/tree/master/tests for real-life
+examples.
+
 
 Pytest fixtures
 ^^^^^^^^^^^^^^^
@@ -468,6 +479,10 @@ Pytest fixtures
 Pytest fixtures are used as parameters of test functions. When used, they are
 specified just with their name. Pytest resolves the parameters of test
 functions to its known fixtures, based upon the parameter name.
+For more details on pytest fixtures in general, see
+`pytest fixtures <https://docs.pytest.org/en/latest/explanation/fixtures.html>`_.
+
+The :mod:`zhmcclient.testutils` module provides the following pytest fixtures:
 
 .. autofunction:: zhmcclient.testutils.hmc_definition
 
@@ -481,6 +496,9 @@ functions to its known fixtures, based upon the parameter name.
 
 Encapsulation of HMC inventory file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :mod:`zhmcclient.testutils` module provides the following elements to
+encapsulate access to the :ref:`HMC inventory file`, e.g. by test functions:
 
 .. autofunction:: zhmcclient.testutils.hmc_definitions
 
@@ -503,12 +521,17 @@ Encapsulation of HMC inventory file
 Encapsulation of HMC vault file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The :mod:`zhmcclient.testutils` module provides the following elements to
+encapsulate access to the :ref:`HMC vault file`, e.g. by test functions:
+
 .. autoclass:: zhmcclient.testutils.HMCVaultFile
    :members:
    :autosummary:
 
 Exceptions
 ^^^^^^^^^^
+
+The :mod:`zhmcclient.testutils` module may raise the following exceptions:
 
 .. autoclass:: zhmcclient.testutils.HMCInventoryFileError
    :members:

--- a/zhmcclient/testutils/_cpc_fixtures.py
+++ b/zhmcclient/testutils/_cpc_fixtures.py
@@ -57,9 +57,12 @@ def all_cpcs(request, hmc_session):  # noqa: F811
     The CPCs to test against are defined in the ``cpcs`` variable for the
     HMC entry in the :ref:`HMC inventory file`.
 
-    A test function parameter using this fixture resolves to a list of
-    :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
+    A test function parameter with the name of this fixture resolves to a list
+    of :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
     objects have the "short" set of properties from :meth:`zhmcclient.Cpc.list`.
+
+    The test function is invoked just once with the list of CPCs, and the
+    test function needs to loop through the CPCs (or a subset).
 
     Because the `hmc_session` parameter of this fixture is again a fixture,
     the :func:`zhmcclient.testutils.hmc_session`
@@ -81,9 +84,12 @@ def dpm_mode_cpcs(request, hmc_session):  # noqa: F811
     HMC entry in the :ref:`HMC inventory file` and have their ``dpm_enabled``
     property set to ``true``.
 
-    A test function parameter using this fixture resolves to a list of
-    :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
+    A test function parameter with the name of this fixture resolves to a list
+    of :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
     objects have the "short" set of properties from :meth:`zhmcclient.Cpc.list`.
+
+    The test function is invoked just once with the list of CPCs, and the
+    test function needs to loop through the CPCs (or a subset).
 
     Because the `hmc_session` parameter of this fixture is again a fixture,
     the :func:`zhmcclient.testutils.hmc_session`
@@ -105,9 +111,12 @@ def classic_mode_cpcs(request, hmc_session):  # noqa: F811
     HMC entry in the :ref:`HMC inventory file` and have their ``dpm_enabled``
     property set to ``false``.
 
-    A test function parameter using this fixture resolves to a list of
-    :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
+    A test function parameter with the name of this fixture resolves to a list
+    of :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
     objects have the "short" set of properties from :meth:`zhmcclient.Cpc.list`.
+
+    The test function is invoked just once with the list of CPCs, and the
+    test function needs to loop through the CPCs (or a subset).
 
     Because the `hmc_session` parameter of this fixture is again a fixture,
     the :func:`zhmcclient.testutils.hmc_session`

--- a/zhmcclient/testutils/_hmc_definition_fixtures.py
+++ b/zhmcclient/testutils/_hmc_definition_fixtures.py
@@ -72,9 +72,12 @@ def hmc_definition(request):
     """
     Pytest fixture representing the set of HMC definitions to use for a test.
 
-    A test function parameter using this fixture resolves to the
+    A test function parameter with the name of this fixture resolves to the
     :class:`~zhmcclient.testutils.HMCDefinition`
     object of each HMC to test against.
+
+    The test function is called once for each HMC, if the targeted HMC is a
+    group.
     """
     return request.param
 
@@ -87,7 +90,7 @@ def hmc_session(request, hmc_definition):
     """
     Pytest fixture representing the set of HMC sessions to run a test against.
 
-    A test function parameter using this fixture resolves to the
+    A test function parameter with the name of this fixture resolves to the
     :class:`zhmcclient.Session` or :class:`zhmcclient_mock.FakedSession` object
     for each HMC to test against.
 

--- a/zhmcclient/testutils/_hmc_definitions.py
+++ b/zhmcclient/testutils/_hmc_definitions.py
@@ -107,7 +107,7 @@ class HMCNoVaultError(Exception):
 
 class HMCNotFound(Exception):
     """
-    The HMC group was not found in the :ref:`HMC inventory file`.
+    The HMC group or nickname was not found in the :ref:`HMC inventory file`.
     """
     pass
 


### PR DESCRIPTION
To look at the section that has been updated:
```
git checkout andy/testutils-docs
make builddoc
open build_doc/html/docs/development.html
```
In the browser page that opens, navigate to section 8.6 "Developing tests".