### PR TITLE
1.14: Improved circumvention for pip cert issue on Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,14 +259,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      if: ${{ ! ( matrix.python-version == '2.7' ) }}
+    - name: Set up Python ${{ matrix.python-version }} (if py==3.5)
+      if: ${{ matrix.python-version == '3.5' }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
       env:
         # Workaround for cert issue on Python 3.5, see https://github.com/actions/setup-python/issues/866
         PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
+    - name: Set up Python ${{ matrix.python-version }} (if py>=3.6)
+      if: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Display initial Python packages
       run: |
         echo "Installed Python packages:"


### PR DESCRIPTION
Rolls back PR #1479 into 1.14.1.