### PR TITLE
Add load-from-ftp operation

### DIFF
--- a/examples/install_from_ftp.py
+++ b/examples/install_from_ftp.py
@@ -1,0 +1,68 @@
+import sys
+import requests.packages.urllib3
+requests.packages.urllib3.disable_warnings()
+import yaml
+import zhmcclient
+
+
+
+def receive_until_KeyboardInterrupt(receiver):
+    try:
+        for headers, message in receiver.notifications():
+            os_msg_list = message['os-messages']
+            for os_msg in os_msg_list:
+                if PRINT_METADATA:
+                    msg_id = os_msg['message-id']
+                    held = os_msg['is-held']
+                    priority = os_msg['is-priority']
+                    prompt = os_msg.get('prompt-text', None)
+                    print("# OS message {} (held: {}, priority: {}, "
+                          "prompt: {}):".
+                          format(msg_id, held, priority, prompt))
+                msg_txt = os_msg['message-text'].strip('\n')
+                print(msg_txt)
+    except KeyboardInterrupt:
+        print("Keyboard interrupt - leaving receiver loop")
+    finally:
+        print("Closing receiver ...")
+        receiver.close()
+
+def get_password(host, userid):
+    return input("password for user %s on host %s:" % (userid, host))
+
+def load_config(config_filepath):
+    """
+    config = {
+        'host': "<host_url>",
+        'userid': "<userid>",
+        'ftp_config': {
+            'host_name' : '<ftp_server_url>',
+            'username' : '<ftp_user>',
+            'password' : '<ftp_password>',
+            'file_path' : '<ftp_file_path>'
+        },
+        'lpar': "<lpar-name>"
+    }
+    """
+    with open(config_filepath) as f:
+        return yaml.safe_load(f)
+
+def main(config_filepath):
+    config = load_config(config_filepath)
+    session = zhmcclient.Session(config['host'], config['userid'], get_password=get_password, verify_cert=False)
+    client = zhmcclient.Client(session)
+    console = client.consoles.console
+    lpars = console.list_permitted_lpars()
+    lpar = [x for x in lpars if x.properties.get("name") == config['lpar']][0]
+    print(lpar)
+    ftp_config = config['ftp_config']
+    lpar.load_from_ftp(host_name=ftp_config['host_name'], username=ftp_config['username'],
+                       password=ftp_config['password'], file_path=ftp_config['file_path'],
+                       wait_for_completion=True)
+    topic = lpar.open_os_message_channel()
+    receiver = zhmcclient.NotificationReceiver(topic, host, session.session_id, session.session_credential)
+    receive_until_KeyboardInterrupt(receiver)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -1107,6 +1107,29 @@ class Lpar(BaseResource):
         return result
 
     @logged_api_call
+    def load_from_ftp(self, host_name=None, username=None, password=None,
+                      file_path=None, protocol='ftp',
+                      wait_for_completion=True, operation_timeout=None,
+                      status_timeout=None, allow_status_exceptions=False):
+        body = {}
+        body['host-name'] = host_name
+        body['username'] = username
+        body['password'] = password
+        body['file-path'] = file_path
+        body['protocol'] = protocol
+        result = self.manager.session.post(
+            self.uri + '/operations/load-from-ftp',
+            body,
+            wait_for_completion=wait_for_completion,
+            operation_timeout=operation_timeout)
+        if wait_for_completion:
+            statuses = ["operating"]
+            if allow_status_exceptions:
+                statuses.append("exceptions")
+            self.wait_for_status(statuses, status_timeout)
+        return result
+
+    @logged_api_call
     def load(self, load_address=None, load_parameter=None,
              clear_indicator=True, store_status_indicator=False,
              wait_for_completion=True, operation_timeout=None,

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -566,6 +566,14 @@ class Session(object):
         return self._session_id
 
     @property
+    def session_credential(self):
+        """
+        :term:`string`: Session credential for this seccion, returned by
+                        the HMC.
+        """
+        return self._session_credential
+
+    @property
     def session(self):
         """
         :term:`string`: :class:`requests.Session` object for this session.
@@ -713,6 +721,7 @@ class Session(object):
         self._session = self._new_session(self.retry_timeout_config)
         logon_res = self.post(logon_uri, logon_body, logon_required=False)
         self._session_id = logon_res['api-session']
+        self._session_credential = logon_res['session-credential']
         self._headers['X-API-Session'] = self._session_id
         self._object_topic = logon_res['notification-topic']
         self._job_topic = logon_res['job-notification-topic']


### PR DESCRIPTION
Add load-from-ftp operation.

The session-credential can be used to connect to the API message broker. Store it as a new property.

Add script to load-from-ftp with a config file.