### PR TITLE
Fixed end2end tests for example mocked environment

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,15 @@ Released: not yet
 
 **Incompatible changes:**
 
+* Fixed BaseResource.pull_properties() by returning None when no properties
+  were specified. Before that, it returned the full set of properties when
+  the Get Properties operation for the resource does not support the 'properties'
+  query parameter, and produced 'properties=' as a query parameter when
+  the resource does support the 'properties' query parameter.
+
+  This is incompatible when your code uses pull_properties() on resource objects
+  and relies on the prior behavior.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -41,6 +50,12 @@ Released: not yet
 
 * Fixed that SubscriptionNotFound exception message did not resolve its
   format string.
+
+* Fixed the zhmcclient_mock support by adding support for query parameters,
+  fixing the the Group operations and the "Query API Version" operation,
+  and fixing the z16 mock environment definitions.
+  Auto-update tests are now skipped when testing against mocked environments,
+  because the mock support does not support notifications.
 
 **Enhancements:**
 

--- a/examples/example_hmc_inventory.yaml
+++ b/examples/example_hmc_inventory.yaml
@@ -24,7 +24,7 @@ all:
           machine_type: "3906"
           dpm_enabled: true
 
-    MOCKED_Z13_CLASSIC:
+    MOCKED_Z16_CLASSIC:
       description: "Example mocked HMC with a z16 in classic mode"
       mock_file: "example_mocked_z16_classic.yaml"
       cpcs:
@@ -32,7 +32,7 @@ all:
           machine_type: "3906"
           dpm_enabled: false
 
-    MOCKED_Z13_DPM:
+    MOCKED_Z16_DPM:
       description: "Example mocked HMC with a z16 in DPM mode"
       mock_file: "example_mocked_z16_dpm.yaml"
       cpcs:

--- a/examples/example_mocked_z16_classic.yaml
+++ b/examples/example_mocked_z16_classic.yaml
@@ -8,34 +8,47 @@ hmc_definition:
   consoles:
   - properties:
       name: HMC 1
+      description: "Console: HMC 1"
       version: 2.16.0
+      api-version: '2.16.0'
     users:
     - properties:
         object-id: user1
         name: User 1
+        description: "User: User 1"
     user_roles:
     - properties:
         object-id: userrole1
         name: User role 1
+        description: "UserRole: User role 1"
+    - properties:
+        object-id: userrole_optasks
+        name: "hmc-operator-tasks"
+        description: "UserRole: hmc-operator-tasks"
     user_patterns:
     - properties:
         element-id: userpattern1
         name: User pattern 1
+        description: "UserPattern: User pattern 1"
     password_rules:
     - properties:
         element-id: passwordrule1
         name: Password rule 1
+        description: "PasswordRule: Password rule 1"
     - properties:
         element-id: Basic
         name: Basic
+        description: "PasswordRule: Basic"
     tasks:
     - properties:
         element-id: task1
         name: Task 1
+        description: "Task: Task 1"
     ldap_server_definitions:
     - properties:
         element-id: lsd1
         name: LDAP server definition 1
+        description: "LSD: LDAP server definition 1"
   cpcs:
     - properties:
         object-id: cpc1
@@ -51,6 +64,7 @@ hmc_definition:
         - properties:
             object-id: lpar1
             name: "LPAR1"
+            description: "LPAR: LPAR1"
             partition-number: 0x41
             partition-identifier: 0x41
             status: "operating"
@@ -60,6 +74,7 @@ hmc_definition:
         - properties:
             object-id: lpar2
             name: "LPAR2"
+            description: "LPAR: LPAR2"
             partition-number: 0x42
             partition-identifier: 0x42
             status: "not-activated"
@@ -69,14 +84,17 @@ hmc_definition:
       reset_activation_profiles:
         - properties:
             name: "CPC1"
+            description: "ResetProfile: CPC1"
             iocds-name: "ABC"
       load_activation_profiles:
         - properties:
             name: "STANDARDLOAD"
+            description: "LoadProfile: STANDARDLOAD"
             ipl-type: "ipltype-standard"
             ipl-address: "189AB"
         - properties:
             name: "SCSILOAD"
+            description: "LoadProfile: SCSILOAD"
             ipl-type: "ipltype-scsi"
             worldwide-port-name: "1234"
             logical-unit-number: "1234"
