### PR TITLE
1.12: Fixed end2end testcase 'test_actprof_crud()'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,10 @@ Released: not yet
   'loadable_lpars' and 'load_profiles' properties in HMC inventory file.
   (issue #1374)
 
+* Test: Fixed end2end testcase 'test_actprof_crud()' to skip the test when the
+  required 'create-delete-activation-profiles' API feature is not available.
+  (issue #1375)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/tests/end2end/test_activation_profile.py
+++ b/tests/end2end/test_activation_profile.py
@@ -32,7 +32,8 @@ from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, runtest_find_list, \
-    runtest_get_properties, setup_logging, End2endTestWarning
+    runtest_get_properties, setup_logging, End2endTestWarning, \
+    skip_missing_api_feature
 
 urllib3.disable_warnings()
 
@@ -97,6 +98,11 @@ def test_actprof_crud(classic_mode_cpcs, profile_type):  # noqa: F811
 
     for cpc in classic_mode_cpcs:
         assert not cpc.dpm_enabled
+
+        console = cpc.manager.console
+        skip_missing_api_feature(
+            console, 'create-delete-activation-profiles',
+            cpc, 'create-delete-activation-profiles')
 
         actprof_mgr = getattr(cpc, profile_type + '_activation_profiles')
 

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -865,3 +865,28 @@ def is_cpc_property_hmc_inventory(name):
         'load_profiles',
     )
     return name not in special_properties
+
+
+def skip_missing_api_feature(
+        console, console_feature, cpc=None, cpc_feature=None):
+    """
+    Skip pytest testcase if an HMC Console or CPC API feature is not
+    available.
+    """
+    client = console.manager.client
+
+    api_version_info = client.version_info()
+    if api_version_info < (4, 10):
+        pytest.skip("HMC API version {} is below minimum version 4.10 "
+                    "required for API features".
+                    format('.'.join(api_version_info)))
+
+    if console_feature:
+        if not console.list_api_features(console_feature):
+            pytest.skip("Console API feature {!r} is not available".
+                        format(console_feature))
+
+    if cpc_feature:
+        if not cpc.list_api_features(cpc_feature):
+            pytest.skip("CPC API feature {!r} is not available for CPC {!r}".
+                        format(cpc_feature, cpc.name))


### PR DESCRIPTION
Rolls back PR #1375 into 1.12.3.
No additional review needed.