### PR TITLE
1.14: Fixed macos version used in test workflow for py35/36/37; Fixed pyzmq install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,36 @@ jobs:
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"latest\" \
               } \
             ], \
             \"include\": [ \
@@ -90,6 +120,36 @@ jobs:
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.7\", \
                 \"package_level\": \"latest\" \
               } \
             ] \
@@ -138,8 +198,18 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
-                \"os\": \"macos-latest\", \
+                \"os\": \"macos-12\", \
                 \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.8\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.8\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -243,7 +243,8 @@ tornado>=6.3.3; python_version >= '3.8'
 
 # pyzmq 17.0.0,17.1.0 fail installation when wheel is used
 pyzmq>=17.1.3; python_version <= '3.5'
-pyzmq>=23.0.0; python_version >= '3.6' and python_version <= '3.11'
+pyzmq>=23.0.0; python_version >= '3.6' and python_version <= '3.7'
+pyzmq>=24.0.0; python_version >= '3.8' and python_version <= '3.11'
 pyzmq>=25.1.1; python_version >= '3.12'
 
 # Aditional dependencies of examples

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* In the Github Actions test workflow for Python 3.5, 3.6 and 3.7, changed
+  macos-latest back to macos-12 because macos-latest got upgraded from macOS 12
+  to macOS 14 which no longer supports these Python versions.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -282,7 +282,8 @@ pywin32==303; sys_platform == 'win32' and python_version >= '3.6' and python_ver
 pywin32==306; sys_platform == 'win32' and python_version >= '3.12'
 
 pyzmq==17.1.3; python_version <= '3.5'
-pyzmq==23.0.0; python_version >= '3.6' and python_version <= '3.11'
+pyzmq==23.0.0; python_version >= '3.6' and python_version <= '3.7'
+pyzmq==24.0.0; python_version >= '3.8' and python_version <= '3.11'
 pyzmq==25.1.1; python_version >= '3.12'
 
 # Aditional dependencies of examples


### PR DESCRIPTION
Rolls back PR #1471 into 1.14.1.