### PR TITLE
1.11: Fixed status to wait for in SSC activation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed the expected status to wait for in Lpar.activate() for inactive
+  SSC or Aware LPARs to be 'operating'.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/tests/unit/zhmcclient/test_lpar.py
+++ b/tests/unit/zhmcclient/test_lpar.py
@@ -120,6 +120,7 @@ class TestLpar(object):
             'ipl-parameter': '',
             'ipl-type': 'ipltype-standard',
             'load-at-activation': False,
+            'operating-mode': 'linux',
         })
         return faked_imageprofile
 
@@ -162,6 +163,7 @@ class TestLpar(object):
             'ipl-parameter': '',
             'ipl-type': 'ipltype-standard',
             'load-at-activation': False,
+            'operating-mode': 'ssc',
         })
         return faked_imageprofile
 

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -247,6 +247,18 @@ class Lpar(BaseResource):
         `allow_status_exceptions` was set additionally in the state
         "exceptions".
 
+        The following approach is used to determine the desired state to wait
+        for if `wait_for_completion=True`:
+
+        - if the 'operating-mode' property of the image profile is 'ssc' or
+          'zaware', the desired state is "operating".
+        - if the profile specified in `activation_profile_name` is not the
+          LPAR's image profile, it is assumed to be a load profile and
+          the desired state is "operating".
+        - if the 'load-at-activation' property of the image profile is True,
+          the desired state is "operating".
+        - else, the desired state is "not-operating".
+
         Authorization requirements:
 
         * Object-access permission to this LPAR.
@@ -359,11 +371,14 @@ class Lpar(BaseResource):
             image_profile_mgr = self.manager.parent.image_activation_profiles
             image_profile = image_profile_mgr.find(name=self.name)
             auto_load = image_profile.get_property('load-at-activation')
-            activation_mode = self.get_property('activation-mode')
+            # Note that the LPAR 'activation-mode' property is 'not-set' while
+            # the LPAR is inactive, so we need to look at the image profile
+            # to determine the mode.
+            op_mode = image_profile.get_property('operating-mode')
             load_profile_specified = activation_profile_name is not None and \
                 activation_profile_name != self.name
-            is_ssc = activation_mode in ('ssc', 'zaware')
-            if auto_load or load_profile_specified or is_ssc:
+            mode_load = op_mode in ('ssc', 'zaware')
+            if auto_load or load_profile_specified or mode_load:
                 statuses = ["operating"]
             else:
                 statuses = ["not-operating"]


### PR DESCRIPTION
Rolls back PR #1320 into 1.11.4.
No review needed.
Needs to wait until PR #1320 is merged.