### PR TITLE
Used Queue for STOMP listener handover; Improved connection loss recovery

### DIFF
--- a/changes/1502.feature.rst
+++ b/changes/1502.feature.rst
@@ -1,0 +1,40 @@
+Improved the notification support in several ways:
+
+- Replaced the event-based handover of a single item from the notification
+  listener thread to the caller's thread with a Python Queue, for better
+  reliability. It turned out that messages could have been lost in some cases
+  with the previous design.
+
+- The 'NotificationReceiver.notifications()' method now continues running
+  when there are no notifications, and only ever returns when
+  'NotificationReceiver.close()' is called (by some other thread).
+
+- Added methods 'connect()' and 'is_connected()' to the 'NotificationReceiver'
+  class. The init method of 'NotificationReceiver' no longer connects,
+  but the 'notifications()' method now calls 'connect()', so overall this is
+  compatible with the prior behavior.
+
+- Added new exceptions 'NotificationConnectionError' and
+  'NotificationSubscriptionError' that may be raised by some
+  'NotificationReceiver' methods.
+
+- Documented the stomp-py exceptions that can be raised from
+  'NotificationReceiver' methods.
+
+- Added proper detection of STOMP connection loss if STOMP heartbeating is
+  enabled. The connection loss is surfaced by raising
+  'NotificationConnectionError' in 'NotificationReceiver.notifications()'.
+  This allows users to retry 'NotificationReceiver.notifications()' upon
+  connection loss.
+
+- Added a new public constant 'STOMP_MIN_CONNECTION_CHECK_TIME' that defines
+  the minimum time between checks for STOMP connection loss. The actual check
+  time is determined by the heartbeat receive time and is bound by this minimum
+  time.
+
+- Added the missing event methods to the internal '_NotificationListener' class
+  in case they are ever invoked (needed due to lazy importing of stomp-py).
+
+- Added more log messages around STOMP connect / disconnect.
+
+Issue:

--- a/changes/1502.incompatible.rst
+++ b/changes/1502.incompatible.rst
@@ -1,0 +1,22 @@
+Incompatible changes in the notification support:
+
+- The 'NotificationReceiver.notifications()' method now continues running when
+  there are no notifications, and only ever returns when
+  'NotificationReceiver.close()' is called (in some other thread).
+  Before this change, the method returned when there were no notifications, so
+  it had to be invoked by the user in a loop. Such user code should be adjusted
+  to remove the loop and deal with the return indicating a close of the
+  receiver.
+
+- In addition, the 'NotificationReceiver.notifications()' method can now raise
+  the new exceptions 'zhmcclient.NotificationConnectionError' and
+  'zhmcclient.NotificationSubscriptionError'.
+
+- The 'NotificationReceiver.subscribe/unsubscribe()' methods can now raise the
+  new exception 'zhmcclient.NotificationSubscriptionError'.
+
+- Note that the 'NotificationReceiver.close()' method can raise
+  'stomp.exception.StompException'. This could already be raised before this
+  change, but had not been documented before.
+
+Issue:

--- a/examples/show_os_messages.py
+++ b/examples/show_os_messages.py
@@ -20,7 +20,7 @@ in DPM mode.
 
 import sys
 import requests.packages.urllib3
-
+import stomp
 import zhmcclient
 from zhmcclient.testutils import hmc_definitions
 
@@ -92,27 +92,37 @@ try:
         print("Error: Cannot create notification receiver: {}".format(exc))
         sys.exit(1)
 
+    print("Debug: STOMP retry/timeout config: {}".format(receiver._rt_config))
+
     print("Showing OS messages ...")
     print("-----------------------")
