### PR TITLE
Support for redundant HMCs

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,13 @@ Released: not yet
   an AssertionError and you need to change your code to specify them as keyword
   arguments, instead.
 
+* When creating a 'zhmcclient.Session' object with a 'session_id' parameter that
+  is not None, the 'host' parameter with the HMC host for that session now also
+  needs to be provided. (related to issue #1024)
+
+* The 'base_url' property of the 'zhmcclient.Session' object is now 'None' when
+  the session is in the logged-off state. (related to issue #1024)
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -50,6 +57,10 @@ Released: not yet
 * Test: Fixed end2end testcase 'test_actprof_crud()' to skip the test when the
   required 'create-delete-activation-profiles' API feature is not available.
   (issue #1375)
+
+* Docs: Clarified that the 'session' and 'session_credential' properties of the
+  'zhmcclient.Session' object are 'None' when the session is in the logged-off
+  state. (related to issue #1024)
 
 **Enhancements:**
 
@@ -77,6 +88,22 @@ Released: not yet
   userid and password, and that in case of MFA being configured, they must be
   the session ID and session credential returned from the HMC logon.
   (issue #1350)
+
+* Added support for targeting multiple redundant HMCs, from which the first
+  one reachable at session creation time will be used for the duration of the
+  session. The multiple HMCs are provided via the same 'Session' init parameter
+  'host' as before, which now can be a list of hosts in addition to being a
+  single host. Because redundant HMCs can be configured differently regarding
+  what data they sync between them, there is no automatic failover to another
+  HMC if the initially determined HMC becomes unavailable during the session.
+  (issue #1024)
+
+* Added support for specifying multiple redundant HMCs in the 'ansible_host'
+  property of HMC definition files. The property can now specify a single HMC
+  like before, or a a list of redundant HMCs. (issue #1024)
+
+* Mock support: Added mock support for the Logon and Logoff HMC operations.
+  (related to issue #1024)
 
 **Cleanup:**
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -101,6 +101,40 @@ need to receive HMC notifications has its own
 very well target the same HMC.
 
 
+.. _`Specifying multiple redundant HMCs`:
+
+Specifying multiple redundant HMCs
+----------------------------------
+
+The zhmcclient package supports the specification of one or more HMCs through
+the `host` init parameter of :class:`zhmcclient.Session`.
+
+That paranmeter can be specified as a single HMC, for example:
+
+.. code-block:: python
+
+    session = zhmcclient.Session(host='10.11.12.13', ...)
+
+or as a list of one or more HMCs, for example:
+
+.. code-block:: python
+
+    session = zhmcclient.Session(host=['10.11.12.13', '10.11.12.14'], ...)
+
+There is no difference between specifying a single HMC as a string or as a
+list with one item.
+
+When a list is specified, it must contain at least one HMC.
+
+If the list contains more than one HMC, a working HMC is selected from that list
+during each logon (and re-logon) to the HMC, and that HMC continues to be used
+by that :class:`zhmcclient.Session` object until logoff.
+
+If a :class:`zhmcclient.Session` object is created by specifying the
+`session_id` init parameter, the corresponding HMC host for that session must
+be provided as the only HMC in the `host` init parameter.
+
+
 .. _`Resource model concepts`:
 
 Resource model concepts

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -326,6 +326,8 @@ The following describes the structure of the HMC inventory file:
 
           ansible_host: <host>          # If real HMC: DNS hostname or IP address of HMC, if
                                         #   arbitrary string was used as HMC nickname.
+                                        #   This can specify a single HMC or a list of redundant
+                                        #   HMCs.
 
           mock_file: <path_name>        # If mocked HMC: Relative path name of HMC mock file.
           cpcs:                         # CPCs to test against. Can be a subset or all CPCs

--- a/tests/common/http_mocked_fixtures.py
+++ b/tests/common/http_mocked_fixtures.py
@@ -80,6 +80,11 @@ def http_mocked_session(request):  # noqa: F811
             'session-credential':
                 'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4'
         })
+        m.get(
+            '/api/version', json={
+                'api-major-version': 4,
+                'api-minor-version': 10,
+            })
         session.logon()
 
     yield session

--- a/tests/unit/zhmcclient/test_port.py
+++ b/tests/unit/zhmcclient/test_port.py
@@ -47,6 +47,11 @@ class TestPort(object):
                     'session-credential':
                         'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4',
                 })
+            m.get(
+                '/api/version', json={
+                    'api-major-version': 4,
+                    'api-minor-version': 10,
+                })
             self.session.logon()
 
         self.cpc_mgr = self.client.cpcs

--- a/tests/unit/zhmcclient/test_virtual_function.py
+++ b/tests/unit/zhmcclient/test_virtual_function.py
@@ -48,6 +48,11 @@ class TestVirtualFunction(object):
                     'session-credential':
                         'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4',
                 })
+            m.get(
+                '/api/version', json={
+                    'api-major-version': 4,
+                    'api-minor-version': 10,
+                })
             self.session.logon()
 
         self.cpc_mgr = self.client.cpcs

--- a/tests/unit/zhmcclient/test_virtual_switch.py
+++ b/tests/unit/zhmcclient/test_virtual_switch.py
@@ -48,6 +48,11 @@ class TestVirtualSwitch(object):
                     'session-credential':
                         'un8bu462g37aw9j0o8pltontz3szt35jh4b1qe2toxt6fkhl4',
                 })
