### PR TITLE
1.11: Fixed max number of threads in bulk ops

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,9 @@ Released: not yet
 
 * Addressed safety issues fro 2023-09-15.
 
+* Fixed the maximum number of concurrent threads in bulk operations to be
+  the documented maximum of 10.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -837,7 +837,8 @@ class BaseManager(object):
 
         if bulk_reqs:
             uri = '/api/services/aggregation/submit'
-            threads = min(16, round(len(props_list) / 2 + 0.51))
+            # 10 threads is the supported maximum
+            threads = min(10, round(len(props_list) / 2 + 0.51))
             body = {
                 'requests': bulk_reqs,
                 'threads': threads,


### PR DESCRIPTION
Rolls back PR #1266 into 1.11.1