### PR TITLE
Added CPC related properties to list_permitted_lpars/partitions(); improved pull

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -101,6 +101,20 @@ Released: not yet
   the description of how to release a version in the development
   documentation. (issue #1393)
 
+* In Console.list_permitted_lpars/partitions(), added CPC-related properties
+  to the returned resource objects, that are returned by the HMC: 'cpc-name',
+  'cpc-object-uri', 'se-version'. (issue #1421)
+
+* In Console.list_permitted_lpars(), the additional_properties parameter
+  is now supported also for HMC versions older than 2.16 GA 1.5. In that
+  case, the zhmcclient handles adding the properties. (related to issue #1421)
+
+* The pull_full_properties() and pull_properties() methods of zhmcclient
+  resource objects no longer replace existing properties but now update them,
+  so that additionally present properties (e.g. the CPC-related properties
+  returned from Console.list_permitted_lpars/partitions()) are preserved.
+  (related to issue #1421)
+
 **Cleanup:**
 
 * Increased versions of GitHub Actions plugins to increase node.js runtime

--- a/tests/unit/zhmcclient/test_lpar.py
+++ b/tests/unit/zhmcclient/test_lpar.py
@@ -50,6 +50,14 @@ IMAGEPROFILE2_NAME = 'imageprofile 2'
 
 CPC_NAME = 'fake-cpc1-name'
 
+# Properties returned by default from list_permitted_lpars()
+LIST_PERMITTED_LPARS_PROPS = [
+    'name', 'object-uri', 'activation-mode', 'status',
+    'has-unacceptable-status', 'cpc-name', 'cpc-object-uri',
+    # The zhmcclient_mock support always returns 'se-version'
+    'se-version'
+]
+
 
 class TestLpar(object):
     """All tests for Lpar and LparManager classes."""
@@ -1465,21 +1473,25 @@ class TestLpar(object):
             names = [p.properties['name'] for p in lpars]
             assert set(names) == set(exp_names)
 
+        for lpar in lpars:
+            lpar_props = dict(lpar.properties)
+            for pname in LIST_PERMITTED_LPARS_PROPS:
+                assert pname in lpar_props, (
+                    "Property {!r} missing from returned LPAR properties, "
+                    "got: {!r}".format(pname, lpar_props))
+
     @pytest.mark.parametrize(
         "list_kwargs, prop_names", [
             ({},
-             ['object-uri', 'name', 'status']),
+             LIST_PERMITTED_LPARS_PROPS),
             (dict(additional_properties=[]),
-             ['object-uri', 'name', 'status']),
+             LIST_PERMITTED_LPARS_PROPS),
             (dict(additional_properties=['description']),
-             ['object-uri', 'name', 'status', 'description']),
+             LIST_PERMITTED_LPARS_PROPS + ['description']),
             (dict(additional_properties=['description', 'activation-mode']),
-             ['object-uri', 'name', 'status', 'description',
-              'activation-mode']),
+             LIST_PERMITTED_LPARS_PROPS + ['description', 'activation-mode']),
             (dict(additional_properties=['ssc-host-name']),
-             ['object-uri', 'name', 'status', 'ssc-host-name']
-             # ssc-host-name is not on every lpar
-             ),
+             LIST_PERMITTED_LPARS_PROPS + ['ssc-host-name']),
         ]
     )
     def test_console_list_permlpars_add_props(

--- a/tests/unit/zhmcclient/test_partition.py
+++ b/tests/unit/zhmcclient/test_partition.py
@@ -36,6 +36,14 @@ PART3_NAME = 'part 3'
 
 CPC_NAME = 'fake-cpc1-name'
 
+# Properties returned by default from list_permitted_partitions()
+LIST_PERMITTED_PARTITIONS_PROPS = [
+    'name', 'object-uri', 'type', 'status', 'has-unacceptable-status',
+    'cpc-name', 'cpc-object-uri',
+    # The zhmcclient_mock support always returns 'se-version'
+    'se-version'
+]
+
 
 class TestPartition(object):
     """All tests for the Partition and PartitionManager classes."""
@@ -984,6 +992,13 @@ class TestPartition(object):
         if exp_names:
             names = [p.properties['name'] for p in partitions]
             assert set(names) == set(exp_names)
+
+        for partition in partitions:
+            partition_props = dict(partition.properties)
+            for pname in LIST_PERMITTED_PARTITIONS_PROPS:
+                assert pname in partition_props, (
+                    "Property {!r} missing from returned partition properties, "
+                    "got: {!r}".format(pname, partition_props))
 
     # TODO: Test for Partition.send_os_command()
 

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -271,7 +271,7 @@ class BaseResource(object):
             raise
 
         with self._property_lock:
-            self._properties = dict(full_properties)
+            self._properties.update(full_properties)
             self._properties_timestamp = int(time.time())
             self._full_properties = True
 
@@ -374,7 +374,7 @@ class BaseResource(object):
 
         with self._property_lock:
             if is_full:
-                self._properties = dict(subset_properties)
+                self._properties.update(subset_properties)
                 self._properties_timestamp = int(time.time())
                 self._full_properties = True
             else:


### PR DESCRIPTION
For details, see the commit message.

End2end tests (after last commit 95cd8d7):
* Classic mode: `TESTHMC=A01 TESTCASES='test_console_list_permitted_lpars' make end2end` passed.
* DPM mode: `TESTHMC=T224 TESTCASES='test_console_list_permitted_partitions' make end2end` passed.
