### PR TITLE
1.12: Additional log entries when HTTP status 403 is received, for easier detection

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,6 +46,8 @@ Released: not yet
 * Added support for retrievel of firmware from an FTP server to the
   Cpc/Console.single_step_install() methods. (issue #1342)
 
+* Additional log entries when HTTP status 403 is received, for easier detection.
+
 **Cleanup:**
 
 **Known issues:**

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -1029,6 +1029,9 @@ class Session(object):
         if result.status_code == 403:
             result_object = _result_object(result)
             reason = result_object.get('reason', None)
+            message = result_object.get('message', None)
+            HMC_LOGGER.debug("Received HTTP status 403.%d on GET %s: %s",
+                             reason, uri, message)
 
             if reason in (4, 5):
                 # 403.4: No session ID was provided
@@ -1279,6 +1282,9 @@ class Session(object):
             if result.status_code == 403:
                 result_object = _result_object(result)
                 reason = result_object.get('reason', None)
+                message = result_object.get('message', None)
+                HMC_LOGGER.debug("Received HTTP status 403.%d on GET %s: %s",
+                                 reason, uri, message)
 
                 if reason in (4, 5):
                     # 403.4: No session ID was provided
@@ -1378,6 +1384,9 @@ class Session(object):
         if result.status_code == 403:
             result_object = _result_object(result)
             reason = result_object.get('reason', None)
+            message = result_object.get('message', None)
+            HMC_LOGGER.debug("Received HTTP status 403.%d on GET %s: %s",
+                             reason, uri, message)
 
             if reason in (4, 5):
                 # 403.4: No session ID was provided


### PR DESCRIPTION
Rolls back PR #1353 into 1.12.1.