### PR TITLE
Tolerate restarts while waiting for job completion

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -56,6 +56,10 @@ Released: not yet
   - "CPC Install and Activate" as 'Cpc.install_and_activate()'
   - "CPC Delete Retrieved Internal Code" as 'Cpc.delete_retrieved_internal_code()'
 
+* Added support for tolerating HMC restarts while waiting for a job to complete.
+  Session.wait_for_completion() now retries in case of ConnectionError instead of
+  raising the error. (issue #1365)
+
 **Cleanup:**
 
 **Known issues:**

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -1773,7 +1773,6 @@ class Job(object):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.ClientAuthError`
           :exc:`~zhmcclient.ServerAuthError`
-          :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.OperationTimeout`: The timeout expired while
             waiting for job completion.
         """
@@ -1785,7 +1784,13 @@ class Job(object):
             start_time = time.time()
 
         while True:
-            job_status, op_result_obj = self.check_for_completion()
+            try:
+                job_status, op_result_obj = self.check_for_completion()
+            except ConnectionError:
+                HMC_LOGGER.debug("Retrying after ConnectionError while waiting"
+                                 " for completion of job %s. This could be "
+                                 "because HMC is restarting.", self.uri)
+                job_status = None
 
             # We give completion of status priority over strictly achieving
             # the timeout, so we check status first. This may cause a longer


### PR DESCRIPTION
Changes:
* Some jobs like single-step-install require restarting the HMC several times. Requests for job status will return ConnectionError while HMC is restarting. This will be ignored to tolerate HMC restarts that will happen while waiting for completion of the job.

This solves #1365 

Signed-off-by: Abhiram Santhosh <abhiram.santhosh1@ibm.com>