### PR TITLE
1.13: Fixed dependency issue with safety; Added minimum-constraints to targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ $(done_dir)/pip_upgrade_$(pymn)_$(PACKAGE_LEVEL).done: Makefile
 develop: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done
 	@echo "Makefile: $@ done."
 
-$(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/pip_upgrade_$(pymn)_$(PACKAGE_LEVEL).done $(done_dir)/install_$(pymn)_$(PACKAGE_LEVEL).done dev-requirements.txt requirements.txt
+$(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/pip_upgrade_$(pymn)_$(PACKAGE_LEVEL).done $(done_dir)/install_$(pymn)_$(PACKAGE_LEVEL).done dev-requirements.txt requirements.txt minimum-constraints.txt
 	-$(call RM_FUNC,$@)
 	@echo 'Installing development requirements with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
 	$(PYTHON_CMD) -m pip install $(pip_level_opts) $(pip_level_opts_new) -r dev-requirements.txt
@@ -456,7 +456,7 @@ safety: $(done_dir)/safety_all_$(pymn)_$(PACKAGE_LEVEL).done $(done_dir)/safety_
 install: $(done_dir)/install_$(pymn)_$(PACKAGE_LEVEL).done
 	@echo "Makefile: $@ done."
 
-$(done_dir)/install_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/pip_upgrade_$(pymn)_$(PACKAGE_LEVEL).done requirements.txt extra-testutils-requirements.txt
+$(done_dir)/install_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/pip_upgrade_$(pymn)_$(PACKAGE_LEVEL).done requirements.txt extra-testutils-requirements.txt minimum-constraints.txt
 	-$(call RM_FUNC,$@)
 	@echo "Installing $(package_name) (editable) and runtime reqs with PACKAGE_LEVEL=$(PACKAGE_LEVEL)"
 	$(PYTHON_CMD) -m pip install $(pip_level_opts) $(pip_level_opts_new) -e .

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -75,7 +75,10 @@ coveralls>=3.3.0; python_version >= '3.5'
 # Safety is run only on Python >=3.6
 # Safety 2.3.5 (running only on Python >=3.6) requires packaging<22.0,>=21.0, but safety 2.3.4 does not
 #   and safety 2.4.0 will also no longer pin it (see https://github.com/pyupio/safety/issues/455).
-safety>=2.2.0,!=2.3.5; python_version >= '3.6'
+# Safety 3.0.0 requires exact versions of authlib==1.2.0 and jwt==1.3.1.
+#   (see issue https://github.com/pyupio/safety/issues/496)
+#   TODO: Unpin safety<3.0.0 once the exact version issue is resolved.
+safety>=2.2.0,!=2.3.5,<3.0.0; python_version >= '3.6'
 dparse>=0.6.2; python_version >= '3.6'
 ruamel.yaml>=0.17.21,<0.17.22; python_version == '3.6'
 ruamel.yaml>=0.17.21; python_version >= '3.7'


### PR DESCRIPTION
Rolls back PR #1413 into 1.13.2.