### PR TITLE
Docs: Fixed and remove broken links to HMC books

### DIFF
--- a/changes/1459.fix.rst
+++ b/changes/1459.fix.rst
@@ -1,0 +1,4 @@
+Docs: Fixed broken links to HMC books since IBM changed the links. As part
+of that, removed Bibliography entries for the HMC API book versions 2.11/2.12,
+and for all versions of the HMC Operations Guide (which changed to become the
+HMC Help System PDFs).

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -620,60 +620,28 @@ Bibliography
    HMC API
        The Web Services API of the z Systems Hardware Management Console, described in the following books:
 
-   HMC API 2.11.1
-       `IBM SC27-2616, System z Hardware Management Console Web Services API (Version 2.11.1) <https://www.ibm.com/support/pages/node/6017542>`_
-
-   HMC API 2.12.0
-       `IBM SC27-2617, System z Hardware Management Console Web Services API (Version 2.12.0) <https://www.ibm.com/support/pages/node/6019030>`_
-
-   HMC API 2.12.1
-       `IBM SC27-2626, System z Hardware Management Console Web Services API (Version 2.12.1) <https://www.ibm.com/support/pages/node/6017614>`_
-
    HMC API 2.13.0
-       `IBM SC27-2627, z Systems Hardware Management Console Web Services API (Version 2.13.0) <https://www.ibm.com/support/pages/node/6018628>`_
+       `IBM SC27-2627-00a, z Systems Hardware Management Console Web Services API (Version 2.13.0) <https://www.ibm.com/docs/en/module_1707928542006/pdf/SC27-2627-00a.pdf>`_
 
    HMC API 2.13.1
-       `IBM SC27-2634, z Systems Hardware Management Console Web Services API (Version 2.13.1) <https://www.ibm.com/support/pages/node/6019732>`_
+       `IBM SC27-2634-03a, z Systems Hardware Management Console Web Services API (Version 2.13.1) <https://www.ibm.com/docs/en/module_1707928542006/pdf/SC27-2634-03a.pdf>`_
 
    HMC API 2.14.0
-       `IBM SC27-2636, IBM Z Hardware Management Console Web Services API (Version 2.14.0) <https://www.ibm.com/support/pages/node/6020008>`_
+       `IBM SC27-2636-04a, IBM Z Hardware Management Console Web Services API (Version 2.14.0) <https://www.ibm.com/docs/en/module_1687361734185/pdf/SC27-2636-04a.pdf>`_
 
    HMC API 2.14.1
-       `IBM SC27-2637, IBM Z Hardware Management Console Web Services API (Version 2.14.1) <https://www.ibm.com/support/pages/node/6019768>`_
+       `IBM SC27-2637-01a, IBM Z Hardware Management Console Web Services API (Version 2.14.1) <https://www.ibm.com/docs/en/module_1687361734185/pdf/SC27-2637-01a.pdf>`_
 
    HMC API 2.15.0
-       `IBM SC27-2638, IBM Z Hardware Management Console Web Services API (Version 2.15.0) <https://www.ibm.com/support/pages/node/6019720>`_
+       `IBM SC27-2638-04c, IBM Z Hardware Management Console Web Services API (Version 2.15.0) <https://www.ibm.com/docs/en/module_1687296212988/pdf/SC27-2638-04c.pdf>`_
        (covers both GA1 and GA2)
 
    HMC API 2.16.0
-       `IBM SC27-2642, IBM Z Hardware Management Console Web Services API (Version 2.16.0) <https://www.ibm.com/support/pages/node/6591083>`_
-       (covers both GA1 and GA2)
-
-   HMC Operations Guide
-       The operations guide of the z Systems Hardware Management Console, in the following books (subset):
-
-   HMC Operations Guide 2.11.1
-       `IBM SC28-6905, System z Hardware Management Console Operations Guide (Version 2.11.1) <https://www.ibm.com/support/pages/node/6019948>`_
-
-   HMC Operations Guide 2.12.1
-       `System z Hardware Management Console Operations Guide (Version 2.12.1) <https://www.ibm.com/support/pages/node/6017692>`_
-
-   HMC Operations Guide 2.13.1
-       `z Systems Hardware Management Console Operations Guide (Version 2.13.1) <https://www.ibm.com/support/pages/node/6016846>`_
-
-   HMC Operations Guide 2.14.1
-       `Hardware Management Console Operations Guide (Version 2.14.1) <https://www.ibm.com/support/pages/node/6019132>`_
-
-   HMC Operations Guide 2.15.0
-       `Hardware Management Console Operations Guide (Version 2.15.0) <https://www.ibm.com/support/pages/node/6018724>`_
-       (covers both GA1 and GA2)
-
-   HMC Operations Guide 2.16.0
-       `Hardware Management Console Operations Guide (Version 2.16.0) <https://www.ibm.com/support/pages/node/6619013>`_
+       `IBM SC27-2642-02, IBM Z Hardware Management Console Web Services API (Version 2.16.0) <https://www.ibm.com/docs/en/module_1675371155154/pdf/SC27-2642-02.pdf>`_
        (covers both GA1 and GA2)
 
    HMC Security
-       `Hardware Management Console Security <https://www.ibm.com/support/pages/node/6017320>`_
+       `IBM SC28-6987-01, Hardware Management Console Security <https://www.ibm.com/docs/en/module_1687361734185/pdf/SC28-6987-01.pdf>`_
 
 
 .. _`Related projects`:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -420,8 +420,6 @@ accordingly:
 
    * LPARs to be accessed
 
-For details, see the :term:`HMC Operations Guide`.
-
 
 .. _`Setting up firewalls or proxies`:
 


### PR DESCRIPTION
For details, see the commit message.

The PR has been updated with the final links, according to the HMC docs lead.