-    try:
-        for headers, message in receiver.notifications():
-            os_msg_list = message['os-messages']
-            for os_msg in os_msg_list:
-                if PRINT_METADATA:
-                    msg_id = os_msg['message-id']
-                    held = os_msg['is-held']
-                    priority = os_msg['is-priority']
-                    prompt = os_msg.get('prompt-text', None)
-                    print("# OS message {} (held: {}, priority: {}, "
-                          "prompt: {}):".
-                          format(msg_id, held, priority, prompt))
-                msg_txt = os_msg['message-text'].strip('\n')
-                print(msg_txt)
-    except KeyboardInterrupt:
-        print("Keyboard interrupt - leaving receiver loop")
-    finally:
-        print("Closing receiver ...")
-        receiver.close()
+    while True:
+        try:
+            for headers, message in receiver.notifications():
+                os_msg_list = message['os-messages']
+                for os_msg in os_msg_list:
+                    if PRINT_METADATA:
+                        msg_id = os_msg['message-id']
+                        held = os_msg['is-held']
+                        priority = os_msg['is-priority']
+                        prompt = os_msg.get('prompt-text', None)
+                        print("# OS message {} (held: {}, priority: {}, "
+                              "prompt: {}):".
+                              format(msg_id, held, priority, prompt))
+                    msg_txt = os_msg['message-text'].strip('\n')
+                    print(msg_txt)
+        except zhmcclient.NotificationError as exc:
+            print("Notification Error: {} - reconnecting".format(exc))
+            continue
+        except stomp.exception.StompException as exc:
+            print("STOMP Error: {} - reconnecting".format(exc))
+            continue
+        except KeyboardInterrupt:
+            print("Keyboard interrupt - leaving receiver loop")
+            receiver.close()
+            break
+        else:
+            raise AssertionError("Receiver was closed - should not happen")
 
 finally:
     print("Logging off ...")

--- a/tests/unit/zhmcclient/test_notification.py
+++ b/tests/unit/zhmcclient/test_notification.py
@@ -24,14 +24,27 @@ from __future__ import absolute_import, print_function
 import json
 import threading
 from collections import namedtuple
+import logging
+import time
 from mock import patch
 import six
 import pytest
 import stomp
 
 from zhmcclient._notification import NotificationReceiver
-from zhmcclient._exceptions import SubscriptionNotFound
 from zhmcclient._utils import stomp_uses_frames
+from zhmcclient._exceptions import SubscriptionNotFound, \
+    NotificationConnectionError
+from zhmcclient._constants import JMS_LOGGER_NAME, \
+    STOMP_MIN_CONNECTION_CHECK_TIME
+
+# We use the JMS logger for logging. The log is reported by pytest in case
+# of testcase errors when using pytest option:
+# --log-level debug
+# Because threads are involved, it makes sense to add the thread name in the
+# log format using pytest option:
+# --log-format "%(asctime)s %(threadName)s %(name)s %(levelname)s %(message)s
+JMS_LOGGER = logging.getLogger(JMS_LOGGER_NAME)
 
 
 def create_event_args(headers, message):
@@ -57,8 +70,8 @@ class MockedStompConnection(object):
 
     def __init__(self, *args, **kwargs):
         # pylint: disable=unused-argument
