### PR TITLE
Fixed LPAR reset methods; Deprecated deferred status parms in LPAR methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,15 @@ Released: not yet
 
 **Deprecations:**
 
+* Use of the 'status_timeout' and 'allow_status_exceptions' parameters of the
+  following methods has been deprecated because the underlying HMC operations
+  do not actually have deferred status behavior. The waiting for an expected
+  status has been removed from these methods:
+  - Lpar.stop()
+  - Lpar.psw_restart()
+  - Lpar.reset_normal()
+  - Lpar.reset_clear()
+
 **Bug fixes:**
 
 * Test: Circumvented a pip-check-reqs issue by excluding its version 2.5.0.
@@ -79,6 +88,14 @@ Released: not yet
 * Added a debug log entry when Lpar.wait_for_status() is called. This happens
   for example when Lpar.activate/deactivate/load() are called with
   wait_for_completion.
+
+* Fixed that the Lpar.reset_normal() and Lpar.reset_clear() methods were
+  waiting for a status "operational", which never happens with these operations.
+  This was fixed by removing the waiting for an expected status, because the
+  underlying HMC operations do not actually have deferred status behavior.
+  (issue #1304)
+
+* Fixed the incorrect empty request body in Lpar.psw_restart().
 
 **Enhancements:**
 

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -20,13 +20,14 @@ from __future__ import absolute_import
 
 import re
 from collections import OrderedDict
-
 try:
     from collections.abc import Mapping, MutableSequence, Iterable
 except ImportError:
     # pylint: disable=deprecated-class
     from collections import Mapping, MutableSequence, Iterable
 from datetime import datetime
+import warnings
+
 from dateutil import parser
 import six
 import pytz
@@ -610,3 +611,29 @@ def get_features(session, base_uri, name):
         if e.http_status == 404:
             return []
         raise e
+
+
+def warn_deprecated_parameter(cls, method, name, value, default):
+    """
+    Issue a DeprecationWarning for a zhmcclient method parameter.
+
+    The method must use the @logged_api_call decorator.
+
+    Parameters:
+      cls (class): The class object that defines the method.
+      method (method): The method object that has the parameter.
+      name (str): The name of the parameter.
+      value (object): The value of the parameter.
+      default (object): The default value of the parameter.
+    """
+    if value != default:
+        warnings.warn(
+            "Use of the '{pn}' parameter of zhmcclient.{cn}.{mn}() has no "
+            "function anymore and is deprecated".
+            format(pn=name, cn=cls.__name__, mn=method.__name__),
+            DeprecationWarning, stacklevel=5)
+        # Note on stacklevel=5:
+        # * base value 1 (get out of warnings.warn)
+        # * +1 to get out of this function
+        # * +1 to get out of method
+        # * +2 to get over the @logged_api_call decorator of method


### PR DESCRIPTION
For details, see the commit message.

I tested on M96 for all four operations where deferred status handling was removed because it is not actually needed.