### PR TITLE
1.11: Bump gitpython from 3.1.34 to 3.1.37

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -95,7 +95,7 @@ sphinx-git>=10.1.1
 # GitPython 3.1.30 fixes safety issues 52322,52518
 GitPython>=2.1.1,<3.0.0; python_version == '2.7'
 GitPython>=2.1.1; python_version >= '3.5' and python_version <= '3.6'
-GitPython>=3.1.34; python_version >= '3.7'
+GitPython>=3.1.37; python_version >= '3.7'
 sphinxcontrib-websupport>=1.1.2
 # Pygments 2.7.4 fixes safety issues 50885,50886
 Pygments>=2.4.1; python_version == '2.7'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -191,7 +191,7 @@ docutils==0.14; python_version == '3.10'
 docutils==0.16; python_version >= '3.11'
 sphinx-git==10.1.1
 GitPython==2.1.1; python_version <= '3.6'
-GitPython==3.1.34; python_version >= '3.7'
+GitPython==3.1.37; python_version >= '3.7'
 sphinxcontrib-websupport==1.1.2
 Pygments==2.4.1; python_version == '2.7'
 Pygments==2.7.4; python_version >= '3.5' and python_version <= '3.6'


### PR DESCRIPTION
Rolls back PR #1293 into 1.11.3.