+            m.get(
+                '/api/version', json={
+                    'api-major-version': 4,
+                    'api-minor-version': 10,
+                })
             self.session.logon()
 
         self.cpc_mgr = self.client.cpcs

--- a/tests/unit/zhmcclient_mock/test_session.py
+++ b/tests/unit/zhmcclient_mock/test_session.py
@@ -271,7 +271,8 @@ def test_session_to_from_yaml():
     hmc_name = console_props['name']
     hmc_version = console_props['version']
 
-    session = FakedSession(host, hmc_name, hmc_version, api_version)
+    session = FakedSession(host, hmc_name, hmc_version, api_version,
+                           userid='fake-user', password='fake-password')
     client = Client(session)
 
     session.hmc.add_resources(HMC1_RESOURCES)
@@ -302,6 +303,7 @@ def test_session_to_from_yaml():
                 ('accelerator-usage', 0),
                 ('crypto-usage', 0),
             ]))
+    session.logon()  # Sets session.host
 
     # The function to be tested:
     hmc_yaml = client.to_hmc_yaml()

--- a/zhmcclient/testutils/_hmc_definition.py
+++ b/zhmcclient/testutils/_hmc_definition.py
@@ -18,6 +18,8 @@ HMC definition for zhmcclient end2end tests.
 
 from __future__ import absolute_import
 
+import six
+
 __all__ = ['HMCDefinition']
 
 
@@ -52,7 +54,8 @@ class HMCDefinition(object):
             HMC: If `None`, it is a real HMC. Otherwise, it is a mocked HMC
             and the path name is stored as provided.
 
-          host (string): IP address or DNS hostname of the real HMC.
+          host (string or list of string): IP address or DNS hostname of the
+            real HMC or list of redundant HMCs.
             Required for real HMCs, must not be `None`. Optional for mocked
             HMCs.
 
@@ -90,7 +93,13 @@ class HMCDefinition(object):
         self._contact = contact or ''
         self._access_via = access_via or ''
         self._mock_file = mock_file
-        self._host = host
+        if host is None:
+            self._hosts = None
+        elif isinstance(host, six.string_types):
+            self._hosts = [host]
+        else:
+            self._hosts = list(host)
+            assert len(self._hosts) >= 1
         self._userid = userid
         self._password = password
         self._verify = verify
@@ -162,17 +171,30 @@ class HMCDefinition(object):
     @property
     def host(self):
         """
-        string: IP address or DNS hostname of the HMC.
+        string or list of string: IP address or DNS hostname of the HMC or
+        list of redundant HMCs.
 
         This is a settable property.
         """
-        return self._host
+        if self._hosts is None:
+            host = None
+        elif len(self._hosts) == 1:
+            host = self._hosts[0]
+        else:
+            host = self._hosts
+        return host
 
     @host.setter
     def host(self, host):
         """Setter method; for a description see the getter method."""
         # pylint: disable=attribute-defined-outside-init
-        self._host = host
+        if host is None:
+            self._hosts = None
+        elif isinstance(host, six.string_types):
+            self._hosts = [host]
+        else:
+            self._hosts = list(host)
+            assert len(self._hosts) >= 1
 
     @property
     def userid(self):

--- a/zhmcclient/testutils/_hmc_definitions.py
+++ b/zhmcclient/testutils/_hmc_definitions.py
@@ -476,6 +476,7 @@ class HMCDefinitions(object):
                 # If ansible_host was set, it is always used, and otherwise
                 # the HMC nickname is used as a DNS name or IP address.
                 ansible_host = host_vars.get('ansible_host')
+                # Note: ansible_host may be a string or list of strings.
                 host = ansible_host or nickname
 
             # Make relative mock_file relative to inventory file

