### PR TITLE
Add example for load-from-ftp

### DIFF
--- a/examples/install_from_ftp.py
+++ b/examples/install_from_ftp.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Sebastian Mitterle <smitterl@redhat.com>
+
+"""
+Example that triggers load from ftp from a specified generic.ins
+and displays the console output.
+This is useful when the .prm file has a kickstart reference for
+a fully automated installation.
+"""
+import sys
+import time
+import requests.packages.urllib3
+requests.packages.urllib3.disable_warnings()
+import yaml
+import zhmcclient
+
+
+PRINT_METADATA = False
+
+def receive_until_KeyboardInterrupt(receiver):
+    try:
+        for headers, message in receiver.notifications():
+            os_msg_list = message['os-messages']
+            for os_msg in os_msg_list:
+                if PRINT_METADATA:
+                    msg_id = os_msg['message-id']
+                    held = os_msg['is-held']
+                    priority = os_msg['is-priority']
+                    prompt = os_msg.get('prompt-text', None)
+                    print("# OS message {} (held: {}, priority: {}, "
+                          "prompt: {}):".
+                          format(msg_id, held, priority, prompt))
+                msg_txt = os_msg['message-text'].strip('\n')
+                print(msg_txt)
+    except KeyboardInterrupt:
+        print("Keyboard interrupt - leaving receiver loop")
+    finally:
+        print("Closing receiver ...")
+        receiver.close()
+
+def get_password(host, userid):
+    return input("password for user %s on host %s:" % (userid, host))
+
+def load_config(config_filepath):
+    """
+    config = {
+        'host': "<host_url>",
+        'userid': "<userid>",
+        'ftp_config': {
+            'host' : '<ftp_server_url>',
+            'username' : '<ftp_user>',
+            'password' : '<ftp_password>',
+            'file_path' : '<ftp_file_path>'
+        },
+        'lpar': "<lpar-name>"
+    }
+    """
+    with open(config_filepath) as f:
+        return yaml.safe_load(f)
+
+def main(config_filepath):
+    config = load_config(config_filepath)
+    session = zhmcclient.Session(config['host'], config['userid'], get_password=get_password, verify_cert=False)
+    client = zhmcclient.Client(session)
+    console = client.consoles.console
+    lpars = console.list_permitted_lpars()
+    lpar = [x for x in lpars if x.properties.get("name") == config['lpar']][0]
+    print(lpar)
+    ftp_config = config['ftp_config']
+    lpar.load_from_ftp(host=ftp_config['host'], username=ftp_config['username'],
+                       password=ftp_config['password'], load_file=ftp_config['file_path'],
+                       wait_for_completion=False)
+    print("Load from FTP issued. Will connect to OS messages in 10 sec.")
+    time.sleep(10)
+    topic = lpar.open_os_message_channel()
+    receiver = zhmcclient.NotificationReceiver(topic, config['host'], session.session_id, session.session_credential)
+    receive_until_KeyboardInterrupt(receiver)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/tests/common/http_mocked_fixtures.py
+++ b/tests/common/http_mocked_fixtures.py
@@ -77,6 +77,8 @@ def http_mocked_session(request):  # noqa: F811
             'api-major-version': 4,
             'api-minor-version': 10,
             'password-expires': 90,
+            'session-credential':
+                'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4'
         })
         session.logon()
 

--- a/tests/unit/zhmcclient/test_port.py
+++ b/tests/unit/zhmcclient/test_port.py
@@ -44,6 +44,8 @@ class TestPort(object):
                     'api-session': 'test-session-id',
                     'notification-topic': 'test-obj-topic.1',
                     'job-notification-topic': 'test-job-topic.1',
+                    'session-credential':
+                        'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4',
                 })
             self.session.logon()
 

--- a/tests/unit/zhmcclient/test_session.py
+++ b/tests/unit/zhmcclient/test_session.py
@@ -47,6 +47,8 @@ def mock_server_1(m):
                        'api-session': 'test-session-id',
                        'notification-topic': 'test-obj-topic.1',
                        'job-notification-topic': 'test-job-topic.1',
+                       'session-credential':
+                           'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4',
                    },
                    headers={'X-Request-Id': 'fake-request-id'})
     m.register_uri('DELETE', '/api/sessions/this-session',
@@ -301,6 +303,8 @@ def test_session_get_notification_topics():
                 'api-session': 'test-session-id',
                 'notification-topic': 'test-obj-topic.1',
                 'job-notification-topic': 'test-job-topic.1',
+                'session-credential':
+                    'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4',
             })
         session.logon()
         gnt_uri = "/api/sessions/operations/get-notification-topics"

--- a/tests/unit/zhmcclient/test_virtual_function.py
+++ b/tests/unit/zhmcclient/test_virtual_function.py
@@ -45,6 +45,8 @@ class TestVirtualFunction(object):
                     'api-session': 'test-session-id',
                     'notification-topic': 'test-obj-topic.1',
                     'job-notification-topic': 'test-job-topic.1',
+                    'session-credential':
+                        'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4',
                 })
             self.session.logon()
 

--- a/tests/unit/zhmcclient/test_virtual_switch.py
+++ b/tests/unit/zhmcclient/test_virtual_switch.py
@@ -45,6 +45,8 @@ class TestVirtualSwitch(object):
                     'api-session': 'test-session-id',
                     'notification-topic': 'test-obj-topic.1',
                     'job-notification-topic': 'test-job-topic.1',
+                    'session-credential':
+                        'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4',
                 })
             self.session.logon()
 

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -430,6 +430,7 @@ class Session(object):
         self._object_topic = None
         self._job_topic = None
         self._auto_updater = AutoUpdater(self)
+        self._session_credential = None
 
     def __repr__(self):
         """
@@ -576,6 +577,14 @@ class Session(object):
         requests to the HMC.
         """
         return self._session_id
+
+    @property
+    def session_credential(self):
+        """
+        :term:`string`: Session credential for this session, returned by
+                        the HMC.
+        """
+        return self._session_credential
 
     @property
     def session(self):
@@ -764,6 +773,7 @@ class Session(object):
         self._session = self._new_session(self.retry_timeout_config)
         logon_res = self.post(logon_uri, body=logon_body, logon_required=False)
         self._session_id = logon_res['api-session']
+        self._session_credential = logon_res['session-credential']
         self._headers['X-API-Session'] = self._session_id
         self._object_topic = logon_res['notification-topic']
         self._job_topic = logon_res['job-notification-topic']


### PR DESCRIPTION
Add example to use load-from-ftp for automated LPAR installation.

The session-credential can be used to connect to the API message broker. Store it as a new property.

Tested on a z16 with API 2.26

Suggested-by: Vance Morris <vmorris@redhat.com>
Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>