### PR TITLE
Added support for SE firmware upgrade related operations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -50,6 +50,12 @@ Released: not yet
 
 * Additional log entries when HTTP status 403 is received, for easier detection.
 
+* Added support for additional SE firmware upgrade related HMC operations:
+  (issue #1357)
+
+  - "CPC Install and Activate" as 'Cpc.install_and_activate()'
+  - "CPC Delete Retrieved Internal Code" as 'Cpc.delete_retrieved_internal_code()'
+
 **Cleanup:**
 
 **Known issues:**


### PR DESCRIPTION
The PR adds support for these HMC operations:
* "CPC Install and Activate"
* "CPC Delete Retrieved Internal Code"

For details, see the commit message.

Particular review points:
* The way the operation parameters are represented in Python.
* Returning the job message in `Cpc.install_and_activate()`
* Statement about not downloading updates from the IBM support site in `Cpc.install_and_activate()`
* Description of which updates are deleted when `ec_levels` is specified in `Cpc.delete_retrieved_internal_code()`