--- a/zhmcclient/testutils/_hmc_inventory_file.py
+++ b/zhmcclient/testutils/_hmc_inventory_file.py
@@ -40,7 +40,8 @@ __all__ = ['HMCInventoryFileError', 'HMCInventoryFile']
 #         description: <string>
 #         contact: <string>
 #         access_via: <string>
-#         ansible_host: <host>  # if real HMC and an alias is used
+#         ansible_host: <host>  # if real HMC and an alias is used;
+#                               # can also be a list of hosts
 #         mock_file: <path_name>  # if mocked HMC
 #         cpcs:
 #           <cpc_name>:
@@ -101,9 +102,10 @@ HMC_INVENTORY_FILE_SCHEMA = {
                 },
                 "ansible_host": {
                     "description": "For real HMCs: DNS host name or IP "
-                                   "address of the HMC. "
+                                   "address of the HMC or of a list of "
+                                   "redundant HMCs. "
                                    "Mandatory for real HMCs.",
-                    "type": "string",
+                    "type": ["string", "array"],
                 },
                 "mock_file": {
                     "description": "For mocked HMCs: Path name of HMC mock "

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -727,11 +727,12 @@ class FakedSession(zhmcclient.Session):
         """
         ret = (
             "{classname} at 0x{id:08x} (\n"
-            "  _host = {s._host!r}\n"
+            "  _hosts = {s._hosts!r}\n"
             "  _userid = {s._userid!r}\n"
             "  _password = '...'\n"
             "  _get_password = {s._get_password!r}\n"
             "  _retry_timeout_config = {s._retry_timeout_config!r}\n"
+            "  _actual_host = {s._actual_host!r}\n"
             "  _base_url = {s._base_url!r}\n"
             "  _headers = {s._headers!r}\n"
             "  _session_id = {s._session_id!r}\n"

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import
 import re
 import time
 import copy
+import uuid
 from random import randrange
 from requests.utils import unquote
 
@@ -605,6 +606,43 @@ class VersionHandler(object):
             'api-major-version': int(api_major),
             'api-minor-version': int(api_minor),
         }
+
+
+class SessionsHandler(object):
+    """
+    Handler class for session operations.
+    """
+
+    @staticmethod
+    def post(method, hmc, uri, uri_parms, body, logon_required,
+             wait_for_completion):
+        # pylint: disable=unused-argument
+        """Operation: Logon."""
+        assert wait_for_completion is True  # synchronous operation
+        check_required_fields(method, uri, body, ['userid', 'password'])
+        result = {
+            'api-session': 'fake-session-id',
+            'notification-topic': 'fake-topic-1',
+            'job-notification-topic': 'fake-topic-2',
+            'api-major-version': 4,
+            'api-minor-version': 40,
+            'password-expires': -1,
+            # 'shared-secret-key' not included
+            'session-credential': uuid.uuid4().hex,
+        }
+        return result
+
+
+class ThisSessionHandler(object):
+    """
+    Handler class for session operations.
+    """
+
+    @staticmethod
+    def delete(method, hmc, uri, uri_parms, logon_required):
+        # pylint: disable=unused-argument
+        """Operation: Logoff."""
+        pass
 
 
 class ConsoleHandler(GenericGetPropertiesHandler):
@@ -5234,6 +5272,9 @@ URIS = (
     # In all modes:
 
     (r'/api/version', VersionHandler),
+
+    (r'/api/sessions', SessionsHandler),
+    (r'/api/sessions/this-session', ThisSessionHandler),
 
     (r'/api/console(?:\?(.*))?', ConsoleHandler),
     (r'/api/console/operations/restart', ConsoleRestartHandler),


### PR DESCRIPTION
For details, see the commit message.

Has been successfully end2end tested with M12 and its two redundant HMCs, using the following test cases:
* a single one of its redundant HMCs
* both of its redundant HMCs
* a non-existing HMC and its two redundant HMCs
* a non-existing HMC
* two non-existing HMCs

In all cases, the first one in the specified list that worked was actually used, and the same error as before was raised when none of them worked.

On cross-checking whether the ibm_zhmc collection works with this extension:
* I verified an HMC inventory file that specifies a list of HMC hosts with the end2end testcases of the ibm_zhmc collection which worked immediately (no surprise, since they use the python-zhmcclient testutils support).
* The ibm_zhmc collection sample playbooks though did not work with such an inventory file. This is caused by the fact that Ansible converts the list of hosts into a string that contains a representation of that list. That string is passed to zhmcclient.Session() which treats it as a single host. This can be fixed by adding support for detecting such a situation in the ibm_zhmc collection and parsing that string back into a list. I have created issue https://github.com/zhmcclient/zhmc-ansible-modules/issues/849 for that.