### PR TITLE
Updated LPAR.activate description; Added end2end tests for LPAR activation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -65,6 +65,10 @@ Released: not yet
 
 * Test: Added unit tests and end2end tests for list permitted partitions operation
 
+* Docs: Corrected and improved the description of the Lpar.activate() method.
+
+* Test: Added end2end tests for LPAR activation in classic mode.
+
 **Enhancements:**
 
 * Added support for Python 3.12. Had to increase the minimum versions of

--- a/tests/end2end/test_lpar.py
+++ b/tests/end2end/test_lpar.py
@@ -22,6 +22,7 @@ test LPARs.
 from __future__ import absolute_import, print_function
 
 import random
+import pdb
 import pytest
 from requests.packages import urllib3
 
@@ -32,12 +33,16 @@ from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, runtest_find_list, \
-    runtest_get_properties
+    runtest_get_properties, ensure_lpar_inactive, setup_logging
 
 urllib3.disable_warnings()
 
 # Print debug messages in tests
 DEBUG = False
+
+# Logging for zhmcclient HMC interactions and test functions
+LOGGING = False
+LOG_FILE = 'test_lpar.log'
 
 # Properties in minimalistic Lpar objects (e.g. find_by_name())
 LPAR_MINIMAL_PROPS = ['object-uri', 'name']
@@ -229,3 +234,219 @@ def test_lpar_list_os_messages(classic_mode_cpcs):  # noqa: F811
             messages = result['os-messages']
             for message in messages:
                 assert message['is-priority'] == is_priority
