### PR TITLE
1.9: Moved 'make safety' to the end of the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,11 +221,6 @@ jobs:
       run: |
         echo "Package dependency tree of installed Python packages:"
         pipdeptree --all
-    - name: Run safety
-      env:
-        PACKAGE_LEVEL: ${{ matrix.package_level }}
-      run: |
-        make safety
     - name: Run check_reqs
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
@@ -278,6 +273,11 @@ jobs:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
       run: |
         make debuginfo
+    - name: Run safety
+      env:
+        PACKAGE_LEVEL: ${{ matrix.package_level }}
+      run: |
+        make safety
 
   test_finish:
     needs: test


### PR DESCRIPTION
Rolls back PR #1280 into 1.9.1