@@ -85,7 +103,9 @@ hmc_definition:
       image_activation_profiles:
         - properties:
             name: "LPAR1"
+            description: "ImageProfile: LPAR1"
             # TODO: Add more properties
         - properties:
             name: "LPAR2"
+            description: "ImageProfile: LPAR2"
             # TODO: Add more properties

--- a/examples/example_mocked_z16_dpm.yaml
+++ b/examples/example_mocked_z16_dpm.yaml
@@ -8,35 +8,47 @@ hmc_definition:
   consoles:
   - properties:
       name: HMC 1
+      description: "Console: HMC 1"
       version: 2.16.0
       api-version: '2.16.0'
     users:
     - properties:
         object-id: user1
         name: User 1
+        description: "User: User 1"
     user_roles:
     - properties:
         object-id: userrole1
         name: User role 1
+        description: "UserRole: User role 1"
+    - properties:
+        object-id: userrole_optasks
+        name: "hmc-operator-tasks"
+        description: "UserRole: hmc-operator-tasks"
     user_patterns:
     - properties:
         element-id: userpattern1
         name: User pattern 1
+        description: "UserPattern: User pattern 1"
     password_rules:
     - properties:
         element-id: passwordrule1
         name: Password rule 1
+        description: "PasswordRule: Password rule 1"
     - properties:
         element-id: Basic
         name: Basic
+        description: "PasswordRule: Basic"
     tasks:
     - properties:
         element-id: task1
         name: Task 1
+        description: "Task: Task 1"
     ldap_server_definitions:
     - properties:
         element-id: lsd1
         name: LDAP server definition 1
+        description: "LSD: LDAP server definition 1"
     storage_groups:
     - properties:
         object-id: sg1

--- a/tests/end2end/test_auto_update.py
+++ b/tests/end2end/test_auto_update.py
@@ -31,6 +31,7 @@ import zhmcclient
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
+from zhmcclient_mock import FakedSession
 
 from .utils import TEST_PREFIX, standard_partition_props, skip_warn
 
@@ -47,6 +48,10 @@ def test_autoupdate_prop(dpm_mode_cpcs):  # noqa: F811
 
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
+
+        if isinstance(cpc.manager.client.session, FakedSession):
+            pytest.skip("Auto-update test requires notifications which are "
+                        "not supported by zhmcclient_mock")
 
         print("Testing on CPC {c}".format(c=cpc.name))
 
@@ -211,6 +216,10 @@ def test_autoupdate_list(dpm_mode_cpcs):  # noqa: F811
 
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
+
+        if isinstance(cpc.manager.client.session, FakedSession):
+            pytest.skip("Auto-update test requires notifications which are "
+                        "not supported by zhmcclient_mock")
 
         session = cpc.manager.session
         hd = session.hmc_definition

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -269,6 +269,8 @@ class BaseResource(object):
         Retrieve the specified set of resource properties and cache them in
         this zhmcclient object.
 
+        If no properties are specified, the method does nothing.
+
         The values of other properties that may already exist in this
         zhmcclient object remain unchanged.
 
@@ -298,6 +300,9 @@ class BaseResource(object):
           :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.CeasedExistence`
         """
+        if not properties:
+            return
+
         with self._property_lock:
             if self._ceased_existence:
                 raise CeasedExistence(self._uri)


### PR DESCRIPTION
For details, see the commit message.

With this PR, the set of errors when running against the example mock support has been reduced to these, which are caused by not having implemented support for the corresponding operations in the mock support. This is left for another PR to add.

```
$ TESTINVENTORY=examples/example_hmc_inventory.yaml TESTVAULT=examples/example_hmc_vault.yaml make end2end
. . .
FAILED tests/end2end/test_adapter.py::test_adapter_list_assigned_part[hmc_definition=MOCKED_Z16_DPM] - zhmcclient._exceptions.HTTPError: 404,1: Unknown resource with URI: /api/adapters/osa1/operations/get-partitions-assigned-to-adapter [GET /api/adapters/osa1/operations...
FAILED tests/end2end/test_cpc.py::test_cpc_export_dpm_config[hmc_definition=MOCKED_Z16_DPM] - zhmcclient._exceptions.HTTPError: 404,1: Unknown resource with URI: /api/services/inventory [POST /api/services/inventory]
```