### PR TITLE
Fixed check_reqs SyntaxWarning on tox by increasing tox to 3.1.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -77,7 +77,7 @@ coveralls>=3.3.0; python_version >= '3.5'
 safety>=3.0.1; python_version >= '3.7'
 
 # Tox
-tox>=2.5.0
+tox>=3.1.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 # Sphinx 6.0.0 started requiring Python>=3.8

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -187,7 +187,7 @@ pydantic==1.10.13; python_version >= '3.7'
 typer==0.9.0; python_version >= '3.7'
 
 # Tox
-tox==2.5.0
+tox==3.1.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==7.1.0; python_version == '3.8'


### PR DESCRIPTION
No review needed.