### PR TITLE
Remove password property before updating local user object

### DIFF
--- a/changes/1490.incompatible.rst
+++ b/changes/1490.incompatible.rst
@@ -1,0 +1,4 @@
+The 'zhmcclient.User' object will no longer be able to store the 'password'
+property. The 'password' property is filtered out when creating the User object
+in 'UserManager.create()' and when updating the User object in
+'User.update_properties()'.

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -178,6 +178,7 @@ class UserManager(BaseManager):
         # returned props should overwrite the input props:
         props = copy.deepcopy(properties)
         props.update(result)
+        props.pop('password', None)
         name = props.get(self._name_prop, None)
         uri = props[self._uri_prop]
         user = User(self, uri, name, props)
@@ -275,7 +276,9 @@ class User(BaseResource):
         # HTTPError to be raised in the POST above, so we assert that here,
         # because we omit the extra code for handling name updates:
         assert self.manager._name_prop not in properties
-        self.update_properties_local(copy.deepcopy(properties))
+        props = copy.deepcopy(properties)
+        props.pop('password', None)
+        self.update_properties_local(props)
 
     @logged_api_call
     def add_user_role(self, user_role):


### PR DESCRIPTION
Changes:
- User object(python object, not HMC) does not need to store password. Filter and remove 'password' from the propertied before updating the local object during user create and update.

Fixes https://github.com/zhmcclient/zhmc-ansible-modules/issues/967