-        """We ignore the args:
-            [(self._host, self._port)], use_ssl="SSL")
+        """
+        For the mocked connection, we ignore the args (host/port, etc).
         """
         self._state_connected = False
         self._listener = None
@@ -73,77 +86,132 @@ class MockedStompConnection(object):
 
     def set_ssl(self, *args, **kwargs):
         # pylint: disable=unused-argument
-        """Mocks the same-named method of stomp.Connection."""
+        """
+        Mocks the same-named method of stomp.Connection.
+        """
         assert not self._state_connected
         self._ssl_args = args
         self._ssl_kwargs = kwargs
 
     def set_listener(self, name, listener):
         # pylint: disable=unused-argument
-        """Mocks the same-named method of stomp.Connection."""
+        """
+        Mocks the same-named method of stomp.Connection.
+        """
         assert not self._state_connected
         self._listener = listener
 
     def start(self):
-        """Mocks the same-named method of stomp.Connection."""
+        """
+        Mocks the same-named method of stomp.Connection.
+        """
         assert not self._state_connected
 
     def connect(self, userid, password, wait):
-        """Mocks the same-named method of stomp.Connection."""
-        assert not self._state_connected
-        self._state_connected = True
-        self._connect_userid = userid
-        self._connect_password = password
-        self._connect_wait = wait
+        """
+        Mocks the same-named method of stomp.Connection.
+        """
+        JMS_LOGGER.debug(
+            "test_notifcation: MockedStompConnection.connect() called")
+        if not self._state_connected:
+            self._state_connected = True
+            self._connect_userid = userid
+            self._connect_password = password
+            self._connect_wait = wait
+
+    def is_connected(self):
+        """
+        Mocks the same-named method of stomp.Connection.
+        """
+        return self._state_connected
 
     def subscribe(self, destination, id, ack):
         # pylint: disable=redefined-builtin
-        """Mocks the same-named method of stomp.Connection."""
+        """
+        Mocks the same-named method of stomp.Connection.
+        """
         assert self._state_connected
         self._subscriptions.append((destination, id, ack))
 
     def unsubscribe(self, id):
         # pylint: disable=redefined-builtin
-        """Mocks the same-named method of stomp.Connection."""
+        """
+        Mocks the same-named method of stomp.Connection.
+        """
         assert self._state_connected
         for _dest, _id, _ack in self._subscriptions:
             if _id == id:
                 self._subscriptions.remove((_dest, _id, _ack))
 
-    def disconnect(self):
-        """Mocks the same-named method of stomp.Connection."""
-        assert self._state_connected
-        self._sender_thread.join()
-        self._sender_thread = None
-        self._state_connected = False
+    def disconnect(self, receipt=None):
+        # pylint: disable=unused-argument
+        """
+        Mocks the same-named method of stomp.Connection.
+        """
+        JMS_LOGGER.debug(
+            "test_notifcation: MockedStompConnection.disconnect() called")
+        if self._state_connected:
+            self._state_connected = False
 
     def mock_add_message(self, headers, message):
-        """Adds a STOMP message to the queue."""
+        """
+        Adds a STOMP message to the queue.
+        """
         assert self._sender_thread is None
         if not isinstance(message, six.string_types):
             message = json.dumps(message)
         self._queued_messages.append((headers, message))
 
     def mock_start(self):
-        """Start the STOMP message sender thread."""
-        assert self._state_connected
+        """
+        Start the STOMP message sender thread.
+
+        This can be done independent of the connection state.
+        """
+        assert self._sender_thread is None
         self._sender_thread = threading.Thread(target=self.mock_sender_run)
+        JMS_LOGGER.debug("test_notifcation: Starting mock sender thread")
         self._sender_thread.start()
 
+    def mock_stop(self):
+        """
+        Wait for the STOMP message sender thread to finish.
+
+        This can be done independent of the connection state.
+        """
+        assert self._sender_thread is not None
+        JMS_LOGGER.debug(
+            "test_notifcation: Waiting for mock sender thread to finish")
+        self._sender_thread.join(STOMP_MIN_CONNECTION_CHECK_TIME + 2)
+        self._sender_thread = None
+        JMS_LOGGER.debug(
+            "test_notifcation: Mock sender thread finished")
+
     def mock_sender_run(self):
-        """Simulates the HMC sending STOMP messages. This method runs in a
-        separate thread and processes the queued STOMP messages and sends
-        them to the notification listener set up by the NotificationReceiver
-        class."""
+        """
+        Thread function that runs in the mock sender thread.
+
+        It simulates the HMC sending STOMP messages by sending the previously
+        queued STOMP messages to the notification listener.
+
+        It returns when all messages have been sent and thus ends the mock
+        sender thread in which it runs.
+        """
+        JMS_LOGGER.debug(
+            "test_notifcation: Mock sender thread gets control")
         for msg_item in self._queued_messages:
             # The following method blocks until it can deliver a message
             headers, message_str = msg_item
             frame_args = create_event_args(headers, message_str)
             self._listener.on_message(*frame_args)
         self._listener.on_disconnected()
+        JMS_LOGGER.debug(
+            "test_notifcation: Mock sender thread is done")
 
     def mock_get_subscription(self, topic):
-        """Find the subscription with the specified topic name and return it"""
+        """
+        Find the subscription with the specified topic name and return it.
+        """
         for _dest, _id, _ack in self._subscriptions:
             dest = '/topic/' + topic
             if _dest == dest:
@@ -153,13 +221,24 @@ class MockedStompConnection(object):
 
 def receiver_run(receiver, msg_items):
     """
