### PR TITLE
1.11: Resolved dependency conflict with importlib-metadata on Python 3.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -48,7 +48,9 @@ packaging>=21.0; python_version >= '3.6'
 # Virtualenv
 # build requires virtualenv.cli_run which was added in 20.1
 # virtualenv 20.0 requires six<2,>=1.12.0
-virtualenv>=20.1.0
+# virtualenv 20.16.0 removed support for Python<3.6
+virtualenv>=20.15.0; python_version <= '3.11'
+virtualenv>=20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):
 # Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -159,7 +159,8 @@ packaging==20.5; python_version <= '3.5'
 packaging==21.0; python_version >= '3.6'
 
 # Virtualenv
-virtualenv==20.1.0
+virtualenv==20.15.0; python_version <= '3.11'
+virtualenv==20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):
 pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'


### PR DESCRIPTION
Rolls back PR #1315 into 1.11.3.
No review needed.