### PR TITLE
Fixed copyright statements that have year-year range

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/design/fake-client.rst
+++ b/design/fake-client.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2017 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2017 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/_static/basic.css
+++ b/docs/_static/basic.css
@@ -4,7 +4,7 @@
  *
  * Sphinx stylesheet -- basic theme.
  *
- * :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+ * :copyright: Copyright 2007,2016 by the Sphinx team, see AUTHORS.
  * :license: BSD, see LICENSE for details.
  *
  */

--- a/docs/_static/classic.css
+++ b/docs/_static/classic.css
@@ -4,7 +4,7 @@
  *
  * Sphinx stylesheet -- default theme.
  *
- * :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+ * :copyright: Copyright 2007,2016 by the Sphinx team, see AUTHORS.
  * :license: BSD, see LICENSE for details.
  *
  */

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,5 +1,5 @@
 
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/notebooks/tututils.py
+++ b/docs/notebooks/tututils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/notifications.rst
+++ b/docs/notifications.rst
@@ -1,4 +1,4 @@
-.. Copyright 2017-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2017,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2021 IBM Corp. All Rights Reserved.
+.. Copyright 2016,2021 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/examples/activation_profiles.py
+++ b/examples/activation_profiles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/adapter_port_vswitch.py
+++ b/examples/adapter_port_vswitch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/api_version.py
+++ b/examples/api_version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/async_operation_notification.py
+++ b/examples/async_operation_notification.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/async_operation_polling.py
+++ b/examples/async_operation_polling.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/discover_storage_group.py
+++ b/examples/discover_storage_group.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2022 IBM Corp. All Rights Reserved.
+# Copyright 2020,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/export_dpm_config.py
+++ b/examples/export_dpm_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2021-2022 IBM Corp. All Rights Reserved.
+# Copyright 2021,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/find_cpcs.py
+++ b/examples/find_cpcs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/get_inventory.py
+++ b/examples/get_inventory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017-2022 IBM Corp. All Rights Reserved.
+# Copyright 2017,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/get_partial_and_full_properties.py
+++ b/examples/get_partial_and_full_properties.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/list_cpcs.py
+++ b/examples/list_cpcs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/list_free_crypto_domains.py
+++ b/examples/list_free_crypto_domains.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017-2022 IBM Corp. All Rights Reserved.
+# Copyright 2017,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/list_storage_groups.py
+++ b/examples/list_storage_groups.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2018-2022 IBM Corp. All Rights Reserved.
+# Copyright 2018,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/lpar_operations.py
+++ b/examples/lpar_operations.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/metrics.py
+++ b/examples/metrics.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/mount_iso.py
+++ b/examples/mount_iso.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/partition_lifecycle.py
+++ b/examples/partition_lifecycle.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2022 IBM Corp. All Rights Reserved.
+# Copyright 2016,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/show_auto_updated_partition.py
+++ b/examples/show_auto_updated_partition.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2021-2022 IBM Corp. All Rights Reserved.
+# Copyright 2021,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/show_os_messages.py
+++ b/examples/show_os_messages.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017-2022 IBM Corp. All Rights Reserved.
+# Copyright 2017,2022 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/end2end/test_activation_profile.py
+++ b/tests/end2end/test_activation_profile.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/end2end/test_cpc.py
+++ b/tests/end2end/test_cpc.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 IBM Corp. All Rights Reserved.
+# Copyright 2019,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/end2end/test_hmc_inventory.py
+++ b/tests/end2end/test_hmc_inventory.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 IBM Corp. All Rights Reserved.
+# Copyright 2019,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/end2end/test_partition.py
+++ b/tests/end2end/test_partition.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/end2end/test_storage_group.py
+++ b/tests/end2end/test_storage_group.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/end2end/test_storage_volume.py
+++ b/tests/end2end/test_storage_volume.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_example.py
+++ b/tests/unit/test_example.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/tests/common/test_utils.py
+++ b/tests/unit/tests/common/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_activation_profile.py
+++ b/tests/unit/zhmcclient/test_activation_profile.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_adapter.py
+++ b/tests/unit/zhmcclient/test_adapter.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_client.py
+++ b/tests/unit/zhmcclient/test_client.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_console.py
+++ b/tests/unit/zhmcclient/test_console.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_cpc.py
+++ b/tests/unit/zhmcclient/test_cpc.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_exceptions.py
+++ b/tests/unit/zhmcclient/test_exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_hba.py
+++ b/tests/unit/zhmcclient/test_hba.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_ldap_server_definition.py
+++ b/tests/unit/zhmcclient/test_ldap_server_definition.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_logging.py
+++ b/tests/unit/zhmcclient/test_logging.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_lpar.py
+++ b/tests/unit/zhmcclient/test_lpar.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_manager.py
+++ b/tests/unit/zhmcclient/test_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_metrics.py
+++ b/tests/unit/zhmcclient/test_metrics.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_nic.py
+++ b/tests/unit/zhmcclient/test_nic.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_notification.py
+++ b/tests/unit/zhmcclient/test_notification.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_partition.py
+++ b/tests/unit/zhmcclient/test_partition.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_password_rule.py
+++ b/tests/unit/zhmcclient/test_password_rule.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_port.py
+++ b/tests/unit/zhmcclient/test_port.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_resource.py
+++ b/tests/unit/zhmcclient/test_resource.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_session.py
+++ b/tests/unit/zhmcclient/test_session.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_storage_group.py
+++ b/tests/unit/zhmcclient/test_storage_group.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 IBM Corp. All Rights Reserved.
+# Copyright 2018,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_task.py
+++ b/tests/unit/zhmcclient/test_task.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_timestats.py
+++ b/tests/unit/zhmcclient/test_timestats.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_unmanaged_cpc.py
+++ b/tests/unit/zhmcclient/test_unmanaged_cpc.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_user.py
+++ b/tests/unit/zhmcclient/test_user.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_user_pattern.py
+++ b/tests/unit/zhmcclient/test_user_pattern.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_user_role.py
+++ b/tests/unit/zhmcclient/test_user_role.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_utils.py
+++ b/tests/unit/zhmcclient/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_virtual_function.py
+++ b/tests/unit/zhmcclient/test_virtual_function.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient/test_virtual_switch.py
+++ b/tests/unit/zhmcclient/test_virtual_switch.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient_mock/test_idpool.py
+++ b/tests/unit/zhmcclient_mock/test_idpool.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_certificates.py
+++ b/zhmcclient/_certificates.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 IBM Corp. All Rights Reserved.
+# Copyright 2016,2023 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_client.py
+++ b/zhmcclient/_client.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_debug_info.py
+++ b/zhmcclient/_debug_info.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 IBM Corp. All Rights Reserved.
+# Copyright 2020,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_ldap_server_definition.py
+++ b/zhmcclient/_ldap_server_definition.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_metrics.py
+++ b/zhmcclient/_metrics.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_password_rule.py
+++ b/zhmcclient/_password_rule.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 IBM Corp. All Rights Reserved.
+# Copyright 2018,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_storage_group_template.py
+++ b/zhmcclient/_storage_group_template.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 IBM Corp. All Rights Reserved.
+# Copyright 2019,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_storage_volume.py
+++ b/zhmcclient/_storage_volume.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 IBM Corp. All Rights Reserved.
+# Copyright 2018,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_storage_volume_template.py
+++ b/zhmcclient/_storage_volume_template.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 IBM Corp. All Rights Reserved.
+# Copyright 2019,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_task.py
+++ b/zhmcclient/_task.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_timestats.py
+++ b/zhmcclient/_timestats.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_unmanaged_cpc.py
+++ b/zhmcclient/_unmanaged_cpc.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_user_pattern.py
+++ b/zhmcclient/_user_pattern.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_user_role.py
+++ b/zhmcclient/_user_role.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 IBM Corp. All Rights Reserved.
+# Copyright 2017,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_version.py
+++ b/zhmcclient/_version.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_virtual_storage_resource.py
+++ b/zhmcclient/_virtual_storage_resource.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 IBM Corp. All Rights Reserved.
+# Copyright 2018,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/testutils/_cpc_fixtures.py
+++ b/zhmcclient/testutils/_cpc_fixtures.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 IBM Corp. All Rights Reserved.
+# Copyright 2019,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/testutils/_hmc_definition_fixtures.py
+++ b/zhmcclient/testutils/_hmc_definition_fixtures.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 IBM Corp. All Rights Reserved.
+# Copyright 2019,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient/testutils/_hmc_definitions.py
+++ b/zhmcclient/testutils/_hmc_definitions.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 IBM Corp. All Rights Reserved.
+# Copyright 2019,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient_mock/__init__.py
+++ b/zhmcclient_mock/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient_mock/_idpool.py
+++ b/zhmcclient_mock/_idpool.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 IBM Corp. All Rights Reserved.
+# Copyright 2016,2021 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
* The Copyright statements used a 'year-year' syntax which is incorrect. Fixed that to use a 'year,year' syntax. (issue #1394).