### PR TITLE
Docs: Clarified that list_candidate_adapter_ports() is for FCP SGs only

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -64,6 +64,9 @@ Released: not yet
 
 * Clarified the HMC version requirements for 'Console.list_permitted_adapters()'.
 
+* Docs: Clarified in 'StorageGroup.list_candidate_adapter_ports()' that the
+  method is only for FCP-type storage groups.
+
 **Enhancements:**
 
 * Added support for retrievel of firmware from an FTP server to the

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -633,8 +633,10 @@ class StorageGroup(BaseResource):
     @logged_api_call
     def list_candidate_adapter_ports(self, full_properties=False):
         """
-        Return the current candidate storage adapter port list of this storage
-        group.
+        Return the current candidate storage adapter port list of this FCP
+        storage group.
+
+        This operation only applies to storage groups of type "fcp".
 
         The result reflects the actual list of ports used by the CPC, including
         any changes that have been made during discovery. The source for this


### PR DESCRIPTION
No review needed.
Related to issue https://github.com/zhmcclient/zhmc-ansible-modules/issues/864