### PR TITLE
Resolved dependency conflict with importlib-metadata on Python 3.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -48,7 +48,8 @@ packaging>=21.0; python_version >= '3.6'
 # Virtualenv
 # build requires virtualenv.cli_run which was added in 20.1
 # virtualenv 20.0 requires six<2,>=1.12.0
-virtualenv>=20.1.0; python_version <= '3.11'
+# virtualenv 20.16.0 removed support for Python<3.6
+virtualenv>=20.15.0; python_version <= '3.11'
 virtualenv>=20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -161,7 +161,7 @@ packaging==20.5; python_version <= '3.5'
 packaging==21.0; python_version >= '3.6'
 
 # Virtualenv
-virtualenv==20.1.0; python_version <= '3.11'
+virtualenv==20.15.0; python_version <= '3.11'
 virtualenv==20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):


### PR DESCRIPTION
For details, see the commit message.
No review needed.