### PR TITLE
Clarified the HMC version requirements for Console.list_permitted_adapters()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -62,6 +62,8 @@ Released: not yet
   'zhmcclient.Session' object are 'None' when the session is in the logged-off
   state. (related to issue #1024)
 
+* Clarified the HMC version requirements for 'Console.list_permitted_adapters()'.
+
 **Enhancements:**
 
 * Added support for retrievel of firmware from an FTP server to the

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -857,7 +857,13 @@ class Console(BaseResource):
         classic-mode CPCs that are managed by the targeted HMC and to which the
         user has object-access permission.
 
-        *Requires HMC 2.16.0 or later and otherwise raises HTTPError(404.4).*
+        *If 'additional_properties' is not used, requires HMC API version 4.1 or
+        later (= HMC version 2.16.0 GA-level) and otherwise raises
+        HTTPError(404.4).*
+
+        *If 'additional_properties' is used, requires HMC API version 4.10 or
+        later (= HMC version 2.16.0 plus some post-GA code level) and
+        otherwise raises HTTPError(404.4).*
 
         The adapters in the result can be additionally limited by specifying
         filter arguments.


### PR DESCRIPTION
No review needed.