### PR TITLE
1.12: Docs: Clarified that list_candidate_adapter_ports() is for FCP SGs only

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,9 @@ Released: not yet
   required 'create-delete-activation-profiles' API feature is not available.
   (issue #1375)
 
+* Docs: Clarified in 'StorageGroup.list_candidate_adapter_ports()' that the
+  method is only for FCP-type storage groups.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -633,8 +633,10 @@ class StorageGroup(BaseResource):
     @logged_api_call
     def list_candidate_adapter_ports(self, full_properties=False):
         """
-        Return the current candidate storage adapter port list of this storage
-        group.
+        Return the current candidate storage adapter port list of this FCP
+        storage group.
+
+        This operation only applies to storage groups of type "fcp".
 
         The result reflects the actual list of ports used by the CPC, including
         any changes that have been made during discovery. The source for this


### PR DESCRIPTION
Rolls back PR #1383 into 1.12.3