### PR TITLE
Test: Added tests for Python 3.13 (rc.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
+            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\", \"3.13.0-rc.1\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ] \
           }" >> $GITHUB_OUTPUT; \
         else \
@@ -52,6 +52,16 @@ jobs:
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.9\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/changes/1505.feature.rst
+++ b/changes/1505.feature.rst
@@ -1,0 +1,1 @@
+Test: Added tests for Python 3.13 (rc.1).

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -86,7 +86,7 @@ sphinxcontrib-serializinghtml>=1.1.5; python_version == '3.8'
 sphinxcontrib-serializinghtml>=1.1.9; python_version >= '3.9'
 sphinxcontrib-websupport>=1.2.4
 autodocsumm>=0.2.12
-Babel>=2.9.1
+Babel>=2.11.0
 
 # PyLint (no imports, invoked via pylint script)
 pylint>=3.0.1

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -80,7 +80,7 @@ sphinxcontrib-serializinghtml==1.1.5; python_version == '3.8'
 sphinxcontrib-serializinghtml==1.1.9; python_version >= '3.9'
 sphinxcontrib-websupport==1.2.4
 autodocsumm==0.2.12
-Babel==2.9.1
+Babel==2.11.0
 
 # PyLint (no imports, invoked via pylint script)
 pylint==3.0.1

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -31,7 +31,7 @@ PyYAML==5.3.1
 yamlloader==0.5.5
 
 # jsonschema pulled in by zhmcclient_mock and zhmcclient.testutils and jupyter
-jsonschema==3.1.0
+jsonschema==4.0.1
 
 
 # Direct dependencies for install of extra 'testutils' (must be consistent with extra-testutils-requirements)

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,8 @@ yamlloader>=0.5.5
 # jsonschema 4.0.0 was yanked (and does not install), but older pip versions don't recognize that
 # jsonschema is also used by jupyter and requires >=3.0.1
 # jsonschema 3.0.1 and 3.0.2 may cause pkg_resources.DistributionNotFound; fixed in 3.1.0.
-jsonschema>=3.1.0,!=4.0.0
+# jsonschema >=3.2.0 is required for Python 3.13 to get rid of the use of js-regex
+jsonschema>=4.0.1
 
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with minimum-constraints-install.txt)


### PR DESCRIPTION
No review needed.

A separate issue #1506 exists to use the final Python 3.13.0 version, once released, so this PR can be merged.