### PR TITLE
Migrated changelog to use towncrier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,6 +275,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Make sure this change adds or changes at least one change fragment file
+      run: |
+        bash -c "! git diff --exit-code origin/${{ github.base_ref }} changes/*.rst >/dev/null || (echo 'Please add or modify a change fragment file in the changes directory - for details read the Making a change section in the docs'; exit 1)"
     - name: Set up Python ${{ matrix.python-version }} (if py==3.5)
       if: ${{ matrix.python-version == '3.5' }}
       uses: actions/setup-python@v5

--- a/Makefile
+++ b/Makefile
@@ -214,22 +214,17 @@ check_py_files := \
     $(wildcard docs/notebooks/*.py) \
 
 # Packages whose dependencies are checked using pip-missing-reqs
+check_reqs_base_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 pylint twine jupyter notebook
 ifeq ($(python_m_version),2)
-  check_reqs_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 pylint twine jupyter notebook
+  check_reqs_packages := $(check_reqs_base_packages)
+else ifeq ($(python_mn_version),3.5)
+  check_reqs_packages := $(check_reqs_base_packages)
+else ifeq ($(python_mn_version),3.6)
+  check_reqs_packages := $(check_reqs_base_packages)
+else ifeq ($(python_mn_version),3.7)
+  check_reqs_packages := $(check_reqs_base_packages) safety towncrier
 else
-ifeq ($(python_mn_version),3.5)
-  check_reqs_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 pylint twine jupyter notebook
-else
-ifeq ($(python_mn_version),3.6)
-  check_reqs_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 pylint twine jupyter notebook
-else
-ifeq ($(python_mn_version),3.7)
-  check_reqs_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 pylint twine jupyter notebook safety
-else
-  check_reqs_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 pylint twine jupyter notebook safety sphinx
-endif
-endif
-endif
+  check_reqs_packages := $(check_reqs_base_packages) safety towncrier sphinx
 endif
 
 ifdef TESTCASES

--- a/changes/.gitignore
+++ b/changes/.gitignore
@@ -1,0 +1,2 @@
+# Keep this directory in git even if empty
+!.gitignore

--- a/changes/1451.feature.rst
+++ b/changes/1451.feature.rst
@@ -1,0 +1,2 @@
+Added new method Nic.backing_port() to return the backing adapter port
+of the NIC.

--- a/changes/1473.fix.rst
+++ b/changes/1473.fix.rst
@@ -1,0 +1,2 @@
+Docs: Fixed formatting of badges on README page by converting it to
+Markdown.

--- a/changes/1485.feature.rst
+++ b/changes/1485.feature.rst
@@ -1,0 +1,5 @@
+Dev: Migrated from a manually maintained change log file to using change
+fragment files with the 'towncrier' package. This simplifies the procedures
+for starting and releasing a version, and avoids merge conflicts when there
+are multiple Pull Requests at the same time. For details, read the new
+'Making a change' section in the documentation.

--- a/changes/changes.rst.j2
+++ b/changes/changes.rst.j2
@@ -1,0 +1,77 @@
+{#
+ # Jinja2 template for towncrier to generate the change log from change fragments.
+ #
+ # Input variables (as of towncrier 22.8.0):
+ # - render_title (bool): Indicates whether a title should be rendered by the
+ #   template. If False, the title is being added by towncrier to the result of
+ #   the template.
+ # - sections: The change fragments, as a dict with key: section
+ #   name, value: dict with key: category (=type) name, value: dict with key:
+ #   change fragment text, value: list of issues.
+ # - definitions: The definitions of change categories (=types), as a dict
+ #   with key: type name, value: dict with items 'name', 'showcontent'.
+ # - underlines (str): The underline characters to use for the different heading
+ #   levels (following the top heading level)
+ # - versiondata (dict): Project name and version data, as a dict with items
+ #   'name', 'version', 'date'.
+ # - top_underline (str): The underline character to be used for the title
+ #   of the change log when the template generates the title.
+ # - get_indent (func): Function to get the indentation for subsequent lines
+ #   given the first line of a multi-line change fragment text.
+ #}
+{% if render_title %}
+{%   if versiondata.name %}
+{{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
+{{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
+{%   else %}
+{{ versiondata.version }} ({{ versiondata.date }})
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
+{%   endif %}
+{% endif %}
+
+Released: {{ versiondata.date }}
+
+{% for section, _ in sections.items() %}
+{%   set underline = underlines[0] %}
+{%   if section %}
+{{ section }}
+{{ underline * section|length }}
+
+{%     set underline = underlines[1] %}
+{%   endif %}
+{%   if sections[section] %}
+{%     for category, val in definitions.items() if category in sections[section] and category != 'notshown' %}
+**{{ definitions[category]['name'] }}:**
+
+{%       if definitions[category]['showcontent'] %}
+{%         for text, values in sections[section][category].items() %}
+{%           set issue_values = [] %}
+{%           for v in values if 'noissue' not in v %}
+{%             set _ = issue_values.append(v) %}
+{%           endfor %}
+{%           set issue_values_str = ' (' + issue_values|join(', ') + ')' if issue_values else '' %}
+* {{ text }}{{ issue_values_str }}
+
+{%         endfor %}
+{%       else %}
+{%         set issue_values = [] %}
+{%         for v in sections[section][category][''] if 'noissue' not in v %}
+{%           set _ = issue_values.append(v) %}
+{%         endfor %}
+{%         if issue_values %}
+* {{ issue_values|join(', ') }}
+
+{%         endif %}
+{%       endif %}
+{%       if sections[section][category]|length == 0 %}
+No significant changes.
+
+{%       endif %}
+{%     endfor %}
+{%   else %}
+No significant changes.
+
+{%   endif %}
+{% endfor %}
+{{ '' }}
+{{ '' }}

--- a/changes/noissue.1.feature.rst
+++ b/changes/noissue.1.feature.rst
@@ -1,0 +1,7 @@
+Test: Added the option 'ignore-unpinned-requirements: False' to both
+safety policy files because for safety 3.0, the default is to ignore
+unpinned requirements (in requirements.txt).
+
+Increased safety minimum version to 3.0 because the new option is not
+tolerated by safety 2.x. Safety now runs only on Python >=3.7 because
+that is what safety 3.0 requires.

--- a/changes/noissue.1.fix.rst
+++ b/changes/noissue.1.fix.rst
@@ -1,0 +1,1 @@
+Fixed safety issues up to 2024-05-17

--- a/changes/noissue.2.feature.rst
+++ b/changes/noissue.2.feature.rst
@@ -1,0 +1,4 @@
+Changed safety run for install dependencies to use the exact minimum versions
+of the dependent packages, by moving them into a separate
+minimum-constraints-install.txt file that is included by the existing
+minimum-constraints.txt file.

--- a/changes/noissue.2.fix.rst
+++ b/changes/noissue.2.fix.rst
@@ -1,0 +1,3 @@
+Dev: In the Github Actions test workflow for Python 3.5, 3.6 and 3.7, changed
+macos-latest back to macos-12 because macos-latest got upgraded from macOS 12
+to macOS 14 which no longer supports these Python versions.

--- a/changes/noissue.3.feature.rst
+++ b/changes/noissue.3.feature.rst
@@ -1,0 +1,2 @@
+The safety run for all dependencies now must succeed when the test workflow
+is run for a release (i.e. branch name 'release\_...').

--- a/changes/noissue.3.fix.rst
+++ b/changes/noissue.3.fix.rst
@@ -1,0 +1,1 @@
+Dev: Workaround for cert issue with pip in Python 3.5 in Github Actions.

--- a/changes/noissue.4.fix.rst
+++ b/changes/noissue.4.fix.rst
@@ -1,0 +1,1 @@
+Dev: Addressed new issues raised by Pylint 3.1.

--- a/changes/noissue.5.fix.rst
+++ b/changes/noissue.5.fix.rst
@@ -1,0 +1,1 @@
+Dev: Fixed new issue 'possibly-used-before-assignment' in Pylint 3.2.0.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,9 @@
 # PEP517 package builder, used in Makefile
 build>=0.5.0
 
+# Change log
+towncrier>=22.8.0; python_version >= '3.7'
+
 # Unit test (imports into testcases):
 funcsigs>=1.0.2; python_version < '3.3'
 # pytest 5.0.0 has removed support for Python < 3.5

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,64 +19,7 @@
 Change log
 ----------
 
-
-Version 1.15.0.dev1
-^^^^^^^^^^^^^^^^^^^
-
-This version contains all fixes up to version 1.14.x.
-
-Released: not yet
-
-**Incompatible changes:**
-
-**Deprecations:**
-
-**Bug fixes:**
-
-* Fixed safety issues up to 2024-05-17.
-
-* In the Github Actions test workflow for Python 3.5, 3.6 and 3.7, changed
-  macos-latest back to macos-12 because macos-latest got upgraded from macOS 12
-  to macOS 14 which no longer supports these Python versions.
-
-* Dev: Workaround for cert issue with pip in Python 3.5 in Github Actions.
-
-* Dev: Fixed new issue 'possibly-used-before-assignment' in Pylint 3.2.0.
-
-* Docs: Fixed formatting of badges on README page by converting it to
-  Markdown. (issue #1473)
-
-**Enhancements:**
-
-* Test: Added the option 'ignore-unpinned-requirements: False' to both
-  safety policy files because for safety 3.0, the default is to ignore
-  unpinned requirements (in requirements.txt).
-  Increased safety minimum version to 3.0 because the new option is not
-  tolerated by safety 2.x. Safety now runs only on Python >=3.7 because
-  that is what safetx 3.0 requires.
-
-* Added new method Nic.backing_port() to return the backing adapter port
-  of the NIC. (issue #1451)
-
-* Changed safety run for install dependencies to use the exact minimum versions
-  of the dependent packages, by moving them into a separate
-  minimum-constraints-install.txt file that is included by the existing
-  minimum-constraints.txt file.
-
-* The safety run for all dependencies now must succeed when the test workflow
-  is run for a release (i.e. branch name 'release_...').
-
-**Cleanup:**
-
-* Addressed new issues raised by Pylint 3.1.
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/python-zhmcclient/issues
-
-
+.. towncrier start
 Version 1.14.0
 ^^^^^^^^^^^^^^
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["README.md", "try", "design",
+exclude_patterns = ["README.md", "try", "design", "changes",
                     "tests", ".tox", ".git", "attic", "dist",
                     "build_doc", "zhmcclient.egg-info", ".eggs"]
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -20,6 +20,11 @@ build==0.5.0
 # build up to version 0.9 requires pep517>=0.9.1
 pep517==0.9.1
 
+# Change log
+towncrier==22.8.0; python_version >= '3.7'
+incremental==22.10.0; python_version >= '3.7'
+click-default-group==1.2.4; python_version >= '3.7'
+
 # Unit test (imports into testcases):
 # Note: pytest is covered in minimum-constraints-install.txt
 funcsigs==1.0.2; python_version == '2.7'

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,46 @@
+# Config file for towncrier change log tool
+
+[tool.towncrier]
+directory = "changes"
+package = "zhmcclient"
+# package_dir = "."
+filename = "docs/changes.rst"
+template = "changes/changes.rst.j2"
+start_string = ".. towncrier start"
+title_format = "Version {version}"
+underlines = "^~"
+issue_format = "`#{issue} <https://github.com/zhmcclient/python-zhmcclient/issues/{issue}>`_"
+
+# The following array defines the allowable change types, in order
+
+[[tool.towncrier.type]]
+directory = "incompatible"
+name = "Incompatible changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecation"
+name = "Deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fix"
+name = "Bug fixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Enhancements"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "cleanup"
+name = "Cleanup"
+showcontent = true
+
+# Type that is not shown in the change log at all, because the towncrier template
+# is skipping this change type. The 'showcontent' flag is not strong enough for that.
+[[tool.towncrier.type]]
+directory = "notshown"
+name = "Changes not shown"
+showcontent = false


### PR DESCRIPTION
For details, see the commit message.

This is a first step for simplifying the procedures for releasing a version and starting a new version. For the complete proposal, see issue #1485 