### PR TITLE
1.16: Install: Changed dependent package 'stomp.py' to use 'stomp-py' name

### DIFF
--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -51,9 +51,9 @@ security:
         67599:
             reason: There is no fixed pip version
         67884:
-            reason: Fixed stomp.py version 8.1.1 requires Python>=3.7 and is used there
+            reason: Fixed stomp-py version 8.1.1 requires Python>=3.7 and is used there
         67894:
-            reason: Fixed stomp.py version 8.1.1 requires Python>=3.7 and is used there
+            reason: Fixed stomp-py version 8.1.1 requires Python>=3.7 and is used there
         67895:
             reason: Fixed idna version 3.7 requires requests>=2.26.0 which requires Python>=3.6 and is used there
 

--- a/changes/1516.bugfix.rst
+++ b/changes/1516.bugfix.rst
@@ -1,0 +1,3 @@
+Install: Changed the name of the dependent package 'stomp.py' to use its
+canonical name 'stomp-py' since that prevented installation of packages using
+zhmcclient under certain circumstances (e.g. with minimum package levels).

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -212,9 +212,9 @@ target system from the downloaded packages:
       Collecting zhmcclient
         Using cached https://files.pythonhosted.org/packages/c3/29/7f0acab22b27ff29453ac87c92a2cbec2b16014b0d32c36fcce1ca285be7/zhmcclient-0.19.0-py2.py3-none-any.whl
         Saved ./zhmcclient-0.19.0-py2.py3-none-any.whl
-      Collecting stomp.py>=4.1.15 (from zhmcclient)
+      Collecting stomp-py>=4.1.15 (from zhmcclient)
       . . .
-      Successfully downloaded zhmcclient decorator pytz stomp.py six requests docopt urllib3 certifi chardet idna
+      Successfully downloaded zhmcclient decorator pytz stomp-py six requests docopt urllib3 certifi chardet idna
 
       [download-system]$ ls -1
       certifi-2019.11.28-py2.py3-none-any.whl
@@ -225,7 +225,7 @@ target system from the downloaded packages:
       pytz-2019.3-py2.py3-none-any.whl
       requests-2.22.0-py2.py3-none-any.whl
       six-1.13.0-py2.py3-none-any.whl
-      stomp.py-4.1.22.tar.gz
+      stomp-py-4.1.22.tar.gz
       urllib3-1.25.7-py2.py3-none-any.whl
       zhmcclient-0.25.1-py2.py3-none-any.whl
 
@@ -252,18 +252,18 @@ target system from the downloaded packages:
       pytz-2019.3-py2.py3-none-any.whl
       requests-2.22.0-py2.py3-none-any.whl
       six-1.13.0-py2.py3-none-any.whl
-      stomp.py-4.1.22.tar.gz
+      stomp-py-4.1.22.tar.gz
       urllib3-1.25.7-py2.py3-none-any.whl
       zhmcclient-0.25.1-py2.py3-none-any.whl
 
       [target-system]$ pip install -f . --no-index --upgrade zhmcclient-*.whl
       Looking in links: .
       . . .
-      Installing collected packages: decorator, pytz, docopt, stomp.py, six,
+      Installing collected packages: decorator, pytz, docopt, stomp-py, six,
         urllib3, certifi, chardet, idna, requests, zhmcclient
       Successfully installed certifi-2019.11.28 chardet-3.0.4 decorator-4.4.1
         docopt-0.6.2 idna-2.8 pytz-2019.3 requests-2.22.0 six-1.13.0
-        stomp.py-4.1.22 urllib3-1.25.7 zhmcclient-0.25.1
+        stomp-py-4.1.22 urllib3-1.25.7 zhmcclient-0.25.1
 
 Alternative installation methods and sources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -189,5 +189,5 @@ See also the :term:`HMC Security` book for details.
 
 The 'zhmcclient' package supports the STOMP protocol for HMC notifications and
 uses the
-`Python 'stomp.py' package <https://pypi.org/project/stomp.py/>`_
+`Python 'stomp-py' package <https://pypi.org/project/stomp-py/>`_
 for this purpose.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -38,8 +38,8 @@ requests==2.26.0; python_version == '3.6'
 requests==2.31.0; python_version >= '3.7'
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
-stomp.py==4.1.23; python_version <= '3.6'
-stomp.py==8.1.1; python_version >= '3.7'
+stomp-py==4.1.23; python_version <= '3.6'
+stomp-py==8.1.1; python_version >= '3.7'
 python-dateutil==2.8.2
 immutable-views==0.6.0
 nocasedict==1.0.2
