### PR TITLE
1.13: Fixed pipdeptree call in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,7 +230,7 @@ jobs:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
       run: |
         echo "Package dependency tree of installed Python packages:"
-        pipdeptree --all
+        python -m pipdeptree --all
     - name: Run build
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,9 @@ Released: not yet
   property. This was fixed in the Console.list_permitted_lpars/partitions()
   methods.
 
+* Fixed the call to pipdeptree in the test workflow to use 'python -m'
+  because otherwise it does not show the correct packages of the virtual env.
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #1426 into 1.13.3.