### PR TITLE
Added support for creation and deletion of activation profiles on z16

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -154,6 +154,11 @@ Released: not yet
   Job.check_for_completion() and Job.wait_for_completion() already existed.
   (issue #1299)
 
+* Added support for creation and deletion of activation profiles on z16.
+  This requires the SE to have a code level that has the
+  'create-delete-activation-profiles' API feature enabled.
+  (issue #1329)
+
 **Cleanup:**
 
 **Known issues:**

--- a/tests/end2end/test_activation_profile.py
+++ b/tests/end2end/test_activation_profile.py
@@ -20,18 +20,25 @@ These tests do not change any activation profiles.
 
 from __future__ import absolute_import, print_function
 
+import warnings
+
 import pytest
 from requests.packages import urllib3
 
+import zhmcclient
 # pylint: disable=line-too-long,unused-import
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, runtest_find_list, \
-    runtest_get_properties
+    runtest_get_properties, setup_logging, End2endTestWarning
 
 urllib3.disable_warnings()
+
+# Logging for zhmcclient HMC interactions and test functions
+LOGGING = False
+LOG_FILE = 'test_profile.log'
 
 # Properties in minimalistic ActivationProfile objects (e.g. find_by_name())
 ACTPROF_MINIMAL_PROPS = ['element-uri', 'name']
@@ -44,6 +51,117 @@ ACTPROF_ADDITIONAL_PROPS = ['description', 'ipl-address']
 
 # Properties whose values can change between retrievals
 ACTPROF_VOLATILE_PROPS = []
+
+
+def standard_activation_profile_props(cpc, profile_name, profile_type):
+    """
+    Return the input properties for creating standard activation profile in the
+    specified CPC.
+    """
+    actprof_input_props = {
+        'profile-name': profile_name,
+        'description': (
+            '{} profile for zhmcclient end2end tests'.format(profile_type)),
+    }
+    if profile_type == 'image':
+        # We provide the minimum set of properties needed to create a profile.
+        if cpc.prop('processor-count-ifl'):
+            actprof_input_props['number-shared-ifl-processors'] = 1
+            actprof_input_props['operating-mode'] = 'linux-only'
+        elif cpc.prop('processor-count-general-purpose'):
+            actprof_input_props['number-shared-general-purpose-processors'] = 1
+            actprof_input_props['operating-mode'] = 'esa390'
+        else:
+            actprof_input_props['number-shared-general-purpose-processors'] = 1
+            actprof_input_props['operating-mode'] = 'esa390'
+            warnings.warn(
+                "CPC {c} shows neither IFL nor CP processors, specifying 1 CP "
+                "for image activation profile creation.".
+                format(c=cpc.name), End2endTestWarning)
+
+    return actprof_input_props
+
+
+@pytest.mark.parametrize(
+    "profile_type", ['reset', 'image', 'load']
+)
+def test_actprof_crud(classic_mode_cpcs, profile_type):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test create, read, update and delete an activation profile.
+    """
+    if not classic_mode_cpcs:
+        pytest.skip("HMC definition does not include any CPCs in classic mode")
+
+    logger = setup_logging(LOGGING, 'test_actprof_crud', LOG_FILE)
+
+    for cpc in classic_mode_cpcs:
+        assert not cpc.dpm_enabled
+
+        actprof_mgr = getattr(cpc, profile_type + '_activation_profiles')
+
+        msg = "Testing on CPC {c}".format(c=cpc.name)
+        print(msg)
+        logger.info(msg)
+
+        actprof_name = 'ZHMC{}1'.format(profile_type[0].upper())
+
+        # Preparation: Ensure clean starting point for this test
+        try:
+            _actprof = actprof_mgr.find(name=actprof_name)
+        except zhmcclient.NotFound:
+            pass
+        else:
+            msg = ("Preparation: Delete {pt} activation profile {ap!r} on CPC "
+                   "{c} from previous run".
+                   format(pt=profile_type, ap=actprof_name, c=cpc.name))
+            warnings.warn(msg, UserWarning)
+            logger.info(msg)
+            _actprof.delete()
+
+        # Test creating the activation profile
+        actprof_input_props = standard_activation_profile_props(
+            cpc, actprof_name, profile_type)
+
+        logger.info("Test: Create %s activation profile %r on CPC %s",
+                    profile_type, actprof_name, cpc.name)
+
+        # The code to be tested
+        actprof = actprof_mgr.create(actprof_input_props)
+
+        try:
+            for pn, exp_value in actprof_input_props.items():
+                assert actprof.properties[pn] == exp_value, \
+                    "Unexpected value for property {!r}".format(pn)
+            actprof.pull_full_properties()
+            for pn, exp_value in actprof_input_props.items():
+                if pn == 'profile-name':
+                    pn = 'name'
+                assert actprof.properties[pn] == exp_value, \
+                    "Unexpected value for property {!r}".format(pn)
+
+            # Test updating a property of the activation profile
+
+            new_desc = "Updated activation profile description."
+
+            logger.info("Test: Update a property of %s activation profile "
+                        "%r on CPC %s", profile_type, actprof_name, cpc.name)
+
+            # The code to be tested
+            actprof.update_properties(dict(description=new_desc))
+
+            assert actprof.properties['description'] == new_desc
+            actprof.pull_full_properties()
+            assert actprof.properties['description'] == new_desc
+
+        finally:
+            # Test deleting the activation profile (also cleanup)
+
+            logger.info("Test: Delete %s activation profile %r on CPC %s",
+                        profile_type, actprof_name, cpc.name)
+
+            # The code to be tested
+            actprof.delete()
 
 
 @pytest.mark.parametrize(
@@ -73,8 +191,8 @@ def test_actprof_find_list(classic_mode_cpcs, profile_type):  # noqa: F811
         actprof_list = pick_test_resources(actprof_list)
 
         for actprof in actprof_list:
-            print("Testing on CPC {c} with {t} activation profile {p!r}".
-                  format(c=cpc.name, t=profile_type, p=actprof.name))
+            print("Testing on CPC {c} with {pt} activation profile {ap!r}".
+                  format(c=cpc.name, pt=profile_type, ap=actprof.name))
             if profile_type == 'image':
                 actprof_additional_props = ACTPROF_ADDITIONAL_PROPS
             else:
@@ -113,8 +231,8 @@ def test_actprof_property(classic_mode_cpcs, profile_type):  # noqa: F811
         actprof_list = pick_test_resources(actprof_list)
 
         for actprof in actprof_list:
-            print("Testing on CPC {c} with {t} activation profile {p!r}".
-                  format(c=cpc.name, t=profile_type, p=actprof.name))
+            print("Testing on CPC {c} with {pt} activation profile {ap!r}".
+                  format(c=cpc.name, pt=profile_type, ap=actprof.name))
 
             # Select a property that is not returned by list()
             non_list_prop = 'description'


### PR DESCRIPTION
For details, see the commit message.
I successfully ran the end2end tests for test_activation_profile.py on A65.