+
+
+# Test LPARs for test_lpar_activate().
+# The outer dict is for different types of LPARs:
+#   Key: LPAR kind, Value: Dict of LPAR names by CPC
+ACTIVATE_TEST_LPARS = {
+    'linux-no-autoload': {
+        # Linux LPAR whose next profile does not auto-load
+        'P0000M96': 'LINUX28',
+        'T28': 'BLUEC1',
+    },
+    'linux-with-autoload': {
+        # Linux LPAR whose next profile auto-loads, and which boots an OS
+        'P0000M96': 'HISOCKE1',
+        # 'T28': 'BCORE2',  # fails with HTTP 500,263: The load failed.
+    },
+    'ssc': {
+        # SSC LPAR (which always auto-loads), and which boots the SSC installer
+        # or an SSC appliance
+        'P0000M96': 'ANGEL',
+        'T28': 'BCORE1',
+    },
+}
+
+# Test image profiles for test_lpar_activate().
+# The outer dict is for different types of image profiles:
+#   Key: LPAR kind, Value: Dict of image profile names by CPC
+ACTIVATE_TEST_PROFILES = {
+    'linux-no-autoload': {
+        # Linux profile that does not auto-load
+        'P0000M96': 'LINUX28',
+        'T28': 'BLUEC1',
+    },
+    'linux-with-autoload': {
+        # Linux profile that does auto-load and specifies a bootable OS
+        'P0000M96': 'HISOCKE1',
+        'T28': 'BCORE2',
+    },
+    'ssc': {
+        # SSC profile (which always auto-loads), that specifies a bootable
+        # SSC image (installer or appliance)
+        'P0000M96': 'ANGEL',
+        'T28': 'BCORE1',
+    },
+}
+
+LPAR_ACTIVATE_TESTCASES = [
+    # Testcases for test_lpar_activate().
+    # The list items are tuples with the following items:
+    # - desc (string): description of the testcase.
+    # - lpar_kind (string): LPAR kind to be used (from ACTIVATE_TEST_LPARS).
+    # - profile_kind (string): Image profile kind to be used (from
+    #   ACTIVATE_TEST_PROFILES). None means to use default (next profile).
+    # - input_kwargs (dict): Input parameters for Lpar.activate() in addition
+    #   to activation_profile_name.
+    # - exp_props (dict): Dict of expected properties of the Lpar after
+    #   calling Lpar.activate().
+    # - exp_exc_type (class): Expected exception type, or None for success.
+    # - run (bool or 'pdb'): Whether to run the test or call the debugger.
+
+    (
+        "Linux LPAR whose same-named profile is w/o auto-load, default parms",
+        'linux-no-autoload',
+        None,
+        dict(),
+        {
+            'status': 'not-operating',
+        },
+        None,
+        True,
+    ),
+    (
+        "Linux LPAR whose same-named profile is with auto-load, default parms",
+        'linux-with-autoload',
+        None,
+        dict(),
+        {
+            'status': 'operating',
+        },
+        None,
+        True,
+    ),
+    (
+        "SSC LPAR (always auto-loads), default parms",
+        'ssc',
+        None,
+        dict(),
+        {
+            'status': 'operating',
+        },
+        None,
+        True,
+    ),
+    (
+        "Linux LPAR, different image profile name than LPAR name specified",
+        'linux-no-autoload',
+        'linux-with-autoload',
+        dict(),
+        None,
+        # HTTP 500,263: LPAR name and image profile name must match
+        zhmcclient.HTTPError,
+        True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, lpar_kind, profile_kind, input_kwargs, exp_props, exp_exc_type, run",
+    LPAR_ACTIVATE_TESTCASES)
+def test_lpar_activate(
+        desc, lpar_kind, profile_kind, input_kwargs, exp_props, exp_exc_type,
+        run, classic_mode_cpcs):  # noqa: F811
+    # pylint: disable=redefined-outer-name, unused-argument
+    """
+    Test Lpar.activate().
+    """
+    if not classic_mode_cpcs:
+        pytest.skip("HMC definition does not include any CPCs in classic mode")
+
+    if not run:
+        skip_warn("Testcase is disabled in testcase definition")
+
+    logger = setup_logging(LOGGING, 'test_lpar_activate', LOG_FILE)
+
+    for cpc in classic_mode_cpcs:
+        assert not cpc.dpm_enabled
+
+        test_lpars = ACTIVATE_TEST_LPARS[lpar_kind]
+        try:
+            lpar_name = test_lpars[cpc.name]
+        except KeyError:
+            pytest.skip("CPC {c} does not have a definition in the "
+                        "ACTIVATE_TEST_LPARS: {tl}".
+                        format(c=cpc.name, tl=test_lpars))
+
+        if profile_kind:
+            test_profiles = ACTIVATE_TEST_PROFILES[profile_kind]
+            try:
+                profile_name = test_profiles[cpc.name]
+            except KeyError:
+                pytest.skip("CPC {c} does not have a definition in the "
+                            "ACTIVATE_TEST_PROFILES: {tp}".
+                            format(c=cpc.name, tp=test_profiles))
+        else:
+            profile_name = None
+
+        try:
+            lpar = cpc.lpars.find(name=lpar_name)
+        except zhmcclient.NotFound:
+            pytest.skip("LPAR {p!r} does not exist on CPC {c}.".
+                        format(c=cpc.name, p=lpar_name))
+
+        msg = ("Testing on CPC {c} with LPAR {p!r}".
+               format(c=cpc.name, p=lpar.name))
+        print(msg)
+        logger.info(msg)
+
+        if run == 'pdb':
+            # pylint: disable=forgotten-debug-statement
+            pdb.set_trace()
+
+        logger.info("Preparation: Ensuring that LPAR %r is inactive",
+                    lpar.name)
+        ensure_lpar_inactive(lpar)
+
+        try:
+            next_profile = lpar.get_property('next-activation-profile-name')
+            logger.info("Test: Activating LPAR %r (next profile: %r, "
+                        "profile arg: %r, add. args: %r)",
+                        lpar.name, next_profile, profile_name, input_kwargs)
+
+            if exp_exc_type:
+
+                with pytest.raises(exp_exc_type):
+
+                    # Exercise the code to be tested
+                    lpar.activate(
+                        activation_profile_name=profile_name, **input_kwargs)
+
+            else:
+
+                # Exercise the code to be tested
+                lpar.activate(
+                    activation_profile_name=profile_name, **input_kwargs)
+
+                # In case of an image profile with auto-load, the activate()
+                # method returns already when status 'non-operating' is reached.
+                # However, we want to see that the LPAR actually gets to
+                # status 'operating' when auto-load is set. So we need to
+                # wait for the desired state to cover for that case.
+                exp_status = exp_props['status']
+                if exp_status == 'operating':
+                    logger.info("Waiting for status of LPAR %r to become %r "
+                                "after test",
+                                lpar.name, exp_status)
+                    lpar.wait_for_status(exp_status, status_timeout=60)
+
+                # Check the expected properties
+                lpar.pull_full_properties()
+                lpar_props = dict(lpar.properties)
+                logger.info("Status of LPAR %r is %r after test",
+                            lpar.name, lpar_props['status'])
+                for pname, exp_value in exp_props.items():
+                    assert pname in lpar_props, (
+                        "Expected property {p!r} does not exist in "
+                        "actual properties of LPAR {ln!r}".
+                        format(p=pname, ln=lpar.name))
+                    act_value = lpar_props[pname]
+                    assert act_value == exp_value, (
+                        "Property {p!r} has unexpected value {av!r}; "
+                        "expected value: {ev!r}".
+                        format(p=pname, av=act_value, ev=exp_value))
+        finally:
+            logger.info("Cleanup: Ensuring that LPAR %r is inactive",
+                        lpar.name)
+            ensure_lpar_inactive(lpar)

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -235,7 +235,7 @@ class Lpar(BaseResource):
         Partition".
 
         This HMC operation has deferred status behavior: If the asynchronous
-        job on the HMC is complete, it takes a few seconds until the LPAR
+        job on the HMC is complete, it may take a few seconds until the LPAR
         status has reached the desired value. If `wait_for_completion=True`,
         this method repeatedly checks the status of the LPAR after the HMC
         operation has completed, and waits until the status is in the desired
@@ -287,10 +287,29 @@ class Lpar(BaseResource):
             set.
 
           activation_profile_name (:term:`string`):
-            Name of the image :class:`ActivationProfile` to use for activation.
+            Name of the load or image activation profile to be used instead
+            of the one specified in the `next-activation-profile-name` property
+            of the LPAR, or `None`.
 
-            `None` means that the activation profile specified in the
-            `next-activation-profile-name` property of the LPAR is used.
+            If this parameter specifies an image activation profile, its name
+            must match the LPAR name. For non-SSC partitions, the image
+            profile's `load-at-activation` property determines whether the
+            activation is followed by a load of the control program using the
+            load-related parameters from the image profile. SSC partitions are
+            always auto-loaded (regardless of the `load-at-activation`
+            property).
+
+            If this parameter specifies a load activation profile, the
+            activation uses the image profile with the same name as the LPAR.
+            The activation is always followed by a load of the control program
+            (regardless of the image profile's `load-at-activation` property)
+            using the parameters from the load profile.
+
+            If this parameter is `None`, the `next-activation-profile-name`
+            property of the LPAR will be used. That property can again specify
+            an image profile or a load profile which are treated as described
+            above. If that property is `None`, the image profile with the same
+            name as the LPAR is used and is treated as described above.
 
           force (bool):
             Boolean controlling whether this operation is permitted when the
@@ -345,7 +364,7 @@ class Lpar(BaseResource):
         Logical Partition".
 
         This HMC operation has deferred status behavior: If the asynchronous
-        job on the HMC is complete, it takes a few seconds until the LPAR
+        job on the HMC is complete, it may take a few seconds until the LPAR
         status has reached the desired value. If `wait_for_completion=True`,
         this method repeatedly checks the status of the LPAR after the HMC
         operation has completed, and waits until the status is in the desired


### PR DESCRIPTION
For details, see the commit message.

Main review points:
* Updated description of `activation_profile_name` parameter of `Lpar.activate()`: https://github.com/zhmcclient/python-zhmcclient/pull/1303/files#diff-e4c63071db073baddf2ce701c8101b698e12316793798a7f5e16aa95909caff3R289