### PR TITLE
Added unit tests and end2end tests for list permitted partitions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -63,6 +63,8 @@ Released: not yet
 * Fixed the maximum number of concurrent threads in bulk operations to be
   the documented maximum of 10.
 
+* Test: Added unit tests and end2end tests for list permitted partitions operation
+
 **Enhancements:**
 
 * Mock support: Improved mocked Hipersocket adapters; they now have all their

--- a/examples/example_mocked_z16_dpm.yaml
+++ b/examples/example_mocked_z16_dpm.yaml
@@ -140,6 +140,7 @@ hmc_definition:
             processor-mode: shared
             ifl-processors: 2
             initial-ifl-processing-weight: 20
+            has-unacceptable-status: false
             initial-memory: 4096
             maximum-memory: 4096
             boot-device: network-adapter

--- a/tests/unit/zhmcclient/test_partition.py
+++ b/tests/unit/zhmcclient/test_partition.py
@@ -26,7 +26,6 @@ from zhmcclient import Client, Partition, HTTPError, NotFound
 from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
-
 # Object IDs and names of our faked partitions:
 PART1_OID = 'part1-oid'
 PART1_NAME = 'part 1'
@@ -954,6 +953,10 @@ class TestPartition(object):
              [PART1_NAME, PART2_NAME]),
             ({'name': PART1_NAME},
              [PART1_NAME]),
+            ({'name': PART1_NAME, 'cpc-name': CPC_NAME},
+             [PART1_NAME]),
+            ({'name': PART1_NAME, 'cpc-name': 'bad'},
+             [])
         ]
     )
     def test_console_list_permitted_partitions(self, filter_args, exp_names):


### PR DESCRIPTION
Details:

* Added some more cases in unit tests to check filter_args funtionality for list permitted partitions
* Added end2end test case to check the list permitted partitions functionality