### PR TITLE
Support additional-properties in list permitted partitions

### DIFF
--- a/tests/end2end/test_partition.py
+++ b/tests/end2end/test_partition.py
@@ -340,6 +340,13 @@ LIST_PERMITTED_PARTITION_TESTCASES = [
         ),
         COMMON_PROPS_LIST
     ),
+    (
+        "additional-properties",
+        dict(
+            additional_properties=['partition-id', 'tape-link-uris']
+        ),
+        COMMON_PROPS_LIST + ['partition-id', 'tape-link-uris']
+    ),
 ]
 
 
@@ -361,6 +368,11 @@ def test_console_list_permitted_partitions(desc, input_kwargs, exp_props,
         hd = session.hmc_definition
         client = zhmcclient.Client(session)
         console = client.consoles.console
+        features = console.list_api_features()
+        if 'additional_properties' in input_kwargs and \
+                'dpm-ctc-partition-link-management' not in features and \
+                'dpm-hipersockets-partition-link-management' not in features:
+            pytest.skip("HMC does not support additional-properties parameter.")
 
         permitted_part_list = console.list_permitted_partitions(**input_kwargs)
         if not permitted_part_list:

--- a/tests/unit/zhmcclient/test_partition.py
+++ b/tests/unit/zhmcclient/test_partition.py
@@ -1000,6 +1000,43 @@ class TestPartition(object):
                     "Property {!r} missing from returned partition properties, "
                     "got: {!r}".format(pname, partition_props))
 
+    def test_console_list_permitted_partitions_with_additional_properties(self):
+        """
+        Test Console.list_permitted_partitions() with additional properties.
+        """
+
+        # Add two faked partitions
+        self.add_partition1()
+        self.add_partition2()
+
+        self.session.hmc.consoles.add({
+            'object-id': None,
+            # object-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        console = self.client.consoles.console
+
+        additional_properties = ['ifl-processors', 'maximum-memory']
+        # Execute the code to be tested
+        partitions = console.list_permitted_partitions(
+            additional_properties=additional_properties)
+
+        assert len(partitions) == 2
+
+        for partition in partitions:
+            partition_props = dict(partition.properties)
+            for pname in LIST_PERMITTED_PARTITIONS_PROPS:
+                assert pname in partition_props, (
+                    "Property {!r} missing from returned partition properties, "
+                    "got: {!r}".format(pname, partition_props))
+            for pname in additional_properties:
+                assert pname in partition_props, (
+                    "Property {!r} missing from returned partition properties, "
+                    "got: {!r}".format(pname, partition_props))
+
     # TODO: Test for Partition.send_os_command()
 
     # TODO: Test for Partition.wait_for_status()

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -596,7 +596,8 @@ class Console(BaseResource):
 
     @logged_api_call
     def list_permitted_partitions(
-            self, full_properties=False, filter_args=None):
+            self, full_properties=False, filter_args=None,
+            additional_properties=None):
         """
         List the permitted partitions of CPCs in DPM mode managed by this HMC.
 
@@ -673,6 +674,14 @@ class Console(BaseResource):
 
             * <property-name>: Any other property of partitions.
 
+          additional_properties (list of string):
+            List of property names that are to be returned in addition to the
+            default properties.
+
+            This parameter requires API feature
+            "dpm-hipersockets-partition-link-management" or
+            "dpm-ctc-partition-link-management".
+
         Returns:
 
           : A list of :class:`~zhmcclient.Partition` objects.
@@ -687,6 +696,10 @@ class Console(BaseResource):
         query_parms, client_filters = divide_filter_args(
             ['name', 'type', 'status', 'has-unacceptable-status', 'cpc-name'],
             filter_args)
+        if additional_properties:
+            ap_parm = 'additional-properties={}'.format(
+                ','.join(additional_properties))
+            query_parms.append(ap_parm)
         query_parms_str = make_query_str(query_parms)
 
         # Perform the operation with the HMC, including any server-side

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -840,7 +840,8 @@ class ConsoleListPermittedPartitionsHandler(object):
     """
 
     valid_query_parms_get = ['name', 'type', 'status',
-                             'has-unacceptable-status', 'cpc-name']
+                             'has-unacceptable-status', 'cpc-name',
+                             'additional-properties']
 
     @classmethod
     def get(cls, method, hmc, uri, uri_parms, logon_required):
@@ -849,6 +850,7 @@ class ConsoleListPermittedPartitionsHandler(object):
         uri, query_parms = parse_query_parms(method, uri)
         check_invalid_query_parms(
             method, uri, query_parms, cls.valid_query_parms_get)
+        add_props = query_parms.pop('additional-properties', '').split(',')
         filter_args = query_parms
 
         result_partitions = []
@@ -865,21 +867,17 @@ class ConsoleListPermittedPartitionsHandler(object):
 
                 for partition in cpc.partitions.list(filter_args):
                     result_partition = {}
-                    result_partition['object-uri'] = \
-                        partition.properties.get('object-uri', None)
-                    result_partition['name'] = \
-                        partition.properties.get('name', None)
-                    result_partition['type'] = \
-                        partition.properties.get('type', None)
-                    result_partition['status'] = \
-                        partition.properties.get('status', None)
-                    result_partition['has-unacceptable-status'] = \
-                        partition.properties.get(
-                            'has-unacceptable-status', None)
+                    for prop in ('object-uri', 'name', 'status',
+                                 'type', 'has-unacceptable-status'):
+                        result_partition[prop] = \
+                            partition.properties.get(prop, None)
                     result_partition['cpc-name'] = cpc.name
                     result_partition['cpc-object-uri'] = cpc.uri
                     result_partition['se-version'] = \
                         cpc.properties.get('se-version', None)
+                    for prop in add_props:
+                        result_partition[prop] = \
+                            partition.properties.get(prop, None)
                     result_partitions.append(result_partition)
 
         return {'partitions': result_partitions}


### PR DESCRIPTION
Latest HMC versions support to include additional properties in the results. This will allow us to optimize list partitions in zhmccli.