### PR TITLE
1.13: Fixed the 'Cpc.delete_retrieved_internal_code()' method ec_level

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed the 'Cpc.delete_retrieved_internal_code()' method which passed its
+  'ec_level' parameter incorrectly to the HMC operation. Added unit tests.
+  (issue #1432)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -2448,7 +2448,8 @@ class Cpc(BaseResource):
 
         body = {}
         if ec_levels is not None:
-            body['ec-levels'] = ec_levels
+            body['ec-levels'] = \
+                [{"number": ec[0], "mcl": ec[1]} for ec in ec_levels]
 
         result = self.manager.session.post(
             self.uri + '/operations/delete-retrieved-internal-code',


### PR DESCRIPTION
Rolls back PR #1433 into 1.13.4.
No review needed.