### PR TITLE
Test: Relaxed the verification of log messages in test_auto_updater.py

### DIFF
--- a/changes/noissue.1.feature.rst
+++ b/changes/noissue.1.feature.rst
@@ -1,0 +1,2 @@
+Test: Relaxed the verification of log messages in test_auto_updater.py
+to tolerate additional log messages.


### PR DESCRIPTION
For details, see the commit message.

Background: Since PR #1474 adds a number of log entries, I wanted to be able to specify the testcases only with the relevant subset of log messages, instead of adding all of them also as expected log messages to the tests.

I tested the verification logic with several failure cases.