### PR TITLE
1.11: Fixed LPAR reset methods; Deprecated deferred status parms in LPAR methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,15 @@ Released: not yet
 
 **Deprecations:**
 
+* Use of the 'status_timeout' and 'allow_status_exceptions' parameters of the
+  following methods has been deprecated because the underlying HMC operations
+  do not actually have deferred status behavior. The waiting for an expected
+  status has been removed from these methods:
+  - Lpar.stop()
+  - Lpar.psw_restart()
+  - Lpar.reset_normal()
+  - Lpar.reset_clear()
+
 **Bug fixes:**
 
 * Addressed safety issues up to 2023-10-05.
@@ -45,6 +54,14 @@ Released: not yet
 * Added a debug log entry when Lpar.wait_for_status() is called. This happens
   for example when Lpar.activate/deactivate/load() are called with
   wait_for_completion.
+
+* Fixed that the Lpar.reset_normal() and Lpar.reset_clear() methods were
+  waiting for a status "operational", which never happens with these operations.
+  This was fixed by removing the waiting for an expected status, because the
+  underlying HMC operations do not actually have deferred status behavior.
+  (issue #1304)
+
+* Fixed the incorrect empty request body in Lpar.psw_restart().
 
 **Enhancements:**
 

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -35,7 +35,7 @@ from ._resource import BaseResource
 from ._exceptions import StatusTimeout
 from ._constants import HMC_LOGGER_NAME
 from ._logging import get_logger, logged_api_call
-from ._utils import RC_LOGICAL_PARTITION
+from ._utils import RC_LOGICAL_PARTITION, warn_deprecated_parameter
 
 __all__ = ['LparManager', 'Lpar']
 
@@ -403,7 +403,7 @@ class Lpar(BaseResource):
 
             * If `True`, this method will wait for completion of the
               asynchronous job performing the operation, and for the status
-              becoming "non-activated" (or in addition "exceptions", if
+              becoming "not-activated" (or in addition "exceptions", if
               `allow_status_exceptions` was set.
 
             * If `False`, this method will return immediately once the HMC has
@@ -1381,13 +1381,15 @@ class Lpar(BaseResource):
         Partition". The stop operation stops the processors from
         processing instructions.
 
-        This HMC operation has deferred status behavior: If the asynchronous
-        job on the HMC is complete, it takes a few seconds until the LPAR
-        status has reached the desired value. If `wait_for_completion=True`,
-        this method repeatedly checks the status of the LPAR after the HMC
-        operation has completed, and waits until the status is in the desired
-        state "not-operating", or if `allow_status_exceptions` was
-        set additionally in the state "exceptions".
+        This operation is not permitted for an LPAR whose 'activation-mode'
+        property is "zaware" or "ssc".
+
+        In order to succeed, the 'status' property of the LPAR must have one of
+        the following values:
+
+        * "not-operating"
+        * "operating"
+        * "exceptions"
 
         Authorization requirements:
 
@@ -1403,9 +1405,7 @@ class Lpar(BaseResource):
             of the requested asynchronous HMC operation, as follows:
 
             * If `True`, this method will wait for completion of the
-              asynchronous job performing the operation, and for the status
-              becoming "not-operating" (or in addition "exceptions", if
-              `allow_status_exceptions` was set.
+              asynchronous job performing the operation.
 
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
@@ -1419,17 +1419,16 @@ class Lpar(BaseResource):
             :exc:`~zhmcclient.OperationTimeout` is raised.
 
           status_timeout (:term:`number`):
-            Timeout in seconds, for waiting that the status of the LPAR has
-            reached the desired status, after the HMC operation has completed.
-            The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.StatusTimeout` is raised.
+            **Deprecated:** This property was used for handling deferred status
+            behavior, which is not actually needed. Setting it to a non-default
+            value will cause a :exc:`~py:exceptions.DeprecationWarning` to be
+            issued.
 
           allow_status_exceptions (bool):
-            Boolean controlling whether LPAR status "exceptions" is considered
-            an additional acceptable end status when `wait_for_completion` is
-            set.
+            **Deprecated:** This property was used for handling deferred status
+            behavior, which is not actually needed. Setting it to a non-default
+            value will cause a :exc:`~py:exceptions.DeprecationWarning` to be
+            issued.
 
         Returns:
 
@@ -1449,19 +1448,17 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
-          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
-            waiting for the desired LPAR status.
         """
+        warn_deprecated_parameter(
+            Lpar, Lpar.stop, 'status_timeout', status_timeout, None)
+        warn_deprecated_parameter(
+            Lpar, Lpar.stop, 'allow_status_exceptions',
+            allow_status_exceptions, False)
         body = None
         result = self.manager.session.post(
             self.uri + '/operations/stop', resource=self, body=body,
             wait_for_completion=wait_for_completion,
             operation_timeout=operation_timeout)
-        if wait_for_completion:
-            statuses = ["not-operating"]
-            if allow_status_exceptions:
-                statuses.append("exceptions")
-            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call
@@ -1475,13 +1472,12 @@ class Lpar(BaseResource):
         subsystem and resetting its processors, and clearing its memory, using
         the HMC operation "Reset Clear".
 
-        This HMC operation has deferred status behavior: If the asynchronous
-        job on the HMC is complete, it takes a few seconds until the LPAR
-        status has reached the desired value. If `wait_for_completion=True`,
-        this method repeatedly checks the status of the LPAR after the HMC
-        operation has completed, and waits until the status is in the desired
-        state "operating", or if `allow_status_exceptions` was
-        set additionally in the state "exceptions".
+        In order to succeed, the 'status' property of the LPAR must have one of
+        the following values:
+
+        * "not-operating"
+        * "operating" - this requires setting the "force" flag
+        * "exceptions" - this requires setting the "force" flag
 
         Authorization requirements:
 
@@ -1501,9 +1497,7 @@ class Lpar(BaseResource):
             of the requested asynchronous HMC operation, as follows:
 
             * If `True`, this method will wait for completion of the
-              asynchronous job performing the operation, and for the status
-              becoming "operating" (or in addition "exceptions", if
-              `allow_status_exceptions` was set.
+              asynchronous job performing the operation.
 
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
@@ -1517,17 +1511,16 @@ class Lpar(BaseResource):
             :exc:`~zhmcclient.OperationTimeout` is raised.
 
           status_timeout (:term:`number`):
-            Timeout in seconds, for waiting that the status of the LPAR has
-            reached the desired status, after the HMC operation has completed.
-            The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.StatusTimeout` is raised.
+            **Deprecated:** This property was used for handling deferred status
+            behavior, which is not actually needed. Setting it to a non-default
+            value will cause a :exc:`~py:exceptions.DeprecationWarning` to be
+            issued.
 
           allow_status_exceptions (bool):
-            Boolean controlling whether LPAR status "exceptions" is considered
-            an additional acceptable end status when `wait_for_completion` is
-            set.
+            **Deprecated:** This property was used for handling deferred status
+            behavior, which is not actually needed. Setting it to a non-default
+            value will cause a :exc:`~py:exceptions.DeprecationWarning` to be
+            issued.
 
           os_ipl_token (:term:`string`):
             Applicable only to z/OS, this parameter requests that this
@@ -1552,9 +1545,12 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
-          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
-            waiting for the desired LPAR status.
         """
+        warn_deprecated_parameter(
+            Lpar, Lpar.reset_clear, 'status_timeout', status_timeout, None)
+        warn_deprecated_parameter(
+            Lpar, Lpar.reset_clear, 'allow_status_exceptions',
+            allow_status_exceptions, False)
         body = {}
         if force:
             body['force'] = force
@@ -1564,11 +1560,6 @@ class Lpar(BaseResource):
             self.uri + '/operations/reset-clear', resource=self, body=body,
             wait_for_completion=wait_for_completion,
             operation_timeout=operation_timeout)
-        if wait_for_completion:
-            statuses = ["operating"]
-            if allow_status_exceptions:
-                statuses.append("exceptions")
-            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call
@@ -1582,13 +1573,12 @@ class Lpar(BaseResource):
         subsystem and resetting its processors, using the HMC operation
         "Reset Normal".
 
-        This HMC operation has deferred status behavior: If the asynchronous
-        job on the HMC is complete, it takes a few seconds until the LPAR
-        status has reached the desired value. If `wait_for_completion=True`,
-        this method repeatedly checks the status of the LPAR after the HMC
-        operation has completed, and waits until the status is in the desired
-        state "operating", or if `allow_status_exceptions` was
-        set additionally in the state "exceptions".
+        In order to succeed, the 'status' property of the LPAR must have one of
+        the following values:
+
+        * "not-operating"
+        * "operating" - this requires setting the "force" flag
+        * "exceptions" - this requires setting the "force" flag
 
         Authorization requirements:
 
@@ -1608,9 +1598,7 @@ class Lpar(BaseResource):
             of the requested asynchronous HMC operation, as follows:
 
             * If `True`, this method will wait for completion of the
-              asynchronous job performing the operation, and for the status
-              becoming "operating" (or in addition "exceptions", if
-              `allow_status_exceptions` was set.
+              asynchronous job performing the operation.
 
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
@@ -1624,17 +1612,16 @@ class Lpar(BaseResource):
             :exc:`~zhmcclient.OperationTimeout` is raised.
 
           status_timeout (:term:`number`):
-            Timeout in seconds, for waiting that the status of the LPAR has
-            reached the desired status, after the HMC operation has completed.
-            The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.StatusTimeout` is raised.
+            **Deprecated:** This property was used for handling deferred status
+            behavior, which is not actually needed. Setting it to a non-default
+            value will cause a :exc:`~py:exceptions.DeprecationWarning` to be
+            issued.
 
           allow_status_exceptions (bool):
-            Boolean controlling whether LPAR status "exceptions" is considered
-            an additional acceptable end status when `wait_for_completion` is
-            set.
+            **Deprecated:** This property was used for handling deferred status
+            behavior, which is not actually needed. Setting it to a non-default
+            value will cause a :exc:`~py:exceptions.DeprecationWarning` to be
+            issued.
 
           os_ipl_token (:term:`string`):
             Applicable only to z/OS, this parameter requests that this
@@ -1659,9 +1646,12 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
-          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
-            waiting for the desired LPAR status.
         """
+        warn_deprecated_parameter(
+            Lpar, Lpar.reset_normal, 'status_timeout', status_timeout, None)
+        warn_deprecated_parameter(
+            Lpar, Lpar.reset_normal, 'allow_status_exceptions',
+            allow_status_exceptions, False)
         body = {}
         if force:
             body['force'] = force
@@ -1671,11 +1661,6 @@ class Lpar(BaseResource):
             self.uri + '/operations/reset-normal', resource=self, body=body,
             wait_for_completion=wait_for_completion,
             operation_timeout=operation_timeout)
-        if wait_for_completion:
-            statuses = ["operating"]
-            if allow_status_exceptions:
-                statuses.append("exceptions")
-            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call
@@ -1770,13 +1755,12 @@ class Lpar(BaseResource):
         """
         Restart this LPAR, using the HMC operation "PSW Restart".
 
-        This HMC operation has deferred status behavior: If the asynchronous
-        job on the HMC is complete, it takes a few seconds until the LPAR
-        status has reached the desired value. If `wait_for_completion=True`,
-        this method repeatedly checks the status of the LPAR after the HMC
-        operation has completed, and waits until the status is in the desired
-        state "operating", or if `allow_status_exceptions` was
-        set additionally in the state "exceptions".
+        In order to succeed, the 'status' property of the LPAR must have one of
+        the following values:
+
+        * "not-operating"
+        * "operating"
+        * "exceptions"
 
         Authorization requirements:
 
@@ -1792,9 +1776,7 @@ class Lpar(BaseResource):
             of the requested asynchronous HMC operation, as follows:
 
             * If `True`, this method will wait for completion of the
-              asynchronous job performing the operation, and for the status
-              becoming "operating" (or in addition "exceptions", if
-              `allow_status_exceptions` was set.
+              asynchronous job performing the operation.
 
             * If `False`, this method will return immediately once the HMC has
               accepted the request to perform the operation.
@@ -1808,17 +1790,16 @@ class Lpar(BaseResource):
             :exc:`~zhmcclient.OperationTimeout` is raised.
 
           status_timeout (:term:`number`):
-            Timeout in seconds, for waiting that the status of the LPAR has
-            reached the desired status, after the HMC operation has completed.
-            The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
-            If the timeout expires when `wait_for_completion=True`, a
-            :exc:`~zhmcclient.StatusTimeout` is raised.
+            **Deprecated:** This property was used for handling deferred status
+            behavior, which is not actually needed. Setting it to a non-default
+            value will cause a :exc:`~py:exceptions.DeprecationWarning` to be
+            issued.
 
           allow_status_exceptions (bool):
-            Boolean controlling whether LPAR status "exceptions" is considered
-            an additional acceptable end status when `wait_for_completion` is
-            set.
+            **Deprecated:** This property was used for handling deferred status
+            behavior, which is not actually needed. Setting it to a non-default
+            value will cause a :exc:`~py:exceptions.DeprecationWarning` to be
+            issued.
 
         Returns:
 
@@ -1838,19 +1819,17 @@ class Lpar(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for completion of the operation.
-          :exc:`~zhmcclient.StatusTimeout`: The timeout expired while
-            waiting for the desired LPAR status.
         """
-        body = {}
+        warn_deprecated_parameter(
+            Lpar, Lpar.psw_restart, 'status_timeout', status_timeout, None)
+        warn_deprecated_parameter(
+            Lpar, Lpar.psw_restart, 'allow_status_exceptions',
+            allow_status_exceptions, False)
+        body = None
         result = self.manager.session.post(
             self.uri + '/operations/psw-restart', resource=self, body=body,
             wait_for_completion=wait_for_completion,
             operation_timeout=operation_timeout)
-        if wait_for_completion:
-            statuses = ["operating"]
-            if allow_status_exceptions:
-                statuses.append("exceptions")
-            self.wait_for_status(statuses, status_timeout)
         return result
 
     @logged_api_call

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -20,13 +20,14 @@ from __future__ import absolute_import
 
 import re
 from collections import OrderedDict
-
 try:
     from collections.abc import Mapping, MutableSequence, Iterable
 except ImportError:
     # pylint: disable=deprecated-class
     from collections import Mapping, MutableSequence, Iterable
 from datetime import datetime
+import warnings
+
 from dateutil import parser
 import six
 import pytz
@@ -610,3 +611,29 @@ def get_features(session, base_uri, name):
         if e.http_status == 404:
             return []
         raise e
+
+
+def warn_deprecated_parameter(cls, method, name, value, default):
+    """
+    Issue a DeprecationWarning for a zhmcclient method parameter.
+
+    The method must use the @logged_api_call decorator.
+
+    Parameters:
+      cls (class): The class object that defines the method.
+      method (method): The method object that has the parameter.
+      name (str): The name of the parameter.
+      value (object): The value of the parameter.
+      default (object): The default value of the parameter.
+    """
+    if value != default:
+        warnings.warn(
+            "Use of the '{pn}' parameter of zhmcclient.{cn}.{mn}() has no "
+            "function anymore and is deprecated".
+            format(pn=name, cn=cls.__name__, mn=method.__name__),
+            DeprecationWarning, stacklevel=5)
+        # Note on stacklevel=5:
+        # * base value 1 (get out of warnings.warn)
+        # * +1 to get out of this function
+        # * +1 to get out of method
+        # * +2 to get over the @logged_api_call decorator of method


### PR DESCRIPTION
Rolls back PR #1305 into 1.11.3.
Needs to wait until that PR is approved - No further review needed on this PR.