### PR TITLE
1.11: Shortened status timeout to 60 sec; fixed status_timeout descriptions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -63,6 +63,17 @@ Released: not yet
 
 * Fixed the incorrect empty request body in Lpar.psw_restart().
 
+* Shortened the status timeout from 900 sec to 60 sec. This timeout is used
+  when waiting for an expected Partition or LPAR status after operations
+  that change the status and that have deferred status behavior (ie. the
+  status changes only after the asynchronous HMC job is complete).
+  This change allows to more reasonably surface the situation where an LPAR
+  load succeeds but the status of the LPAR does not go to 'operating' due to
+  issues with the operating system.
+
+* Docs: Fixed the description of the 'status_timeout' parameter of the Partition
+  and Lpar methods that have deferred status behavior.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -95,14 +95,10 @@ DEFAULT_MAX_REDIRECTS = 30
 DEFAULT_OPERATION_TIMEOUT = 3600
 
 #: Default timeout in seconds for waiting for completion of deferred status
-#: changes for LPARs,
+#: changes for LPARs and Partitions,
 #: if not specified in the ``retry_timeout_config`` init argument to
 #: :class:`~zhmcclient.Session`.
-#:
-#: This is used as a default value in asynchronous methods
-#: of the :class:`~zhmcclient.Lpar` class that change its status (e.g.
-#: :meth:`zhmcclient.Lpar.activate`)).
-DEFAULT_STATUS_TIMEOUT = 900
+DEFAULT_STATUS_TIMEOUT = 60
 
 #: Default time to the next automatic invalidation of the Name-URI cache of
 #: manager objects, in seconds since the last invalidation,

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -280,7 +280,7 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status, after the HMC operation has completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 
@@ -421,7 +421,7 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status, after the HMC operation has completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 
@@ -564,7 +564,7 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status, after the HMC operation has completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 
@@ -741,7 +741,7 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status, after the HMC operation has completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 
@@ -914,7 +914,7 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status, after the HMC operation has completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 
@@ -1066,7 +1066,7 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status, after the HMC operation has completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 
@@ -1194,7 +1194,7 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status, after the HMC operation has completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 
@@ -1325,7 +1325,7 @@ class Lpar(BaseResource):
             Timeout in seconds, for waiting that the status of the LPAR has
             reached the desired status, after the HMC operation has completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -414,7 +414,7 @@ class Partition(BaseResource):
             has reached the desired status, after the HMC operation has
             completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 
@@ -486,7 +486,7 @@ class Partition(BaseResource):
             has reached the desired status, after the HMC operation has
             completed.
             The special value 0 means that no timeout is set. `None` means that
-            the default async operation timeout of the session is used.
+            the default status timeout of the session is used.
             If the timeout expires when `wait_for_completion=True`, a
             :exc:`~zhmcclient.StatusTimeout` is raised.
 


### PR DESCRIPTION
Rolls back PR #1311 into 1.11.3.
Needs to wait until that PR is approved - No further review needed on this PR.