### PR TITLE
1.12: Undo regexp matching of name in find(); Fixed case insensitive regexp matching

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,14 @@ Released: not yet
 
 **Incompatible changes:**
 
+* The incompatibility caused by the recent change to support regular expression
+  matching for the resource name in the 'find()' method, which was released in
+  zhmcclient versions 1.12.3 and 1.13.0, turned out to be too heavy. The change
+  is now undone to go back to string comparison for the name matching in
+  'find()'. The 'findall()' method which was also changed in these releases
+  keeps the regular expression matching for consistency with 'list()'.
+  (issue #1395)
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -36,6 +44,16 @@ Released: not yet
   incompatibility between sphinxcontrib-applehelp and Sphinx.
   Disabled Sphinx runs on Python <=3.7 in order to no longer having to deal
   with older Sphinx versions. (issue #1396)
+
+* Changed the recently released support for regular expression matching for the
+  resource name in 'find()' back to matching by string comparison. The
+  'findall()' method keeps the regular expression matching for consistency
+  with 'list()'. (issue #1395)
+
+* Fixed that the resource name in the filter arguments of 'findall()' and
+  'list()' was not matched case insensitvely with regular expressions for the
+  resource types that have case insensitive names (user, user pattern, password
+  rule, LDAP server definition). (related to issue #1395)
 
 **Enhancements:**
 

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -1214,6 +1214,16 @@ class BaseManager(object):
             keyword arguments causes no filtering to happen. See the examples
             for usage details.
 
+            If the resource name is specified in the filter arguments, it
+            is matched with string comparison (i.e. not as a regular
+            expression).
+            The string comparison is case sensitive or case insensitive,
+            dependent on the resource type.
+
+            Any other filter arguments are ignored if the resource name is
+            specified, because the name is unique within the scope of this
+            resource manager.
+
         Returns:
 
           Resource object in scope of this manager object that matches the
@@ -1252,6 +1262,9 @@ class BaseManager(object):
               filter_args = {'object-id': '12345-abc...de-12345'}
               cpc = client.cpcs.find(**filter_args)
         """
+        if self._name_prop in filter_args:
+            return self.find_by_name(filter_args[self._name_prop])
+
         obj_list = self.findall(**filter_args)
         num_objs = len(obj_list)
         if num_objs == 0:
@@ -1360,9 +1373,10 @@ class BaseManager(object):
         Parameters:
 
           name (string):
-            Name of the resource (value of its 'name' resource property).
-            Regular expression matching is not supported for the name for this
-            optimized lookup.
+            Name of the resource. The name is matched with string comparison
+            (i.e. not as a regular expression). The string comparison is case
+            sensitive or case insensitive, dependent on the resource type.
+            Must not be `None`.
 
         Returns:
 
@@ -1410,7 +1424,10 @@ class BaseManager(object):
         Parameters:
 
           name (string):
-            Name of the resource. Must not be `None`.
+            Name of the resource. The name is matched with string comparison
+            (i.e. not as a regular expression). The string comparison is case
+            sensitive or case insensitive, dependent on the resource type.
+            Must not be `None`.
 
           uri (string):
             Object URI of the resource. Must not be `None`.

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -473,12 +473,16 @@ def matches_filters(obj, filter_args):
     if filter_args is not None:
         for prop_name in filter_args:
             prop_match = filter_args[prop_name]
-            if not matches_prop(obj, prop_name, prop_match):
+            if prop_name == obj.manager.name_prop:
+                case_insensitive = obj.manager.case_insensitive_names
+            else:
+                case_insensitive = False
+            if not matches_prop(obj, prop_name, prop_match, case_insensitive):
                 return False
     return True
 
 
-def matches_prop(obj, prop_name, prop_match):
+def matches_prop(obj, prop_name, prop_match, case_insensitive):
     """
     Return a boolean indicating whether a resource object matches with
     a single property against a property match value.
@@ -507,6 +511,10 @@ def matches_prop(obj, prop_name, prop_match):
         - Else the property value is matched by exact value comparison
           with the match value.
 
+      case_insensitive (bool):
+        Controls whether the values of string typed properties are matched
+        case insensitively.
+
     Returns:
 
       bool: Boolean indicating whether the resource object matches w.r.t.
@@ -515,7 +523,7 @@ def matches_prop(obj, prop_name, prop_match):
     if isinstance(prop_match, (list, tuple)):
         # List items are logically ORed, so one matching item suffices.
         for pm in prop_match:
-            if matches_prop(obj, prop_name, pm):
+            if matches_prop(obj, prop_name, pm, case_insensitive):
                 return True
     else:
         # Some lists of resources do not have all properties, for example
@@ -540,7 +548,8 @@ def matches_prop(obj, prop_name, prop_match):
             # pattern, and begin matching is done by re.match()
             # automatically.
             re_match = prop_match + '$'
-            m = re.match(re_match, prop_value)
+            re_flags = re.IGNORECASE if case_insensitive else 0
+            m = re.match(re_match, prop_value, flags=re_flags)
             if m:
                 return True
         else:


### PR DESCRIPTION
Rolls back PR #1395 to 1.12.4.
No review needed.