### PR TITLE
Removed the pinning of stomp.py to <7.0.0 to pick up fixes

### DIFF
--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -51,11 +51,9 @@ security:
         67599:
             reason: There is no fixed pip version
         67884:
-            # TODO: Adjust once we remove stomp-py pinning
-            reason: Fixed stomp-py version 8.1.1 conflicts with our pinning of stomp-py to <7.0.0
+            reason: Fixed stomp.py version 8.1.1 requires Python>=3.7 and is used there
         67894:
-            # TODO: Adjust once we remove stomp-py pinning
-            reason: Fixed stomp-py version 8.1.1 conflicts with our pinning of stomp-py to <7.0.0
+            reason: Fixed stomp.py version 8.1.1 requires Python>=3.7 and is used there
         67895:
             reason: Fixed idna version 3.7 requires requests>=2.26.0 which requires Python>=3.6 and is used there
 

--- a/changes/1499.cleanup.rst
+++ b/changes/1499.cleanup.rst
@@ -1,0 +1,3 @@
+Removed the pinning of stomp.py to <7.0.0 and increased its minimum version
+to 8.1.1 (for Python>=3.7) to pick up fixes, and adjusted to the changed
+interface of the stomp event listener methods and the 'stomp.Connection()' call.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -38,7 +38,8 @@ requests==2.26.0; python_version == '3.6'
 requests==2.31.0; python_version >= '3.7'
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
-stomp.py==4.1.23
+stomp.py==4.1.23; python_version <= '3.6'
+stomp.py==8.1.1; python_version >= '3.7'
 python-dateutil==2.8.2
 immutable-views==0.6.0
 nocasedict==1.0.2
@@ -88,3 +89,6 @@ packaging==20.5; python_version <= '3.5'
 packaging==21.0; python_version >= '3.6'
 pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'
 pluggy==0.13.0; python_version >= '3.7'
+
+# websocket-client is used by stomp.py 8.0 and notebook(?) 6.4
+websocket-client==1.5.3; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,10 +25,17 @@ six>=1.14.0; python_version <= '3.9'
 six>=1.16.0; python_version >= '3.10'
 
 # stomp.py 5.0.0 (now deleted) and 6.0.0 removed support for Python 2.7, 3.4 and 3.5
-# stomp.py 6.1.0 on Pypi contained older code than v6.1.0 in the repo -> will be yanked on Pypi
-# stomp.py 6.1.1 broke compatibility -> will be yanked on Pypi and re-released as 7.0.0
+# stomp.py<6.0.0 did not declare supported Python versions
+# stomp.py 6.1.0 on Pypi contained older code than v6.1.0 in the repo -> was yanked
+# stomp.py 6.1.1 broke compatibility -> was yanked (and re-released as 7.0.0)
+# stpmp.py 7.0.0 changed the interface of the listener methods incompatibly, and requires Python >=3.6
+# stomp.py 8.0.0 removed the use_ssl parameter of stomp.Connection. set_ssl() can be used instead.
+# stomp.py 8.0.0 cannot be imported due to an issue
+# stomp.py 8.1.1 changed __version__ from tuple to string
+# stomp.py versions 7.0.0 - 8.1.0 cause test failures.
 stomp.py>=4.1.23,<5.0.0; python_version <= '3.5'
-stomp.py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version >= '3.6'
+stomp.py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version == '3.6'
+stomp.py>=8.1.1; python_version >= '3.7'
 
 python-dateutil>=2.8.2
 immutable-views>=0.6.0

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -646,3 +646,18 @@ def warn_deprecated_parameter(cls, method, name, value, default):
         # * +1 to get out of this function
         # * +1 to get out of method
         # * +2 to get over the @logged_api_call decorator of method
+
+
+def stomp_uses_frames(stomp_version):
+    """
+    Returns whether stomp.py uses Frame objects for the event listener methods.
+
+    Parameters:
+      stomp_version: The __version__ attribute of the stomp module.
+    """
+    # stomp.py introduced the use of Frame objects in version 7.0.0, but since
+    # it changed its __version__ attribute from tuple to string in version
+    # 8.1.1, it would be fairly complex to check for the use of Frame objects
+    # based upon its version. Instead, we utilize the fact that we have either
+    # versions <5.0 or >8.1.1 and thus can test for the __version__ type.
+    return isinstance(stomp_version, str)


### PR DESCRIPTION
For details, see the commit message.