### PR TITLE
Upgraded Actions plugins to no longer use deprecated node 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Development setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,7 +289,7 @@ jobs:
         PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
     - name: Set up Python ${{ matrix.python-version }} (if py>=3.6)
       if: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Display initial Python packages

--- a/changes/1503.cleanup.rst
+++ b/changes/1503.cleanup.rst
@@ -1,0 +1,2 @@
+Test: Upgraded Github Actions plugin actions/setup-python to v5 to no longer
+use the deprecated node version 16.


### PR DESCRIPTION
No review needed.