-    Receiver function that will be run in a thread.
-    It invokes the receiver until out of notifications, then return them as a
-    list.
+    Thread function that will be run in the receiver thread.
+
+    It invokes receiver.notifications() to get notifications which are
+    appended to the msg_items list.
+
+    It ends when the main thread calls receiver.close() which causes
+    receiver.notifications() to return and thus end the loop.
     """
-    for headers, message in receiver.notifications():
-        msg_items.append((headers, message))
-    return msg_items
+    JMS_LOGGER.debug(
+        "test_notifcation: Receiver thread gets control")
+    try:
+        for headers, message in receiver.notifications():
+            msg_items.append((headers, message))
+    except NotificationConnectionError:
+        # This happens at the end of some testcases.
+        pass
+    JMS_LOGGER.debug(
+        "test_notifcation: Receiver thread is done")
 
 
 def receive_notifications(receiver):
@@ -169,9 +248,17 @@ def receive_notifications(receiver):
     msg_items = []
     receiver_thread = threading.Thread(target=receiver_run,
                                        args=(receiver, msg_items))
+    JMS_LOGGER.debug(
+        "test_notifcation: Starting receiver thread")
     receiver_thread.start()
+    # Allow for some time to process the received messages
+    time.sleep(0.5)
+    JMS_LOGGER.debug(
+        "test_notifcation: Triggering receiver close")
     receiver.close()
-    receiver_thread.join(1.0)
+    JMS_LOGGER.debug(
+        "test_notifcation: Waiting for receiver thread to finish")
+    receiver_thread.join(STOMP_MIN_CONNECTION_CHECK_TIME + 1)
     if receiver_thread.is_alive():
         raise AssertionError("receiver_thread is still alive")
     return msg_items
@@ -196,18 +283,26 @@ class TestNotificationOneTopic(object):
             'notification-type': 'fake-type'
         }
 
+    def setup_receiver(self):
+        """Set up the notification receiver for the test"""
+        receiver = NotificationReceiver(self.topic, self.hmc, self.userid,
+                                        self.password)
+        receiver.connect()
+        mocked_conn = receiver._conn  # pylint: disable=protected-access
+        assert isinstance(mocked_conn, MockedStompConnection)
+        return receiver, mocked_conn
+
     @patch(target='stomp.Connection', new=MockedStompConnection)
     def test_no_messages(self):
         """Test function for not receiving any notification."""
 
-        receiver = NotificationReceiver(self.topic, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         # We do not add any STOMP messages
 
-        conn.mock_start()  # pylint: disable=no-member
+        mocked_conn.mock_start()  # pylint: disable=no-member
         msg_items = receive_notifications(receiver)
+        mocked_conn.mock_stop()  # pylint: disable=no-member
 
         assert msg_items == []
 
@@ -215,17 +310,16 @@ class TestNotificationOneTopic(object):
     def test_one_message(self):
         """Test function for receiving one notification."""
 
-        receiver = NotificationReceiver(self.topic, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         # Add one STOMP message to be sent
         message_obj = dict(a=1, b=2)
         # pylint: disable=no-member
-        conn.mock_add_message(self.std_headers, message_obj)
+        mocked_conn.mock_add_message(self.std_headers, message_obj)
 
-        conn.mock_start()  # pylint: disable=no-member
+        mocked_conn.mock_start()  # pylint: disable=no-member
         msg_items = receive_notifications(receiver)
+        mocked_conn.mock_stop()  # pylint: disable=no-member
 
         assert len(msg_items) == 1
 
@@ -253,18 +347,26 @@ class TestNotificationTwoTopics(object):
             'notification-type': 'fake-type'
         }
 
+    def setup_receiver(self):
+        """Set up the notification receiver for the test"""
+        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
+                                        self.password)
+        receiver.connect()
+        mocked_conn = receiver._conn  # pylint: disable=protected-access
+        assert isinstance(mocked_conn, MockedStompConnection)
+        return receiver, mocked_conn
+
     @patch(target='stomp.Connection', new=MockedStompConnection)
     def test_no_messages(self):
         """Test function for not receiving any notification."""
 
-        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         # We do not add any STOMP messages
 
-        conn.mock_start()  # pylint: disable=no-member
+        mocked_conn.mock_start()  # pylint: disable=no-member
         msg_items = receive_notifications(receiver)
+        mocked_conn.mock_stop()  # pylint: disable=no-member
 
         assert msg_items == []
 
@@ -272,17 +374,16 @@ class TestNotificationTwoTopics(object):
     def test_one_message(self):
         """Test function for receiving one notification."""
 
-        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         # Add one STOMP message to be sent
         message_obj = dict(a=1, b=2)
         # pylint: disable=no-member
-        conn.mock_add_message(self.std_headers, message_obj)
+        mocked_conn.mock_add_message(self.std_headers, message_obj)
 
-        conn.mock_start()  # pylint: disable=no-member
+        mocked_conn.mock_start()  # pylint: disable=no-member
         msg_items = receive_notifications(receiver)
+        mocked_conn.mock_stop()  # pylint: disable=no-member
 
         assert len(msg_items) == 1
 
@@ -310,18 +411,25 @@ class TestNotificationSubscriptionMgmt(object):
             'notification-type': 'fake-type'
         }
 
+    def setup_receiver(self):
+        """Set up the notification receiver for the test"""
+        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
+                                        self.password)
+        receiver.connect()
+        mocked_conn = receiver._conn  # pylint: disable=protected-access
+        assert isinstance(mocked_conn, MockedStompConnection)
+        return receiver, mocked_conn
+
     @patch(target='stomp.Connection', new=MockedStompConnection)
     def test_is_subscribed(self):
         """Test function for is_subscribed() method."""
 
-        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic1')
+        assert mocked_conn.mock_get_subscription('fake-topic1')
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic2')
+        assert mocked_conn.mock_get_subscription('fake-topic2')
 
         result = receiver.is_subscribed('fake-topic1')
         assert result is True
@@ -333,9 +441,7 @@ class TestNotificationSubscriptionMgmt(object):
     def test_get_subscription(self):
         """Test function for get_subscription() method."""
 
-        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         id_value1 = receiver.get_subscription('fake-topic1')
         id_value2 = receiver.get_subscription('fake-topic2')
@@ -343,77 +449,69 @@ class TestNotificationSubscriptionMgmt(object):
 
         # Check that the subscriptions are still in place
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic1')
+        assert mocked_conn.mock_get_subscription('fake-topic1')
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic2')
+        assert mocked_conn.mock_get_subscription('fake-topic2')
 
     @patch(target='stomp.Connection', new=MockedStompConnection)
     def test_get_subscription_nonexisting(self):
         """Test function for get_subscription() method for a non-existing
         subscription.."""
 
-        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         with pytest.raises(SubscriptionNotFound):
             receiver.get_subscription('bla')
 
         # Check that the subscriptions are still in place
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic1')
+        assert mocked_conn.mock_get_subscription('fake-topic1')
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic2')
+        assert mocked_conn.mock_get_subscription('fake-topic2')
 
     @patch(target='stomp.Connection', new=MockedStompConnection)
     def test_subscribe(self):
         """Test function for subscribe() method."""
 
-        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         receiver.subscribe('foo')
 
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('foo')
+        assert mocked_conn.mock_get_subscription('foo')
 
         # Check that the subscriptions are still in place
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic1')
+        assert mocked_conn.mock_get_subscription('fake-topic1')
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic2')
+        assert mocked_conn.mock_get_subscription('fake-topic2')
 
     @patch(target='stomp.Connection', new=MockedStompConnection)
     def test_unsubscribe(self):
         """Test function for unsubscribe() method."""
 
-        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         receiver.unsubscribe('fake-topic1')
 
         # pylint: disable=no-member
-        assert not conn.mock_get_subscription('fake-topic1')
+        assert not mocked_conn.mock_get_subscription('fake-topic1')
 
         # Check that the subscriptions are still in place
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic2')
+        assert mocked_conn.mock_get_subscription('fake-topic2')
 
     @patch(target='stomp.Connection', new=MockedStompConnection)
     def test_unsubscribe_nonexisting(self):
         """Test function for unsubscribe() for a non-existing subscription."""
 
-        receiver = NotificationReceiver(self.topics, self.hmc, self.userid,
-                                        self.password)
-        conn = receiver._conn  # pylint: disable=protected-access
+        receiver, mocked_conn = self.setup_receiver()
 
         with pytest.raises(SubscriptionNotFound):
             receiver.unsubscribe('bla')
 
         # Check that the subscriptions are still in place
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic1')
+        assert mocked_conn.mock_get_subscription('fake-topic1')
         # pylint: disable=no-member
-        assert conn.mock_get_subscription('fake-topic2')
+        assert mocked_conn.mock_get_subscription('fake-topic2')

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -47,7 +47,8 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'JMS_LOGGER_NAME',
            'API_LOGGER_NAME',
            'HTML_REASON_WEB_SERVICES_DISABLED',
-           'HTML_REASON_OTHER']
+           'HTML_REASON_OTHER',
+           'STOMP_MIN_CONNECTION_CHECK_TIME']
 
 
 #: Default HTTP connect timeout in seconds,
@@ -174,3 +175,6 @@ HTML_REASON_WEB_SERVICES_DISABLED = 900
 #: HTTP reason code: Other HTML-formatted error response. Note that over time,
 #: there may be more specific reason codes introduced for such situations.
 HTML_REASON_OTHER = 999
+
+#: Minimum time between checks for STOMP connection loss.
+STOMP_MIN_CONNECTION_CHECK_TIME = 5.0

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -25,6 +25,7 @@ __all__ = ['Error', 'ConnectionError', 'ConnectTimeout', 'ReadTimeout',
            'OperationTimeout', 'StatusTimeout', 'NoUniqueMatch', 'NotFound',
            'MetricsResourceNotFound', 'NotificationError',
            'NotificationJMSError', 'NotificationParseError',
+           'NotificationConnectionError', 'NotificationSubscriptionError',
            'SubscriptionNotFound', 'ConsistencyError', 'CeasedExistence']
 
 
@@ -1380,6 +1381,71 @@ class NotificationParseError(NotificationError):
         """
         return "{}(message={!r}, jms_message={!r})". \
             format(self.__class__.__name__, self.args[0], self.jms_message)
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; message={}
+        """
+        return "classname={!r}; message={!r};". \
+            format(self.__class__.__name__, self.args[0])
+
+
+class NotificationConnectionError(NotificationError):
+    """
+    This exception indicates an issue with the STOMP connection to the HMC.
+
+    Derived from :exc:`~zhmcclient.NotificationError`.
+    """
+
+    def __init__(self, msg):
+        """
+        Parameters:
+
+          msg (:term:`string`):
+            A human readable message describing the problem.
+
+        ``args[0]`` will be set to the ``msg`` parameter.
+        """
+        # pylint: disable=useless-super-delegation
+        super(NotificationConnectionError, self).__init__(msg)
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; message={}
+        """
+        return "classname={!r}; message={!r};". \
+            format(self.__class__.__name__, self.args[0])
+
+
+class NotificationSubscriptionError(NotificationError):
+    """
+    This exception indicates an issue with the STOMP subscription or
+    unsubscription to the HMC.
+
+    Derived from :exc:`~zhmcclient.NotificationError`.
+    """
+
+    def __init__(self, msg):
+        """
+        Parameters:
+
+          msg (:term:`string`):
+            A human readable message describing the problem.
+
+        ``args[0]`` will be set to the ``msg`` parameter.
+        """
+        # pylint: disable=useless-super-delegation
+        super(NotificationSubscriptionError, self).__init__(msg)
 
     def str_def(self):
         """


### PR DESCRIPTION
For details, see the commit message.

This change was tested with:
* The example script "show_os_messages.py"
* The zhmc-log-forwarder (as of its PR https://github.com/zhmcclient/zhmc-log-forwarder/pull/14)

In both cases, the default STOMP retry/timeout config was used (i.e. with STOMP heartbeating enabled), the network was disconnected and connected again, and the notification receiver detected the disconnect properly and also reconnected properly.