### PR TITLE
Fixed end2end test function test_hmcdef_cpcs() to tolerate 'loadable_lpars' etc

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,10 @@ Released: not yet
 
 * Addressed safety issues up to 2023-11-26.
 
+* Test: Fixed end2end test function test_hmcdef_cpcs() to no longer stumble over
+  'loadable_lpars' and 'load_profiles' properties in HMC inventory file.
+  (issue #1374)
+
 **Enhancements:**
 
 * Added support for retrievel of firmware from an FTP server to the

--- a/tests/end2end/test_hmc_inventory.py
+++ b/tests/end2end/test_hmc_inventory.py
@@ -27,6 +27,8 @@ import zhmcclient
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401
 from zhmcclient.testutils import HMCDefinitions
 
+from .utils import is_cpc_property_hmc_inventory
+
 urllib3.disable_warnings()
 
 
@@ -65,6 +67,9 @@ def test_hmcdef_cpcs(hmc_session):  # noqa: F811
 
         cpc_props = dict(cpc.properties)
         for def_prop_name in def_cpc_props:
+
+            if not is_cpc_property_hmc_inventory(def_prop_name):
+                continue
 
             hmc_prop_name = def_prop_name.replace('_', '-')
             assert hmc_prop_name in cpc_props, \

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -853,3 +853,15 @@ def pull_lpar_status(lpar):
     this_lpar = lpars[0]
     actual_status = this_lpar.get_property('status')
     return actual_status
+
+
+def is_cpc_property_hmc_inventory(name):
+    """
+    Return whether a CPC property defined in the HMC inventory file is
+    actually a CPC property (vs. a special property).
+    """
+    special_properties = (
+        'loadable_lpars',
+        'load_profiles',
+    )
+    return name not in special_properties


### PR DESCRIPTION
For details, see the commit message.