@@ -90,5 +90,5 @@ packaging==21.0; python_version >= '3.6'
 pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'
 pluggy==0.13.0; python_version >= '3.7'
 
-# websocket-client is used by stomp.py 8.0 and notebook(?) 6.4
+# websocket-client is used by stomp-py 8.0 and notebook(?) 6.4
 websocket-client==1.5.3; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,18 +24,18 @@ requests>=2.31.0; python_version >= '3.7'
 six>=1.14.0; python_version <= '3.9'
 six>=1.16.0; python_version >= '3.10'
 
-# stomp.py 5.0.0 (now deleted) and 6.0.0 removed support for Python 2.7, 3.4 and 3.5
-# stomp.py<6.0.0 did not declare supported Python versions
-# stomp.py 6.1.0 on Pypi contained older code than v6.1.0 in the repo -> was yanked
-# stomp.py 6.1.1 broke compatibility -> was yanked (and re-released as 7.0.0)
-# stpmp.py 7.0.0 changed the interface of the listener methods incompatibly, and requires Python >=3.6
-# stomp.py 8.0.0 removed the use_ssl parameter of stomp.Connection. set_ssl() can be used instead.
-# stomp.py 8.0.0 cannot be imported due to an issue
-# stomp.py 8.1.1 changed __version__ from tuple to string
-# stomp.py versions 7.0.0 - 8.1.0 cause test failures.
-stomp.py>=4.1.23,<5.0.0; python_version <= '3.5'
-stomp.py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version == '3.6'
-stomp.py>=8.1.1; python_version >= '3.7'
+# stomp-py 5.0.0 (now deleted) and 6.0.0 removed support for Python 2.7, 3.4 and 3.5
+# stomp-py<6.0.0 did not declare supported Python versions
+# stomp-py 6.1.0 on Pypi contained older code than v6.1.0 in the repo -> was yanked
+# stomp-py 6.1.1 broke compatibility -> was yanked (and re-released as 7.0.0)
+# stomp-py 7.0.0 changed the interface of the listener methods incompatibly, and requires Python >=3.6
+# stomp-py 8.0.0 removed the use_ssl parameter of stomp.Connection. set_ssl() can be used instead.
+# stomp-py 8.0.0 cannot be imported due to an issue
+# stomp-py 8.1.1 changed __version__ from tuple to string
+# stomp-py versions 7.0.0 - 8.1.0 cause test failures.
+stomp-py>=4.1.23,<5.0.0; python_version <= '3.5'
+stomp-py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version == '3.6'
+stomp-py>=8.1.1; python_version >= '3.7'
 
 python-dateutil>=2.8.2
 immutable-views>=0.6.0

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -650,12 +650,12 @@ def warn_deprecated_parameter(cls, method, name, value, default):
 
 def stomp_uses_frames(stomp_version):
     """
-    Returns whether stomp.py uses Frame objects for the event listener methods.
+    Returns whether stomp-py uses Frame objects for the event listener methods.
 
     Parameters:
       stomp_version: The __version__ attribute of the stomp module.
     """
-    # stomp.py introduced the use of Frame objects in version 7.0.0, but since
+    # stomp-py introduced the use of Frame objects in version 7.0.0, but since
     # it changed its __version__ attribute from tuple to string in version
     # 8.1.1, it would be fairly complex to check for the use of Frame objects
     # based upon its version. Instead, we utilize the fact that we have either
@@ -713,14 +713,14 @@ def get_stomp_rt_kwargs(rt_config):
 def get_headers_message(frame_args):
     """
     Transform STOMP event method parameters to a tuple(headers, message),
-    dependent on the stomp.py version that is used.
+    dependent on the stomp-py version that is used.
 
     Parameters:
 
-      frame_args: The STOMP frame, represented depending on the stomp.py
+      frame_args: The STOMP frame, represented depending on the stomp-py
         package version as follows:
 
-          * if stomp.py uses Frames, a single stomp.Frame object:
+          * if stomp-py uses Frames, a single stomp.Frame object:
 
             frame (stomp.Frame): Object with STOMP message headers and
               message body.


### PR DESCRIPTION
Rolls back PR #1516 into 1.16.1.
No additional review needed.