### PR TITLE
Dropped support for Python < 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,124 +35,8 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
-            \"package_level\": [ \"minimum\", \"latest\" ], \
-            \"exclude\": [ \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.7\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.7\", \
-                \"package_level\": \"latest\" \
-              } \
-            ], \
-            \"include\": [ \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"2.7\", \
-                \"package_level\": \"minimum\", \
-                \"container\": {\"image\": \"python:2.7.18-buster\"} \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"2.7\", \
-                \"package_level\": \"latest\", \
-                \"container\": {\"image\": \"python:2.7.18-buster\"} \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.7\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.7\", \
-                \"package_level\": \"latest\" \
-              } \
-            ] \
+            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
+            \"package_level\": [ \"minimum\", \"latest\" ] \
           }" >> $GITHUB_OUTPUT; \
         else \
           echo "matrix={ \
@@ -161,51 +45,14 @@ jobs:
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"2.7\", \
-                \"package_level\": \"minimum\", \
-                \"container\": {\"image\": \"python:2.7.18-buster\"} \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"2.7\", \
-                \"package_level\": \"latest\", \
-                \"container\": {\"image\": \"python:2.7.18-buster\"} \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.6\", \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.8\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
                 \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.7\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.8\", \
+                \"python-version\": \"3.9\", \
                 \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.8\", \
-                \"package_level\": \"minimum\" \
               }, \
               { \
                 \"os\": \"macos-latest\", \
@@ -216,20 +63,10 @@ jobs:
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"3.12\", \
                 \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.12\", \
-                \"package_level\": \"latest\" \
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"windows-latest\", \
-                \"python-version\": \"3.12\", \
+                \"python-version\": \"3.8\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
@@ -279,16 +116,7 @@ jobs:
       if: ${{ ! startsWith(github.head_ref, 'start_') }}
       run: |
         bash -c "! git diff --exit-code origin/${{ github.base_ref }} changes/*.rst >/dev/null || (echo 'Please add or modify a change fragment file in the changes directory - for details read the Making a change section in the docs'; exit 1)"
-    - name: Set up Python ${{ matrix.python-version }} (if py==3.5)
-      if: ${{ matrix.python-version == '3.5' }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-      env:
-        # Workaround for cert issue on Python 3.5, see https://github.com/actions/setup-python/issues/866
-        PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
-    - name: Set up Python ${{ matrix.python-version }} (if py>=3.6)
-      if: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}

--- a/.safety-policy-all.yml
+++ b/.safety-policy-all.yml
@@ -30,66 +30,22 @@ security:
     #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports
     #     expires: {date}   # optional: Date when this ignore will expire
     ignore-vulnerabilities:
-        37504:
-            reason: Fixed Twine version requires Python>=3.6 and is used there
-        39621:
-            reason: Fixed Pylint version requires Python>=3.6 and is used there
-        40380:
-            reason: Fixed Notebook version requires Python>=3.6 and is used there
-        40381:
-            reason: Fixed Notebook version requires Python>=3.6 and is used there
-        40383:
-            reason: Fixed Notebook version requires Python>=3.6 and is used there
-        40384:
-            reason: Fixed Notebook version requires Python>=3.6 and is used there
-        40385:
-            reason: Fixed Notebook version requires Python>=3.6 and is used there
-        40386:
-            reason: Fixed Notebook version requires Python>=3.6 and is used there
-        42253:
-            reason: Fixed Notebook version requires Python>=3.6 and is used there
-        42254:
-            reason: Fixed Notebook version requires Python>=3.6 and is used there
         44634:
-            reason: Fixed Ipython version requires Python>=3.3 and is used there
-        45185:
-            reason: Fixed Pylint version requires Python>=3.6.2 and is used there
+            reason: Fixed ipython version 6.0.0 cannot be used without major work on dependencies; Risk is minimal since these versions are used only in development
         50463:
-            reason: Fixed Ipywidgets version requires Python>=3.7 and is used there
+            reason: Fixed ipywidgets version 8.0.0 cannot be used without major work on dependencies; Risk is minimal since these versions are used only in development
         50664:
-            reason: Fixed Ipywidgets version requires Python>=3.7 and is used there
+            reason: Fixed ipywidgets version 8.0.0 cannot be used without major work on dependencies; Risk is minimal since these versions are used only in development
         50792:
-            reason: Fixed Nbconvert version requires Python>=3.7 and is used there
+            reason: Fixed nbconvert version 6.5.1 cannot be used without major work on dependencies; Risk is minimal since these versions are used only in development
         51457:
             reason: Py package is no longer being fixed (latest version 1.11.0)
         53269:
-            reason: Fixed Ipython version 8.1.0 cannot be used without major work on dependencies; Risk is minimal since this is used only in development
-        54678:
-            reason: Fixed notebook version 5.7.8 only works on Python>=3.6 and is used there
-        54682:
-            reason: Fixed notebook version 5.5.0 only works on Python>=3.6 and is used there
-        54684:
-            reason: Fixed notebook version 6.4.12 requires Python>=3.7 and is used there
-        54687:
-            reason: Fixed pywin32 version 301 requires Python>=3.5 and is used there
-        54689:
-            reason: Fixed notebook version 5.7.11 only works on Python>=3.6 and is used there
-        54713:
-            reason: Fixed notebook version 6.4.10 requires Python>=3.6 and is used there
-        54717:
-            reason: Fixed jupyter-core version 4.11.2 requires Python>=3.7 and is used there
-        59071:
-            reason: Fixed tornado version 6.3.2 requires Python>=3.8 and is used there
-        61949:
-            reason: Fixed tornado version 6.3.3 requires Python>=3.8 and is used there
-        64227:
-            reason: Fixed Jinja2 version 3.1.3 requires Python>=3.7 and is used there
+            reason: Fixed ipython version 8.1.0 cannot be used without major work on dependencies; Risk is minimal since these versions are used only in development
         68477:
-            reason: Fixed virtualenv version 20.21.0 requires Python>=3.7 and is used there
+            reason: Fixed virtualenv version 20.21.0 requires Python>=3.7 but is used only on Python>=3.12 due to other constraints
         70612:
             reason: Disputed issue in jinja2 version 3.1.3 - No known fix
-        70790:
-            reason: Fixed tqdm version 4.66.3 requires Python>=3.7 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -27,35 +27,9 @@ security:
     #     expires: {date}   # optional: Date when this ignore will expire
     ignore-vulnerabilities:
         39611:
-            reason: PyYAML full_load method or FullLoader is not used
-        40291:
-            reason: Fixed Pip version requires Python>=3.6 and is used there
-        42559:
-            reason: Fixed Pip version requires Python>=3.6 and is used there; Pip is not shipped with this package
-        51499:
-            reason: Fixed Wheel version requires Python>=3.7 and is used there; Risk is on Pypi side
-        52365:
-            reason: Fixed Certifi version requires Python>=3.6 and is used there
-        52495:
-            reason: Fixed Setuptools version requires Python>=3.7 and is used there; Risk is on Pypi side
-        58755:
-            reason: Fixed requests version 2.31.0 requires Python>=3.7 and is used there
-        59956:
-            reason: Fixed certifi version 2023.07.22 requires Python>=3.6 and is used there
-        61601:
-            reason: Fixed urllib3 version 1.26.17 requires Python>=3.6 and is used there
-        61893:
-            reason: Fixed urllib3 version 1.26.18 requires Python>=3.6 and is used there
-        62044:
-            reason: Fixed pip version 23.3 requires Python>=3.7 and is used there
+            reason: Fixed version PyYAML 5.4.0 (and 6.0.0) fails to install since Cython 3 was released; No risk since full_load method and FullLoader are not used
         67599:
             reason: There is no fixed pip version
-        67884:
-            reason: Fixed stomp-py version 8.1.1 requires Python>=3.7 and is used there
-        67894:
-            reason: Fixed stomp-py version 8.1.1 requires Python>=3.7 and is used there
-        67895:
-            reason: Fixed idna version 3.7 requires requests>=2.26.0 which requires Python>=3.6 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@ jobs:
 
     - os: linux
       language: python
-      python: "3.6"
+      python: "3.8"
       env:
         - PACKAGE_LEVEL=minimum
       cache: pip
 
     - os: linux
       language: python
-      python: "3.6"
+      python: "3.8"
       env:
         - PACKAGE_LEVEL=latest
       cache: pip

--- a/Makefile
+++ b/Makefile
@@ -214,18 +214,7 @@ check_py_files := \
     $(wildcard docs/notebooks/*.py) \
 
 # Packages whose dependencies are checked using pip-missing-reqs
-check_reqs_base_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 pylint twine jupyter notebook
-ifeq ($(python_m_version),2)
-  check_reqs_packages := $(check_reqs_base_packages)
-else ifeq ($(python_mn_version),3.5)
-  check_reqs_packages := $(check_reqs_base_packages)
-else ifeq ($(python_mn_version),3.6)
-  check_reqs_packages := $(check_reqs_base_packages)
-else ifeq ($(python_mn_version),3.7)
-  check_reqs_packages := $(check_reqs_base_packages) safety towncrier
-else
-  check_reqs_packages := $(check_reqs_base_packages) safety towncrier sphinx
-endif
+check_reqs_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 pylint twine jupyter notebook safety towncrier sphinx
 
 ifdef TESTCASES
   pytest_opts := $(TESTOPTS) -k "$(TESTCASES)"
@@ -534,53 +523,25 @@ $(bdist_file) $(sdist_file): Makefile MANIFEST.in $(dist_included_files)
 	$(PYTHON_CMD) -m build --outdir $(dist_dir)
 
 $(done_dir)/pylint_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done Makefile $(pylint_rc_file) $(check_py_files)
-ifeq ($(python_m_version),2)
-	@echo "Makefile: Warning: Skipping Pylint on Python $(python_version)" >&2
-else
 	@echo "Makefile: Running Pylint"
 	-$(call RM_FUNC,$@)
 	pylint $(pylint_opts) --rcfile=$(pylint_rc_file) --output-format=text $(check_py_files)
 	echo "done" >$@
 	@echo "Makefile: Done running Pylint"
-endif
 
 $(done_dir)/safety_all_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done Makefile $(safety_all_policy_file) minimum-constraints.txt minimum-constraints-install.txt
-ifeq ($(python_m_version),2)
-	@echo "Makefile: Warning: Skipping Safety for all packages on Python $(python_version)" >&2
-else
-ifeq ($(python_mn_version),3.5)
-	@echo "Makefile: Warning: Skipping Safety for all packages on Python $(python_version)" >&2
-else
-ifeq ($(python_mn_version),3.6)
-	@echo "Makefile: Warning: Skipping Safety for all packages on Python $(python_version)" >&2
-else
 	@echo "Makefile: Running Safety for all packages"
 	-$(call RM_FUNC,$@)
 	bash -c "safety check --policy-file $(safety_all_policy_file) -r minimum-constraints.txt --full-report || test '$(RUN_TYPE)' != 'release' || exit 1"
 	echo "done" >$@
 	@echo "Makefile: Done running Safety for all packages"
-endif
-endif
-endif
 
 $(done_dir)/safety_install_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done Makefile $(safety_install_policy_file) minimum-constraints-install.txt
-ifeq ($(python_m_version),2)
-	@echo "Makefile: Warning: Skipping Safety for install packages on Python $(python_version)" >&2
-else
-ifeq ($(python_mn_version),3.5)
-	@echo "Makefile: Warning: Skipping Safety for install packages on Python $(python_version)" >&2
-else
-ifeq ($(python_mn_version),3.6)
-	@echo "Makefile: Warning: Skipping Safety for all packages on Python $(python_version)" >&2
-else
 	@echo "Makefile: Running Safety for install packages"
 	-$(call RM_FUNC,$@)
 	safety check --policy-file $(safety_install_policy_file) -r minimum-constraints-install.txt --full-report
 	echo "done" >$@
 	@echo "Makefile: Done running Safety for install packages"
-endif
-endif
-endif
 
 $(done_dir)/flake8_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done Makefile $(flake8_rc_file) $(check_py_files)
 	-$(call RM_FUNC,$@)

--- a/changes/1489.cleanup.rst
+++ b/changes/1489.cleanup.rst
@@ -1,2 +1,8 @@
 Dropped support for Python below 3.8. Cleaned up the dependencies, Makefile,
 source code, and test code.
+
+Increased minimum version of the following Python packages the installation
+depends upon:
+- pytz to 2019.1 (only on Python 3.8/3.9 - was already there on Python >= 3.10)
+- pytest (extra: test) to 6.2.5 (only on Python 3.8/3.9 - was already there
+  on Python >= 3.10)

--- a/changes/1489.cleanup.rst
+++ b/changes/1489.cleanup.rst
@@ -1,0 +1,2 @@
+Dropped support for Python below 3.8. Cleaned up the dependencies, Makefile,
+source code, and test code.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,49 +12,36 @@
 build>=0.5.0
 
 # Change log
-towncrier>=22.8.0; python_version >= '3.7'
+towncrier>=22.8.0
 
 # Unit test (imports into testcases):
-funcsigs>=1.0.2; python_version < '3.3'
-# pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest>=4.3.1,<5.0.0; python_version == '2.7'
-pytest>=4.3.1; python_version >= '3.5' and python_version <= '3.6'
-pytest>=4.4.0; python_version >= '3.7' and python_version <= '3.9'
+pytest>=4.4.0; python_version <= '3.9'
 pytest>=6.2.5; python_version >= '3.10'
 testfixtures>=6.9.0
 # flake8 up to 6.0.0 has not yet adjusted to the removed interfaces of importlib-metadata 5.0
-importlib-metadata>=2.1.3,<5; python_version <= '3.6'
-importlib-metadata>=4.8.3,<5; python_version >= '3.7'
+importlib-metadata>=4.8.3,<5
 mock>=2.0.0
 # requests: covered in direct deps for installation
 requests-mock>=1.6.0
 requests-toolbelt>=0.8.0
-# more-itertools 8.11.0 does not support py35 but incorrectly installs on it
-more-itertools>=4.0.0,!=8.11.0; python_version <= '3.5'
-more-itertools>=4.0.0; python_version >= '3.6'
+more-itertools>=4.0.0
 # pytz: covered in requirements.txt
 
 # packaging is used by pytest, pip-check-reqs, sphinx
 # packaging>=20.5 is needed by pip-check-reqs 2.4.3 but it requires only packaging>=16.0
-# packaging 21.0 removed support for py27,35
-# packaging 22.0 removed support for py36
-packaging>=20.5; python_version <= '3.5'
-packaging>=21.0; python_version >= '3.6'
+packaging>=21.0
 
 # Virtualenv
 # build requires virtualenv.cli_run which was added in 20.1
 # virtualenv 20.0 requires six<2,>=1.12.0
-# virtualenv 20.16.0 removed support for Python<3.6
 virtualenv>=20.15.0; python_version <= '3.11'
 virtualenv>=20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):
 # Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38
-pluggy>=0.7.1; python_version >= '2.7' and python_version <= '3.6'
-pluggy>=0.13.0; python_version >= '3.7'
+pluggy>=0.13.0
 # decorator: covered in requirements.txt
-backports.statistics>=0.1.0; python_version == '2.7'
 
 # Coverage reporting (no imports, invoked via coveralls script):
 # coveralls pins coverage to <7.0, causing pip backtracking to happen. Pinning
@@ -62,75 +49,58 @@ backports.statistics>=0.1.0; python_version == '2.7'
 # occasionally check for new versions of coveralls without pinning.
 coverage>=5.0,<7.0
 pytest-cov>=2.7.0
-# coveralls 2.0 has removed support for Python 2.7
-git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls>=3.3.0; python_version >= '3.5'
+coveralls>=3.3.0
 # PyYAML: covered in direct deps for development
 
 # Safety CI by pyup.io
-# Safety is run only on Python >=3.7
 # Safety 3.0.0 requires exact versions of authlib==1.2.0 and jwt==1.3.1.
-safety>=3.0.1; python_version >= '3.7'
+safety>=3.0.1
 
 # Tox
 tox>=3.1.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
-# Sphinx 6.0.0 started requiring Python>=3.8
 # Sphinx 7.2.0 started requiring Python>=3.9
-# Sphinx is used only on Python>=3.8
 Sphinx>=7.1.0; python_version == '3.8'
 Sphinx>=7.2.0; python_version >= '3.9'
 # Sphinx 7.1.0 pins docutils to <0.21
 docutils>=0.18.1,<0.21; python_version == '3.8'
-sphinx-git>=10.1.1; python_version >= '3.8'
-GitPython>=3.1.41; python_version >= '3.8'
-Pygments>=2.15.0; python_version >= '3.8'
-sphinx-rtd-theme>=2.0.0; python_version >= '3.8'
-sphinxcontrib-applehelp>=1.0.4; python_version >= '3.8'
-sphinxcontrib-devhelp>=1.0.2; python_version >= '3.8'
-sphinxcontrib-htmlhelp>=2.0.1; python_version >= '3.8'
-sphinxcontrib-jquery>=4.1; python_version >= '3.8'
-sphinxcontrib-jsmath>=1.0.1; python_version >= '3.8'
-sphinxcontrib-qthelp>=1.0.3; python_version >= '3.8'
+sphinx-git>=10.1.1
+GitPython>=3.1.41
+Pygments>=2.15.0
+sphinx-rtd-theme>=2.0.0
+sphinxcontrib-applehelp>=1.0.4
+sphinxcontrib-devhelp>=1.0.2
+sphinxcontrib-htmlhelp>=2.0.1
+sphinxcontrib-jquery>=4.1
+sphinxcontrib-jsmath>=1.0.1
+sphinxcontrib-qthelp>=1.0.3
 sphinxcontrib-serializinghtml>=1.1.5; python_version == '3.8'
 sphinxcontrib-serializinghtml>=1.1.9; python_version >= '3.9'
-sphinxcontrib-websupport>=1.2.4; python_version >= '3.8'
-autodocsumm>=0.2.12; python_version >= '3.8'
-Babel>=2.9.1; python_version >= '3.8'
+sphinxcontrib-websupport>=1.2.4
+autodocsumm>=0.2.12
+Babel>=2.9.1
 
 # PyLint (no imports, invoked via pylint script)
-# Pylint is not run on py27 anymore
 # Pylint requires astroid
-# Pylint 1.x / astroid 1.x supports py27 and py34/35/36
-# Pylint 2.0 / astroid 2.0 removed py27, added py37
-# Pylint 2.4 / astroid 2.3 removed py34
-# Issue #2673: Pinning Pylint to <2.7.0 is a circumvention for Pylint issue
-#   https://github.com/PyCQA/pylint/issues/4120 that appears in Pylint 2.7.0.
-#   Pylint 2.10 has fixed the issue.
-pylint>=2.6.2,<2.7.0; python_version == '3.5'
-pylint>=2.13.0,<2.14.0; python_version == '3.6'
-pylint>=2.13.0; python_version >= '3.7' and python_version <= '3.10'
+pylint>=2.13.0; python_version <= '3.10'
 pylint>=2.15.0; python_version >= '3.11'
-astroid>=2.4.2,<2.6.0; python_version == '3.5'
-astroid>=2.11.0; python_version >= '3.6' and python_version <= '3.10'
+astroid>=2.11.0; python_version <= '3.10'
 astroid>=2.12.4; python_version >= '3.11'
-typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
 # lazy-object-proxy is used by astroid
-lazy-object-proxy>=1.4.3; python_version >= '3.5'
-wrapt>=1.11.2; python_version >= '3.5' and python_version <= '3.10'
+lazy-object-proxy>=1.4.3
+wrapt>=1.11.2; python_version <= '3.10'
 wrapt>=1.14; python_version >= '3.11'
 # platformdirs is used by pylint starting with its 2.10
-platformdirs>=2.2.0; python_version >= '3.6' and python_version <= '3.11'
+platformdirs>=2.2.0; python_version <= '3.11'
 platformdirs>=3.2.0; python_version >= '3.12'
-# isort 5.0.0 removed support for py27,py35
 # isort 4.2.8 fixes a pylint issue with false positive on import order of ssl on Windows
 # isort 4.3.8 fixes an issue with py310 and works on py310 (Note that isort 5.10.0 has official support for py310)
 isort>=4.3.8
-# Pylint 2.14 uses tomlkit>=0.10.1 and requires py>=3.7
-tomlkit>=0.10.1; python_version >= '3.7'
+# Pylint 2.14 uses tomlkit>=0.10.1
+tomlkit>=0.10.1
 # dill is used by pylint >=2.13
-dill>=0.2; python_version >= '3.6' and python_version <= '3.10'
+dill>=0.2; python_version <= '3.10'
 dill>=0.3.6; python_version >= '3.11'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
@@ -139,19 +109,14 @@ flake8>=3.8.0; python_version <= '3.9'
 flake8>=5.0.0; python_version >= '3.10'
 mccabe>=0.6.0; python_version <= '3.9'
 mccabe>=0.7.0; python_version >= '3.10'
-pycodestyle>=2.6.0,<2.8.0; python_version == '2.7'
-pycodestyle>=2.6.0; python_version >= '3.5' and python_version <= '3.9'
+pycodestyle>=2.6.0; python_version <= '3.9'
 pycodestyle>=2.9.0; python_version >= '3.10'
-pyflakes>=2.2.0,<2.4.0; python_version == '2.7'
-pyflakes>=2.2.0; python_version >= '3.5' and python_version <= '3.9'
+pyflakes>=2.2.0; python_version <= '3.9'
 pyflakes>=2.5.0; python_version >= '3.10'
 entrypoints>=0.3.0
-functools32>=3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
 # Twine (no imports, invoked via twine script):
-# twine 2.0.0 removed support for Python < 3.6
-twine>=1.8.1,<2.0.0; python_version <= '3.5'
-twine>=3.0.0; python_version >= '3.6'
+twine>=3.0.0
 # readme-renderer 23.0 has made cmarkgfm part of extras (it fails on Cygwin)
 readme-renderer>=23.0
 # twine uses keyring, and keyring requires pywin32-ctypes!=0.1.0,0.1.1 but 0.2.0 is required on py38+
@@ -165,75 +130,38 @@ pywin32-ctypes>=0.2.0; sys_platform=="win32"
 #       which conflicts with flake8 (which still uses the deprecated interfaces importlib-metadata
 #       removed). Therefore, we cannot currently use the latest versions of Jupyter Notebook
 #       packages.
-# Note: notebook 6.1 started using f-strings but requires py>=3.5 (f-strings were introduced in py36),
-#       so we need to pin notebook to <6.1 on Python<=3.5.
 # Note: notebook 6.5.1 starts using nbclassic which seems to introduce some challenges for pip
 #       dependency resolution, so for now we pin notebook to <6.5.
-# notebook 6.4.11 removed support for Python 3.6
-notebook>=4.3.1,<6.1; python_version <= '3.5'
-notebook>=6.4.10,<6.5; python_version == '3.6'
-notebook>=6.4.12,<6.5; python_version >= '3.7'
+notebook>=6.4.12,<6.5
 jupyter>=1.0.0
-jupyter-console>=5.2.0,<6.0.0; python_version == '2.7'
-jupyter-console>=5.2.0,<6.0.0; python_version >= '3.5'
-ipywidgets>=5.2.2,<6.0.0; python_version <= '3.6'
-ipywidgets>=5.2.2,<6.0.0; python_version >= '3.7'
-nbconvert>=5.0.0,<6.0.0; python_version <= '3.6'
-nbconvert>=6.0.0,<7.0.0; python_version >= '3.7'
+jupyter-console>=5.2.0,<6.0.0
+ipywidgets>=5.2.2,<6.0.0
+nbconvert>=6.0.0,<7.0.0
 # nbconvert 6.x requires nbclient>=0.5.0,<0.6.0
-nbclient>=0.5.9,<0.6.0; python_version == '3.6'
-nbclient>=0.5.9,<0.6.0; python_version >= '3.7'
+nbclient>=0.5.9,<0.6.0
 # nbclient 0.5.x requires nbformat>=5.0
-nbformat>=4.2.0,<5.0.0; python_version <= '3.5'
-nbformat>=5.0.2,<6.0.0; python_version >= '3.6'
-qtconsole>=4.7.0; python_version <= '3.5'
-qtconsole>=5.0.1; python_version == '3.6'
-qtconsole>=5.4.0; python_version >= '3.7'
-ipykernel>=4.5.2,<5.0.0; python_version <= '3.6'
-ipykernel>=4.5.2,<5.0.0; python_version >= '3.7'
-jupyter-client>=5.3.4,<6.0.0; python_version <= '3.5'
-jupyter-client>=6.1.5,<7.0.0; python_version >= '3.6'
-jupyterlab-widgets>=0.6.15,<1.0.0; python_version <= '3.5'
-jupyterlab-widgets>=1.0.2,<2.0.0; python_version == '3.6'
-jupyterlab-widgets>=1.0.2,<2.0.0; python_version >= '3.7'
-jupyterlab-pygments>=0.1.0; python_version <= '3.6'
-jupyterlab-pygments>=0.2.0; python_version >= '3.7'
-jupyter-core>=4.6.1,<5.0.0; python_version <= '3.5'
-jupyter-core>=4.6.1,<5.0.0; python_version == '3.6'
-jupyter-core>=4.11.2,<5.0.0; python_version >= '3.7'
+nbformat>=5.0.2,<6.0.0
+qtconsole>=5.4.0
+ipykernel>=4.5.2,<5.0.0
+jupyter-client>=6.1.5,<7.0.0
+jupyterlab-widgets>=1.0.2,<2.0.0
+jupyterlab-pygments>=0.2.0
+jupyter-core>=4.11.2,<5.0.0
 ipython-genutils>=0.2.0
-ipython>=5.1.0,<6.0; python_version <= '3.6'
-ipython>=5.1.0,<6.0; python_version >= '3.7'
+ipython>=5.1.0,<6.0
 
 # Pywin32 is used (at least?) by jupyter.
 # Pywin32 version 226 needs to be excluded, see issues #1946 and #1975.
-# pywin32 version 300 removed support for Python 2.7
-# pywin32 version 302 removed support for Python 3.5 and added support for Python 3.10
+# pywin32 version 302 added support for Python 3.10
 # pywin32 version 303 added support for Python 3.11
-pywin32>=222,!=226,<300; sys_platform == 'win32' and python_version == '2.7'
-pywin32>=301,<302; sys_platform == 'win32' and python_version == '3.5'
-pywin32>=303; sys_platform == 'win32' and python_version >= '3.6' and python_version <= '3.11'
+pywin32>=303; sys_platform == 'win32' and python_version <= '3.11'
 pywin32>=306; sys_platform == 'win32' and python_version >= '3.12'
 
 # The tornado package is used by ipykernel which is used by jupyter.
-# Tornado 5.0.0 and 5.0.1 rejects installation if the Python ssl module
-# does not have certain symbols required by Tornado. This issue exists for
-# example with Python 2.7.6 on Ubuntu 14.04, but not with Python 2.7.5 on
-# RHEL 7.4. This can be checked with:
-#   python -c "import ssl; ssl.SSLContext; ssl.create_default_context; ssl.match_hostname"
-# Other projects have the same issue:
-#   https://github.com/floydhub/dl-docker/issues/84
-# The following is a circumvention of this issue that nails the tornado
-# version to below 5.0 on Python 2.
-# TODO: Follow up on resolution of this issue.
-tornado>=4.2.1,<5.0; python_version == '2.7'
-tornado>=6.1; python_version >= '3.5' and python_version <= '3.7'
-tornado>=6.4.1; python_version >= '3.8'
+tornado>=6.4.1
 
 # pyzmq 17.0.0,17.1.0 fail installation when wheel is used
-pyzmq>=17.1.3; python_version <= '3.5'
-pyzmq>=23.0.0; python_version >= '3.6' and python_version <= '3.7'
-pyzmq>=24.0.0; python_version >= '3.8' and python_version <= '3.11'
+pyzmq>=24.0.0; python_version <= '3.11'
 pyzmq>=25.1.1; python_version >= '3.12'
 
 # Aditional dependencies of examples
@@ -242,17 +170,13 @@ progressbar2>=3.12.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.2.0
-# pip-check-reqs is not used on Python 2.7
 # pip-check-reqs 2.3.2 is needed to have proper support for pip<21.3.
-# pip-check-reqs 2.4.0 requires Python>=3.8.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
-pip-check-reqs>=2.3.2; python_version >= '3.5' and python_version <= '3.7'
-pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8' and python_version <= '3.11'
+pip-check-reqs>=2.4.3,!=2.5.0; python_version <= '3.11'
 pip-check-reqs>=2.5.1; python_version >= '3.12'
 
 # pywinpty is used by terminado <- notebook <- jupyter
 # pywinpty <1.1.1 does not have metadata for required Python or dependent packages.
-# pywinpty 1.0 has removed support for py27.
-# pywinpty 1.0 requires maturin which requires py>=3.6 and on py>=3.7 it fails installation
+# pywinpty 1.0 requires maturin which fails installation on py>=3.7
 pywinpty>=0.5,<1.0; os_name == "nt"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,32 +11,31 @@
 # PEP517 package builder, used in Makefile
 build>=1.0.0
 # build requires virtualenv.cli_run which was added in virtualenv 20.1
-virtualenv>=20.23.0
+virtualenv>=20.25.0
 pyproject-hooks>=1.1.0
+
+# six (only needed by packages that still support Python 2)
+six>=1.16.0
 
 # Change log
 towncrier>=22.8.0
 
 # Unit test (imports into testcases):
-# pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest>=4.4.0; python_version <= '3.9'
-pytest>=6.2.5; python_version >= '3.10'
+# pytest is covered in extra-testutils-requirements.txt
 testfixtures>=6.9.0
-# flake8 up to 6.0.0 has not yet adjusted to the removed interfaces of importlib-metadata 5.0
-importlib-metadata>=4.8.3,<5
+importlib-metadata>=4.8.3
 # requests: covered in direct deps for installation
+colorama>=0.4.6
 requests-mock>=1.6.0
 requests-toolbelt>=0.8.0
 more-itertools>=4.0.0
 # pytz: covered in requirements.txt
 
 # packaging is used by pytest, pip-check-reqs, sphinx
-# packaging>=20.5 is needed by pip-check-reqs 2.4.3 but it requires only packaging>=16.0
-packaging>=21.0
+packaging>=23.2
 
 # Unit test (indirect dependencies):
-# Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38
-pluggy>=0.13.0
+pluggy>=1.3.0
 # decorator: covered in requirements.txt
 
 # Coverage reporting (no imports, invoked via coveralls script):
@@ -51,9 +50,20 @@ coveralls>=3.3.0
 # Safety CI by pyup.io
 # Safety 3.0.0 requires exact versions of authlib==1.2.0 and jwt==1.3.1.
 safety>=3.0.1
+safety-schemas>=0.0.2
+# TODO: Change to dparse 0.6.4 once released
+dparse>=0.6.4b0
+ruamel.yaml>=0.17.21
+click>=8.0.2
+Authlib>=1.2.0
+marshmallow>=3.15.0
+pydantic>=1.10.13
+typer>=0.12.0
+typer-cli>=0.12.0
+typer-slim>=0.12.0
 
 # Tox
-tox>=3.1.0
+tox>=4.15.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 # Sphinx 7.2.0 started requiring Python>=3.9
@@ -61,6 +71,7 @@ Sphinx>=7.1.0; python_version == '3.8'
 Sphinx>=7.2.0; python_version >= '3.9'
 # Sphinx 7.1.0 pins docutils to <0.21
 docutils>=0.18.1,<0.21; python_version == '3.8'
+docutils>=0.18.1; python_version >= '3.9'
 sphinx-git>=10.1.1
 GitPython>=3.1.41
 Pygments>=2.15.0
@@ -82,7 +93,7 @@ pylint>=2.15.0
 astroid>=2.12.4
 lazy-object-proxy>=1.4.3
 wrapt>=1.14
-platformdirs>=3.2.0
+platformdirs>=4.1.0
 isort>=4.3.8
 tomlkit>=0.10.1
 dill>=0.3.6
@@ -149,11 +160,11 @@ progressbar2>=3.12.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.2.0
-# pip-check-reqs 2.3.2 is needed to have proper support for pip<21.3.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
+# pip-check-reqs 2.5.0 dropped support for py38
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
-pip-check-reqs>=2.4.3,!=2.5.0; python_version <= '3.11'
-pip-check-reqs>=2.5.1; python_version >= '3.12'
+pip-check-reqs>=2.4.3,!=2.5.0; python_version == '3.8'
+pip-check-reqs>=2.5.1; python_version >= '3.9'
 
 # pywinpty is used by terminado <- notebook <- jupyter
 # pywinpty <1.1.1 does not have metadata for required Python or dependent packages.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,10 @@
 # that are needed for some reason (must be consistent with minimum-constraints.txt)
 
 # PEP517 package builder, used in Makefile
-build>=0.5.0
+build>=1.0.0
+# build requires virtualenv.cli_run which was added in virtualenv 20.1
+virtualenv>=20.23.0
+pyproject-hooks>=1.1.0
 
 # Change log
 towncrier>=22.8.0
@@ -21,7 +24,6 @@ pytest>=6.2.5; python_version >= '3.10'
 testfixtures>=6.9.0
 # flake8 up to 6.0.0 has not yet adjusted to the removed interfaces of importlib-metadata 5.0
 importlib-metadata>=4.8.3,<5
-mock>=2.0.0
 # requests: covered in direct deps for installation
 requests-mock>=1.6.0
 requests-toolbelt>=0.8.0
@@ -31,12 +33,6 @@ more-itertools>=4.0.0
 # packaging is used by pytest, pip-check-reqs, sphinx
 # packaging>=20.5 is needed by pip-check-reqs 2.4.3 but it requires only packaging>=16.0
 packaging>=21.0
-
-# Virtualenv
-# build requires virtualenv.cli_run which was added in 20.1
-# virtualenv 20.0 requires six<2,>=1.12.0
-virtualenv>=20.15.0; python_version <= '3.11'
-virtualenv>=20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):
 # Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38
@@ -82,37 +78,20 @@ autodocsumm>=0.2.12
 Babel>=2.9.1
 
 # PyLint (no imports, invoked via pylint script)
-# Pylint requires astroid
-pylint>=2.13.0; python_version <= '3.10'
-pylint>=2.15.0; python_version >= '3.11'
-astroid>=2.11.0; python_version <= '3.10'
-astroid>=2.12.4; python_version >= '3.11'
-# lazy-object-proxy is used by astroid
+pylint>=2.15.0
+astroid>=2.12.4
 lazy-object-proxy>=1.4.3
-wrapt>=1.11.2; python_version <= '3.10'
-wrapt>=1.14; python_version >= '3.11'
-# platformdirs is used by pylint starting with its 2.10
-platformdirs>=2.2.0; python_version <= '3.11'
-platformdirs>=3.2.0; python_version >= '3.12'
-# isort 4.2.8 fixes a pylint issue with false positive on import order of ssl on Windows
-# isort 4.3.8 fixes an issue with py310 and works on py310 (Note that isort 5.10.0 has official support for py310)
+wrapt>=1.14
+platformdirs>=3.2.0
 isort>=4.3.8
-# Pylint 2.14 uses tomlkit>=0.10.1
 tomlkit>=0.10.1
-# dill is used by pylint >=2.13
-dill>=0.2; python_version <= '3.10'
-dill>=0.3.6; python_version >= '3.11'
+dill>=0.3.6
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
-# flake8 4.0.0 fixes an AttributeError on Python 3.10.
-flake8>=3.8.0; python_version <= '3.9'
-flake8>=5.0.0; python_version >= '3.10'
-mccabe>=0.6.0; python_version <= '3.9'
-mccabe>=0.7.0; python_version >= '3.10'
-pycodestyle>=2.6.0; python_version <= '3.9'
-pycodestyle>=2.9.0; python_version >= '3.10'
-pyflakes>=2.2.0; python_version <= '3.9'
-pyflakes>=2.5.0; python_version >= '3.10'
+flake8>=6.1.0
+mccabe>=0.7.0
+pycodestyle>=2.11.0
+pyflakes>=3.1.0
 entrypoints>=0.3.0
 
 # Twine (no imports, invoked via twine script):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for Sphinx builds for the zhmcclient project.
 #
@@ -33,7 +32,7 @@ def get_version(version_file):
     a fresh Python environment).
     """
     # pylint: disable=unspecified-encoding
-    with open(version_file, 'r') as fp:
+    with open(version_file) as fp:
         version_source = fp.read()
     _globals = {}
     exec(version_source, _globals)  # pylint: disable=exec-used
@@ -90,13 +89,13 @@ else:
     master_doc = 'docs/index'
 
 # General information about the project.
-project = u'zhmcclient'
-copyright = u'IBM'  # pylint: disable=redefined-builtin
-author = u'zhmcclient team'
+project = 'zhmcclient'
+copyright = 'IBM'  # pylint: disable=redefined-builtin
+author = 'zhmcclient team'
 
 # The short description of the package.
-_short_description = u'Client library for IBM Z Hardware Management Console ' \
-    u'Web Services API'
+_short_description = 'Client library for IBM Z Hardware Management Console ' \
+    'Web Services API'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -117,8 +116,8 @@ version = get_version(os.path.join('..', 'zhmcclient', '_version.py'))
 release = version
 
 # Some prints, for extra information
-print("conf.py: pwd: {}".format(os.getcwd()))
-print("conf.py: zhmcclient version: {}".format(version))
+print(f"conf.py: pwd: {os.getcwd()}")
+print(f"conf.py: zhmcclient version: {version}")
 print("conf.py: Last 5 commits:")
 sys.stdout.flush()
 os.system('git log --decorate --oneline |head -5')

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -152,10 +152,10 @@ For example:
 .. code-block:: text
 
     $ tox                              # Run all tests on all supported Python versions
-    $ tox -e py27                      # Run all tests on Python 2.7
-    $ tox -e py27 test_resource.py     # Run only this test source file on Python 2.7
-    $ tox -e py27 TestInit             # Run only this test class on Python 2.7
-    $ tox -e py27 TestInit or TestSet  # pytest -k expressions are possible
+    $ tox -e py38                      # Run all tests on Python 3.8
+    $ tox -e py38 test_resource.py     # Run only this test source file on Python 3.8
+    $ tox -e py38 TestInit             # Run only this test class on Python 3.8
+    $ tox -e py38 TestInit or TestSet  # pytest -k expressions are possible
 
 
 .. _`Running end2end tests`:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -78,7 +78,7 @@ The zhmcclient package is supported in these environments:
 .. # - python_requires and classifiers in setup.py
 .. # - Version checking in zhmcclient/_version.py
 
-* Python versions: 2.7, 3.5, and higher 3.x
+* Python versions: 3.8 and higher
 
 * HMC versions: 2.11.1 and higher
 
@@ -548,7 +548,7 @@ Deprecated functionality is marked accordingly in this documentation and in the
 type :exc:`~py:exceptions.DeprecationWarning` (see :mod:`py:warnings` for
 details).
 
-Since Python 2.7, :exc:`~py:exceptions.DeprecationWarning` warnings are
+In Python, :exc:`~py:exceptions.DeprecationWarning` warnings are
 suppressed by default. They can be shown for example in any of these ways:
 
 * by specifying the Python command line option:

--- a/docs/notebooks/tututils.py
+++ b/docs/notebooks/tututils.py
@@ -42,9 +42,9 @@ def make_client(zhmc, userid=None, password=None):
     global USERID, PASSWORD  # pylint: disable=global-statement
 
     USERID = userid or USERID or \
-        six.input('Enter userid for HMC {}: '.format(zhmc))
+        six.input(f'Enter userid for HMC {zhmc}: ')
     PASSWORD = password or PASSWORD or \
-        getpass.getpass('Enter password for {}: '.format(USERID))
+        getpass.getpass(f'Enter password for {USERID}: ')
 
     session = zhmcclient.Session(zhmc, USERID, PASSWORD)
     session.logon()

--- a/examples/activation_profiles.py
+++ b/examples/activation_profiles.py
@@ -36,7 +36,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -57,10 +57,10 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
     # Reset activation profiles
-    print("Listing reset activation profiles for CPC {} ...".format(cpc.name))
+    print(f"Listing reset activation profiles for CPC {cpc.name} ...")
     try:
         profiles = cpc.reset_activation_profiles.list()
     except zhmcclient.Error as exc:
@@ -71,7 +71,7 @@ try:
         print(profile.name, profile.get_property('element-uri'))
 
     # Image activation profiles
-    print("Listing image activation profiles for CPC {} ...".format(cpc.name))
+    print(f"Listing image activation profiles for CPC {cpc.name} ...")
     try:
         profiles = cpc.image_activation_profiles.list()
     except zhmcclient.Error as exc:
@@ -82,7 +82,7 @@ try:
         print(profile.name, profile.get_property('element-uri'))
 
     # Load activation profiles
-    print("Listing load activation profiles for CPC {} ...".format(cpc.name))
+    print(f"Listing load activation profiles for CPC {cpc.name} ...")
     try:
         profiles = cpc.load_activation_profiles.list()
     except zhmcclient.Error as exc:

--- a/examples/adapter_port_vswitch.py
+++ b/examples/adapter_port_vswitch.py
@@ -36,7 +36,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -57,16 +57,16 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    print("Listing adapters on CPC {} ...".format(cpc.name))
+    print(f"Listing adapters on CPC {cpc.name} ...")
     adapters = cpc.adapters.list()
     for adapter in adapters:
         print("{} ({})".format(
             adapter.name, adapter.get_property('detected-card-type')))
         ports = adapter.ports.list(full_properties=False)
         for port in ports:
-            print("\t{}".format(port.name))
+            print(f"\t{port.name}")
 
     print("Listing virtual switches and backing adapters on CPC {} ...".
           format(cpc.name))

--- a/examples/api_version.py
+++ b/examples/api_version.py
@@ -33,7 +33,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} ...".format(nickname, host))
+print(f"Using HMC {nickname} at {host} ...")
 
 print("Creating an unauthenticated session with the HMC ...")
 try:
@@ -46,4 +46,4 @@ except zhmcclient.Error as exc:
 client = zhmcclient.Client(session)
 
 vi = client.version_info()
-print("HMC API version: {}.{}".format(vi[0], vi[1]))
+print(f"HMC API version: {vi[0]}.{vi[1]}")

--- a/examples/async_operation_notification.py
+++ b/examples/async_operation_notification.py
@@ -43,7 +43,7 @@ JOB_TOPIC_TYPE = 'job-notification'
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -64,7 +64,7 @@ try:
         if topic['topic-type'] == JOB_TOPIC_TYPE:
             job_topic_name = topic['topic-name']
             break
-    print("Using job completion notification topic: {}".format(job_topic_name))
+    print(f"Using job completion notification topic: {job_topic_name}")
 
     print("Finding a CPC in DPM mode ...")
     cpcs = client.cpcs.list(filter_args={'dpm-enabled': True})
@@ -73,10 +73,10 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    part_name = "zhmc_test_{}".format(uuid.uuid4())
-    print("Creating partition {} ...".format(part_name))
+    part_name = f"zhmc_test_{uuid.uuid4()}"
+    print(f"Creating partition {part_name} ...")
     try:
         part = cpc.partitions.create(
             properties={
@@ -92,7 +92,7 @@ try:
         sys.exit(1)
 
     try:
-        print("Starting partition {} asynchronously ...".format(part.name))
+        print(f"Starting partition {part.name} asynchronously ...")
         job = part.start(wait_for_completion=False)
 
         print("Creating a notification receiver for topic {} ...".
@@ -101,7 +101,7 @@ try:
             receiver = zhmcclient.NotificationReceiver(
                 job_topic_name, host, userid, password)
         except Exception as exc:
-            print("Error: Cannot create notification receiver: {}".format(exc))
+            print(f"Error: Cannot create notification receiver: {exc}")
             sys.exit(1)
 
         print("Waiting for job completion notifications ...")
@@ -116,10 +116,10 @@ try:
                         print("Received completion notification for another job: "
                               "{} - continue to wait".format(headers['job-uri']))
             except zhmcclient.NotificationError as exc:
-                print("Notification Error: {} - reconnecting".format(exc))
+                print(f"Notification Error: {exc} - reconnecting")
                 continue
             except stomp.exception.StompException as exc:
-                print("STOMP Error: {} - reconnecting".format(exc))
+                print(f"STOMP Error: {exc} - reconnecting")
                 continue
             except KeyboardInterrupt:
                 print("Keyboard interrupt - leaving receiver loop")
@@ -140,7 +140,7 @@ try:
 
     finally:
         if part.get_property('status') != 'stopped':
-            print("Stopping partition {} ...".format(part.name))
+            print(f"Stopping partition {part.name} ...")
             try:
                 part.stop(wait_for_completion=True)
             except zhmcclient.Error as exc:
@@ -148,7 +148,7 @@ try:
                       format(exc.__class__.__name__, exc))
                 sys.exit(1)
 
-        print("Deleting partition {} ...".format(part.name))
+        print(f"Deleting partition {part.name} ...")
         try:
             part.delete()
         except zhmcclient.Error as exc:

--- a/examples/async_operation_polling.py
+++ b/examples/async_operation_polling.py
@@ -38,7 +38,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -59,10 +59,10 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    part_name = "zhmc_test_{}".format(uuid.uuid4())
-    print("Creating partition {} ...".format(part_name))
+    part_name = f"zhmc_test_{uuid.uuid4()}"
+    print(f"Creating partition {part_name} ...")
     try:
         part = cpc.partitions.create(
             properties={
@@ -78,7 +78,7 @@ try:
         sys.exit(1)
 
     try:
-        print("Starting partition {} asynchronously ...".format(part.name))
+        print(f"Starting partition {part.name} asynchronously ...")
         job = part.start(wait_for_completion=False)
 
         sleep_time = 1
@@ -91,7 +91,7 @@ try:
                 print("Error: Job completed; Start operation failed with "
                       "{}: {}".format(exc.__class__.__name__, exc))
                 break
-            print("Job status: {}".format(job_status))
+            print(f"Job status: {job_status}")
             if job_status == 'complete':
                 break
             time.sleep(sleep_time)
@@ -99,7 +99,7 @@ try:
 
     finally:
         if part.get_property('status') != 'stopped':
-            print("Stopping partition {} ...".format(part.name))
+            print(f"Stopping partition {part.name} ...")
             try:
                 part.stop(wait_for_completion=True)
             except zhmcclient.Error as exc:
@@ -107,7 +107,7 @@ try:
                       format(exc.__class__.__name__, exc))
                 sys.exit(1)
 
-        print("Deleting partition {} ...".format(part.name))
+        print(f"Deleting partition {part.name} ...")
         try:
             part.delete()
         except zhmcclient.Error as exc:

--- a/examples/cleanup_test_partitions.py
+++ b/examples/cleanup_test_partitions.py
@@ -36,7 +36,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -60,10 +60,10 @@ try:
                     print("Stopping test partition: {} ...".
                           format(part.name))
                     part.stop()
-                print("Deleting test partition: {} ...".format(part.name))
+                print(f"Deleting test partition: {part.name} ...")
                 part.delete()
     except zhmcclient.Error as exc:
-        print("Error: {}: {}".format(exc.__class__.__name__, exc))
+        print(f"Error: {exc.__class__.__name__}: {exc}")
         sys.exit(1)
 
 finally:

--- a/examples/discover_storage_group.py
+++ b/examples/discover_storage_group.py
@@ -37,7 +37,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -89,14 +89,14 @@ try:
           format(sg.name, sg.get_property('type'), sg.get_property('shared'),
                  sg.get_property('fulfillment-state')))
 
-    print("Listing partitions attached to storage group {} ...".format(sg.name))
+    print(f"Listing partitions attached to storage group {sg.name} ...")
     parts = sg.list_attached_partitions()
     part_names = [p.name for p in parts]
     part_names_str = ', '.join(part_names) if part_names else "<none>"
     print("Partitions attached to storage group {}: {}".
           format(sg.name, part_names_str))
 
-    print("Getting connection report for storage group {} ...".format(sg.name))
+    print(f"Getting connection report for storage group {sg.name} ...")
     report = sg.get_connection_report()
 
     print("fcp-storage-subsystems section of connection report, before "
@@ -106,7 +106,7 @@ try:
     print("Discovering LUNs of storage group (waiting for completion) ...")
     sg.discover_fcp()
 
-    print("Getting connection report for storage group {} ...".format(sg.name))
+    print(f"Getting connection report for storage group {sg.name} ...")
     report = sg.get_connection_report()
 
     print("fcp-storage-subsystems section of connection report, after "

--- a/examples/dump_hmc_definition.py
+++ b/examples/dump_hmc_definition.py
@@ -37,7 +37,7 @@ hmc_yaml_file = 'hmc_definition.yaml'
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -54,7 +54,7 @@ try:
     print("Dumping HMC resources as an HMC definition ...")
     hmc_yaml_str = client.to_hmc_yaml()
 
-    print("Writing HMC definition to file: {}".format(hmc_yaml_file))
+    print(f"Writing HMC definition to file: {hmc_yaml_file}")
     with open(hmc_yaml_file, 'w') as fp:
         fp.write(hmc_yaml_str)
 

--- a/examples/export_dpm_config.py
+++ b/examples/export_dpm_config.py
@@ -43,10 +43,10 @@ def check(config_items, inventory_data, classname, uri_prop, prop, value):
         value = [value]
     inventory_items = [x for x in inventory_data if x['class'] == classname
                        and (True if prop is None else x[prop] in value)]
-    extra_uris = set([x[uri_prop] for x in config_items]) - \
-        set([x[uri_prop] for x in inventory_items])
-    missing_uris = set([x[uri_prop] for x in inventory_items]) - \
-        set([x[uri_prop] for x in config_items])
+    extra_uris = {x[uri_prop] for x in config_items} - \
+        {x[uri_prop] for x in inventory_items}
+    missing_uris = {x[uri_prop] for x in inventory_items} - \
+        {x[uri_prop] for x in config_items}
     status = 'Error' if extra_uris or missing_uris else 'Ok'
     print("Checking resource class {!r}: Inventory: {}; DPM config: {} "
           "(extra: {}, missing: {}); Check status: {}".
@@ -56,7 +56,7 @@ def check(config_items, inventory_data, classname, uri_prop, prop, value):
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -77,13 +77,13 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    print("Exporting DPM configuration of CPC {} ...".format(cpc.name))
+    print(f"Exporting DPM configuration of CPC {cpc.name} ...")
     try:
         dpm_config = cpc.export_dpm_configuration()
     except zhmcclient.ConsistencyError as exc:
-        print("Error: Cannot export DPM configuration: {}".format(exc))
+        print(f"Error: Cannot export DPM configuration: {exc}")
         sys.exit(1)
 
     print("Fields in exported DPM configuration: {}".

--- a/examples/find_cpcs.py
+++ b/examples/find_cpcs.py
@@ -35,7 +35,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -59,13 +59,13 @@ try:
     print("Found CPCs: {}".format(', '.join(cpc_names)))
 
     cpc_name = cpc_names[0]
-    print("Finding CPC by name={} ...".format(cpc_name))
+    print(f"Finding CPC by name={cpc_name} ...")
     try:
         cpc = client.cpcs.find(name=cpc_name)
     except zhmcclient.NotFound:
-        print("Error: Could not find CPC {}".format(cpc_name))
+        print(f"Error: Could not find CPC {cpc_name}")
         sys.exit(1)
-    print("Found CPC: {}".format(cpc.name))
+    print(f"Found CPC: {cpc.name}")
 
 finally:
     print("Logging off ...")

--- a/examples/get_inventory.py
+++ b/examples/get_inventory.py
@@ -35,7 +35,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:

--- a/examples/get_partial_and_full_properties.py
+++ b/examples/get_partial_and_full_properties.py
@@ -37,7 +37,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -58,7 +58,7 @@ try:
         cpcs = client.cpcs.list(full_properties)
         end_dt = datetime.now()
         duration = end_dt - start_dt
-        print("Duration: {}".format(duration))
+        print(f"Duration: {duration}")
         for cpc in cpcs:
             print("Number of properties returned for CPC {}: {}".
                   format(cpc.name, len(cpc.properties)))

--- a/examples/get_partition_properties_filter.py
+++ b/examples/get_partition_properties_filter.py
@@ -37,7 +37,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC at {} with userid {} ...".format(host, userid))
+print(f"Using HMC at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -58,11 +58,11 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
     partitions = cpc.partitions.list()
     partition = random.choice(partitions)
-    print("Using partition {} ...".format(partition.name))
+    print(f"Using partition {partition.name} ...")
 
     print("\nLocal partition properties after list: {}".
           format(list(partition.properties.keys())))

--- a/examples/get_sustainability_data.py
+++ b/examples/get_sustainability_data.py
@@ -39,7 +39,7 @@ resolution = "fifteen-minutes"
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -58,20 +58,20 @@ try:
     cpcs = client.cpcs.list()
     cpc = cpcs[0]
     print('')
-    print('Getting sustainability metrics on CPC: {}'.format(cpc.name))
-    print('Range: {}'.format(range))
-    print('Resolution: {}'.format(resolution))
+    print(f'Getting sustainability metrics on CPC: {cpc.name}')
+    print(f'Range: {range}')
+    print(f'Resolution: {resolution}')
     try:
         data = cpc.get_sustainability_data(
             range=range, resolution=resolution)
     except zhmcclient.Error as exc:
-        print("Error: {}".format(exc))
+        print(f"Error: {exc}")
         rc = 1
     else:
         print('')
         print('CPC sustainability metrics:')
         for metric_name, metric_array in data.items():
-            print("{}:".format(metric_name))
+            print(f"{metric_name}:")
             for dp in metric_array:
                 print("  {}: {}".format(dp['timestamp'], dp['data']))
 
@@ -85,19 +85,19 @@ try:
     print('')
     print('Getting sustainability metrics on {}: {}'.
           format(part_str, part.name))
-    print('Range: {}'.format(range))
-    print('Resolution: {}'.format(resolution))
+    print(f'Range: {range}')
+    print(f'Resolution: {resolution}')
     try:
         data = part.get_sustainability_data(
             range=range, resolution=resolution)
     except zhmcclient.Error as exc:
-        print("Error: {}".format(exc))
+        print(f"Error: {exc}")
         rc = 1
     else:
         print('')
-        print('{} sustainability metrics:'.format(part_str))
+        print(f'{part_str} sustainability metrics:')
         for metric_name, metric_array in data.items():
-            print("{}:".format(metric_name))
+            print(f"{metric_name}:")
             for dp in metric_array:
                 print("  {}: {}".format(dp['timestamp'], dp['data']))
 

--- a/examples/increase_crypto_config.py
+++ b/examples/increase_crypto_config.py
@@ -44,13 +44,13 @@ access_mode = 'control'
 
 
 def get_password(host, userid):
-    prompt = "Enter password for userid {} on HMC at {}: ".format(userid, host)
+    prompt = f"Enter password for userid {userid} on HMC at {host}: "
     return getpass.getpass(prompt)
 
 
 print(__doc__)
 
-print("Using HMC at {} with userid {} ...".format(host, userid))
+print(f"Using HMC at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -65,15 +65,15 @@ try:
     client = zhmcclient.Client(session)
 
     try:
-        print("Finding CPC {} ...".format(cpc_name))
+        print(f"Finding CPC {cpc_name} ...")
         cpc = client.cpcs.find(name=cpc_name)
 
-        print("Finding partition {} ...".format(partition_name))
+        print(f"Finding partition {partition_name} ...")
         partition = cpc.partitions.find(name=partition_name)
 
         crypto_adapters = []
         for aname in crypto_adapter_names:
-            print("Finding crypto adapter {} ...".format(aname))
+            print(f"Finding crypto adapter {aname} ...")
             adapter = cpc.adapters.find(name=aname)
             crypto_adapters.append(adapter)
 
@@ -88,7 +88,7 @@ try:
         partition.increase_crypto_config(crypto_adapters, crypto_domain_config)
 
     except zhmcclient.Error as exc:
-        print("Error: {}".format(exc))
+        print(f"Error: {exc}")
         sys.exit(1)
 
 finally:

--- a/examples/install_from_ftp.py
+++ b/examples/install_from_ftp.py
@@ -42,10 +42,10 @@ def receive_until_KeyboardInterrupt(receiver):
                     msg_txt = os_msg['message-text'].strip('\n')
                     print(msg_txt)
         except zhmcclient.NotificationError as exc:
-            print("Notification Error: {} - reconnecting".format(exc))
+            print(f"Notification Error: {exc} - reconnecting")
             continue
         except stomp.exception.StompException as exc:
-            print("STOMP Error: {} - reconnecting".format(exc))
+            print(f"STOMP Error: {exc} - reconnecting")
             continue
         except KeyboardInterrupt:
             print("Keyboard interrupt - leaving receiver loop")
@@ -55,7 +55,7 @@ def receive_until_KeyboardInterrupt(receiver):
             raise AssertionError("Receiver was closed - should not happen")
 
 def get_password(host, userid):
-    return input("password for user %s on host %s:" % (userid, host))
+    return input("password for user {} on host {}:".format(userid, host))
 
 def load_config(config_filepath):
     """

--- a/examples/list_cpcs.py
+++ b/examples/list_cpcs.py
@@ -35,7 +35,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:

--- a/examples/list_free_crypto_domains.py
+++ b/examples/list_free_crypto_domains.py
@@ -36,7 +36,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -57,9 +57,9 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    print("Finding all crypto adapters of CPC {} ...".format(cpc.name))
+    print(f"Finding all crypto adapters of CPC {cpc.name} ...")
     crypto_adapters = cpc.adapters.findall(type='crypto')
     crypto_adapter_names = [ca.name for ca in crypto_adapters]
     print("Found crypto adapters:")
@@ -82,19 +82,19 @@ try:
             pass
         else:
             if range_start == last_d:
-                ranges.append("{}".format(last_d))
+                ranges.append(f"{last_d}")
             else:
-                ranges.append("{}-{}".format(range_start, last_d))
+                ranges.append(f"{range_start}-{last_d}")
             range_start = d
         last_d = d
         continue
     if range_start != -1:  # Process the last range, if any
         if range_start == last_d:
-            ranges.append("{}".format(last_d))
+            ranges.append(f"{last_d}")
         else:
-            ranges.append("{}-{}".format(range_start, last_d))
+            ranges.append(f"{range_start}-{last_d}")
     free_domains_str = ', '.join(ranges)
-    print("Free domains (as ranges): {}".format(free_domains_str))
+    print(f"Free domains (as ranges): {free_domains_str}")
 
 finally:
     print("Logging off ...")

--- a/examples/list_partitions_filtered.py
+++ b/examples/list_partitions_filtered.py
@@ -41,7 +41,7 @@ FILTERS_LIST = [
 print(__doc__)
 
 if len(sys.argv) <= 1:
-    print("Usage: {} CPC [PARTITION]".format(sys.argv[0]))
+    print(f"Usage: {sys.argv[0]} CPC [PARTITION]")
     print("Where:")
     print("  CPC        Name of the CPC")
     print("  PARTITION  Optional: Filter string for matching the partition name")
@@ -53,7 +53,7 @@ try:
 except IndexError:
     partition_name_filter = None
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -68,7 +68,7 @@ try:
     client = zhmcclient.Client(session)
 
     cpc = client.cpcs.find(name=cpc_name)
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
     if partition_name_filter:
         filter_args = {'name': partition_name_filter}
@@ -80,7 +80,7 @@ try:
     partitions = cpc.partitions.list(filter_args=filter_args)
     print("Resulting partitions (sorted):")
     for part in sorted(partitions, key=lambda p: p.name):
-        print("  name={}".format(part.name))
+        print(f"  name={part.name}")
 
 finally:
     print("Logging off ...")

--- a/examples/list_partitions_partial_and_full.py
+++ b/examples/list_partitions_partial_and_full.py
@@ -37,7 +37,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -57,11 +57,11 @@ try:
         cpc_name = None
     if cpc_name:
         cpc = client.cpcs.find(name=cpc_name)
-        print("Using specified CPC {}".format(cpc.name))
+        print(f"Using specified CPC {cpc.name}")
     else:
         cpcs = client.cpcs.list()
         cpc = cpcs[0]
-        print("Using first CPC {}".format(cpc.name))
+        print(f"Using first CPC {cpc.name}")
 
     for full_properties in (False, True):
         print("\nListing partitions with full_properties={} ...".
@@ -75,8 +75,8 @@ try:
         num_props = 0
         for partition in partitions:
             num_props += len(partition.properties)
-        print("Duration: {:.2f} s".format(duration.total_seconds()))
-        print("Number of partitions: {}".format(len(partitions)))
+        print(f"Duration: {duration.total_seconds():.2f} s")
+        print(f"Number of partitions: {len(partitions)}")
         print("Number of non-stopped partitions: {}".
               format(len(non_stopped_partitions)))
         print("Average number of properties per partition: {:.1f}".

--- a/examples/list_storage_groups.py
+++ b/examples/list_storage_groups.py
@@ -35,7 +35,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -56,9 +56,9 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    print("Listing storage groups of CPC {} ...".format(cpc.name))
+    print(f"Listing storage groups of CPC {cpc.name} ...")
     try:
         storage_groups = cpc.list_associated_storage_groups()
     except zhmcclient.Error as exc:
@@ -80,9 +80,9 @@ try:
                   "{}: {}".format(sg.name, exc.__class__.__name__, exc))
             sys.exit(1)
 
-        print("    Storage Volumes: {}".format(len(volumes)))
+        print(f"    Storage Volumes: {len(volumes)}")
         for sv in volumes:
-            print("    Storage Volume: {}".format(sv.name))
+            print(f"    Storage Volume: {sv.name}")
 
         if sg.get_property('type') == 'fcp':
 

--- a/examples/lpar_operations.py
+++ b/examples/lpar_operations.py
@@ -43,7 +43,7 @@ lpar_load_devno = '0100'
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -64,9 +64,9 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    print("Finding LPAR by name={} ...".format(lpar_name))
+    print(f"Finding LPAR by name={lpar_name} ...")
     # We use list() instead of find() because find(name=..) is optimized by
     # using the name-to-uri cache and therefore returns an Lpar object with
     # only a minimal set of properties, and particularly no 'status' property.
@@ -83,17 +83,17 @@ try:
         sys.exit(1)
     lpar = lpars[0]
     status = lpar.get_property('status')
-    print("Found LPAR {} with status {}".format(lpar.name, status))
+    print(f"Found LPAR {lpar.name} with status {status}")
 
     retries = 10
 
     if status != "not-activated":
-        print("Deactivating LPAR {} ...".format(lpar.name))
+        print(f"Deactivating LPAR {lpar.name} ...")
         lpar.deactivate()
         for i in range(0, retries):
             lpar = cpc.lpars.list(filter_args={'name': lpar_name})[0]
             status = lpar.get_property('status')
-            print("LPAR status: {}".format(status))
+            print(f"LPAR status: {status}")
             if status == 'not-activated':
                 break
             time.sleep(1)
@@ -101,12 +101,12 @@ try:
             print("Warning: After {} retries, status of LPAR {} after "
                   "Deactivate is still: {}".format(retries, lpar.name, status))
 
-    print("Activating LPAR {} ...".format(lpar.name))
+    print(f"Activating LPAR {lpar.name} ...")
     lpar.activate()
     for i in range(0, retries):
         lpar = cpc.lpars.list(filter_args={'name': lpar_name})[0]
         status = lpar.get_property('status')
-        print("LPAR status: {}".format(status))
+        print(f"LPAR status: {status}")
         if status == 'not-operating':
             break
         time.sleep(1)
@@ -120,7 +120,7 @@ try:
     for i in range(0, retries):
         lpar = cpc.lpars.list(filter_args={'name': lpar_name})[0]
         status = lpar.get_property('status')
-        print("LPAR status: {}".format(status))
+        print(f"LPAR status: {status}")
         if status == 'operating':
             break
         time.sleep(1)
@@ -128,12 +128,12 @@ try:
         print("Warning: After {} retries, status of LPAR {} after "
               "Load is still: {}".format(retries, lpar.name, status))
 
-    print("Deactivating LPAR {} ...".format(lpar.name))
+    print(f"Deactivating LPAR {lpar.name} ...")
     lpar.deactivate()
     for i in range(0, retries):
         lpar = cpc.lpars.list(filter_args={'name': lpar_name})[0]
         status = lpar.get_property('status')
-        print("LPAR status: {}".format(status))
+        print(f"LPAR status: {status}")
         if status == 'not-activated':
             break
         time.sleep(1)

--- a/examples/metrics.py
+++ b/examples/metrics.py
@@ -37,7 +37,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -81,7 +81,7 @@ try:
 
         sleep_time = 15  # seconds
 
-        print("Sleeping for {} seconds ...".format(sleep_time))
+        print(f"Sleeping for {sleep_time} seconds ...")
         time.sleep(sleep_time)
 
         print("Retrieving the current metric values ...")
@@ -92,16 +92,16 @@ try:
         for mg in mr.metric_group_values:
             mg_name = mg.name
             mg_def = mc.metric_group_definitions[mg_name]
-            print("  Metric group: {}".format(mg_name))
+            print(f"  Metric group: {mg_name}")
             for ov in mg.object_values:
-                print("    Resource: {}".format(ov.resource_uri))
-                print("    Timestamp: {}".format(ov.timestamp))
+                print(f"    Resource: {ov.resource_uri}")
+                print(f"    Timestamp: {ov.timestamp}")
                 print("    Metric values:")
                 for m_name in ov.metrics:
                     m_value = ov.metrics[m_name]
                     m_def = mg_def.metric_definitions[m_name]
                     m_unit = m_def.unit or ''
-                    print("      {:30}  {} {}".format(m_name, m_value, m_unit))
+                    print(f"      {m_name:30}  {m_value} {m_unit}")
             if not mg.object_values:
                 print("    No resources")
 
@@ -109,7 +109,7 @@ try:
         mc.delete()
 
     except zhmcclient.Error as exc:
-        print("{}: {}".format(exc.__class__.__name__, exc))
+        print(f"{exc.__class__.__name__}: {exc}")
         sys.exit(1)
 
 finally:

--- a/examples/mount_iso.py
+++ b/examples/mount_iso.py
@@ -44,7 +44,7 @@ image_insfile = 'my_insfile'
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -65,10 +65,10 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    part_name = "zhmc_test_{}".format(uuid.uuid4())
-    print("Creating partition {} ...".format(part_name))
+    part_name = f"zhmc_test_{uuid.uuid4()}"
+    print(f"Creating partition {part_name} ...")
     try:
         part = cpc.partitions.create(
             properties={
@@ -92,15 +92,15 @@ try:
                       format(part.name))
                 print("  Image file: {} (size: {:.1f} MB)".
                       format(image_file, image_size_mb))
-                print("  Image name: {}".format(image_name))
-                print("  Image INS file: {}".format(image_insfile))
+                print(f"  Image name: {image_name}")
+                print(f"  Image INS file: {image_insfile}")
                 try:
                     part.mount_iso_image(image_fp, image_name, image_insfile)
                 except zhmcclient.Error as exc:
                     print("Error: Cannot mount ISO file {}: {}: {}".
                           format(image_file, exc.__class__.__name__, exc))
                     sys.exit(1)
-        except (IOError, OSError) as exc:
+        except OSError as exc:
             print("Error: Cannot open image file {}: {}: {}".
                   format(image_file, exc.__class__.__name__, exc))
             sys.exit(1)
@@ -117,7 +117,7 @@ try:
                   format(part.name, exc.__class__.__name__, exc))
             sys.exit(1)
 
-        print("Starting partition {} ...".format(part.name))
+        print(f"Starting partition {part.name} ...")
         try:
             part.start()
         except zhmcclient.Error as exc:
@@ -127,11 +127,11 @@ try:
 
         part.pull_full_properties()
         status = part.get_property('status')
-        print("Partition status: {}".format(status))
+        print(f"Partition status: {status}")
 
     finally:
         if part.get_property('status') != 'stopped':
-            print("Stopping partition {} ...".format(part.name))
+            print(f"Stopping partition {part.name} ...")
             try:
                 part.stop(wait_for_completion=True)
             except zhmcclient.Error as exc:
@@ -139,7 +139,7 @@ try:
                       format(exc.__class__.__name__, exc))
                 sys.exit(1)
 
-        print("Deleting partition {} ...".format(part.name))
+        print(f"Deleting partition {part.name} ...")
         try:
             part.delete()
         except zhmcclient.Error as exc:

--- a/examples/partition_lifecycle.py
+++ b/examples/partition_lifecycle.py
@@ -37,7 +37,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -58,10 +58,10 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    part_name = "zhmc_test_{}".format(uuid.uuid4())
-    print("Creating partition {} ...".format(part_name))
+    part_name = f"zhmc_test_{uuid.uuid4()}"
+    print(f"Creating partition {part_name} ...")
     part_props = {
         'name': part_name,
         'description': 'Original partition description.',
@@ -78,7 +78,7 @@ try:
               format(part_name, cpc.name, exc.__class__.__name__, exc))
         sys.exit(1)
 
-    print("Starting partition {} ...".format(part.name))
+    print(f"Starting partition {part.name} ...")
     part.start()
 
     print("Current partition description: {}".
@@ -87,7 +87,7 @@ try:
     updated_properties = {}
     updated_properties["description"] = new_description
 
-    print("Updating partition description to: {}".format(new_description))
+    print(f"Updating partition description to: {new_description}")
     part.update_properties(updated_properties)
 
     print("Partition description on local resource object: {}".

--- a/examples/show_auto_updated_partition.py
+++ b/examples/show_auto_updated_partition.py
@@ -38,7 +38,7 @@ verify_cert = hmc_def.verify_cert
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -59,10 +59,10 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    part_name = "zhmc_test_{}".format(uuid.uuid4())
-    print("Creating partition {} ...".format(part_name))
+    part_name = f"zhmc_test_{uuid.uuid4()}"
+    print(f"Creating partition {part_name} ...")
     part_props = {
         'name': part_name,
         'description': 'Original partition description.',
@@ -81,7 +81,7 @@ try:
 
     try:
         obj_topic = session.object_topic
-        print("Object notification topic: {}".format(obj_topic))
+        print(f"Object notification topic: {obj_topic}")
 
         # Two different zhmcclient.Partition objects representing the same
         # partition on the HMC
@@ -123,7 +123,7 @@ try:
             partition1.disable_auto_update()
 
     finally:
-        print("Deleting partition {} ...".format(part.name))
+        print(f"Deleting partition {part.name} ...")
         try:
             part.delete()
         except zhmcclient.Error as exc:

--- a/examples/show_auto_updated_partition_manager.py
+++ b/examples/show_auto_updated_partition_manager.py
@@ -56,7 +56,7 @@ def delta_ms(start_dt, end_dt):
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -78,7 +78,7 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
     part_mgr = cpc.partitions
 
@@ -105,8 +105,8 @@ try:
     print("Result of list(): returned {} partitions in {} ms".
           format(len(part_list), delta_ms(start_dt, end_dt)))
 
-    part_name = "zhmc_test_{}".format(uuid.uuid4())
-    print("Creating partition {} ...".format(part_name))
+    part_name = f"zhmc_test_{uuid.uuid4()}"
+    print(f"Creating partition {part_name} ...")
     part_props = {
         'name': part_name,
         'description': 'Original partition description.',
@@ -122,7 +122,7 @@ try:
         print("Error: Cannot create partition {} on CPC {}: {}: {}".
               format(part_name, cpc.name, exc.__class__.__name__, exc))
         sys.exit(1)
-    print("Partition uri: {}".format(part.uri))
+    print(f"Partition uri: {part.uri}")
 
     print("Listing partitions using list() "
           "(auto-enabled - added partition causes pull from HMC) ...")
@@ -140,7 +140,7 @@ try:
     print("Result of list(): returned {} partitions in {} ms".
           format(len(part_list), delta_ms(start_dt, end_dt)))
 
-    print("Deleting partition {} (uri: {}) ...".format(part.name, part.uri))
+    print(f"Deleting partition {part.name} (uri: {part.uri}) ...")
     try:
         part.delete()
         cleanup_partition = None
@@ -170,7 +170,7 @@ try:
 
 finally:
     if cleanup_partition:
-        print("Cleanup: Deleting partition {} ...".format(cleanup_partition.name))
+        print(f"Cleanup: Deleting partition {cleanup_partition.name} ...")
         try:
             cleanup_partition.delete()
         except zhmcclient.Error as exc:

--- a/examples/show_os_messages.py
+++ b/examples/show_os_messages.py
@@ -39,7 +39,7 @@ PRINT_METADATA = False
 
 print(__doc__)
 
-print("Using HMC {} at {} with userid {} ...".format(nickname, host, userid))
+print(f"Using HMC {nickname} at {host} with userid {userid} ...")
 
 print("Creating a session with the HMC ...")
 try:
@@ -60,9 +60,9 @@ try:
               format(host))
         sys.exit(1)
     cpc = cpcs[0]
-    print("Using CPC {}".format(cpc.name))
+    print(f"Using CPC {cpc.name}")
 
-    print("Finding an active partition on CPC {} ...".format(cpc.name))
+    print(f"Finding an active partition on CPC {cpc.name} ...")
     parts = cpc.partitions.list(filter_args={'status': 'active'})
     if not parts:
         print("Error: CPC {} does not have any active partitions".
@@ -81,7 +81,7 @@ try:
         print("Error: Cannot open OS message channel for partition {}: {}: {}".
               format(part.name, exc.__class__.__name__, exc))
         sys.exit(1)
-    print("OS message channel notification topic: {}".format(msg_topic))
+    print(f"OS message channel notification topic: {msg_topic}")
 
     print("Creating a notification receiver for topic {} ...".
           format(msg_topic))
@@ -89,10 +89,10 @@ try:
         receiver = zhmcclient.NotificationReceiver(
             msg_topic, host, userid, password)
     except Exception as exc:
-        print("Error: Cannot create notification receiver: {}".format(exc))
+        print(f"Error: Cannot create notification receiver: {exc}")
         sys.exit(1)
 
-    print("Debug: STOMP retry/timeout config: {}".format(receiver._rt_config))
+    print(f"Debug: STOMP retry/timeout config: {receiver._rt_config}")
 
     print("Showing OS messages ...")
     print("-----------------------")
@@ -112,10 +112,10 @@ try:
                     msg_txt = os_msg['message-text'].strip('\n')
                     print(msg_txt)
         except zhmcclient.NotificationError as exc:
-            print("Notification Error: {} - reconnecting".format(exc))
+            print(f"Notification Error: {exc} - reconnecting")
             continue
         except stomp.exception.StompException as exc:
-            print("STOMP Error: {} - reconnecting".format(exc))
+            print(f"STOMP Error: {exc} - reconnecting")
             continue
         except KeyboardInterrupt:
             print("Keyboard interrupt - leaving receiver loop")

--- a/extra-testutils-requirements.txt
+++ b/extra-testutils-requirements.txt
@@ -7,9 +7,7 @@
 # Direct dependencies for install of extra 'testutils' (must be consistent with minimum-constraints-install.txt)
 
 # zhmcclient.testutils defines pytest fixtures:
-# pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest>=4.4.0; python_version <= '3.9'
-pytest>=6.2.5; python_version >= '3.10'
+pytest>=6.2.5
 
 # Packages used by zhmcclient.testutils that are also used by zhmcclient and thus
 # are specified already in requirements.txt:

--- a/extra-testutils-requirements.txt
+++ b/extra-testutils-requirements.txt
@@ -7,11 +7,8 @@
 # Direct dependencies for install of extra 'testutils' (must be consistent with minimum-constraints-install.txt)
 
 # zhmcclient.testutils defines pytest fixtures:
-# pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest>=4.3.1,<5.0.0; python_version == '2.7'
-pytest>=4.3.1; python_version >= '3.5' and python_version <= '3.6'
-pytest>=4.4.0; python_version >= '3.7' and python_version <= '3.9'
+pytest>=4.4.0; python_version <= '3.9'
 pytest>=6.2.5; python_version >= '3.10'
 
 # Packages used by zhmcclient.testutils that are also used by zhmcclient and thus

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -10,22 +10,13 @@
 # pip 10.0.0 introduced the --exclude-editable option.
 # pip 18.0 is needed on pypy3 (py36) to support constraints like cffi!=1.11.3,>=1.8.
 # Pip 20.2 introduced a new resolver whose backtracking had issues that were resolved only in 21.2.2.
-# Pip 21.0 removed support for Python<=3.5
 # pip>=21.0 is needed for the cryptography package on Windows on GitHub Actions.
-pip==19.3.1; python_version <= '3.5'
-pip==21.3.1; python_version == '3.6'
-pip==23.3; python_version >= '3.7'
+pip==23.3
 
-# setuptools 51.0.0 removed support for py35
-# setuptools 59.7.0 removed support for py36
-setuptools==39.0.1; python_version == '2.7'
-setuptools==50.3.2; python_version == '3.5'
-setuptools==59.6.0; python_version == '3.6'
-setuptools==65.5.1; python_version >= '3.7' and python_version <= '3.11'
+setuptools==65.5.1; python_version <= '3.11'
 setuptools==66.1.0; python_version >= '3.12'
 
-wheel==0.30.0; python_version <= '3.6'
-wheel==0.38.1; python_version >= '3.7'
+wheel==0.38.1
 
 
 # Direct dependencies for install (must be consistent with requirements.txt)
@@ -33,13 +24,10 @@ wheel==0.38.1; python_version >= '3.7'
 decorator==4.0.11
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
-requests==2.25.0; python_version <= '3.5'
-requests==2.26.0; python_version == '3.6'
-requests==2.31.0; python_version >= '3.7'
+requests==2.31.0
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
-stomp-py==4.1.23; python_version <= '3.6'
-stomp-py==8.1.1; python_version >= '3.7'
+stomp-py==8.1.1
 python-dateutil==2.8.2
 immutable-views==0.6.0
 nocasedict==1.0.2
@@ -58,37 +46,30 @@ jsonschema==3.1.0
 
 # Used by zhmcclient.testutils
 # pytest 6.2.5 is needed on Python 3.10 to address issues.
-pytest==4.3.1; python_version <= '3.6'
-pytest==4.4.0; python_version >= '3.7' and python_version <= '3.9'
+pytest==4.4.0; python_version <= '3.9'
 pytest==6.2.5; python_version >= '3.10'
 
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with requirements.txt)
 
-urllib3==1.26.18; python_version == '2.7'
-urllib3==1.26.9; python_version == '3.5'
-urllib3==1.26.18; python_version >= '3.6'
+urllib3==1.26.18
 
 pyrsistent==0.15.1
 
 
 # All other indirect dependencies for install that are not in requirements.txt
 
-attrs==19.2.0; python_version >= '3.5'
-certifi==2019.9.11; python_version <= '3.5'
-certifi==2023.07.22; python_version >= '3.6'
+attrs==19.2.0
+certifi==2023.07.22
 chardet==3.0.3
 docopt==0.6.2
 # idna>3 requires using requests >=2.26.0
-idna==2.5; python_version <= '3.5'
-idna==3.7; python_version >= '3.6'
+idna==3.7
 
 
 # Used by zhmcclient.testutils
-packaging==20.5; python_version <= '3.5'
-packaging==21.0; python_version >= '3.6'
-pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'
-pluggy==0.13.0; python_version >= '3.7'
+packaging==21.0
+pluggy==0.13.0
 
 # websocket-client is used by stomp-py 8.0 and notebook(?) 6.4
-websocket-client==1.5.3; python_version >= '3.7'
+websocket-client==1.5.3

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -7,26 +7,16 @@
 
 # Base dependencies
 
-# pip 10.0.0 introduced the --exclude-editable option.
-# pip 18.0 is needed on pypy3 (py36) to support constraints like cffi!=1.11.3,>=1.8.
-# Pip 20.2 introduced a new resolver whose backtracking had issues that were resolved only in 21.2.2.
-# pip>=21.0 is needed for the cryptography package on Windows on GitHub Actions.
 pip==23.3
-
-setuptools==65.5.1; python_version <= '3.11'
-setuptools==66.1.0; python_version >= '3.12'
-
+setuptools==66.1.0
 wheel==0.38.1
 
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
 decorator==4.0.11
-pytz==2016.10; python_version <= '3.9'
-pytz==2019.1; python_version >= '3.10'
+pytz==2019.1
 requests==2.31.0
-six==1.14.0; python_version <= '3.9'
-six==1.16.0; python_version >= '3.10'
 stomp-py==8.1.1
 python-dateutil==2.8.2
 immutable-views==0.6.0
@@ -46,8 +36,7 @@ jsonschema==3.1.0
 
 # Used by zhmcclient.testutils
 # pytest 6.2.5 is needed on Python 3.10 to address issues.
-pytest==4.4.0; python_version <= '3.9'
-pytest==6.2.5; python_version >= '3.10'
+pytest==6.2.5
 
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with requirements.txt)
@@ -61,15 +50,15 @@ pyrsistent==0.15.1
 
 attrs==19.2.0
 certifi==2023.07.22
-chardet==3.0.3
+chardet==5.2.0
 docopt==0.6.2
 # idna>3 requires using requests >=2.26.0
 idna==3.7
 
 
 # Used by zhmcclient.testutils
-packaging==21.0
-pluggy==0.13.0
+packaging==23.2
+pluggy==1.3.0
 
 # websocket-client is used by stomp-py 8.0 and notebook(?) 6.4
 websocket-client==1.5.3

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -16,9 +16,10 @@
 # that are needed for some reason (must be consistent with dev-requirements.txt)
 
 # PEP517 package builder, used in Makefile
-build==0.5.0
-# build up to version 0.9 requires pep517>=0.9.1
-pep517==0.9.1
+build==1.0.0
+# build requires virtualenv.cli_run which was added in virtualenv 20.1
+virtualenv==20.23.0
+pyproject-hooks==1.1.0
 
 # Change log
 towncrier==22.8.0
@@ -30,16 +31,11 @@ click-default-group==1.2.4
 testfixtures==6.9.0
 colorama==0.4.5
 importlib-metadata==4.8.3
-mock==2.0.0
 more-itertools==4.0.0
 # pytz: covered in direct deps for installation
 # requests: covered in direct deps for installation
 requests-mock==1.6.0
 requests-toolbelt==0.8.0
-
-# Virtualenv
-virtualenv==20.15.0; python_version <= '3.11'
-virtualenv==20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):
 # decorator: covered in direct deps for installation
@@ -86,30 +82,21 @@ sphinxcontrib-websupport==1.2.4
 autodocsumm==0.2.12
 Babel==2.9.1
 
-# PyLint (no imports, invoked via pylint script):
-pylint==2.13.0; python_version <= '3.10'
-pylint==2.15.0; python_version >= '3.11'
-astroid==2.11.0; python_version <= '3.10'
-astroid==2.12.4; python_version >= '3.11'
+# PyLint (no imports, invoked via pylint script)
+pylint==2.15.0
+astroid==2.12.4
 lazy-object-proxy==1.4.3
-wrapt==1.12; python_version <= '3.10'
-wrapt==1.14; python_version >= '3.11'
-platformdirs==2.2.0; python_version <= '3.11'
-platformdirs==3.2.0; python_version >= '3.12'
+wrapt==1.14
+platformdirs==3.2.0
 isort==4.3.8
 tomlkit==0.10.1
-dill==0.2; python_version <= '3.10'
-dill==0.3.6; python_version >= '3.11'
+dill==0.3.6
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
-flake8==3.8.0; python_version <= '3.9'
-flake8==5.0.0; python_version >= '3.10'
-mccabe==0.6.0; python_version <= '3.9'
-mccabe==0.7.0; python_version >= '3.10'
-pycodestyle==2.6.0; python_version <= '3.9'
-pycodestyle==2.9.0; python_version >= '3.10'
-pyflakes==2.2.0; python_version <= '3.9'
-pyflakes==2.5.0; python_version >= '3.10'
+flake8==6.1.0
+mccabe==0.7.0
+pycodestyle==2.11.0
+pyflakes==3.1.0
 entrypoints==0.3.0
 
 # Twine (no imports, invoked via twine script):
@@ -174,8 +161,7 @@ configparser==4.0.2
 dataclasses==0.8
 defusedxml==0.7.1
 distlib==0.3.6
-filelock==3.2.0; python_version <= "3.11"
-filelock==3.11.0; python_version >= "3.12"
+filelock==3.11.0
 gitdb==4.0.8
 gitdb2==2.0.0
 html5lib==1.1
@@ -198,8 +184,6 @@ pickleshare==0.7.4
 pkginfo==1.4.2
 # tox 4.0.0 started using pyproject-api and requires pyproject-api>=1.2.1
 pyproject-api==1.2.1
-# build is using pyproject-hooks
-pyproject-hooks==1.0.0
 prometheus-client==0.13.1
 ptyprocess==0.5.1
 py==1.11.0

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -21,18 +21,15 @@ build==0.5.0
 pep517==0.9.1
 
 # Change log
-towncrier==22.8.0; python_version >= '3.7'
-incremental==22.10.0; python_version >= '3.7'
-click-default-group==1.2.4; python_version >= '3.7'
+towncrier==22.8.0
+incremental==22.10.0
+click-default-group==1.2.4
 
 # Unit test (imports into testcases):
 # Note: pytest is covered in minimum-constraints-install.txt
-funcsigs==1.0.2; python_version == '2.7'
 testfixtures==6.9.0
-colorama==0.3.9; python_version == '2.7'
-colorama==0.4.5; python_version >= '3.5'
-importlib-metadata==2.1.3; python_version <= '3.6'
-importlib-metadata==4.8.3; python_version >= '3.7'
+colorama==0.4.5
+importlib-metadata==4.8.3
 mock==2.0.0
 more-itertools==4.0.0
 # pytz: covered in direct deps for installation
@@ -50,24 +47,21 @@ virtualenv==20.23.0; python_version >= '3.12'
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==5.0
 pytest-cov==2.7.0
-# handled by dev-requirements.txt: git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls==3.3.0; python_version >= '3.5'
+coveralls==3.3.0
 
 # Safety CI by pyup.io
-# Safety is run only on Python >=3.7
-safety==3.0.1; python_version >= '3.7'
-
-safety-schemas==0.0.1; python_version >= '3.7'
+safety==3.0.1
+safety-schemas==0.0.1
 # TODO: Change to dparse 0.6.4 once released
-dparse==0.6.4b0; python_version >= '3.7'
-ruamel.yaml==0.17.21; python_version >= '3.7'
-click==8.0.2; python_version >= '3.7'
-Authlib==1.2.0; python_version >= '3.7'
-marshmallow==3.15.0; python_version >= '3.7'
-pydantic==1.10.13; python_version >= '3.7'
-typer==0.12.0; python_version >= '3.7'
-typer-cli==0.12.0; python_version >= '3.7'
-typer-slim==0.12.0; python_version >= '3.7'
+dparse==0.6.4b0
+ruamel.yaml==0.17.21
+click==8.0.2
+Authlib==1.2.0
+marshmallow==3.15.0
+pydantic==1.10.13
+typer==0.12.0
+typer-cli==0.12.0
+typer-slim==0.12.0
 
 # Tox
 tox==3.1.0
@@ -75,39 +69,36 @@ tox==3.1.0
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==7.1.0; python_version == '3.8'
 Sphinx==7.2.0; python_version >= '3.9'
-docutils==0.18.1; python_version >= '3.8'
-sphinx-git==10.1.1; python_version >= '3.8'
-GitPython==3.1.41; python_version >= '3.8'
-Pygments==2.15.0; python_version >= '3.8'
-sphinx-rtd-theme==2.0.0; python_version >= '3.8'
-sphinxcontrib-applehelp==1.0.4; python_version >= '3.8'
-sphinxcontrib-devhelp==1.0.2; python_version >= '3.8'
-sphinxcontrib-htmlhelp==2.0.1; python_version >= '3.8'
-sphinxcontrib-jquery==4.1; python_version >= '3.8'
-sphinxcontrib-jsmath==1.0.1; python_version >= '3.8'
-sphinxcontrib-qthelp==1.0.3; python_version >= '3.8'
+docutils==0.18.1
+sphinx-git==10.1.1
+GitPython==3.1.41
+Pygments==2.15.0
+sphinx-rtd-theme==2.0.0
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-jquery==4.1
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5; python_version == '3.8'
 sphinxcontrib-serializinghtml==1.1.9; python_version >= '3.9'
-sphinxcontrib-websupport==1.2.4; python_version >= '3.8'
-autodocsumm==0.2.12; python_version >= '3.8'
-Babel==2.9.1; python_version >= '3.8'
+sphinxcontrib-websupport==1.2.4
+autodocsumm==0.2.12
+Babel==2.9.1
 
 # PyLint (no imports, invoked via pylint script):
-pylint==2.6.2; python_version == '3.5'
-pylint==2.13.0; python_version >= '3.6' and python_version <= '3.10'
+pylint==2.13.0; python_version <= '3.10'
 pylint==2.15.0; python_version >= '3.11'
-astroid==2.4.2; python_version == '3.5'
-astroid==2.11.0; python_version >= '3.6' and python_version <= '3.10'
+astroid==2.11.0; python_version <= '3.10'
 astroid==2.12.4; python_version >= '3.11'
-typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
-lazy-object-proxy==1.4.3; python_version >= '3.5'
-wrapt==1.12; python_version >= '3.5' and python_version <= '3.10'
+lazy-object-proxy==1.4.3
+wrapt==1.12; python_version <= '3.10'
 wrapt==1.14; python_version >= '3.11'
-platformdirs==2.2.0; python_version >= '3.6' and python_version <= '3.11'
+platformdirs==2.2.0; python_version <= '3.11'
 platformdirs==3.2.0; python_version >= '3.12'
 isort==4.3.8
-tomlkit==0.10.1; python_version >= '3.7'
-dill==0.2; python_version >= '3.6' and python_version <= '3.10'
+tomlkit==0.10.1
+dill==0.2; python_version <= '3.10'
 dill==0.3.6; python_version >= '3.11'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
@@ -120,57 +111,34 @@ pycodestyle==2.9.0; python_version >= '3.10'
 pyflakes==2.2.0; python_version <= '3.9'
 pyflakes==2.5.0; python_version >= '3.10'
 entrypoints==0.3.0
-functools32==3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
 # Twine (no imports, invoked via twine script):
-twine==1.8.1; python_version <= '3.5'
-twine==3.0.0; python_version >= '3.6'
+twine==3.0.0
 readme-renderer==23.0
 pywin32-ctypes==0.2.0; sys_platform=="win32"
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
-notebook==4.3.1; python_version <= '3.5'
-notebook==6.4.10; python_version == '3.6'
-notebook==6.4.12; python_version >= '3.7'
+notebook==6.4.12
 jupyter==1.0.0
-jupyter-console==5.2.0; python_version == '2.7'
-jupyter-console==5.2.0; python_version >= '3.5'
-ipywidgets==5.2.2; python_version <= '3.6'
-ipywidgets==5.2.2; python_version >= '3.7'
-nbconvert==5.0.0; python_version <= '3.6'
-nbconvert==6.0.0; python_version >= '3.7'
-nbclient==0.5.9; python_version == '3.6'
-nbclient==0.5.9; python_version >= '3.7'
-nbformat==4.2.0; python_version <= '3.5'
-nbformat==5.0.2; python_version >= '3.6'
-qtconsole==4.7.0; python_version <= '3.5'
-qtconsole==5.0.1; python_version == '3.6'
-qtconsole==5.4.0; python_version >= '3.7'
-ipykernel==4.5.2; python_version <= '3.6'
-ipykernel==4.5.2; python_version >= '3.7'
-jupyter-client==5.3.4; python_version <= '3.5'
-jupyter-client==6.1.5; python_version >= '3.6'
-jupyterlab-widgets==0.6.15; python_version <= '3.5'
-jupyterlab-widgets==1.0.2; python_version == '3.6'
-jupyterlab-widgets==1.0.2; python_version >= '3.7'
-jupyterlab-pygments==0.1.0; python_version <= '3.6'
-jupyterlab-pygments==0.2.0; python_version >= '3.7'
-jupyter-core==4.6.1; python_version <= '3.5'
-jupyter-core==4.6.1; python_version == '3.6'
-jupyter-core==4.11.2; python_version >= '3.7'
+jupyter-console==5.2.0
+ipywidgets==5.2.2
+nbconvert==6.0.0
+nbclient==0.5.9
+nbformat==5.0.2
+qtconsole==5.4.0
+ipykernel==4.5.2
+jupyter-client==6.1.5
+jupyterlab-widgets==1.0.2
+jupyterlab-pygments==0.2.0
+jupyter-core==4.11.2
 ipython-genutils==0.2.0
-ipython==5.1.0; python_version <= '3.6'
-ipython==5.1.0; python_version >= '3.7'
+ipython==5.1.0
 
 # Pywin32 is used (at least?) by jupyter.
-pywin32==222; sys_platform == 'win32' and python_version == '2.7'
-pywin32==301; sys_platform == 'win32' and python_version == '3.5'
-pywin32==303; sys_platform == 'win32' and python_version >= '3.6' and python_version <= '3.11'
+pywin32==303; sys_platform == 'win32' and python_version <= '3.11'
 pywin32==306; sys_platform == 'win32' and python_version >= '3.12'
 
-pyzmq==17.1.3; python_version <= '3.5'
-pyzmq==23.0.0; python_version >= '3.6' and python_version <= '3.7'
-pyzmq==24.0.0; python_version >= '3.8' and python_version <= '3.11'
+pyzmq==24.0.0; python_version <= '3.11'
 pyzmq==25.1.1; python_version >= '3.12'
 
 # Aditional dependencies of examples
@@ -179,8 +147,7 @@ progressbar2==3.12.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.2.0
-pip-check-reqs==2.3.2; python_version >= '3.5' and python_version <= '3.7'
-pip-check-reqs==2.4.3; python_version >= '3.8' and python_version <= '3.11'
+pip-check-reqs==2.4.3; python_version <= '3.11'
 pip-check-reqs==2.5.1; python_version >= '3.12'
 
 # pywinpty is used by terminado <- notebook <- jupyter
@@ -193,44 +160,35 @@ alabaster==0.7.9
 anyio==3.1.0
 appdirs==1.4.3
 appnope==0.1.0
-argon2-cffi==21.2.0; python_version >= '3.6'
+argon2-cffi==21.2.0
 args==0.1.0
 atomicwrites==1.4.0
 backports-abc==0.5
-backports.functools-lru-cache==1.5; python_version < "3.3"
 backports.shutil-get-terminal-size==1.0.0
 backports.ssl-match-hostname==3.5.0.1
 bleach==3.3.0
-# tox 4.0.0 started using cachetools and requires cachetools>=5.2
-cachetools==5.2.0; python_version >= '3.7'
-# Click is used only by safety (which is run only on Python >=3.6)
-Click==8.0.2; python_version >= '3.6'
+cachetools==5.2.0
+Click==8.0.2
 clint==0.5.1
 configparser==4.0.2
-# dataclasses is used by safety>=2.3.1 and argon-cffi
-dataclasses==0.8; python_version >= '3.6'
-# defusedxml is used by sphinx.testing and nbconvert
+dataclasses==0.8
 defusedxml==0.7.1
 distlib==0.3.6
-enum34==1.1.6; python_version < "3.4"
 filelock==3.2.0; python_version <= "3.11"
 filelock==3.11.0; python_version >= "3.12"
-gitdb==4.0.8; python_version >= '3.7'
+gitdb==4.0.8
 gitdb2==2.0.0
 html5lib==1.1
 imagesize==1.3.0
 importlib-resources==1.4.0
-jedi==0.17.2; python_version >= '3.5'
-Jinja2==2.11.3; python_version <= '3.5'
-Jinja2==3.0.3; python_version == '3.6'
-Jinja2==3.1.3; python_version >= '3.7'
+jedi==0.17.2
+Jinja2==3.1.3
 keyring==18.0.0
 lxml==4.9.2
-MarkupSafe==1.1.1; python_version <= '3.5'
-MarkupSafe==2.0.0; python_version >= '3.6'
+MarkupSafe==2.0.0
 # nbconvert 6.x depends on mistune<2 and >=0.8.1 (mistune 0.8.4 is the highest version that satisfies that)
 mistune==0.8.4
-nest-asyncio==1.5.4; python_version >= '3.5'
+nest-asyncio==1.5.4
 # nose is used by older versions of notebook, e.g. 4.3.1
 nose==1.3.7
 pandocfilters==1.4.1
@@ -239,40 +197,29 @@ pexpect==4.3.1
 pickleshare==0.7.4
 pkginfo==1.4.2
 # tox 4.0.0 started using pyproject-api and requires pyproject-api>=1.2.1
-pyproject-api==1.2.1; python_version >= '3.7'
+pyproject-api==1.2.1
 # build is using pyproject-hooks
-pyproject-hooks==1.0.0; python_version >= '3.7'
-prometheus-client==0.12; python_version <= '3.5'
-prometheus-client==0.13.1; python_version >= '3.6'
+pyproject-hooks==1.0.0
+prometheus-client==0.13.1
 ptyprocess==0.5.1
 py==1.11.0
-pyparsing==2.4.7; python_version <= '3.5'
-pyparsing==3.0.7; python_version >= '3.6'
+pyparsing==3.0.7
 rfc3986==1.4.0
-rich==12.0.0; python_version >= '3.6'
+rich==12.0.0
 scandir==1.9.0
 Send2Trash==1.8.0
 simplegeneric==0.8.1
-singledispatch==3.4.0.3; python_version < "3.4"
 smmap2==2.0.1
 sniffio==1.3.0
 snowballstemmer==2.0.0
 terminado==0.8.3
 testpath==0.3
 toml==0.10.0
-# tomli 2.0.0 removed support for py36
-tomli==1.1.0; python_version == '3.6'
-tomli==2.0.1; python_version >= '3.7'
-tornado==4.2.1; python_version == '2.7'
-tornado==6.1; python_version >= '3.5' and python_version <= '3.7'
-tornado==6.4.1; python_version >= '3.8'
-tqdm==4.11.2; python_version <= '3.5'
-tqdm==4.14; python_version >= '3.6'
-traitlets==4.3.1; python_version <= '3.6'
-traitlets==5.4; python_version >= '3.7'
+tomli==2.0.1
+tornado==6.4.1
+tqdm==4.66.3
+traitlets==5.4
 typing==3.6.1
-typing-extensions==3.10.0; python_version <= '3.6'
-typing-extensions==4.7.1; python_version >= '3.7'
+typing-extensions==4.7.1
 webencodings==0.5.1
-widgetsnbextension==1.2.6; python_version <= '3.6'
-widgetsnbextension==4.0.0; python_version >= '3.7'
+widgetsnbextension==4.0.0

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -15,10 +15,13 @@
 # Direct dependencies for development and indirect dependencies for development
 # that are needed for some reason (must be consistent with dev-requirements.txt)
 
+# six (only needed by packages that still support Python 2)
+six==1.16.0
+
 # PEP517 package builder, used in Makefile
 build==1.0.0
 # build requires virtualenv.cli_run which was added in virtualenv 20.1
-virtualenv==20.23.0
+virtualenv==20.25.0
 pyproject-hooks==1.1.0
 
 # Change log
@@ -29,7 +32,7 @@ click-default-group==1.2.4
 # Unit test (imports into testcases):
 # Note: pytest is covered in minimum-constraints-install.txt
 testfixtures==6.9.0
-colorama==0.4.5
+colorama==0.4.6
 importlib-metadata==4.8.3
 more-itertools==4.0.0
 # pytz: covered in direct deps for installation
@@ -47,7 +50,7 @@ coveralls==3.3.0
 
 # Safety CI by pyup.io
 safety==3.0.1
-safety-schemas==0.0.1
+safety-schemas==0.0.2
 # TODO: Change to dparse 0.6.4 once released
 dparse==0.6.4b0
 ruamel.yaml==0.17.21
@@ -60,7 +63,7 @@ typer-cli==0.12.0
 typer-slim==0.12.0
 
 # Tox
-tox==3.1.0
+tox==4.15.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==7.1.0; python_version == '3.8'
@@ -87,7 +90,7 @@ pylint==2.15.0
 astroid==2.12.4
 lazy-object-proxy==1.4.3
 wrapt==1.14
-platformdirs==3.2.0
+platformdirs==4.1.0
 isort==4.3.8
 tomlkit==0.10.1
 dill==0.3.6
@@ -134,8 +137,8 @@ progressbar2==3.12.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.2.0
-pip-check-reqs==2.4.3; python_version <= '3.11'
-pip-check-reqs==2.5.1; python_version >= '3.12'
+pip-check-reqs==2.4.3; python_version <= '3.8'
+pip-check-reqs==2.5.1; python_version >= '3.9'
 
 # pywinpty is used by terminado <- notebook <- jupyter
 pywinpty==0.5; os_name == "nt"
@@ -154,14 +157,14 @@ backports-abc==0.5
 backports.shutil-get-terminal-size==1.0.0
 backports.ssl-match-hostname==3.5.0.1
 bleach==3.3.0
-cachetools==5.2.0
+cachetools==5.3.2
 Click==8.0.2
 clint==0.5.1
 configparser==4.0.2
 dataclasses==0.8
 defusedxml==0.7.1
-distlib==0.3.6
-filelock==3.11.0
+distlib==0.3.7
+filelock==3.13.1
 gitdb==4.0.8
 gitdb2==2.0.0
 html5lib==1.1
@@ -182,8 +185,7 @@ pathlib2==2.3.3
 pexpect==4.3.1
 pickleshare==0.7.4
 pkginfo==1.4.2
-# tox 4.0.0 started using pyproject-api and requires pyproject-api>=1.2.1
-pyproject-api==1.2.1
+pyproject-api==1.6.1  # used by tox since its 4.0.0
 prometheus-client==0.13.1
 ptyprocess==0.5.1
 py==1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,16 +9,11 @@
 decorator>=4.0.11
 
 # pytz 2019.1 fixes an ImportError for collections.Mapping on Python 3.10
-pytz>=2016.10; python_version <= '3.9'
-pytz>=2019.1; python_version >= '3.10'
+pytz>=2019.1
 
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six
 requests>=2.31.0
-
-# six 1.16.0 removes the ImportWarning raised by Python 3.10
-six>=1.14.0; python_version <= '3.9'
-six>=1.16.0; python_version >= '3.10'
 
 stomp-py>=8.1.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,7 @@
 
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
-# decorator 5.0.0 removes support for Python 2.7 and 3.4
-decorator>=4.0.11,<5.0; python_version == '2.7'
-decorator>=4.0.11; python_version >= '3.5'
+decorator>=4.0.11
 
 # pytz 2019.1 fixes an ImportError for collections.Mapping on Python 3.10
 pytz>=2016.10; python_version <= '3.9'
@@ -16,26 +14,13 @@ pytz>=2019.1; python_version >= '3.10'
 
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six
-requests>=2.25.0; python_version <= '3.5'
-requests>=2.26.0; python_version == '3.6'
-requests>=2.31.0; python_version >= '3.7'
+requests>=2.31.0
 
 # six 1.16.0 removes the ImportWarning raised by Python 3.10
 six>=1.14.0; python_version <= '3.9'
 six>=1.16.0; python_version >= '3.10'
 
-# stomp-py 5.0.0 (now deleted) and 6.0.0 removed support for Python 2.7, 3.4 and 3.5
-# stomp-py<6.0.0 did not declare supported Python versions
-# stomp-py 6.1.0 on Pypi contained older code than v6.1.0 in the repo -> was yanked
-# stomp-py 6.1.1 broke compatibility -> was yanked (and re-released as 7.0.0)
-# stomp-py 7.0.0 changed the interface of the listener methods incompatibly, and requires Python >=3.6
-# stomp-py 8.0.0 removed the use_ssl parameter of stomp.Connection. set_ssl() can be used instead.
-# stomp-py 8.0.0 cannot be imported due to an issue
-# stomp-py 8.1.1 changed __version__ from tuple to string
-# stomp-py versions 7.0.0 - 8.1.0 cause test failures.
-stomp-py>=4.1.23,<5.0.0; python_version <= '3.5'
-stomp-py>=4.1.23,<7.0.0,!=6.1.0,!=6.1.1; python_version == '3.6'
-stomp-py>=8.1.1; python_version >= '3.7'
+stomp-py>=8.1.1
 
 python-dateutil>=2.8.2
 immutable-views>=0.6.0
@@ -43,23 +28,18 @@ nocasedict>=1.0.2
 
 # PyYAML pulled in by zhmcclient_mock (and zhmcclient examples, and python-coveralls)
 # PyYAML 5.3 fixes narrow build error
-# PyYAML 5.4 removed support for py35
-# PyYAML 6.0 removed support for py27
 # PyYAML 5.3 has wheel archives for Python 2.7, 3.5 - 3.9
 # PyYAML 5.4 has wheel archives for Python 2.7, 3.6 - 3.9
 # PyYAML 6.0 has wheel archives for Python 3.6 - 3.11
 # PyYAML 5.4 and 6.0.0 fails install since Cython 3 was released, see issue
 #   https://github.com/yaml/pyyaml/issues/724.
-PyYAML>=5.3.1; python_version <= '3.5'
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version >= '3.6' and python_version <= '3.11'
+PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version <= '3.11'
 PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
 
 # yamlloader pulled in by zhmcclient_mock and zhmcclient.testutils
-# yamlloader 1.0 removed support for py27,35
 yamlloader>=0.5.5
 
 # jsonschema pulled in by zhmcclient_mock and zhmcclient.testutils
-# jsonschema 4.0 removed support for py27,35,36
 # jsonschema 4.0.0 was yanked (and does not install), but older pip versions don't recognize that
 # jsonschema is also used by jupyter and requires >=3.0.1
 # jsonschema 3.0.1 and 3.0.2 may cause pkg_resources.DistributionNotFound; fixed in 3.1.0.
@@ -71,10 +51,7 @@ jsonschema>=3.1.0,!=4.0.0
 # Since we changed to use the allowed_methods attribute introduced in urllib3
 # 1.26.0, and our minimum version of requests (2.25.0) only requires
 # urllib3>=1.21.0, we need to require a minimum version of urllib3.
-# urllib3 1.26.10 removed support for py35
-urllib3>=1.26.18; python_version == '2.7'
-urllib3>=1.26.9; python_version == '3.5'
-urllib3>=1.26.18; python_version >= '3.6'
+urllib3>=1.26.18
 
 # pyrsistent is used by jsonschema>=3.0
 # pyrsistent 0.15.0 started using the FileNotFoundError built-in exception that

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_version(version_file):
     a fresh Python environment).
     """
     # pylint: disable=unspecified-encoding
-    with open(version_file, 'r') as fp:
+    with open(version_file) as fp:
         version_source = fp.read()
     _globals = {}
     exec(version_source, _globals)  # pylint: disable=exec-used
@@ -46,7 +46,7 @@ def get_requirements(requirements_file):
     characters.
     """
     # pylint: disable=unspecified-encoding
-    with open(requirements_file, 'r') as fp:
+    with open(requirements_file) as fp:
         lines = fp.readlines()
     reqs = []
     for line in lines:
@@ -61,7 +61,7 @@ def read_file(a_file):
     Read the specified file and return its content as one string.
     """
     # pylint: disable=unspecified-encoding
-    with open(a_file, 'r') as fp:
+    with open(a_file) as fp:
         content = fp.read()
     return content
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ dependency_links = [req for req in requirements
 package_version = get_version(os.path.join('zhmcclient', '_version.py'))
 
 # Docs on setup():
-# * https://docs.python.org/2.7/distutils/apiref.html?
+# * https://docs.python.org/3.8/distutils/apiref.html?
 #   highlight=setup#distutils.core.setup
 # * https://setuptools.readthedocs.io/en/latest/setuptools.html#
 #   new-and-changed-setup-keywords
@@ -125,7 +125,7 @@ setuptools.setup(
     # Keep these Python versions in sync with:
     # - Section "Supported environments" in docs/intro.rst
     # - Version checking in zhmcclient/_version.py
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -133,12 +133,7 @@ setuptools.setup(
         'Intended Audience :: Information Technology',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -63,10 +63,10 @@ def assert_resources(resources, exp_resources, prop_names):
     """
 
     # Assert the resource URIs
-    uris = set([res.uri for res in resources])
-    exp_uris = set([res.uri for res in exp_resources])
+    uris = {res.uri for res in resources}
+    exp_uris = {res.uri for res in exp_resources}
     assert uris == exp_uris, \
-        "Unexpected URIs: got: {}, expected: {}".format(uris, exp_uris)
+        f"Unexpected URIs: got: {uris}, expected: {exp_uris}"
 
     for res in resources:
 
@@ -147,17 +147,17 @@ def print_logger(logger):
     """
     Debug function that prints the relevant settings of a Python logger.
     """
-    print("Debug: Logger {!r}:".format(logger.name))
+    print(f"Debug: Logger {logger.name!r}:")
     print("Debug:   logger level: {} ({})"
           .format(logger.level, logging.getLevelName(logger.level)))
     if not logger.handlers:
         print("Debug:   No handlers")
     for handler in logger.handlers:
-        print("Debug:   Handler {}:".format(type(handler)))
+        print(f"Debug:   Handler {type(handler)}:")
         print("Debug:     handler level: {} ({})"
               .format(handler.level, logging.getLevelName(handler.level)))
         _fmt = getattr(handler.formatter, '_fmt', None)
-        print("Debug:     handler format: {!r}".format(_fmt))
+        print(f"Debug:     handler format: {_fmt!r}")
 
 
 def setup_logging():

--- a/tests/end2end/test_activation_profile.py
+++ b/tests/end2end/test_activation_profile.py
@@ -18,7 +18,6 @@ End2end tests for activation profiles (with CPCs in classic mode).
 These tests do not change any activation profiles.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 
@@ -62,7 +61,7 @@ def standard_activation_profile_props(cpc, profile_name, profile_type):
     actprof_input_props = {
         'profile-name': profile_name,
         'description': (
-            '{} profile for zhmcclient end2end tests'.format(profile_type)),
+            f'{profile_type} profile for zhmcclient end2end tests'),
     }
     if profile_type == 'image':
         # We provide the minimum set of properties needed to create a profile.
@@ -106,11 +105,11 @@ def test_actprof_crud(classic_mode_cpcs, profile_type):  # noqa: F811
 
         actprof_mgr = getattr(cpc, profile_type + '_activation_profiles')
 
-        msg = "Testing on CPC {c}".format(c=cpc.name)
+        msg = f"Testing on CPC {cpc.name}"
         print(msg)
         logger.info(msg)
 
-        actprof_name = 'ZHMC{}1'.format(profile_type[0].upper())
+        actprof_name = f'ZHMC{profile_type[0].upper()}1'
 
         # Preparation: Ensure clean starting point for this test
         try:
@@ -138,13 +137,13 @@ def test_actprof_crud(classic_mode_cpcs, profile_type):  # noqa: F811
         try:
             for pn, exp_value in actprof_input_props.items():
                 assert actprof.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
             actprof.pull_full_properties()
             for pn, exp_value in actprof_input_props.items():
                 if pn == 'profile-name':
                     pn = 'name'
                 assert actprof.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
 
             # Test updating a property of the activation profile
 

--- a/tests/end2end/test_adapter.py
+++ b/tests/end2end/test_adapter.py
@@ -19,7 +19,6 @@ These tests do not change any existing adapters, but create, modify
 and delete Hipersocket adapters.
 """
 
-from __future__ import absolute_import, print_function
 
 import uuid
 import warnings
@@ -126,7 +125,7 @@ def test_adapter_hs_crud(dpm_mode_cpcs):  # noqa: F811
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         adapter_name = TEST_PREFIX + ' test_adapter_crud adapter1'
         adapter_name_new = adapter_name + ' new'
@@ -167,14 +166,14 @@ def test_adapter_hs_crud(dpm_mode_cpcs):  # noqa: F811
 
         for pn, exp_value in adapter_input_props.items():
             assert adapter.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         adapter.pull_full_properties()
         for pn, exp_value in adapter_input_props.items():
             assert adapter.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         for pn, exp_value in adapter_auto_props.items():
             assert adapter.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
 
         # Test updating a property of the adapter
 
@@ -255,7 +254,7 @@ def test_adapter_list_assigned_part(dpm_mode_cpcs):  # noqa: F811
         try:
 
             # Create a temporary partition for test purposes
-            part_name = "{}_{}".format(TEST_PREFIX, uuid.uuid4().hex)
+            part_name = f"{TEST_PREFIX}_{uuid.uuid4().hex}"
             part_props = standard_partition_props(cpc, part_name)
             tmp_part = cpc.partitions.create(part_props)
 
@@ -285,7 +284,7 @@ def test_adapter_list_assigned_part(dpm_mode_cpcs):  # noqa: F811
                         vswitch = vswitches[0]
 
                         # Create a NIC in the temporary partition
-                        nic_name = "{}_{}".format(family, uuid.uuid4().hex)
+                        nic_name = f"{family}_{uuid.uuid4().hex}"
                         nic_props = {
                             'name': nic_name,
                             'virtual-switch-uri': vswitch.uri,
@@ -319,7 +318,7 @@ def test_adapter_list_assigned_part(dpm_mode_cpcs):  # noqa: F811
                         test_port = test_adapter.ports.list()[0]
 
                         # Create a NIC in the temporary partition
-                        nic_name = "{}_{}".format(family, uuid.uuid4().hex)
+                        nic_name = f"{family}_{uuid.uuid4().hex}"
                         nic_props = {
                             'name': nic_name,
                             'network-adapter-port-uri': test_port.uri,
@@ -398,7 +397,7 @@ def test_adapter_list_assigned_part(dpm_mode_cpcs):  # noqa: F811
                         before_parts = test_adapter.list_assigned_partitions()
 
                         # Create a VF in the temporary partition
-                        vf_name = "{}_{}".format(family, uuid.uuid4().hex)
+                        vf_name = f"{family}_{uuid.uuid4().hex}"
                         vf_props = {
                             'name': vf_name,
                             'adapter-uri': test_adapter.uri,
@@ -459,16 +458,16 @@ def test_adapter_list_assigned_part(dpm_mode_cpcs):  # noqa: F811
                             format(c=cpc.name), UserWarning)
 
                 elif family == 'nvme':
-                    print("TODO: Implement test for family {}".format(family))
+                    print(f"TODO: Implement test for family {family}")
 
                 elif family == 'coupling':
-                    print("TODO: Implement test for family {}".format(family))
+                    print(f"TODO: Implement test for family {family}")
 
                 elif family == 'ism':
-                    print("TODO: Implement test for family {}".format(family))
+                    print(f"TODO: Implement test for family {family}")
 
                 elif family == 'zhyperlink':
-                    print("TODO: Implement test for family {}".format(family))
+                    print(f"TODO: Implement test for family {family}")
 
         finally:
             # Cleanup
@@ -510,7 +509,7 @@ def base_adapter_id(adapter_id, family):
         # Calculate the base PCHID for the slot.
         base_pchid = pchid // 4 * 4
 
-    return '{:03x}'.format(base_pchid)
+    return f'{base_pchid:03x}'
 
 
 def test_adapter_list_sibling_adapters(dpm_mode_cpcs):  # noqa: F811
@@ -555,15 +554,15 @@ def test_adapter_list_sibling_adapters(dpm_mode_cpcs):  # noqa: F811
 
             assert isinstance(sibling_adapters, list)
 
-            sibling_ids = set([a.get_property('adapter-id')
-                               for a in sibling_adapters])
+            sibling_ids = {a.get_property('adapter-id')
+                               for a in sibling_adapters}
             sibling_names = [a.name for a in sibling_adapters]
             if base_id not in adapters_by_base:
                 exp_ids = set()
                 exp_names = []
             else:
-                exp_ids = set([a.get_property('adapter-id')
-                               for a in adapters_by_base[base_id]])
+                exp_ids = {a.get_property('adapter-id')
+                               for a in adapters_by_base[base_id]}
                 exp_ids.remove(adapter_id)
                 exp_names = [a.name for a in adapters_by_base[base_id]]
                 exp_names.remove(adapter.name)
@@ -705,4 +704,4 @@ def test_adapter_list_permitted(
                             format(cn=cpc.name, cv=cpc.prop('se-version')))
                     else:
                         assert pname in actual_pnames, \
-                            "Actual adapter: {a!r}".format(a=adapter)
+                            f"Actual adapter: {adapter!r}"

--- a/tests/end2end/test_adapter.py
+++ b/tests/end2end/test_adapter.py
@@ -555,14 +555,14 @@ def test_adapter_list_sibling_adapters(dpm_mode_cpcs):  # noqa: F811
             assert isinstance(sibling_adapters, list)
 
             sibling_ids = {a.get_property('adapter-id')
-                               for a in sibling_adapters}
+                           for a in sibling_adapters}
             sibling_names = [a.name for a in sibling_adapters]
             if base_id not in adapters_by_base:
                 exp_ids = set()
                 exp_names = []
             else:
                 exp_ids = {a.get_property('adapter-id')
-                               for a in adapters_by_base[base_id]}
+                           for a in adapters_by_base[base_id]}
                 exp_ids.remove(adapter_id)
                 exp_names = [a.name for a in adapters_by_base[base_id]]
                 exp_names.remove(adapter.name)

--- a/tests/end2end/test_auto_update.py
+++ b/tests/end2end/test_auto_update.py
@@ -19,7 +19,6 @@ These tests use partitions to test the auto-updating of resources. They do not
 change any existing partitions, but create, modify and delete test partitions.
 """
 
-from __future__ import absolute_import, print_function
 
 import uuid
 from time import sleep
@@ -53,9 +52,9 @@ def test_autoupdate_prop(dpm_mode_cpcs):  # noqa: F811
             pytest.skip("Auto-update test requires notifications which are "
                         "not supported by zhmcclient_mock")
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
-        part_name = "{}_{}".format(TEST_PREFIX, uuid.uuid4().hex)
+        part_name = f"{TEST_PREFIX}_{uuid.uuid4().hex}"
 
         # Create the partition
         part_input_props = standard_partition_props(cpc, part_name)
@@ -226,19 +225,19 @@ def test_autoupdate_list(dpm_mode_cpcs):  # noqa: F811
         session = cpc.manager.session
         hd = session.hmc_definition
 
-        new_part_name = "{}_{}".format(TEST_PREFIX, uuid.uuid4().hex)
+        new_part_name = f"{TEST_PREFIX}_{uuid.uuid4().hex}"
 
         # Get the initial set of partitions, for later comparison
         initial_part_list = cpc.partitions.list()
         if not initial_part_list:
             skip_warn("No partitions on CPC {c} managed by HMC {h}".
                       format(c=cpc.name, h=hd.host))
-        initial_part_names = set([p.name for p in initial_part_list])
+        initial_part_names = {p.name for p in initial_part_list}
 
         # Enable auto-updating on partition manager and check partition list
         cpc.partitions.enable_auto_update()
         part_list = cpc.partitions.list()
-        part_names = set([p.name for p in part_list])
+        part_names = {p.name for p in part_list}
         assert part_names == initial_part_names
 
         try:
@@ -247,34 +246,34 @@ def test_autoupdate_list(dpm_mode_cpcs):  # noqa: F811
             new_part_input_props = standard_partition_props(cpc, new_part_name)
             new_part = cpc.partitions.create(new_part_input_props)
             part_list = cpc.partitions.list()
-            part_names = set([p.name for p in part_list])
-            exp_part_names = initial_part_names | set([new_part.name])
+            part_names = {p.name for p in part_list}
+            exp_part_names = initial_part_names | {new_part.name}
             assert part_names == exp_part_names
 
             # Delete the partition and check partition list
             new_part.delete()
             part_list = cpc.partitions.list()
-            part_names = set([p.name for p in part_list])
+            part_names = {p.name for p in part_list}
             assert part_names == initial_part_names
 
             # Disable auto-updating on partition manager and check part. list
             cpc.partitions.disable_auto_update()
             part_list = cpc.partitions.list()
-            part_names = set([p.name for p in part_list])
+            part_names = {p.name for p in part_list}
             assert part_names == initial_part_names
 
             # Create a partition and check partition list
             new_part_input_props = standard_partition_props(cpc, new_part_name)
             new_part = cpc.partitions.create(new_part_input_props)
             part_list = cpc.partitions.list()
-            part_names = set([p.name for p in part_list])
-            exp_part_names = initial_part_names | set([new_part.name])
+            part_names = {p.name for p in part_list}
+            exp_part_names = initial_part_names | {new_part.name}
             assert part_names == exp_part_names
 
             # Delete the partition and check partition list
             new_part.delete()
             part_list = cpc.partitions.list()
-            part_names = set([p.name for p in part_list])
+            part_names = {p.name for p in part_list}
             assert part_names == initial_part_names
 
         finally:

--- a/tests/end2end/test_capacity_group.py
+++ b/tests/end2end/test_capacity_group.py
@@ -19,7 +19,6 @@ These tests do not change any existing capacity groups, but create, modify and
 delete test capacity groups.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -120,7 +119,7 @@ def test_capgrp_crud(dpm_mode_cpcs):  # noqa: F811
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         capgrp_name = TEST_PREFIX + ' test_capgrp_crud capgrp1'
         capgrp_name_new = capgrp_name + ' new'
@@ -163,14 +162,14 @@ def test_capgrp_crud(dpm_mode_cpcs):  # noqa: F811
 
         for pn, exp_value in capgrp_input_props.items():
             assert capgrp.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         capgrp.pull_full_properties()
         for pn, exp_value in capgrp_input_props.items():
             assert capgrp.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         for pn, exp_value in capgrp_auto_props.items():
             assert capgrp.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
 
         # Test updating a property of the capacity group
 

--- a/tests/end2end/test_certificates.py
+++ b/tests/end2end/test_certificates.py
@@ -16,7 +16,6 @@
 End2end tests for Certificates.
 """
 
-from __future__ import absolute_import, print_function
 
 import pytest
 from requests.packages import urllib3
@@ -90,7 +89,7 @@ def test_cert_crud(all_cpcs):  # noqa: F811
     for cpc in all_cpcs:
         skipif_no_secure_boot_feature(cpc)
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         console = cpc.manager.console
         assert console == console.certificates.console
@@ -108,14 +107,14 @@ def test_cert_crud(all_cpcs):  # noqa: F811
 
         for pn, exp_value in cert_input_props.items():
             assert cert.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         cert.pull_full_properties()
         for pn, exp_value in cert_input_props.items():
             assert cert.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         for pn, exp_value in cert_auto_props.items():
             assert cert.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
 
         # Test get_encoded()
         assert cert.get_encoded()['certificate'] == encoded
@@ -149,7 +148,7 @@ def test_cert_crud(all_cpcs):  # noqa: F811
 
         # The code to be tested
         if cpc.dpm_enabled:
-            print("Testing for DPM on CPC {c}".format(c=cpc.name))
+            print(f"Testing for DPM on CPC {cpc.name}")
 
             part_name = cert_name_new + " partition"
             part = cpc.partitions.create(

--- a/tests/end2end/test_console.py
+++ b/tests/end2end/test_console.py
@@ -18,7 +18,6 @@ End2end tests for the single console object.
 These tests do not change the console object.
 """
 
-from __future__ import absolute_import, print_function
 
 from requests.packages import urllib3
 

--- a/tests/end2end/test_cpc.py
+++ b/tests/end2end/test_cpc.py
@@ -18,7 +18,6 @@ End2end tests for CPCs.
 These tests do not change any CPC properties.
 """
 
-from __future__ import absolute_import, print_function
 
 from datetime import timedelta, datetime, timezone
 import pytest
@@ -96,7 +95,7 @@ def test_cpc_find_list(hmc_session):  # noqa: F811
     hd = hmc_session.hmc_definition
 
     for cpc_name in hd.cpcs:
-        print("Testing with CPC {c}".format(c=cpc_name))
+        print(f"Testing with CPC {cpc_name}")
 
         cpc_list_props = CPC_LIST_PROPS
         se_version = hd.cpcs[cpc_name].get('se_version', None)
@@ -119,7 +118,7 @@ def test_cpc_property(all_cpcs):  # noqa: F811
         pytest.skip("HMC definition does not include any CPCs")
 
     for cpc in all_cpcs:
-        print("Testing with CPC {c}".format(c=cpc.name))
+        print(f"Testing with CPC {cpc.name}")
 
         client = cpc.manager.client
 
@@ -143,7 +142,7 @@ def test_cpc_features(all_cpcs):  # noqa: F811
         pytest.skip("HMC definition does not include any CPCs")
 
     for cpc in all_cpcs:
-        print("Testing with CPC {c}".format(c=cpc.name))
+        print(f"Testing with CPC {cpc.name}")
 
         cpc.pull_full_properties()
         cpc_mach_type = cpc.properties.get('machine-type', None)
@@ -246,7 +245,7 @@ def test_cpc_export_profiles(classic_mode_cpcs):  # noqa: F811
         session = cpc.manager.session
         hd = session.hmc_definition
 
-        print("Testing with CPC {c}".format(c=cpc.name))
+        print(f"Testing with CPC {cpc.name}")
 
         try:
 
@@ -281,7 +280,7 @@ def test_cpc_export_dpm_config(dpm_mode_cpcs):  # noqa: F811
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         cert, cert_props = (None, None)
         if has_api_feature('secure-boot-with-certificates', cpc):
@@ -369,7 +368,7 @@ def test_cpc_get_sustainability_data(
         session = cpc.manager.session
         hd = session.hmc_definition
 
-        print("Testing with CPC {c}".format(c=cpc.name))
+        print(f"Testing with CPC {cpc.name}")
 
         try:
 
@@ -410,7 +409,7 @@ def test_cpc_get_sustainability_data(
                 dp_timestamp_dt = dp_item['timestamp']
 
                 assert isinstance(dp_data, metric_type), \
-                    "Invalid data type for metric {!r}".format(metric_name)
+                    f"Invalid data type for metric {metric_name!r}"
 
                 if first_item:
                     first_item = False

--- a/tests/end2end/test_group.py
+++ b/tests/end2end/test_group.py
@@ -19,7 +19,6 @@ These tests do not change any existing groups, but create, modify and delete
 groups for testing purposes.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -59,11 +58,11 @@ def test_group_find_list(hmc_session):  # noqa: F811
     # Pick the groups to test with
     group_list = console.groups.list()
     if not group_list:
-        skip_warn("No groups defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No groups defined on HMC {hd.host}")
     group_list = pick_test_resources(group_list)
 
     for group in group_list:
-        print("Testing with group {g!r}".format(g=group.name))
+        print(f"Testing with group {group.name!r}")
         runtest_find_list(
             hmc_session, console.groups, group.name, 'name',
             'object-uri', GROUP_VOLATILE_PROPS, GROUP_MINIMAL_PROPS,
@@ -83,7 +82,7 @@ def test_group_crud(hmc_session):  # noqa: F811
 
     # TODO: Get group issue on T224 HMC resolved.
     if hd.host == '9.114.87.7':
-        skip_warn("Issues with group support on HMC {h}".format(h=hd.host))
+        skip_warn(f"Issues with group support on HMC {hd.host}")
 
     group_name = TEST_PREFIX + ' test_group_crud group'
 
@@ -122,14 +121,14 @@ def test_group_crud(hmc_session):  # noqa: F811
 
         for pn, exp_value in group_input_props.items():
             assert group.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         group.pull_full_properties()
         for pn, exp_value in group_input_props.items():
             assert group.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         for pn, exp_value in group_auto_props.items():
             assert group.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
 
         # Add a member
         cpc = client.cpcs.list()[0]

--- a/tests/end2end/test_hba.py
+++ b/tests/end2end/test_hba.py
@@ -19,7 +19,6 @@ These tests do not change any existing partitions or HBAs, but create, modify
 and delete test partitions with HBAs.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -131,7 +130,7 @@ def test_hba_crud(dpm_mode_cpcs):  # noqa: F811
         assert cpc.dpm_enabled
         skipif_storage_mgmt_feature(cpc)
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         part_name = TEST_PREFIX + ' test_hba_crud part1'
         hba_name = 'hba1'
@@ -181,14 +180,14 @@ def test_hba_crud(dpm_mode_cpcs):  # noqa: F811
 
             for pn, exp_value in hba_input_props.items():
                 assert hba.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
             hba.pull_full_properties()
             for pn, exp_value in hba_input_props.items():
                 assert hba.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
             for pn, exp_value in hba_auto_props.items():
                 assert hba.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
 
             # Test updating a property of the HBA
 

--- a/tests/end2end/test_hmc_inventory.py
+++ b/tests/end2end/test_hmc_inventory.py
@@ -17,7 +17,6 @@ End2end tests for testing whether the HMCs in the HMC inventory file match
 reality.
 """
 
-from __future__ import absolute_import, print_function
 
 from requests.packages import urllib3
 import pytest
@@ -47,7 +46,7 @@ def test_hmcdef_cpcs(hmc_session):  # noqa: F811
     for cpc_name in hd.cpcs:
         def_cpc_props = dict(hd.cpcs[cpc_name])
 
-        print("Checking CPC {c}".format(c=cpc_name))
+        print(f"Checking CPC {cpc_name}")
 
         assert cpc_name in cpc_names, \
             "CPC {c} defined in inventory file for HMC {n!r} at {h} is not " \
@@ -107,7 +106,7 @@ def test_hmcdef_check_all_hmcs():
     for hd in hd_list:
 
         if hd.mock_file:
-            print("Skipping mocked HMC {n!r}".format(n=hd.nickname))
+            print(f"Skipping mocked HMC {hd.nickname!r}")
             continue
 
         for cpc_name in hd.cpcs:

--- a/tests/end2end/test_ldap_server_definition.py
+++ b/tests/end2end/test_ldap_server_definition.py
@@ -19,7 +19,6 @@ These tests do not change any existing LDAP server definitions, but create,
 modify and delete test LDAP server definitions.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -171,14 +170,14 @@ def test_ldapsrvdef_crud(hmc_session):  # noqa: F811
 
     for pn, exp_value in ldapsrvdef_input_props.items():
         assert ldapsrvdef.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     ldapsrvdef.pull_full_properties()
     for pn, exp_value in ldapsrvdef_input_props.items():
         assert ldapsrvdef.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     for pn, exp_value in ldapsrvdef_auto_props.items():
         assert ldapsrvdef.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
 
     # Test updating a property of the LDAP server definition
 

--- a/tests/end2end/test_lpar.py
+++ b/tests/end2end/test_lpar.py
@@ -19,7 +19,6 @@ These tests do not change any existing LPARs, but create, modify and delete
 test LPARs.
 """
 
-from __future__ import absolute_import, print_function
 
 import random
 from datetime import timedelta, datetime, timezone
@@ -831,7 +830,7 @@ def test_lpar_get_sustainability_data(
         session = lpar.manager.session
         hd = session.hmc_definition
 
-        print("Testing with LPAR {n}".format(n=lpar.name))
+        print(f"Testing with LPAR {lpar.name}")
 
         try:
 
@@ -873,7 +872,7 @@ def test_lpar_get_sustainability_data(
                 dp_timestamp_dt = dp_item['timestamp']
 
                 assert isinstance(dp_data, metric_type), \
-                    "Invalid data type for metric {!r}".format(metric_name)
+                    f"Invalid data type for metric {metric_name!r}"
 
                 if first_item:
                     first_item = False

--- a/tests/end2end/test_nic.py
+++ b/tests/end2end/test_nic.py
@@ -19,7 +19,6 @@ These tests do not change any existing partitions or NICs, but create, modify
 and delete test partitions with NICs.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import random
@@ -134,7 +133,7 @@ def test_nic_crud(dpm_mode_cpcs):  # noqa: F811
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         hs_adapter_name = TEST_PREFIX + ' test_nic_crud adapter1'
         part_name = TEST_PREFIX + ' test_nic_crud part1'
@@ -202,14 +201,14 @@ def test_nic_crud(dpm_mode_cpcs):  # noqa: F811
 
             for pn, exp_value in nic_input_props.items():
                 assert nic.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
             nic.pull_full_properties()
             for pn, exp_value in nic_input_props.items():
                 assert nic.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
             for pn, exp_value in nic_auto_props.items():
                 assert nic.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
 
             # Test updating a property of the NIC
 

--- a/tests/end2end/test_partition.py
+++ b/tests/end2end/test_partition.py
@@ -19,7 +19,6 @@ These tests do not change any existing partitions, but create, modify and delete
 test partitions.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import random
@@ -128,7 +127,7 @@ def test_part_crud(dpm_mode_cpcs):  # noqa: F811
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         part_name = TEST_PREFIX + ' test_part_crud part1'
         part_name_new = part_name + ' new'
@@ -171,14 +170,14 @@ def test_part_crud(dpm_mode_cpcs):  # noqa: F811
 
         for pn, exp_value in part_input_props.items():
             assert part.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         part.pull_full_properties()
         for pn, exp_value in part_input_props.items():
             assert part.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
         for pn, exp_value in part_auto_props.items():
             assert part.properties[pn] == exp_value, \
-                "Unexpected value for property {!r}".format(pn)
+                f"Unexpected value for property {pn!r}"
 
         # Test updating a property of the partition
 
@@ -388,7 +387,7 @@ def test_console_list_permitted_partitions(desc, input_kwargs, exp_props,
                 # The property is supposed to be in the result
                 actual_pnames = list(partition.properties.keys())
                 assert pname in actual_pnames, \
-                    "Actual partition: {p!r}".format(p=partition)
+                    f"Actual partition: {partition!r}"
 
         # Test list permitted partitions with filtering
         permitted_partitions_filter_agrs = (console.list_permitted_partitions(
@@ -483,7 +482,7 @@ def test_part_get_sustainability_data(
         session = part.manager.session
         hd = session.hmc_definition
 
-        print("Testing with partition {n}".format(n=part.name))
+        print(f"Testing with partition {part.name}")
 
         try:
 
@@ -525,7 +524,7 @@ def test_part_get_sustainability_data(
                 dp_timestamp_dt = dp_item['timestamp']
 
                 assert isinstance(dp_data, metric_type), \
-                    "Invalid data type for metric {!r}".format(metric_name)
+                    f"Invalid data type for metric {metric_name!r}"
 
                 if first_item:
                     first_item = False

--- a/tests/end2end/test_password_rule.py
+++ b/tests/end2end/test_password_rule.py
@@ -19,7 +19,6 @@ These tests do not change any existing password rules, but create,
 modify and delete test password rules.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -64,11 +63,11 @@ def test_pwrule_find_list(hmc_session):  # noqa: F811
     # Pick the password rules to test with
     pwrule_list = console.password_rules.list()
     if not pwrule_list:
-        skip_warn("No password rules defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No password rules defined on HMC {hd.host}")
     pwrule_list = pick_test_resources(pwrule_list)
 
     for pwrule in pwrule_list:
-        print("Testing with password rule {r!r}".format(r=pwrule.name))
+        print(f"Testing with password rule {pwrule.name!r}")
         runtest_find_list(
             hmc_session, console.password_rules, pwrule.name, 'name',
             'element-uri', PWRULE_VOLATILE_PROPS, PWRULE_MINIMAL_PROPS,
@@ -94,11 +93,11 @@ def test_pwrule_property(hmc_session):  # noqa: F811
     # Pick the password rules to test with
     pwrule_list = console.password_rules.list()
     if not pwrule_list:
-        skip_warn("No password rules defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No password rules defined on HMC {hd.host}")
     pwrule_list = pick_test_resources(pwrule_list)
 
     for pwrule in pwrule_list:
-        print("Testing with password rule {r!r}".format(r=pwrule.name))
+        print(f"Testing with password rule {pwrule.name!r}")
 
         # Select a property that is not returned by list()
         non_list_prop = 'description'
@@ -162,14 +161,14 @@ def test_pwrule_crud(hmc_session):  # noqa: F811
 
     for pn, exp_value in pwrule_input_props.items():
         assert pwrule.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     pwrule.pull_full_properties()
     for pn, exp_value in pwrule_input_props.items():
         assert pwrule.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     for pn, exp_value in pwrule_auto_props.items():
         assert pwrule.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
 
     # Test updating a property of the password rule
 

--- a/tests/end2end/test_port.py
+++ b/tests/end2end/test_port.py
@@ -19,7 +19,6 @@ These tests do not change any existing ports, but create and delete Hipersocket
 adapters and modify their ports.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -128,7 +127,7 @@ def test_port_update(dpm_mode_cpcs):  # noqa: F811
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         adapter_name = TEST_PREFIX + ' test_adapter_crud adapter1'
 

--- a/tests/end2end/test_storage_group.py
+++ b/tests/end2end/test_storage_group.py
@@ -19,7 +19,6 @@ These tests do not change any existing storage groups, but create, modify and
 delete test storage groups.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -125,7 +124,7 @@ def test_stogrp_crud(dpm_mode_cpcs):  # noqa: F811
         assert cpc.dpm_enabled
         skipif_no_storage_mgmt_feature(cpc)
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         console = cpc.manager.client.consoles.console
         stogrp_name = TEST_PREFIX + ' test_stogrp_crud stogrp1'

--- a/tests/end2end/test_storage_group_template.py
+++ b/tests/end2end/test_storage_group_template.py
@@ -19,7 +19,6 @@ These tests do not change any existing storage group templates, but create,
 modify and delete test storage group templates.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -129,7 +128,7 @@ def test_stogrptpl_crud(dpm_mode_cpcs):  # noqa: F811
         assert cpc.dpm_enabled
         skipif_no_storage_mgmt_feature(cpc)
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         console = cpc.manager.client.consoles.console
         stogrptpl_name = TEST_PREFIX + ' test_stogrptpl_crud stogrptpl1'

--- a/tests/end2end/test_storage_volume.py
+++ b/tests/end2end/test_storage_volume.py
@@ -19,7 +19,6 @@ These tests do not change any existing storage volumes, but create, modify and
 delete test storage volumes.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -157,7 +156,7 @@ def test_stovol_crud(dpm_mode_cpcs):  # noqa: F811
         assert cpc.dpm_enabled
         skipif_no_storage_mgmt_feature(cpc)
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         console = cpc.manager.client.consoles.console
 

--- a/tests/end2end/test_storage_volume_template.py
+++ b/tests/end2end/test_storage_volume_template.py
@@ -19,7 +19,6 @@ These tests do not change any existing storage volume templates, but create,
 modify and delete test storage volume templates.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -142,7 +141,7 @@ def test_stovoltpl_crud(dpm_mode_cpcs):  # noqa: F811
         assert cpc.dpm_enabled
         skipif_no_storage_mgmt_feature(cpc)
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         console = cpc.manager.client.consoles.console
 

--- a/tests/end2end/test_task.py
+++ b/tests/end2end/test_task.py
@@ -18,7 +18,6 @@ End2end tests for tasks (on CPCs in DPM mode).
 These tests do not change any existing tasks.
 """
 
-from __future__ import absolute_import, print_function
 
 from requests.packages import urllib3
 
@@ -64,7 +63,7 @@ def test_task_find_list(hmc_session):  # noqa: F811
     task_list = pick_test_resources(task_list)
 
     for task in task_list:
-        print("Testing with task {t!r}".format(t=task.name))
+        print(f"Testing with task {task.name!r}")
         runtest_find_list(
             hmc_session, console.tasks, task.name, 'name', 'element-uri',
             TASK_VOLATILE_PROPS, TASK_MINIMAL_PROPS, TASK_LIST_PROPS)
@@ -92,7 +91,7 @@ def test_task_property(hmc_session):  # noqa: F811
     task_list = pick_test_resources(task_list)
 
     for task in task_list:
-        print("Testing with task {t!r}".format(t=task.name))
+        print(f"Testing with task {task.name!r}")
 
         # Select a property that is not returned by list()
         non_list_prop = 'description'

--- a/tests/end2end/test_user.py
+++ b/tests/end2end/test_user.py
@@ -19,7 +19,6 @@ These tests do not change any existing users, but create,
 modify and delete test users.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -64,11 +63,11 @@ def test_user_find_list(hmc_session):  # noqa: F811
     # Pick the users to test with
     user_list = console.users.list()
     if not user_list:
-        skip_warn("No users defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No users defined on HMC {hd.host}")
     user_list = pick_test_resources(user_list)
 
     for user in user_list:
-        print("Testing with user {u!r}".format(u=user.name))
+        print(f"Testing with user {user.name!r}")
         runtest_find_list(
             hmc_session, console.users, user.name, 'name',
             'object-uri', USER_VOLATILE_PROPS, USER_MINIMAL_PROPS,
@@ -94,11 +93,11 @@ def test_user_property(hmc_session):  # noqa: F811
     # Pick the users to test with
     user_list = console.users.list()
     if not user_list:
-        skip_warn("No users defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No users defined on HMC {hd.host}")
     user_list = pick_test_resources(user_list)
 
     for user in user_list:
-        print("Testing with user {u!r}".format(u=user.name))
+        print(f"Testing with user {user.name!r}")
 
         # Select a property that is not returned by list()
         non_list_prop = 'description'
@@ -184,16 +183,16 @@ def test_user_crud(hmc_session):  # noqa: F811
         if pn == 'password':
             continue
         assert user.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     user.pull_full_properties()
     for pn, exp_value in user_input_props.items():
         if pn == 'password':
             continue
         assert user.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     for pn, exp_value in user_auto_props.items():
         assert user.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
 
     # Test updating a property of the user
 

--- a/tests/end2end/test_user_pattern.py
+++ b/tests/end2end/test_user_pattern.py
@@ -19,7 +19,6 @@ These tests do not change any existing user patterns, but create,
 modify and delete test user patterns.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -64,11 +63,11 @@ def test_upatt_find_list(hmc_session):  # noqa: F811
     # Pick the user patterns to test with
     upatt_list = console.user_patterns.list()
     if not upatt_list:
-        skip_warn("No user patterns defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No user patterns defined on HMC {hd.host}")
     upatt_list = pick_test_resources(upatt_list)
 
     for upatt in upatt_list:
-        print("Testing with user pattern {p!r}".format(p=upatt.name))
+        print(f"Testing with user pattern {upatt.name!r}")
         runtest_find_list(
             hmc_session, console.user_patterns, upatt.name, 'name',
             'element-uri', UPATT_VOLATILE_PROPS, UPATT_MINIMAL_PROPS,
@@ -94,11 +93,11 @@ def test_upatt_property(hmc_session):  # noqa: F811
     # Pick the user patterns to test with
     upatt_list = console.user_patterns.list()
     if not upatt_list:
-        skip_warn("No user patterns defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No user patterns defined on HMC {hd.host}")
     upatt_list = pick_test_resources(upatt_list)
 
     for upatt in upatt_list:
-        print("Testing with user pattern {p!r}".format(p=upatt.name))
+        print(f"Testing with user pattern {upatt.name!r}")
 
         # Select a property that is not returned by list()
         non_list_prop = 'description'
@@ -139,7 +138,7 @@ def test_upatt_crud(hmc_session):  # noqa: F811
     # Pick a template user to be the template user for the user pattern
     template_users = console.users.findall(type='template')
     if not template_users:
-        skip_warn("No template users on HMC {h}".format(h=hd.host))
+        skip_warn(f"No template users on HMC {hd.host}")
     template_user = template_users[0]
 
     # Test creating the user pattern
@@ -167,14 +166,14 @@ def test_upatt_crud(hmc_session):  # noqa: F811
 
     for pn, exp_value in upatt_input_props.items():
         assert upatt.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     upatt.pull_full_properties()
     for pn, exp_value in upatt_input_props.items():
         assert upatt.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     for pn, exp_value in upatt_auto_props.items():
         assert upatt.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
 
     # Test updating a property of the user pattern
 

--- a/tests/end2end/test_user_role.py
+++ b/tests/end2end/test_user_role.py
@@ -19,7 +19,6 @@ These tests do not change any existing user roles, but create,
 modify and delete test user roles.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -64,11 +63,11 @@ def test_urole_find_list(hmc_session):  # noqa: F811
     # Pick the user roles to test with
     urole_list = console.user_roles.list()
     if not urole_list:
-        skip_warn("No user roles defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No user roles defined on HMC {hd.host}")
     urole_list = pick_test_resources(urole_list)
 
     for urole in urole_list:
-        print("Testing with user role {r!r}".format(r=urole.name))
+        print(f"Testing with user role {urole.name!r}")
         runtest_find_list(
             hmc_session, console.user_roles, urole.name, 'name',
             'object-uri', UROLE_VOLATILE_PROPS, UROLE_MINIMAL_PROPS,
@@ -94,11 +93,11 @@ def test_urole_property(hmc_session):  # noqa: F811
     # Pick the user roles to test with
     urole_list = console.user_roles.list()
     if not urole_list:
-        skip_warn("No user roles defined on HMC {h}".format(h=hd.host))
+        skip_warn(f"No user roles defined on HMC {hd.host}")
     urole_list = pick_test_resources(urole_list)
 
     for urole in urole_list:
-        print("Testing with user role {r!r}".format(r=urole.name))
+        print(f"Testing with user role {urole.name!r}")
 
         # Select a property that is not returned by list()
         non_list_prop = 'description'
@@ -161,14 +160,14 @@ def test_urole_crud(hmc_session):  # noqa: F811
 
     for pn, exp_value in urole_input_props.items():
         assert urole.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     urole.pull_full_properties()
     for pn, exp_value in urole_input_props.items():
         assert urole.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
     for pn, exp_value in urole_auto_props.items():
         assert urole.properties[pn] == exp_value, \
-            "Unexpected value for property {!r}".format(pn)
+            f"Unexpected value for property {pn!r}"
 
     # Test updating a property of the user role
 

--- a/tests/end2end/test_virtual_function.py
+++ b/tests/end2end/test_virtual_function.py
@@ -19,7 +19,6 @@ These tests do not change any existing partitions or virtual functions, but
 create, modify and delete test partitions with virtual functions.
 """
 
-from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
@@ -135,7 +134,7 @@ def test_vfunc_crud(dpm_mode_cpcs):  # noqa: F811
         session = cpc.manager.session
         hd = session.hmc_definition
 
-        print("Testing on CPC {c}".format(c=cpc.name))
+        print(f"Testing on CPC {cpc.name}")
 
         part_name = TEST_PREFIX + ' test_vfunc_crud part1'
         vfunc_name = 'vfunc1'
@@ -184,14 +183,14 @@ def test_vfunc_crud(dpm_mode_cpcs):  # noqa: F811
 
             for pn, exp_value in vfunc_input_props.items():
                 assert vfunc.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
             vfunc.pull_full_properties()
             for pn, exp_value in vfunc_input_props.items():
                 assert vfunc.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
             for pn, exp_value in vfunc_auto_props.items():
                 assert vfunc.properties[pn] == exp_value, \
-                    "Unexpected value for property {!r}".format(pn)
+                    f"Unexpected value for property {pn!r}"
 
             # Test updating a property of the virtual function
 

--- a/tests/end2end/test_virtual_switch.py
+++ b/tests/end2end/test_virtual_switch.py
@@ -18,7 +18,6 @@ End2end tests for virtual switches (on CPCs in DPM mode).
 These tests do not change any existing virtual switches.
 """
 
-from __future__ import absolute_import, print_function
 
 import pytest
 from requests.packages import urllib3

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -16,7 +16,6 @@
 Utility functions for end2end tests.
 """
 
-from __future__ import absolute_import, print_function
 
 import os
 import re
@@ -439,7 +438,7 @@ def runtest_get_properties(
     resource = random.choice(resources)
 
     local_pnames = set(resource.properties.keys())
-    local_pnames_plus = local_pnames | set([non_list_prop])
+    local_pnames_plus = local_pnames | {non_list_prop}
 
     # Validate that the non_list_prop property is not listed.
     # This is really just checking that the testcase was invoked correctly.
@@ -454,7 +453,7 @@ def runtest_get_properties(
     for pname in local_pnames:
         _ = resource.get_property(pname)
         assert resource.full_properties is False, \
-            "resource={!r}".format(resource)
+            f"resource={resource!r}"
         current_pnames = set(resource.properties.keys())
         assert current_pnames == local_pnames, \
             "current_pnames={!r}, local_pnames={!r}". \
@@ -464,7 +463,7 @@ def runtest_get_properties(
     for pname in local_pnames:
         _ = resource.prop(pname)
         assert resource.full_properties is False, \
-            "resource={!r}".format(resource)
+            f"resource={resource!r}"
         current_pnames = set(resource.properties.keys())
         assert current_pnames == local_pnames, \
             "current_pnames={!r}, local_pnames={!r}". \
@@ -473,7 +472,7 @@ def runtest_get_properties(
     # Validate that get_property() on non_list_prop pulls full properties
     _ = resource.get_property(non_list_prop)
     assert resource.full_properties is True, \
-        "resource={!r}".format(resource)
+        f"resource={resource!r}"
     current_pnames = set(resource.properties.keys())
     assert current_pnames > local_pnames_plus, \
         "current_pnames={!r}, local_pnames_plus={!r}". \
@@ -487,7 +486,7 @@ def runtest_get_properties(
     resource = random.choice(resources)
 
     local_pnames = set(resource.properties.keys())
-    local_pnames_plus = local_pnames | set([non_list_prop])
+    local_pnames_plus = local_pnames | {non_list_prop}
 
     # Validate initial state of the resource w.r.t. properties
     assert resource.full_properties is False
@@ -510,11 +509,11 @@ def runtest_get_properties(
             "current_pnames={!r}, local_pnames_plus={!r}". \
             format(current_pnames, local_pnames_plus)
         assert resource.full_properties is False, \
-            "resource={!r}".format(resource)
+            f"resource={resource!r}"
     else:
         # We get the full set of properties
         assert resource.full_properties is True, \
-            "resource={!r}".format(resource)
+            f"resource={resource!r}"
 
     # Part 3: Third chunk of methods to be tested
 
@@ -572,9 +571,9 @@ def validate_list_features(api_version, all_features, regex_reduced_features):
         expected_features = ['cpc-install-and-activate']
         for feature in expected_features:
             assert feature in all_features, \
-                '{} missing from {}'.format(feature, all_features)
+                f'{feature} missing from {all_features}'
             assert feature in regex_reduced_features, \
-                '{} missing from {}'.format(feature, regex_reduced_features)
+                f'{feature} missing from {regex_reduced_features}'
 
         # Ensure pattern matching using 'cpc.*' worked
         assert len(regex_reduced_features) < len(all_features)
@@ -680,7 +679,7 @@ def standard_partition_props(cpc, part_name):
         part_input_props['cp-processors'] = 1
         pc_names = filter(lambda p: p.startswith('processor-count-'),
                           cpc.properties.keys())
-        pc_list = ["{n}={v}".format(n=n, v=cpc.properties[n]) for n in pc_names]
+        pc_list = [f"{n}={cpc.properties[n]}" for n in pc_names]
         warnings.warn(
             "CPC {c} shows neither IFL nor CP processors, specifying 1 CP "
             "for partition creation. "

--- a/tests/installtest/test_install.sh
+++ b/tests/installtest/test_install.sh
@@ -171,14 +171,6 @@ function make_virtualenv()
     pip list --format=columns 2>/dev/null || pip list 2>/dev/null
   fi
 
-  # We ensure that Pip is at least at 10.0.1 to have support for the features used in the requirements
-  # and constraints files (e.g. implementation_name)
-  pip_version=$(pip --version | sed -e 's/pip \([0-9.]*\) .*/\1/')
-  if [[ $pip_version =~ (^[1-9]\..*) ]]; then
-    run "pip install 'pip==10.0.1'" "Upgrading pip $pip_version to 10.0.1"
-    run "pip --version"
-  fi
-
   run "pip install pip $PIP_OPTS" "Reinstalling pip with PACKAGE_LEVEL=$PACKAGE_LEVEL"
   run "pip install setuptools $PIP_OPTS" "Reinstalling setuptools with PACKAGE_LEVEL=$PACKAGE_LEVEL"
   run "pip install wheel $PIP_OPTS" "Reinstalling wheel with PACKAGE_LEVEL=$PACKAGE_LEVEL"

--- a/tests/unit/test_example.py
+++ b/tests/unit/test_example.py
@@ -16,7 +16,6 @@
 Example unit test for a user of the zhmcclient package.
 """
 
-from __future__ import absolute_import, print_function
 
 from requests.packages import urllib3
 

--- a/tests/unit/tests/common/test_utils.py
+++ b/tests/unit/tests/common/test_utils.py
@@ -18,7 +18,6 @@
 Unit test cases for the tests/common/utils.py module.
 """
 
-from __future__ import absolute_import, print_function
 
 import pytest
 
@@ -28,7 +27,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestUtilsAssertResources(object):
+class TestUtilsAssertResources:
     """All tests for utils.assert_resources()."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_activation_profile.py
+++ b/tests/unit/zhmcclient/test_activation_profile.py
@@ -16,7 +16,6 @@
 Unit tests for _activation_profile module.
 """
 
-from __future__ import absolute_import, print_function
 
 import copy
 import re
@@ -27,7 +26,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestActivationProfile(object):
+class TestActivationProfile:
     """
     All tests for the ActivationProfile and ActivationProfileManager classes.
     """

--- a/tests/unit/zhmcclient/test_adapter.py
+++ b/tests/unit/zhmcclient/test_adapter.py
@@ -16,7 +16,6 @@
 Unit tests for _adapter module.
 """
 
-from __future__ import absolute_import, print_function
 
 import copy
 import re
@@ -34,7 +33,7 @@ HS2_OID = 'hs2-oid'
 HS2_NAME = 'hs 2'
 
 
-class TestAdapter(object):
+class TestAdapter:
     """All tests for the Adapter and AdapterManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_auto_updater.py
+++ b/tests/unit/zhmcclient/test_auto_updater.py
@@ -16,13 +16,12 @@
 Unit tests for _auto_updater module.
 """
 
-from __future__ import absolute_import, print_function
 
 import time
 import re
 import logging
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from zhmcclient import Client
 from zhmcclient_mock import FakedSession

--- a/tests/unit/zhmcclient/test_auto_updater.py
+++ b/tests/unit/zhmcclient/test_auto_updater.py
@@ -20,8 +20,8 @@ Unit tests for _auto_updater module.
 import time
 import re
 import logging
-import pytest
 from unittest.mock import patch
+import pytest
 
 from zhmcclient import Client
 from zhmcclient_mock import FakedSession

--- a/tests/unit/zhmcclient/test_capacity_group.py
+++ b/tests/unit/zhmcclient/test_capacity_group.py
@@ -16,7 +16,6 @@
 Unit tests for _capacity_group module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -30,7 +29,7 @@ from tests.common.utils import assert_resources
 
 # Object IDs and names of our faked capacity groups:
 CPC_OID = 'fake-cpc1-oid'
-CPC_URI = '/api/cpcs/{}'.format(CPC_OID)
+CPC_URI = f'/api/cpcs/{CPC_OID}'
 CG1_OID = 'cg1-oid'
 CG1_NAME = 'cg 1'
 CG1_SHORT_NAME = 'CG1'
@@ -39,7 +38,7 @@ CG2_NAME = 'cg 2'
 CG2_SHORT_NAME = 'CG2'
 
 
-class TestCapacityGroup(object):
+class TestCapacityGroup:
     """All tests for the CapacityGroup and CapacityGroupManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_client.py
+++ b/tests/unit/zhmcclient/test_client.py
@@ -16,7 +16,6 @@
 Unit tests for _client module.
 """
 
-from __future__ import absolute_import, print_function
 
 import pytest
 

--- a/tests/unit/zhmcclient/test_console.py
+++ b/tests/unit/zhmcclient/test_console.py
@@ -16,7 +16,6 @@
 Unit tests for _console module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import pytest
@@ -28,7 +27,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestConsole(object):
+class TestConsole:
     """All tests for the Console and ConsoleManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_cpc.py
+++ b/tests/unit/zhmcclient/test_cpc.py
@@ -16,7 +16,6 @@
 Unit tests for _cpc module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -370,7 +369,7 @@ def updated(dict1, dict2):
     return dictres
 
 
-class TestCpc(object):
+class TestCpc:
     """All tests for the Cpc and CpcManager classes."""
 
     def setup_method(self):
@@ -449,7 +448,7 @@ class TestCpc(object):
                 'available-features-list': [],
             })
         else:
-            raise ValueError("Invalid value for cpc_name: {}".format(cpc_name))
+            raise ValueError(f"Invalid value for cpc_name: {cpc_name}")
         return faked_cpc
 
     @staticmethod
@@ -2062,7 +2061,7 @@ def test_cpc_install_and_activate(
                 assert result.op_uri == op_uri
             else:
                 raise AssertionError(
-                    "Unexpected HTTP status: {}".format(response_status))
+                    f"Unexpected HTTP status: {response_status}")
 
 
 TESTCASES_CPC_DELETE_RETRIEVED_INTERNAL_CODE = [
@@ -2163,4 +2162,4 @@ def test_delete_retrieved_internal_code(
                 assert result.op_uri == op_uri
             else:
                 raise AssertionError(
-                    "Unexpected HTTP status: {}".format(response_status))
+                    f"Unexpected HTTP status: {response_status}")

--- a/tests/unit/zhmcclient/test_exceptions.py
+++ b/tests/unit/zhmcclient/test_exceptions.py
@@ -18,7 +18,6 @@ Unit tests for _exceptions module.
 
 
 import re
-import six
 import pytest
 
 from zhmcclient import Error, ConnectTimeout, ReadTimeout, \

--- a/tests/unit/zhmcclient/test_exceptions.py
+++ b/tests/unit/zhmcclient/test_exceptions.py
@@ -16,7 +16,6 @@
 Unit tests for _exceptions module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import six
@@ -165,7 +164,7 @@ def test_connectionerror_repr(msg, details):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -206,8 +205,8 @@ def test_connectionerror_str_def(msg, details):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
 
 
 @pytest.mark.parametrize(
@@ -264,7 +263,7 @@ def test_connecttimeout_repr(
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -307,8 +306,8 @@ def test_connecttimeout_str_def(
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
     assert str_def.find(' connect_timeout={!r};'.
                         format(connect_timeout)) >= 0
     assert str_def.find(' connect_retries={!r};'.
@@ -368,7 +367,7 @@ def test_readtimeout_repr(msg, details, read_timeout, read_retries):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -409,10 +408,10 @@ def test_readtimeout_str_def(msg, details, read_timeout, read_retries):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
-    assert str_def.find(' read_timeout={!r};'.format(read_timeout)) >= 0
-    assert str_def.find(' read_retries={!r};'.format(read_retries)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
+    assert str_def.find(f' read_timeout={read_timeout!r};') >= 0
+    assert str_def.find(f' read_retries={read_retries!r};') >= 0
 
 
 @pytest.mark.parametrize(
@@ -467,7 +466,7 @@ def test_retriesexceeded_repr(msg, details, connect_retries):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -508,8 +507,8 @@ def test_retriesexceeded_str_def(msg, details, connect_retries):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
     assert str_def.find(' connect_retries={!r};'.
                         format(connect_retries)) >= 0
 
@@ -563,7 +562,7 @@ def test_clientautherror_repr(msg):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -604,8 +603,8 @@ def test_clientautherror_str_def(msg):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
 
 
 @pytest.mark.parametrize(
@@ -660,7 +659,7 @@ def test_serverautherror_repr(msg, details):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -705,13 +704,13 @@ def test_serverautherror_str_def(msg, details):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
     assert str_def.find(' request_method={!r};'.
                         format(request_method)) >= 0
-    assert str_def.find(' request_uri={!r};'.format(request_uri)) >= 0
-    assert str_def.find(' http_status={!r};'.format(http_status)) >= 0
-    assert str_def.find(' reason={!r};'.format(reason)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' request_uri={request_uri!r};') >= 0
+    assert str_def.find(f' http_status={http_status!r};') >= 0
+    assert str_def.find(f' reason={reason!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
 
 
 @pytest.mark.parametrize(
@@ -770,7 +769,7 @@ def test_parseerror_repr(msg):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -813,10 +812,10 @@ def test_parseerror_str_def(msg):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' line={!r};'.format(exc.line)) >= 0
-    assert str_def.find(' column={!r};'.format(exc.column)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' line={exc.line!r};') >= 0
+    assert str_def.find(f' column={exc.column!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
 
 
 @pytest.mark.parametrize(
@@ -871,7 +870,7 @@ def test_versionerror_repr(msg, min_api_version, api_version):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -912,8 +911,8 @@ def test_versionerror_str_def(msg, min_api_version, api_version):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
     assert str_def.find(' min_api_version={!r};'.
                         format(min_api_version)) >= 0
     assert str_def.find(' api_version={!r};'.
@@ -985,7 +984,7 @@ def test_httperror_repr(body):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -1028,13 +1027,13 @@ def test_httperror_str_def(body):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
     assert str_def.find(' request_method={!r};'.
                         format(request_method)) >= 0
-    assert str_def.find(' request_uri={!r};'.format(request_uri)) >= 0
-    assert str_def.find(' http_status={!r};'.format(http_status)) >= 0
-    assert str_def.find(' reason={!r};'.format(reason)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' request_uri={request_uri!r};') >= 0
+    assert str_def.find(f' http_status={http_status!r};') >= 0
+    assert str_def.find(f' reason={reason!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
 
 
 @pytest.mark.parametrize(
@@ -1088,7 +1087,7 @@ def test_operationtimeout_repr(msg, operation_timeout):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -1129,8 +1128,8 @@ def test_operationtimeout_str_def(msg, operation_timeout):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
     assert str_def.find(' operation_timeout={!r};'.
                         format(operation_timeout)) >= 0
 
@@ -1190,7 +1189,7 @@ def test_statustimeout_repr(
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -1235,8 +1234,8 @@ def test_statustimeout_str_def(
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
     assert str_def.find(' actual_status={!r};'.
                         format(actual_status)) >= 0
     assert str_def.find(' desired_statuses={!r};'.
@@ -1245,7 +1244,7 @@ def test_statustimeout_str_def(
                         format(status_timeout)) >= 0
 
 
-class TestNoUniqueMatch(object):
+class TestNoUniqueMatch:
     """All tests for exception class NoUniqueMatch."""
 
     def setup_method(self):
@@ -1324,7 +1323,7 @@ class TestNoUniqueMatch(object):
 
         assert isinstance(exc, Error)
         assert len(exc.args) == 1
-        assert isinstance(exc.args[0], six.string_types)
+        assert isinstance(exc.args[0], str)
         # auto-generated message, we don't expect a particular value
         assert exc.filter_args == filter_args
         assert exc.manager == manager
@@ -1352,7 +1351,7 @@ class TestNoUniqueMatch(object):
 
         # We check the one-lined string just roughly
         repr_str = repr_str.replace('\n', '\\n')
-        assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+        assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
     @pytest.mark.parametrize(
         "filter_args", [
@@ -1395,10 +1394,10 @@ class TestNoUniqueMatch(object):
         str_def = exc.str_def()
 
         str_def = ' ' + str_def
-        assert str_def.find(' classname={!r};'.format(classname)) >= 0
+        assert str_def.find(f' classname={classname!r};') >= 0
         assert str_def.find(' resource_classname={!r};'.
                             format(manager.resource_class.__name__)) >= 0
-        assert str_def.find(' filter_args={!r};'.format(filter_args)) >= 0
+        assert str_def.find(f' filter_args={filter_args!r};') >= 0
         assert str_def.find(' parent_classname={!r};'.
                             format(manager.parent.__class__.__name__)) >= 0
         assert str_def.find(' parent_name={!r};'.
@@ -1406,7 +1405,7 @@ class TestNoUniqueMatch(object):
         assert str_def.find(' message=') >= 0
 
 
-class NotFoundManagerIndicator(object):
+class NotFoundManagerIndicator:
     # pylint: disable=too-few-public-methods
     """
     Indicator class for the 'manager' argument of NotFound().
@@ -1534,7 +1533,7 @@ TESTCASES_NOTFOUND_INITIAL_ATTRS = [
 ]
 
 
-class TestNotFound(object):
+class TestNotFound:
     """All tests for exception class NotFound."""
 
     def setup_method(self):
@@ -1598,7 +1597,7 @@ class TestNotFound(object):
         # Validate exception message
         assert len(exc.args) == 1
         message = exc.args[0]
-        assert isinstance(message, six.string_types)
+        assert isinstance(message, str)
         if exp_message_pattern:
             assert re.match(exp_message_pattern, message)
 
@@ -1630,7 +1629,7 @@ class TestNotFound(object):
 
         # We check the one-lined string just roughly
         repr_str = repr_str.replace('\n', '\\n')
-        assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+        assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
     @pytest.mark.parametrize(
         "filter_args", [
@@ -1671,10 +1670,10 @@ class TestNotFound(object):
         str_def = exc.str_def()
 
         str_def = ' ' + str_def
-        assert str_def.find(' classname={!r};'.format(classname)) >= 0
+        assert str_def.find(f' classname={classname!r};') >= 0
         assert str_def.find(' resource_classname={!r};'.
                             format(manager.resource_class.__name__)) >= 0
-        assert str_def.find(' filter_args={!r};'.format(filter_args)) >= 0
+        assert str_def.find(f' filter_args={filter_args!r};') >= 0
         assert str_def.find(' parent_classname={!r};'.
                             format(manager.parent.__class__.__name__)) >= 0
         assert str_def.find(' parent_name={!r};'.
@@ -1730,7 +1729,7 @@ def test_notijmserror_repr(msg, jms_headers, jms_message):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -1767,8 +1766,8 @@ def test_notijmserror_str_def(msg, jms_headers, jms_message):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
 
 
 @pytest.mark.parametrize(
@@ -1818,7 +1817,7 @@ def test_notiparseerror_repr(msg, jms_message):
 
     # We check the one-lined string just roughly
     repr_str = repr_str.replace('\n', '\\n')
-    assert re.match(r'^{}\s*\(.*\)$'.format(classname), repr_str)
+    assert re.match(fr'^{classname}\s*\(.*\)$', repr_str)
 
 
 @pytest.mark.parametrize(
@@ -1855,8 +1854,8 @@ def test_notiparseerror_str_def(msg, jms_message):
     str_def = exc.str_def()
 
     str_def = ' ' + str_def
-    assert str_def.find(' classname={!r};'.format(classname)) >= 0
-    assert str_def.find(' message={!r};'.format(msg)) >= 0
+    assert str_def.find(f' classname={classname!r};') >= 0
+    assert str_def.find(f' message={msg!r};') >= 0
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/zhmcclient/test_group.py
+++ b/tests/unit/zhmcclient/test_group.py
@@ -16,7 +16,6 @@
 Unit tests for _group module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import pytest
@@ -26,7 +25,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestGroup(object):
+class TestGroup:
     """All tests for the Group and GroupManager classes."""
 
     def setup_method(self):
@@ -56,12 +55,12 @@ class TestGroup(object):
         Add a faked group object to the faked Console and return it.
         """
         faked_group = self.faked_console.groups.add({
-            'object-id': 'oid-{}'.format(name),
+            'object-id': f'oid-{name}',
             # object-uri will be automatically set
             'parent': None,
             'class': 'group',
             'name': name,
-            'description': 'Group {}'.format(name),
+            'description': f'Group {name}',
         })
         return faked_group
 

--- a/tests/unit/zhmcclient/test_hba.py
+++ b/tests/unit/zhmcclient/test_hba.py
@@ -16,7 +16,6 @@
 Unit tests for _hba module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -36,10 +35,10 @@ HBA2_NAME = 'hba 2'
 # URIs and Object IDs of elements referenced in HBA properties:
 FCP1_OID = 'fake-fcp1-oid'
 PORT11_OID = 'fake-port11-oid'
-PORT11_URI = '/api/adapters/{}/storage-ports/{}'.format(FCP1_OID, PORT11_OID)
+PORT11_URI = f'/api/adapters/{FCP1_OID}/storage-ports/{PORT11_OID}'
 
 
-class TestHba(object):
+class TestHba:
     """All tests for Hba and HbaManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_ldap_server_definition.py
+++ b/tests/unit/zhmcclient/test_ldap_server_definition.py
@@ -16,7 +16,6 @@
 Unit tests for _ldap_srv_def module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -27,7 +26,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestLdapServerDefinition(object):
+class TestLdapServerDefinition:
     """All tests for the LdapServerDefinition and LdapServerDefinitionManager
     classes."""
 
@@ -60,13 +59,13 @@ class TestLdapServerDefinition(object):
         """
 
         faked_ldap_srv_def = self.faked_console.ldap_server_definitions.add({
-            'element-id': 'oid-{}'.format(name),
+            'element-id': f'oid-{name}',
             # element-uri will be automatically set
             'parent': '/api/console',
             'class': 'ldap-server-definition',
             'name': name,
-            'description': 'LDAP Server Definition {}'.format(name),
-            'primary-hostname-ipaddr': 'host-{}'.format(name),
+            'description': f'LDAP Server Definition {name}',
+            'primary-hostname-ipaddr': f'host-{name}',
         })
         return faked_ldap_srv_def
 
@@ -317,7 +316,7 @@ class TestLdapServerDefinition(object):
             assert prop_name in ldap_srv_def.properties
             prop_value = ldap_srv_def.properties[prop_name]
             assert prop_value == exp_prop_value, \
-                "Unexpected value for property {!r}".format(prop_name)
+                f"Unexpected value for property {prop_name!r}"
 
         # Refresh the resource object and verify that the resource object
         # still reflects the property updates.

--- a/tests/unit/zhmcclient/test_logging.py
+++ b/tests/unit/zhmcclient/test_logging.py
@@ -16,7 +16,6 @@
 Unit tests for _logging module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import logging
@@ -74,7 +73,7 @@ def get_decorated_inner2_function():
     return global2_function()
 
 
-class Decorator1Class(object):
+class Decorator1Class:
     # pylint: disable=too-few-public-methods
     """A class that has a decorated method."""
 
@@ -84,7 +83,7 @@ class Decorator1Class(object):
         pass
 
 
-class Decorator2Class(object):
+class Decorator2Class:
     """A class that has a decorated method inside a method."""
 
     @staticmethod
@@ -108,7 +107,7 @@ class Decorator2Class(object):
 # Supporting definitions
 #
 
-class CallerClass(object):
+class CallerClass:
     # pylint: disable=too-few-public-methods
     """
     A supporting class.
@@ -301,7 +300,7 @@ def test_decorated_class():
     with pytest.raises(TypeError):
 
         @logged_api_call
-        class DecoratedClass(object):
+        class DecoratedClass:
             # pylint: disable=too-few-public-methods
             """A decorated class"""
             pass
@@ -313,7 +312,7 @@ def test_decorated_property():
 
     with pytest.raises(TypeError):
 
-        class Class(object):
+        class Class:
             # pylint: disable=too-few-public-methods
             """A class with a decorated property"""
 

--- a/tests/unit/zhmcclient/test_lpar.py
+++ b/tests/unit/zhmcclient/test_lpar.py
@@ -16,11 +16,10 @@
 Unit tests for _lpar module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
-import mock
+from unittest import mock
 import pytest
 import requests_mock
 
@@ -59,7 +58,7 @@ LIST_PERMITTED_LPARS_PROPS = [
 ]
 
 
-class TestLpar(object):
+class TestLpar:
     """All tests for Lpar and LparManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_manager.py
+++ b/tests/unit/zhmcclient/test_manager.py
@@ -18,7 +18,6 @@
 Unit tests for _manager module.
 """
 
-from __future__ import absolute_import, print_function
 
 from datetime import datetime
 import time
@@ -43,7 +42,7 @@ class MyResource(BaseResource):
     # This init method is not part of the external API, so this testcase may
     # need to be updated if the API changes.
     def __init__(self, manager, uri, name=None, properties=None):
-        super(MyResource, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
 
 class MyManager(BaseManager):
@@ -54,7 +53,7 @@ class MyManager(BaseManager):
     # This init method is not part of the external API, so this testcase may
     # need to be updated if the API changes.
     def __init__(self, session, case_insensitive_names=False):
-        super(MyManager, self).__init__(
+        super().__init__(
             resource_class=MyResource,
             class_name='myresource',
             session=session,
@@ -80,7 +79,7 @@ class MyManager(BaseManager):
         return result_list
 
 
-class TestManager0(object):
+class TestManager0:
     """
     Tests for the BaseManager class with no initial resources.
     """
@@ -156,7 +155,7 @@ class TestManager0(object):
         assert res.properties['prop1'] == add_props['prop1']
 
 
-class TestManager1(object):
+class TestManager1:
     """
     Tests for the BaseManager class with one resource.
     """
@@ -237,7 +236,7 @@ class TestManager1(object):
         assert len(wngs) == 1
         wng = wngs[0]
         assert issubclass(wng.category, DeprecationWarning), \
-            "Unexpected warnings class: {}".format(wng.category)
+            f"Unexpected warnings class: {wng.category}"
 
         # Check that on the third find by name, list() is called again, because
         # the cache had been invalidated.
@@ -261,7 +260,7 @@ class TestManager1(object):
             manager.list()
 
 
-class TestManager2(object):
+class TestManager2:
     """
     Tests for the BaseManager class with two resources.
     """
@@ -353,8 +352,8 @@ class TestManager2(object):
         resources = self.manager.findall(same="fake-same")
 
         assert len(resources) == 2
-        assert set([res.uri for res in resources]) == \
-            set([self.resource1.uri, self.resource2.uri])
+        assert {res.uri for res in resources} == \
+            {self.resource1.uri, self.resource2.uri}
 
     def test_findall_str_two_or(self):
         """Test BaseManager.findall() with two resources matching by a
@@ -365,8 +364,8 @@ class TestManager2(object):
                                                 "fake-other-2"])
 
         assert len(resources) == 2
-        assert set([res.uri for res in resources]) == \
-            set([self.resource1.uri, self.resource2.uri])
+        assert {res.uri for res in resources} == \
+            {self.resource1.uri, self.resource2.uri}
 
     def test_findall_int_none(self):
         """Test BaseManager.findall() with no resource matching by a
@@ -393,8 +392,8 @@ class TestManager2(object):
         resources = self.manager.findall(int_same=42)
 
         assert len(resources) == 2
-        assert set([res.uri for res in resources]) == \
-            set([self.resource1.uri, self.resource2.uri])
+        assert {res.uri for res in resources} == \
+            {self.resource1.uri, self.resource2.uri}
 
     def test_find_name_none(self):
         """Test BaseManager.find() with no resource matching by the name
@@ -477,7 +476,7 @@ class TestManager2(object):
         assert resource.name == self.resource2.name
 
 
-class TestNameUriCache(object):
+class TestNameUriCache:
     """All tests for the _NameUriCache class."""
 
     @staticmethod

--- a/tests/unit/zhmcclient/test_metrics.py
+++ b/tests/unit/zhmcclient/test_metrics.py
@@ -16,7 +16,6 @@
 Unit tests for _metrics module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import pytest
@@ -38,7 +37,7 @@ MG2_NAME = 'dpm-system-usage-overview'
 MC_BASE_URI = '/api/services/metrics/context/'
 
 
-class TestMetricsContext(object):
+class TestMetricsContext:
     """All tests for the MetricsContext and MetricsContextManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_nic.py
+++ b/tests/unit/zhmcclient/test_nic.py
@@ -16,7 +16,6 @@
 Unit tests for _nic module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -35,13 +34,13 @@ NIC2_NAME = 'nic 2'
 
 # URIs and Object IDs of elements referenced in NIC properties:
 VSWITCH11_OID = 'fake-vswitch11-oid'
-VSWITCH11_URI = '/api/virtual-switches/{}'.format(VSWITCH11_OID)
+VSWITCH11_URI = f'/api/virtual-switches/{VSWITCH11_OID}'
 ROCE2_OID = 'fake-roce2-oid'
 PORT21_OID = 'fake-port21-oid'
-PORT21_URI = '/api/adapters/{}/network-ports/{}'.format(ROCE2_OID, PORT21_OID)
+PORT21_URI = f'/api/adapters/{ROCE2_OID}/network-ports/{PORT21_OID}'
 
 
-class TestNic(object):
+class TestNic:
     """All tests for Nic and NicManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_notification.py
+++ b/tests/unit/zhmcclient/test_notification.py
@@ -19,14 +19,13 @@ The test strategy is to mock the STOMP messages of the HMC using the
 requests_mock package.
 """
 
-from __future__ import absolute_import, print_function
 
 import json
 import threading
 from collections import namedtuple
 import logging
 import time
-from mock import patch
+from unittest.mock import patch
 import six
 import pytest
 import stomp
@@ -61,7 +60,7 @@ def create_event_args(headers, message):
     return frame_args
 
 
-class MockedStompConnection(object):
+class MockedStompConnection:
     """
     A class that replaces stomp.Connection for the usage scope in the
     zhmcclient._notification module, and that adds the ability to
@@ -158,7 +157,7 @@ class MockedStompConnection(object):
         Adds a STOMP message to the queue.
         """
         assert self._sender_thread is None
-        if not isinstance(message, six.string_types):
+        if not isinstance(message, str):
             message = json.dumps(message)
         self._queued_messages.append((headers, message))
 
@@ -264,7 +263,7 @@ def receive_notifications(receiver):
     return msg_items
 
 
-class TestNotificationOneTopic(object):
+class TestNotificationOneTopic:
     """
     Test class for one notification topic.
     """
@@ -328,7 +327,7 @@ class TestNotificationOneTopic(object):
         assert msg0[1] == message_obj
 
 
-class TestNotificationTwoTopics(object):
+class TestNotificationTwoTopics:
     """
     Test class for two notification topics.
     """
@@ -392,7 +391,7 @@ class TestNotificationTwoTopics(object):
         assert msg0[1] == message_obj
 
 
-class TestNotificationSubscriptionMgmt(object):
+class TestNotificationSubscriptionMgmt:
     """
     Test class for subscription management.
     """

--- a/tests/unit/zhmcclient/test_notification.py
+++ b/tests/unit/zhmcclient/test_notification.py
@@ -26,7 +26,6 @@ from collections import namedtuple
 import logging
 import time
 from unittest.mock import patch
-import six
 import pytest
 import stomp
 

--- a/tests/unit/zhmcclient/test_partition.py
+++ b/tests/unit/zhmcclient/test_partition.py
@@ -16,7 +16,6 @@
 Unit tests for _partition module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -45,7 +44,7 @@ LIST_PERMITTED_PARTITIONS_PROPS = [
 ]
 
 
-class TestPartition(object):
+class TestPartition:
     """All tests for the Partition and PartitionManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_password_rule.py
+++ b/tests/unit/zhmcclient/test_password_rule.py
@@ -16,7 +16,6 @@
 Unit tests for _password_rule module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -27,7 +26,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestPasswordRule(object):
+class TestPasswordRule:
     """All tests for the PasswordRule and PasswordRuleManager classes."""
 
     def setup_method(self):
@@ -57,12 +56,12 @@ class TestPasswordRule(object):
         Add a faked password rule object to the faked Console and return it.
         """
         faked_password_rule = self.faked_console.password_rules.add({
-            'element-id': 'oid-{}'.format(name),
+            'element-id': f'oid-{name}',
             # element-uri will be automatically set
             'parent': '/api/console',
             'class': 'password-rule',
             'name': name,
-            'description': 'Password Rule {}'.format(name),
+            'description': f'Password Rule {name}',
             'type': type_,
         })
         return faked_password_rule
@@ -72,12 +71,12 @@ class TestPasswordRule(object):
         Add a faked user object to the faked Console and return it.
         """
         faked_user = self.faked_console.users.add({
-            'object-id': 'oid-{}'.format(name),
+            'object-id': f'oid-{name}',
             # object-uri will be automatically set
             'parent': '/api/console',
             'class': 'user',
             'name': name,
-            'description': 'User {}'.format(name),
+            'description': f'User {name}',
             'type': type_,
             'authentication-type': 'local',
         })
@@ -330,7 +329,7 @@ class TestPasswordRule(object):
             assert prop_name in password_rule.properties
             prop_value = password_rule.properties[prop_name]
             assert prop_value == exp_prop_value, \
-                "Unexpected value for property {!r}".format(prop_name)
+                f"Unexpected value for property {prop_name!r}"
 
         # Refresh the resource object and verify that the resource object
         # still reflects the property updates.

--- a/tests/unit/zhmcclient/test_port.py
+++ b/tests/unit/zhmcclient/test_port.py
@@ -16,7 +16,6 @@
 Unit tests for _port module.
 """
 
-from __future__ import absolute_import, print_function
 
 # FIXME: Migrate requests_mock to zhmcclient_mock.
 import requests_mock
@@ -24,7 +23,7 @@ import requests_mock
 from zhmcclient import Session, Client
 
 
-class TestPort(object):
+class TestPort:
     """All tests for Port and PortManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_resource.py
+++ b/tests/unit/zhmcclient/test_resource.py
@@ -18,7 +18,6 @@
 Unit tests for _resource module.
 """
 
-from __future__ import absolute_import, print_function
 
 import time
 import re
@@ -43,7 +42,7 @@ class MyResource(BaseResource):
     # need to be updated if the API changes.
     def __init__(self, manager, uri, name, properties):
         # pylint: disable=useless-super-delegation
-        super(MyResource, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
 
 class MyManager(BaseManager):
@@ -57,7 +56,7 @@ class MyManager(BaseManager):
     # This init method is not part of the external API, so this testcase may
     # need to be updated if the API changes.
     def __init__(self, session):
-        super(MyManager, self).__init__(
+        super().__init__(
             resource_class=MyResource,
             class_name='myresource',
             session=session,
@@ -75,7 +74,7 @@ class MyManager(BaseManager):
         raise NotImplementedError
 
 
-class ResourceTestCase(object):
+class ResourceTestCase:
     """
     Base class for all tests in this file.
     """
@@ -466,7 +465,7 @@ class TestManagerDivideFilter(ResourceTestCase):
         parm_str, cf_args = divide_filter_args(
             self.mgr._query_props, filter_args)
 
-        assert parm_str == ['qp1={}'.format(escape_str)]
+        assert parm_str == [f'qp1={escape_str}']
         assert cf_args == {}
 
     def test_one_str_reserved_val_cf(self):
@@ -504,7 +503,7 @@ class TestManagerDivideFilter(ResourceTestCase):
         parm_str, cf_args = divide_filter_args(
             self.mgr._query_props, filter_args)
 
-        assert parm_str == ['{}=bar'.format(escape_str)]
+        assert parm_str == [f'{escape_str}=bar']
         assert cf_args == {}
 
     def test_two_qp(self):
@@ -560,7 +559,7 @@ class TestManagerDivideFilter(ResourceTestCase):
         parm_str, cf_args = divide_filter_args(
             self.mgr._query_props, filter_args)
 
-        assert parm_str == ['qp1=bar', 'qp2=42', 'qp2={}'.format(escape_str)]
+        assert parm_str == ['qp1=bar', 'qp2=42', f'qp2={escape_str}']
         assert cf_args == {}
 
 
@@ -654,10 +653,10 @@ class TestThreadingSerialization(ResourceTestCase):
             exp_value = exp_values[i]
 
             assert value == exp_value, \
-                "Unexpected property value for '{}'".format(name)
+                f"Unexpected property value for '{name}'"
 
 
-class TestPropertyMethodsMocked(object):
+class TestPropertyMethodsMocked:
     """
     All tests of property methods that need mocked resources.
     """

--- a/tests/unit/zhmcclient/test_session.py
+++ b/tests/unit/zhmcclient/test_session.py
@@ -20,9 +20,9 @@ Unit tests for _session module.
 import time
 import json
 import re
+from unittest import mock
 import requests
 import requests_mock
-from unittest import mock
 import pytest
 
 from zhmcclient import Session, ParseError, Job, HTTPError, OperationTimeout, \

--- a/tests/unit/zhmcclient/test_session.py
+++ b/tests/unit/zhmcclient/test_session.py
@@ -16,14 +16,13 @@
 Unit tests for _session module.
 """
 
-from __future__ import absolute_import, print_function
 
 import time
 import json
 import re
 import requests
 import requests_mock
-import mock
+from unittest import mock
 import pytest
 
 from zhmcclient import Session, ParseError, Job, HTTPError, OperationTimeout, \
@@ -81,7 +80,7 @@ def test_session_init(
 
     if use_get_password:
         def get_password(host, userid):
-            pw = 'fake-pw-{}-{}'.format(host, userid)
+            pw = f'fake-pw-{host}-{userid}'
             return pw
     else:
         get_password = None
@@ -112,7 +111,7 @@ def test_session_init(
         assert session.headers['X-API-Session'] == session_id
         assert len(session.headers) == 4
         assert session.actual_host == host
-        base_url = 'https://{}:{!s}'.format(session.actual_host, session.port)
+        base_url = f'https://{session.actual_host}:{session.port!s}'
         assert session.base_url == base_url
 
 
@@ -151,7 +150,7 @@ def test_session_logon(
         if use_get_password:
             get_password = mock.MagicMock()
             get_password.return_value = \
-                'fake-pw-{}-{}'.format(host, userid)
+                f'fake-pw-{host}-{userid}'
         else:
             get_password = None
 
@@ -367,7 +366,7 @@ def test_session_get_error_html_1():
         get_resp_headers = {
             'content-type': get_resp_content_type,
         }
-        get_resp_content = u"""\
+        get_resp_content = """\
 <!doctype html public "-//IETF//DTD HTML 2.0//EN">\
  <html>\
 <head>\

--- a/tests/unit/zhmcclient/test_storage_group.py
+++ b/tests/unit/zhmcclient/test_storage_group.py
@@ -16,7 +16,6 @@
 Unit tests for _storage_group module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -31,14 +30,14 @@ from tests.common.utils import assert_resources
 
 # Object IDs and names of our faked storage groups:
 CPC_OID = 'fake-cpc1-oid'
-CPC_URI = '/api/cpcs/{}'.format(CPC_OID)
+CPC_URI = f'/api/cpcs/{CPC_OID}'
 SG1_OID = 'sg1-oid'
 SG1_NAME = 'sg 1'
 SG2_OID = 'sg2-oid'
 SG2_NAME = 'sg 2'
 
 
-class TestStorageGroup(object):
+class TestStorageGroup:
     """All tests for the StorageGroup and StorageGroupManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/test_task.py
+++ b/tests/unit/zhmcclient/test_task.py
@@ -16,7 +16,6 @@
 Unit tests for _task module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import pytest
@@ -26,7 +25,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestTask(object):
+class TestTask:
     """All tests for the Task and TaskManager classes."""
 
     def setup_method(self):
@@ -56,12 +55,12 @@ class TestTask(object):
         Add a faked task object to the faked Console and return it.
         """
         faked_task = self.faked_console.tasks.add({
-            'element-id': 'oid-{}'.format(name),
+            'element-id': f'oid-{name}',
             # element-uri will be automatically set
             'parent': '/api/console',
             'class': 'task',
             'name': name,
-            'description': 'Task {}'.format(name),
+            'description': f'Task {name}',
             'view-only-mode-supported': view_only,
         })
         return faked_task

--- a/tests/unit/zhmcclient/test_timestats.py
+++ b/tests/unit/zhmcclient/test_timestats.py
@@ -16,7 +16,6 @@
 Unit tests for _timestats module.
 """
 
-from __future__ import absolute_import, print_function
 
 import time
 import pytest
@@ -311,10 +310,10 @@ def test_timestatskeeper_str_one():
 
     s = str(keeper)
     assert s.startswith(PRINT_HEADER), \
-        "Unexpected str(keeper): {!r}".format(s)
+        f"Unexpected str(keeper): {s!r}"
     num_lines = len(s.split('\n'))
     assert num_lines == 3, \
-        "Unexpected str(keeper): {!r}".format(s)
+        f"Unexpected str(keeper): {s!r}"
 
 
 def test_timestats_str():
@@ -325,7 +324,7 @@ def test_timestats_str():
 
     s = str(timestats)
     assert s.startswith("TimeStats:"), \
-        "Unexpected str(timestats): {!r}".format(s)
+        f"Unexpected str(timestats): {s!r}"
     num_lines = len(s.split('\n'))
     assert num_lines == 1, \
-        "Unexpected str(timestats): {!r}".format(s)
+        f"Unexpected str(timestats): {s!r}"

--- a/tests/unit/zhmcclient/test_unmanaged_cpc.py
+++ b/tests/unit/zhmcclient/test_unmanaged_cpc.py
@@ -16,7 +16,6 @@
 Unit tests for _unmanaged_cpc module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import pytest
@@ -26,7 +25,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestUnmanagedCpc(object):
+class TestUnmanagedCpc:
     """All tests for the UnmanagedCpc and UnmanagedCpcManager classes."""
 
     def setup_method(self):
@@ -56,12 +55,12 @@ class TestUnmanagedCpc(object):
         Add a faked unmanaged CPC object to the faked Console and return it.
         """
         faked_unmanaged_cpc = self.faked_console.unmanaged_cpcs.add({
-            'object-id': 'oid-{}'.format(name),
+            'object-id': f'oid-{name}',
             # object-uri will be automatically set
             'parent': '/api/console',
             'class': 'cpc',
             'name': name,
-            'description': 'Unmanaged CPC {}'.format(name),
+            'description': f'Unmanaged CPC {name}',
         })
         return faked_unmanaged_cpc
 

--- a/tests/unit/zhmcclient/test_user.py
+++ b/tests/unit/zhmcclient/test_user.py
@@ -16,7 +16,6 @@
 Unit tests for _user module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -27,7 +26,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestUser(object):
+class TestUser:
     """All tests for the User and UserManager classes."""
 
     def setup_method(self):
@@ -57,12 +56,12 @@ class TestUser(object):
         Add a faked user object to the faked Console and return it.
         """
         faked_user = self.faked_console.users.add({
-            'object-id': 'oid-{}'.format(name),
+            'object-id': f'oid-{name}',
             # object-uri will be automatically set
             'parent': '/api/console',
             'class': 'user',
             'name': name,
-            'description': 'User {}'.format(name),
+            'description': f'User {name}',
             'type': type_,
             'authentication-type': 'local',
         })
@@ -73,12 +72,12 @@ class TestUser(object):
         Add a faked user role object to the faked Console and return it.
         """
         faked_user_role = self.faked_console.user_roles.add({
-            'object-id': 'oid-{}'.format(name),
+            'object-id': f'oid-{name}',
             # object-uri will be automatically set
             'parent': '/api/console',
             'class': 'user-role',
             'name': name,
-            'description': 'User Role {}'.format(name),
+            'description': f'User Role {name}',
             'type': type_,
         })
         return faked_user_role
@@ -345,7 +344,7 @@ class TestUser(object):
             assert prop_name in user.properties
             prop_value = user.properties[prop_name]
             assert prop_value == exp_prop_value, \
-                "Unexpected value for property {!r}".format(prop_name)
+                f"Unexpected value for property {prop_name!r}"
 
         # Refresh the resource object and verify that the resource object
         # still reflects the property updates.

--- a/tests/unit/zhmcclient/test_user_pattern.py
+++ b/tests/unit/zhmcclient/test_user_pattern.py
@@ -16,7 +16,6 @@
 Unit tests for _user_pattern module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -27,7 +26,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestUserPattern(object):
+class TestUserPattern:
     """All tests for the UserPattern and UserPatternManager classes."""
 
     def setup_method(self):
@@ -57,12 +56,12 @@ class TestUserPattern(object):
         Add a faked user pattern object to the faked Console and return it.
         """
         faked_user_pattern = self.faked_console.user_patterns.add({
-            'element-id': 'oid-{}'.format(name),
+            'element-id': f'oid-{name}',
             # element-uri will be automatically set
             'parent': '/api/console',
             'class': 'user-pattern',
             'name': name,
-            'description': 'User Pattern {}'.format(name),
+            'description': f'User Pattern {name}',
             'pattern': pattern,
             'type': type_,
             'retention-time': 0,
@@ -75,12 +74,12 @@ class TestUserPattern(object):
         Add a faked user object to the faked Console and return it.
         """
         faked_user = self.faked_console.users.add({
-            'object-id': 'oid-{}'.format(name),
+            'object-id': f'oid-{name}',
             # object-uri will be automatically set
             'parent': '/api/console',
             'class': 'user',
             'name': name,
-            'description': 'User {}'.format(name),
+            'description': f'User {name}',
             'type': type_,
             'authentication-type': 'local',
         })
@@ -387,7 +386,7 @@ class TestUserPattern(object):
             assert prop_name in user_pattern.properties
             prop_value = user_pattern.properties[prop_name]
             assert prop_value == exp_prop_value, \
-                "Unexpected value for property {!r}".format(prop_name)
+                f"Unexpected value for property {prop_name!r}"
 
         # Refresh the resource object and verify that the resource object
         # still reflects the property updates.

--- a/tests/unit/zhmcclient/test_user_role.py
+++ b/tests/unit/zhmcclient/test_user_role.py
@@ -19,7 +19,6 @@ Unit tests for _user_role module.
 
 import re
 import copy
-import six
 import pytest
 
 from zhmcclient import Client, HTTPError, NotFound, BaseResource, UserRole

--- a/tests/unit/zhmcclient/test_user_role.py
+++ b/tests/unit/zhmcclient/test_user_role.py
@@ -16,7 +16,6 @@
 Unit tests for _user_role module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 import copy
@@ -28,7 +27,7 @@ from zhmcclient_mock import FakedSession
 from tests.common.utils import assert_resources
 
 
-class TestUserRole(object):
+class TestUserRole:
     """All tests for the UserRole and UserRoleManager classes."""
 
     def setup_method(self):
@@ -58,12 +57,12 @@ class TestUserRole(object):
         Add a faked user role object to the faked Console and return it.
         """
         faked_user_role = self.faked_console.user_roles.add({
-            'object-id': 'oid-{}'.format(name),
+            'object-id': f'oid-{name}',
             # object-uri will be automatically set
             'parent': '/api/console',
             'class': 'user-role',
             'name': name,
-            'description': 'User Role {}'.format(name),
+            'description': f'User Role {name}',
             'type': type_,
         })
         return faked_user_role
@@ -323,7 +322,7 @@ class TestUserRole(object):
             assert prop_name in user_role.properties
             prop_value = user_role.properties[prop_name]
             assert prop_value == exp_prop_value, \
-                "Unexpected value for property {!r}".format(prop_name)
+                f"Unexpected value for property {prop_name!r}"
 
         # Refresh the resource object and verify that the resource object
         # still reflects the property updates.
@@ -364,7 +363,7 @@ class TestUserRole(object):
             perm_obj = permitted_object.uri
             perm_type = 'object'
         else:
-            assert isinstance(permitted_object, six.string_types)
+            assert isinstance(permitted_object, str)
             perm_obj = permitted_object
             perm_type = 'object-class'
         permission_parms = {
@@ -431,7 +430,7 @@ class TestUserRole(object):
             perm_obj = permitted_object.uri
             perm_type = 'object'
         else:
-            assert isinstance(permitted_object, six.string_types)
+            assert isinstance(permitted_object, str)
             perm_obj = permitted_object
             perm_type = 'object-class'
         permission_parms = {

--- a/tests/unit/zhmcclient/test_utils.py
+++ b/tests/unit/zhmcclient/test_utils.py
@@ -16,7 +16,6 @@
 Unit tests for _utils module.
 """
 
-from __future__ import absolute_import, print_function
 
 import os
 import sys

--- a/tests/unit/zhmcclient/test_virtual_function.py
+++ b/tests/unit/zhmcclient/test_virtual_function.py
@@ -16,7 +16,6 @@
 Unit tests for _virtual_function module.
 """
 
-from __future__ import absolute_import, print_function
 
 # FIXME: Migrate requests_mock to zhmcclient_mock.
 import requests_mock
@@ -24,7 +23,7 @@ import requests_mock
 from zhmcclient import Session, Client, VirtualFunction
 
 
-class TestVirtualFunction(object):
+class TestVirtualFunction:
     """
     All tests for VirtualFunction and VirtualFunctionManager classes.
     """

--- a/tests/unit/zhmcclient/test_virtual_switch.py
+++ b/tests/unit/zhmcclient/test_virtual_switch.py
@@ -16,7 +16,6 @@
 Unit tests for _virtual_switch module.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 # FIXME: Migrate requests_mock to zhmcclient_mock.
@@ -25,7 +24,7 @@ import requests_mock
 from zhmcclient import Session, Client, Nic
 
 
-class TestVirtualSwitch(object):
+class TestVirtualSwitch:
     """All tests for VirtualSwitch and VirtualSwitchManager classes."""
 
     def setup_method(self):

--- a/tests/unit/zhmcclient/testutils/test_hmc_definitions.py
+++ b/tests/unit/zhmcclient/testutils/test_hmc_definitions.py
@@ -16,7 +16,6 @@
 Unit tests for testutils._hmc_definitions module.
 """
 
-from __future__ import absolute_import, print_function
 
 import os
 import tempfile

--- a/tests/unit/zhmcclient/testutils/test_hmc_inventory_file.py
+++ b/tests/unit/zhmcclient/testutils/test_hmc_inventory_file.py
@@ -16,7 +16,6 @@
 Unit tests for testutils._hmc_inventory_file module.
 """
 
-from __future__ import absolute_import, print_function
 
 import os
 import tempfile

--- a/tests/unit/zhmcclient/testutils/test_hmc_vault_file.py
+++ b/tests/unit/zhmcclient/testutils/test_hmc_vault_file.py
@@ -16,7 +16,6 @@
 Unit tests for testutils._hmc_vault_file module.
 """
 
-from __future__ import absolute_import, print_function
 
 import os
 import tempfile

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -18,7 +18,6 @@
 Unit tests for _hmc module of the zhmcclient_mock package.
 """
 
-from __future__ import absolute_import, print_function
 
 import re
 from datetime import datetime
@@ -46,7 +45,7 @@ from zhmcclient_mock._hmc import \
 from tests.common.utils import timestamp_aware
 
 
-class TestFakedHmc(object):
+class TestFakedHmc:
     """All tests for the zhmcclient_mock.FakedHmc class."""
 
     def setup_method(self):
@@ -268,7 +267,7 @@ class TestFakedHmc(object):
             hmc.remove_session_id(session_id)
 
 
-class TestFakedBase(object):
+class TestFakedBase:
     """All tests for the FakedBaseManager and FakedBaseResource classes."""
 
     def setup_method(self):
@@ -281,7 +280,7 @@ class TestFakedBase(object):
         self.hmc = session.hmc
 
         self.cpc1_oid = '42-abc-543'
-        self.cpc1_uri = '/api/cpcs/{}'.format(self.cpc1_oid)
+        self.cpc1_uri = f'/api/cpcs/{self.cpc1_oid}'
 
         self.cpc1_in_props = {
             # All properties that are otherwise defaulted (but with non-default
@@ -358,7 +357,7 @@ class TestFakedBase(object):
         assert self.cpc_resource.uri == self.cpc1_out_props['object-uri']
 
 
-class TestFakedActivationProfile(object):
+class TestFakedActivationProfile:
     """All tests for the FakedActivationProfileManager and
     FakedActivationProfile classes."""
 
@@ -538,7 +537,7 @@ class TestFakedActivationProfile(object):
         # same class, we don't need to test them.
 
 
-class TestFakedAdapter(object):
+class TestFakedAdapter:
     """All tests for the FakedAdapterManager and FakedAdapter classes."""
 
     def setup_method(self):
@@ -670,7 +669,7 @@ class TestFakedAdapter(object):
         assert len(adapters) == 0
 
 
-class TestFakedCpc(object):
+class TestFakedCpc:
     """All tests for the FakedCpcManager and FakedCpc classes."""
 
     def setup_method(self):
@@ -794,7 +793,7 @@ class TestFakedCpc(object):
         assert len(cpcs) == 0
 
 
-class TestFakedHba(object):
+class TestFakedHba:
     """All tests for the FakedHbaManager and FakedHba classes."""
 
     def setup_method(self):
@@ -808,7 +807,7 @@ class TestFakedHba(object):
         self.hmc = session.hmc
 
         self.adapter1_oid = '747-abc-12345'
-        self.adapter1_uri = '/api/adapters/{}'.format(self.adapter1_oid)
+        self.adapter1_uri = f'/api/adapters/{self.adapter1_oid}'
         self.port1_oid = '23'
         self.port1_uri = '/api/adapters/{}/storage-ports/{}' \
             .format(self.adapter1_oid, self.port1_oid)
@@ -962,7 +961,7 @@ class TestFakedHba(object):
 # TODO: Add unit tests for FakedCapacityGroup/Manager.
 
 
-class TestFakedLpar(object):
+class TestFakedLpar:
     """All tests for the FakedLparManager and FakedLpar classes."""
 
     def setup_method(self):
@@ -1071,7 +1070,7 @@ class TestFakedLpar(object):
         assert len(lpars) == 0
 
 
-class TestFakedNic(object):
+class TestFakedNic:
     """All tests for the FakedNicManager and FakedNic classes."""
 
     def setup_method(self):
@@ -1085,7 +1084,7 @@ class TestFakedNic(object):
         self.hmc = session.hmc
 
         self.adapter1_oid = '380-xyz-12345'
-        self.adapter1_uri = '/api/adapters/{}'.format(self.adapter1_oid)
+        self.adapter1_uri = f'/api/adapters/{self.adapter1_oid}'
         self.port1_oid = '32'
         self.port1_uri = '/api/adapters/{}/network-ports/{}' \
             .format(self.adapter1_oid, self.port1_oid)
@@ -1238,7 +1237,7 @@ class TestFakedNic(object):
     # TODO: Add testcases for updating 'nic-uris' parent property
 
 
-class TestFakedPartition(object):
+class TestFakedPartition:
     """All tests for the FakedPartitionManager and FakedPartition classes."""
 
     def setup_method(self):
@@ -1377,7 +1376,7 @@ class TestFakedPartition(object):
         assert len(partitions) == 0
 
 
-class TestFakedPort(object):
+class TestFakedPort:
     """All tests for the FakedPortManager and FakedPort classes."""
 
     def setup_method(self):
@@ -1502,7 +1501,7 @@ class TestFakedPort(object):
     #       'storage-port-uris' parent properties
 
 
-class TestFakedVirtualFunction(object):
+class TestFakedVirtualFunction:
     """All tests for the FakedVirtualFunctionManager and FakedVirtualFunction
     classes."""
 
@@ -1633,7 +1632,7 @@ class TestFakedVirtualFunction(object):
     # TODO: Add testcases for updating 'virtual-function-uris' parent property
 
 
-class TestFakedVirtualSwitch(object):
+class TestFakedVirtualSwitch:
     """All tests for the FakedVirtualSwitchManager and FakedVirtualSwitch
     classes."""
 
@@ -1745,7 +1744,7 @@ class TestFakedVirtualSwitch(object):
         assert len(virtual_switches) == 0
 
 
-class TestFakedCapacityGroup(object):
+class TestFakedCapacityGroup:
     """All tests for the FakedCapacityGroupManager and FakedCapacityGroup
     classes."""
 
@@ -1859,7 +1858,7 @@ class TestFakedCapacityGroup(object):
         assert len(capacity_groups) == 0
 
 
-class TestFakedMetricsContext(object):
+class TestFakedMetricsContext:
     """All tests for the FakedMetricsContextManager and FakedMetricsContext
     classes."""
 

--- a/tests/unit/zhmcclient_mock/test_idpool.py
+++ b/tests/unit/zhmcclient_mock/test_idpool.py
@@ -16,7 +16,6 @@
 Unit tests for _idpool module of the zhmcclient_mock package.
 """
 
-from __future__ import absolute_import, print_function
 
 from requests.packages import urllib3
 import pytest

--- a/tests/unit/zhmcclient_mock/test_session.py
+++ b/tests/unit/zhmcclient_mock/test_session.py
@@ -18,7 +18,6 @@
 Unit tests for _session module of the zhmcclient_mock package.
 """
 
-from __future__ import absolute_import, print_function
 
 from datetime import datetime
 

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -20,11 +20,11 @@ Unit tests for _urihandler module of the zhmcclient_mock package.
 
 
 from datetime import datetime
+# TODO: Migrate mock to zhmcclient_mock
+from unittest.mock import MagicMock
 from dateutil import tz
 import pytz
 from requests.packages import urllib3
-# TODO: Migrate mock to zhmcclient_mock
-from unittest.mock import MagicMock
 import pytest
 
 from zhmcclient_mock._session import FakedSession

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -18,14 +18,13 @@
 Unit tests for _urihandler module of the zhmcclient_mock package.
 """
 
-from __future__ import absolute_import, print_function
 
 from datetime import datetime
 from dateutil import tz
 import pytz
 from requests.packages import urllib3
 # TODO: Migrate mock to zhmcclient_mock
-from mock import MagicMock
+from unittest.mock import MagicMock
 import pytest
 
 from zhmcclient_mock._session import FakedSession
@@ -141,7 +140,7 @@ def test_connectionerror_attrs():
     assert exc.message == msg
 
 
-class DummyHandler1(object):
+class DummyHandler1:
     # pylint: disable=too-few-public-methods
     """
     Dummy URI handler class.
@@ -149,7 +148,7 @@ class DummyHandler1(object):
     pass
 
 
-class DummyHandler2(object):
+class DummyHandler2:
     # pylint: disable=too-few-public-methods
     """
     Dummy URI handler class.
@@ -157,7 +156,7 @@ class DummyHandler2(object):
     pass
 
 
-class DummyHandler3(object):
+class DummyHandler3:
     # pylint: disable=too-few-public-methods
     """
     Dummy URI handler class.
@@ -578,7 +577,7 @@ def test_urihandler_handle_cpcs(
             urihandler.handler(uri, method)
 
 
-class TestUriHandlerMethod(object):
+class TestUriHandlerMethod:
     """
     All tests for get(), post(), delete() methods of class UriHandler.
     """
@@ -1039,7 +1038,7 @@ def standard_test_hmc():
     return hmc, hmc_resources
 
 
-class TestGenericGetPropertiesHandler(object):
+class TestGenericGetPropertiesHandler:
     """
     All tests for class GenericGetPropertiesHandler.
     """
@@ -1098,7 +1097,7 @@ class _GenericGetUpdatePropertiesHandler(GenericGetPropertiesHandler,
     pass
 
 
-class TestGenericUpdatePropertiesHandler(object):
+class TestGenericUpdatePropertiesHandler:
     """
     All tests for class GenericUpdatePropertiesHandler.
     """
@@ -1150,7 +1149,7 @@ class TestGenericUpdatePropertiesHandler(object):
                                  True)
 
 
-class TestGenericDeleteHandler(object):
+class TestGenericDeleteHandler:
     """
     All tests for class GenericDeleteHandler.
     """
@@ -1200,7 +1199,7 @@ class TestGenericDeleteHandler(object):
             self.urihandler.delete(self.hmc, uri, True)
 
 
-class TestVersionHandler(object):
+class TestVersionHandler:
     """
     All tests for class VersionHandler.
     """
@@ -1235,7 +1234,7 @@ class TestVersionHandler(object):
         assert resp == exp_resp
 
 
-class TestConsoleHandler(object):
+class TestConsoleHandler:
     """
     All tests for class ConsoleHandler.
     """
@@ -1272,7 +1271,7 @@ class TestConsoleHandler(object):
         assert console == exp_console
 
 
-class TestConsoleRestartHandler(object):
+class TestConsoleRestartHandler:
     """
     All tests for class ConsoleRestartHandler.
     """
@@ -1328,7 +1327,7 @@ class TestConsoleRestartHandler(object):
         assert exc.reason == 1
 
 
-class TestConsoleShutdownHandler(object):
+class TestConsoleShutdownHandler:
     """
     All tests for class ConsoleShutdownHandler.
     """
@@ -1384,7 +1383,7 @@ class TestConsoleShutdownHandler(object):
         assert exc.reason == 1
 
 
-class TestConsoleMakePrimaryHandler(object):
+class TestConsoleMakePrimaryHandler:
     """
     All tests for class ConsoleMakePrimaryHandler.
     """
@@ -1439,7 +1438,7 @@ class TestConsoleMakePrimaryHandler(object):
         assert exc.reason == 1
 
 
-class TestConsoleReorderUserPatternsHandler(object):
+class TestConsoleReorderUserPatternsHandler:
     """
     All tests for class ConsoleReorderUserPatternsHandler.
     """
@@ -1550,7 +1549,7 @@ class TestConsoleReorderUserPatternsHandler(object):
         assert exc.reason == 1
 
 
-class TestConsoleGetAuditLogHandler(object):
+class TestConsoleGetAuditLogHandler:
     """
     All tests for class ConsoleGetAuditLogHandler.
     """
@@ -1602,7 +1601,7 @@ class TestConsoleGetAuditLogHandler(object):
         assert exc.reason == 1
 
 
-class TestConsoleGetSecurityLogHandler(object):
+class TestConsoleGetSecurityLogHandler:
     """
     All tests for class ConsoleGetSecurityLogHandler.
     """
@@ -1654,7 +1653,7 @@ class TestConsoleGetSecurityLogHandler(object):
         assert exc.reason == 1
 
 
-class TestConsoleListUnmanagedCpcsHandler(object):
+class TestConsoleListUnmanagedCpcsHandler:
     """
     All tests for class ConsoleListUnmanagedCpcsHandler.
     """
@@ -1707,7 +1706,7 @@ class TestConsoleListUnmanagedCpcsHandler(object):
         assert exc.reason == 1
 
 
-class TestUserHandlers(object):
+class TestUserHandlers:
     """
     All tests for classes UsersHandler and UserHandler.
     """
@@ -1916,7 +1915,7 @@ class TestUserHandlers(object):
         """
 
         user_oid = user_props['object-id']
-        user_uri = '/api/users/{}'.format(user_oid)
+        user_uri = f'/api/users/{user_oid}'
 
         # Create the user
         self.urihandler.post(self.hmc, '/api/console/users', user_props, True,
@@ -1949,7 +1948,7 @@ class TestUserHandlers(object):
                 self.urihandler.get(self.hmc, user_uri, True)
 
 
-class TestUserAddUserRoleHandler(object):
+class TestUserAddUserRoleHandler:
     """
     All tests for class UserAddUserRoleHandler.
     """
@@ -2089,7 +2088,7 @@ class TestUserAddUserRoleHandler(object):
         assert exc.reason == 2
 
 
-class TestUserRemoveUserRoleHandler(object):
+class TestUserRemoveUserRoleHandler:
     """
     All tests for class UserRemoveUserRoleHandler.
     """
@@ -2281,7 +2280,7 @@ class TestUserRemoveUserRoleHandler(object):
         assert exc.reason == 316
 
 
-class TestUserRoleHandlers(object):
+class TestUserRoleHandlers:
     """
     All tests for classes UserRolesHandler and UserRoleHandler.
     """
@@ -2474,7 +2473,7 @@ class TestUserRoleHandlers(object):
             self.urihandler.get(self.hmc, new_user_role2_uri, True)
 
 
-class TestUserRoleAddPermissionHandler(object):
+class TestUserRoleAddPermissionHandler:
     """
     All tests for class UserRoleAddPermissionHandler.
     """
@@ -2609,7 +2608,7 @@ class TestUserRoleAddPermissionHandler(object):
         assert exc.reason == 314
 
 
-class TestUserRoleRemovePermissionHandler(object):
+class TestUserRoleRemovePermissionHandler:
     """
     All tests for class UserRoleRemovePermissionHandler.
     """
@@ -2751,7 +2750,7 @@ class TestUserRoleRemovePermissionHandler(object):
         assert exc.reason == 314
 
 
-class TestTaskHandlers(object):
+class TestTaskHandlers:
     """
     All tests for classes TasksHandler and TaskHandler.
     """
@@ -2828,7 +2827,7 @@ class TestTaskHandlers(object):
         assert task1 == exp_task1
 
 
-class TestUserPatternHandlers(object):
+class TestUserPatternHandlers:
     """
     All tests for classes UserPatternsHandler and UserPatternHandler.
     """
@@ -3016,7 +3015,7 @@ class TestUserPatternHandlers(object):
             self.urihandler.get(self.hmc, new_user_pattern_uri, True)
 
 
-class TestPasswordRuleHandlers(object):
+class TestPasswordRuleHandlers:
     """
     All tests for classes PasswordRulesHandler and PasswordRuleHandler.
     """
@@ -3195,7 +3194,7 @@ class TestPasswordRuleHandlers(object):
             self.urihandler.get(self.hmc, new_password_rule_uri, True)
 
 
-class TestLdapServerDefinitionHandlers(object):
+class TestLdapServerDefinitionHandlers:
     """
     All tests for classes LdapServerDefinitionsHandler and
     LdapServerDefinitionHandler.
@@ -3393,7 +3392,7 @@ class TestLdapServerDefinitionHandlers(object):
             self.urihandler.get(self.hmc, new_ldap_srv_def_uri, True)
 
 
-class TestCpcHandlers(object):
+class TestCpcHandlers:
     """
     All tests for classes CpcsHandler and CpcHandler.
     """
@@ -3474,7 +3473,7 @@ class TestCpcHandlers(object):
         assert cpc1['description'] == 'updated cpc #1'
 
 
-class TestCpcSetPowerSaveHandler(object):
+class TestCpcSetPowerSaveHandler:
     """
     All tests for class CpcSetPowerSaveHandler.
     """
@@ -3541,7 +3540,7 @@ class TestCpcSetPowerSaveHandler(object):
             assert cpc1['zcpc-power-saving'] == power_saving
 
 
-class TestCpcSetPowerCappingHandler(object):
+class TestCpcSetPowerCappingHandler:
     """
     All tests for class CpcSetPowerCappingHandler.
     """
@@ -3612,7 +3611,7 @@ class TestCpcSetPowerCappingHandler(object):
             assert cpc1['zcpc-power-cap-current'] == power_cap_current
 
 
-class TestCpcGetEnergyManagementDataHandler(object):
+class TestCpcGetEnergyManagementDataHandler:
     """
     All tests for class CpcGetEnergyManagementDataHandler.
     """
@@ -3687,7 +3686,7 @@ class TestCpcGetEnergyManagementDataHandler(object):
             assert act_energy_props[p] == exp_value
 
 
-class TestCpcStartStopHandler(object):
+class TestCpcStartStopHandler:
     """
     All tests for classes CpcStartHandler and CpcStopHandler.
     """
@@ -3765,7 +3764,7 @@ class TestCpcStartStopHandler(object):
         assert cpc2['status'] == 'active'
 
 
-class TestCpcActivateDeactivateHandler(object):
+class TestCpcActivateDeactivateHandler:
     """
     All tests for classes CpcActivateHandler and CpcDeactivateHandler.
     """
@@ -3847,7 +3846,7 @@ class TestCpcActivateDeactivateHandler(object):
         assert cpc1['status'] == 'operating'
 
 
-class TestCpcExportPortNamesListHandler(object):
+class TestCpcExportPortNamesListHandler:
     """
     All tests for class CpcExportPortNamesListHandler.
     """
@@ -3904,7 +3903,7 @@ class TestCpcExportPortNamesListHandler(object):
         assert wwpn_list == exp_wwpn_list
 
 
-class TestCpcImportProfilesHandler(object):
+class TestCpcImportProfilesHandler:
     """
     All tests for class CpcImportProfilesHandler.
     """
@@ -3953,7 +3952,7 @@ class TestCpcImportProfilesHandler(object):
         assert resp is None
 
 
-class TestCpcExportProfilesHandler(object):
+class TestCpcExportProfilesHandler:
     """
     All tests for class CpcExportProfilesHandler.
     """
@@ -4002,7 +4001,7 @@ class TestCpcExportProfilesHandler(object):
         assert resp is None
 
 
-class TestCpcSetAutoStartListHandler(object):
+class TestCpcSetAutoStartListHandler:
     """
     All tests for class CpcSetAutoStartListHandler.
     """
@@ -4046,7 +4045,7 @@ class TestCpcSetAutoStartListHandler(object):
         assert resp is None
 
 
-class TestMetricsContextHandlers(object):
+class TestMetricsContextHandlers:
     """
     All tests for classes MetricsContextsHandler and MetricsContextHandler.
     """
@@ -4183,7 +4182,7 @@ class TestMetricsContextHandlers(object):
         self.urihandler.delete(self.hmc, uri, True)
 
 
-class TestAdapterHandlers(object):
+class TestAdapterHandlers:
     """
     All tests for classes AdaptersHandler and AdapterHandler.
     """
@@ -4290,7 +4289,7 @@ class TestAdapterHandlers(object):
         assert adapter1['description'] == 'updated adapter #1'
 
 
-class TestAdapterChangeCryptoTypeHandler(object):
+class TestAdapterChangeCryptoTypeHandler:
     """
     All tests for class AdapterChangeCryptoTypeHandler.
     """
@@ -4358,7 +4357,7 @@ class TestAdapterChangeCryptoTypeHandler(object):
         assert resp is None
 
 
-class TestAdapterChangeAdapterTypeHandler(object):
+class TestAdapterChangeAdapterTypeHandler:
     """
     All tests for class AdapterChangeAdapterTypeHandler.
     """
@@ -4426,7 +4425,7 @@ class TestAdapterChangeAdapterTypeHandler(object):
         assert resp is None
 
 
-class TestNetworkPortHandlers(object):
+class TestNetworkPortHandlers:
     """
     All tests for class NetworkPortHandler.
     """
@@ -4482,7 +4481,7 @@ class TestNetworkPortHandlers(object):
         assert port1['description'] == 'updated port #1'
 
 
-class TestStoragePortHandlers(object):
+class TestStoragePortHandlers:
     """
     All tests for class StoragePortHandler.
     """
@@ -4538,7 +4537,7 @@ class TestStoragePortHandlers(object):
         assert port1['description'] == 'updated port #1'
 
 
-class TestPartitionHandlers(object):
+class TestPartitionHandlers:
     """
     All tests for classes PartitionsHandler and PartitionHandler.
     """
@@ -4645,7 +4644,7 @@ class TestPartitionHandlers(object):
             assert pname in partition2
             act_value = partition2[pname]
             assert act_value == exp_value, \
-                "property {!r}".format(pname)
+                f"property {pname!r}"
 
     def test_part_update_verify(self):
         """
@@ -4677,7 +4676,7 @@ class TestPartitionHandlers(object):
             self.urihandler.get(self.hmc, '/api/partitions/1', True)
 
 
-class TestPartitionStartStopHandler(object):
+class TestPartitionStartStopHandler:
     """
     All tests for classes PartitionStartHandler and PartitionStopHandler.
     """
@@ -4733,7 +4732,7 @@ class TestPartitionStartStopHandler(object):
                                  None, True, True)
 
 
-class TestPartitionScsiDumpHandler(object):
+class TestPartitionScsiDumpHandler:
     """
     All tests for class PartitionScsiDumpHandler.
     """
@@ -4864,7 +4863,7 @@ class TestPartitionScsiDumpHandler(object):
         assert resp == {}
 
 
-class TestPartitionStartDumpProgramHandler(object):
+class TestPartitionStartDumpProgramHandler:
     """
     All tests for class PartitionStartDumpProgramHandler.
     """
@@ -4959,7 +4958,7 @@ class TestPartitionStartDumpProgramHandler(object):
         assert resp == {}
 
 
-class TestPartitionPswRestartHandler(object):
+class TestPartitionPswRestartHandler:
     """
     All tests for class PartitionPswRestartHandler.
     """
@@ -5012,7 +5011,7 @@ class TestPartitionPswRestartHandler(object):
         assert resp == {}
 
 
-class TestPartitionMountIsoImageHandler(object):
+class TestPartitionMountIsoImageHandler:
     """
     All tests for class PartitionMountIsoImageHandler.
     """
@@ -5098,7 +5097,7 @@ class TestPartitionMountIsoImageHandler(object):
         assert boot_iso_ins_file == 'fake-ins'
 
 
-class TestPartitionUnmountIsoImageHandler(object):
+class TestPartitionUnmountIsoImageHandler:
     """
     All tests for class PartitionUnmountIsoImageHandler.
     """
@@ -5156,7 +5155,7 @@ class TestPartitionUnmountIsoImageHandler(object):
         assert boot_iso_ins_file is None
 
 
-class TestPartitionIncreaseCryptoConfigHandler(object):
+class TestPartitionIncreaseCryptoConfigHandler:
     """
     All tests for class PartitionIncreaseCryptoConfigHandler.
     """
@@ -5277,7 +5276,7 @@ class TestPartitionIncreaseCryptoConfigHandler(object):
             assert domain_configs == exp_domain_configs
 
 
-class TestPartitionDecreaseCryptoConfigHandler(object):
+class TestPartitionDecreaseCryptoConfigHandler:
     """
     All tests for class PartitionDecreaseCryptoConfigHandler.
     """
@@ -5398,7 +5397,7 @@ class TestPartitionDecreaseCryptoConfigHandler(object):
             assert isinstance(domain_configs, list)
 
 
-class TestPartitionChangeCryptoConfigHandler(object):
+class TestPartitionChangeCryptoConfigHandler:
     """
     All tests for class PartitionChangeCryptoConfigHandler.
     """
@@ -5546,7 +5545,7 @@ class TestPartitionChangeCryptoConfigHandler(object):
             assert isinstance(domain_configs, list)
 
 
-class TestHbaHandler(object):
+class TestHbaHandler:
     """
     All tests for classes HbasHandler and HbaHandler.
     """
@@ -5671,7 +5670,7 @@ class TestHbaHandler(object):
             self.urihandler.get(self.hmc, '/api/partitions/1/hbas/1', True)
 
 
-class TestHbaReassignPortHandler(object):
+class TestHbaReassignPortHandler:
     """
     All tests for class HbaReassignPortHandler.
     """
@@ -5748,7 +5747,7 @@ class TestHbaReassignPortHandler(object):
         assert adapter_port_uri == new_adapter_port_uri
 
 
-class TestNicHandler(object):
+class TestNicHandler:
     """
     All tests for classes NicsHandler and NicHandler.
     """
@@ -5875,7 +5874,7 @@ class TestNicHandler(object):
             self.urihandler.get(self.hmc, '/api/partitions/1/nics/1', True)
 
 
-class TestVirtualFunctionHandler(object):
+class TestVirtualFunctionHandler:
     """
     All tests for classes VirtualFunctionsHandler and VirtualFunctionHandler.
     """
@@ -6006,7 +6005,7 @@ class TestVirtualFunctionHandler(object):
                                 '/api/partitions/1/virtual-functions/1', True)
 
 
-class TestVirtualSwitchHandlers(object):
+class TestVirtualSwitchHandlers:
     """
     All tests for classes VirtualSwitchesHandler and VirtualSwitchHandler.
     """
@@ -6067,7 +6066,7 @@ class TestVirtualSwitchHandlers(object):
         assert vswitch1 == exp_vswitch1
 
 
-class TestVirtualSwitchGetVnicsHandler(object):
+class TestVirtualSwitchGetVnicsHandler:
     """
     All tests for class VirtualSwitchGetVnicsHandler.
     """
@@ -6111,7 +6110,7 @@ class TestVirtualSwitchGetVnicsHandler(object):
         assert resp == exp_resp
 
 
-class TestStorageGroupHandlers(object):
+class TestStorageGroupHandlers:
     """
     All tests for classes StorageGroupsHandler and StorageGroupHandler.
     """
@@ -6187,7 +6186,7 @@ class TestStorageGroupHandlers(object):
 # TODO: Test StorageGroupRemoveCandidatePortsHandler
 
 
-class TestStorageVolumeHandlers(object):
+class TestStorageVolumeHandlers:
     """
     All tests for classes StorageVolumesHandler and StorageVolumeHandler.
     """
@@ -6257,7 +6256,7 @@ class TestStorageVolumeHandlers(object):
         assert stovol1 == exp_stovol1
 
 
-class TestCapacityGroupHandlers(object):
+class TestCapacityGroupHandlers:
     """
     All tests for classes CapacityGroupsHandler and CapacityGroupHandler.
     """
@@ -6320,7 +6319,7 @@ class TestCapacityGroupHandlers(object):
         assert cg1 == exp_cg1
 
 
-class TestCapacityGroupAddPartitionHandler(object):
+class TestCapacityGroupAddPartitionHandler:
     """
     All tests for class CapacityGroupAddPartitionHandler.
     """
@@ -6359,7 +6358,7 @@ class TestCapacityGroupAddPartitionHandler(object):
             True, True)
 
 
-class TestCapacityGroupRemovePartitionHandler(object):
+class TestCapacityGroupRemovePartitionHandler:
     """
     All tests for class CapacityGroupRemovePartitionHandler.
     """
@@ -6403,7 +6402,7 @@ class TestCapacityGroupRemovePartitionHandler(object):
         assert exc.reason == 140
 
 
-class TestLparHandlers(object):
+class TestLparHandlers:
     """
     All tests for classes LparsHandler and LparHandler.
     """
@@ -6463,7 +6462,7 @@ class TestLparHandlers(object):
         assert lpar1 == exp_lpar1
 
 
-class TestLparActLoadDeactHandler(object):
+class TestLparActLoadDeactHandler:
     """
     All tests for classes LparActivateHandler, LparLoadHandler, and
     LparDeactivateHandler.
@@ -6530,7 +6529,7 @@ class TestLparActLoadDeactHandler(object):
         assert lpar1['status'] == 'not-activated'
 
 
-class TestLparScsiLoadHandler(object):
+class TestLparScsiLoadHandler:
     """
     All tests for class LparScsiLoadHandler and other needed classes.
     """
@@ -6598,7 +6597,7 @@ class TestLparScsiLoadHandler(object):
         assert lpar1['status'] == 'not-activated'
 
 
-class TestLparScsiDumpHandler(object):
+class TestLparScsiDumpHandler:
     """
     All tests for class LparScsiDumpHandler and other needed classes.
     """
@@ -6666,7 +6665,7 @@ class TestLparScsiDumpHandler(object):
         assert lpar1['status'] == 'not-activated'
 
 
-class TestLparNvmeLoadHandler(object):
+class TestLparNvmeLoadHandler:
     """
     All tests for class LparNvmeLoadHandler and other needed classes.
     """
@@ -6732,7 +6731,7 @@ class TestLparNvmeLoadHandler(object):
         assert lpar1['status'] == 'not-activated'
 
 
-class TestLparNvmeDumpHandler(object):
+class TestLparNvmeDumpHandler:
     """
     All tests for class LparNvmeDumpHandler and other needed classes.
     """
@@ -6805,7 +6804,7 @@ class TestLparNvmeDumpHandler(object):
 # TODO: Add test for handler for reset-normal
 
 
-class TestResetActProfileHandlers(object):
+class TestResetActProfileHandlers:
     """
     All tests for classes ResetActProfilesHandler and ResetActProfileHandler.
     """
@@ -6867,7 +6866,7 @@ class TestResetActProfileHandlers(object):
         assert rap1 == exp_rap1
 
 
-class TestImageActProfileHandlers(object):
+class TestImageActProfileHandlers:
     """
     All tests for classes ImageActProfilesHandler and ImageActProfileHandler.
     """
@@ -6929,7 +6928,7 @@ class TestImageActProfileHandlers(object):
         assert iap1 == exp_iap1
 
 
-class TestLoadActProfileHandlers(object):
+class TestLoadActProfileHandlers:
     """
     All tests for classes LoadActProfilesHandler and LoadActProfileHandler.
     """
@@ -6991,7 +6990,7 @@ class TestLoadActProfileHandlers(object):
         assert lap1 == exp_lap1
 
 
-class TestSubmitRequestsHandler(object):
+class TestSubmitRequestsHandler:
     """
     All tests for class SubmitRequestsHandler.
     """

--- a/tools/python_version.py
+++ b/tools/python_version.py
@@ -4,7 +4,7 @@ import sys
 
 if len(sys.argv) != 2:
     print("Error: Incorrect number of command line arguments")
-    print("Usage: {0}  version_level".format(sys.argv[0]))
+    print(f"Usage: {sys.argv[0]}  version_level")
     print("Where version_level is the number of components in the "
           "version string from 1 to 3, e.g. 3 means Python 2.7.11")
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,23 +9,11 @@
 [tox]
 minversion = 2.0
 envlist =
-    py27
-    py35
-    py36
-    py37
     py38
     py39
     py310
     py311
     py312
-    win64_py27_32
-    win64_py27_64
-    win64_py35_32
-    win64_py35_64
-    win64_py36_32
-    win64_py36_64
-    win64_py37_32
-    win64_py37_64
     win64_py38_32
     win64_py38_64
     win64_py39_32
@@ -36,10 +24,6 @@ envlist =
     win64_py311_64
     win64_py312_32
     win64_py312_64
-    cygwin32_py27
-    cygwin64_py27
-    cygwin64_py36
-    msys64_py27
 skip_missing_interpreters = true
 skipsdist = true
 
@@ -73,22 +57,6 @@ whitelist_externals =
 commands =
     make platform pip_list env test debuginfo
 
-[testenv:py27]
-platform = linux2|darwin
-basepython = python2.7
-
-[testenv:py35]
-platform = linux2|darwin
-basepython = python3.5
-
-[testenv:py36]
-platform = linux2|darwin
-basepython = python3.6
-
-[testenv:py37]
-platform = linux2|darwin
-basepython = python3.7
-
 [testenv:py38]
 platform = linux2|darwin
 basepython = python3.8
@@ -108,54 +76,6 @@ basepython = python3.11
 [testenv:py312]
 platform = linux2|darwin
 basepython = python3.12
-
-[testenv:win64_py27_32]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python27;{env:PATH}
-
-[testenv:win64_py27_64]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python27-x64;{env:PATH}
-
-[testenv:win64_py35_32]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python35;{env:PATH}
-
-[testenv:win64_py35_64]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python35-x64;{env:PATH}
-
-[testenv:win64_py36_32]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python36;{env:PATH}
-
-[testenv:win64_py36_64]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python36-x64;{env:PATH}
-
-[testenv:win64_py37_32]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python37;{env:PATH}
-
-[testenv:win64_py37_64]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python37-x64;{env:PATH}
 
 [testenv:win64_py38_32]
 platform = win32
@@ -216,19 +136,3 @@ platform = win32
 basepython = python
 setenv =
     PATH = C:\Python312-x64;{env:PATH}
-
-[testenv:cygwin32_py27]
-platform = cygwin
-basepython = python2.7
-
-[testenv:cygwin64_py27]
-platform = cygwin
-basepython = python2.7
-
-[testenv:cygwin64_py36]
-platform = cygwin
-basepython = python3.6m
-
-[testenv:msys64_py27]
-platform = msys
-basepython = python2.7

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -19,7 +19,6 @@ API.
 For documentation, see TODO: Add link to RTD once available.
 """
 
-from __future__ import absolute_import
 
 from ._version import *       # noqa: F401
 from ._constants import *     # noqa: F401

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -44,7 +44,6 @@ There are three types of Activation Profiles:
    the operating system for that LPAR will be loaded (booted) from.
 """
 
-from __future__ import absolute_import
 
 import copy
 import warnings
@@ -114,12 +113,12 @@ class ActivationProfileManager(BaseManager):
             raise ValueError("Unknown activation profile type: {}".
                              format(profile_type))
 
-        super(ActivationProfileManager, self).__init__(
+        super().__init__(
             resource_class=ActivationProfile,
             class_name=activation_profile_class,
             session=cpc.manager.session,
             parent=cpc,
-            base_uri='{}/{}-activation-profiles'.format(cpc.uri, profile_type),
+            base_uri=f'{cpc.uri}/{profile_type}-activation-profiles',
             oid_prop='name',  # This is an exception!
             uri_prop='element-uri',
             name_prop='name',
@@ -213,7 +212,7 @@ class ActivationProfileManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = self._profile_type + '-activation-profiles'
-        list_uri = '{}/{}'.format(self.cpc.uri, result_prop)
+        list_uri = f'{self.cpc.uri}/{result_prop}'
         if self._profile_type != 'image' and additional_properties is not None:
             raise TypeError(
                 "list() for {} profiles does not support "
@@ -262,7 +261,7 @@ class ActivationProfileManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         ap_selector = self._profile_type + '-activation-profiles'
-        uri = '{}/{}'.format(self.cpc.uri, ap_selector)
+        uri = f'{self.cpc.uri}/{ap_selector}'
 
         result = self.session.post(uri, body=properties)
 
@@ -275,7 +274,7 @@ class ActivationProfileManager(BaseManager):
                 "response data with properties: {pl!r}".
                 format(pt=self._profile_type, pl=result.keys()), UserWarning)
         name = properties['profile-name']
-        uri = '{}/{}'.format(uri, name)
+        uri = f'{uri}/{name}'
 
         props = copy.deepcopy(properties)
         props[self._uri_prop] = uri
@@ -310,7 +309,7 @@ class ActivationProfile(BaseResource):
         assert isinstance(manager, ActivationProfileManager), \
             "ActivationProfile init: Expected manager type {}, got {}" \
             .format(ActivationProfileManager, type(manager))
-        super(ActivationProfile, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -60,7 +60,6 @@ There are four types of Adapters:
    on the CPC.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -116,7 +115,7 @@ class AdapterManager(BaseManager):
             'status',
         ]
 
-        super(AdapterManager, self).__init__(
+        super().__init__(
             resource_class=Adapter,
             class_name=RC_ADAPTER,
             session=cpc.manager.session,
@@ -200,7 +199,7 @@ class AdapterManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'adapters'
-        list_uri = '{}/adapters'.format(self.cpc.uri)
+        list_uri = f'{self.cpc.uri}/adapters'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args,
             additional_properties)
@@ -306,7 +305,7 @@ class Adapter(BaseResource):
         assert isinstance(manager, AdapterManager), \
             "Adapter init: Expected manager type {}, got {}" \
             .format(AdapterManager, type(manager))
-        super(Adapter, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
         # The manager objects for child resources (with lazy initialization):
         self._ports = None
         self._port_uris_prop = None
@@ -614,7 +613,7 @@ class Adapter(BaseResource):
         """
 
         # Dump the resource properties
-        resource_dict = super(Adapter, self).dump()
+        resource_dict = super().dump()
 
         # Dump the child resources
         ports = self.ports.dump()
@@ -737,7 +736,7 @@ class Adapter(BaseResource):
         pchid_base = self_pchid // 4 * 4
         sibling_pchids = list(range(pchid_base, pchid_base + 4))
         sibling_pchids.remove(self_pchid)
-        sibling_adapter_ids = ['{:03x}'.format(p) for p in sibling_pchids]
+        sibling_adapter_ids = [f'{p:03x}' for p in sibling_pchids]
         filter_args = {'adapter-id': sibling_adapter_ids}
         sibling_adapters = self.manager.cpc.adapters.list(
             full_properties, filter_args)

--- a/zhmcclient/_auto_updater.py
+++ b/zhmcclient/_auto_updater.py
@@ -21,10 +21,7 @@ objects based on HMC notifications.
 
 import logging
 import json
-try:
-    from json import JSONDecodeError as _JSONDecodeError
-except ImportError:
-    _JSONDecodeError = ValueError
+from json import JSONDecodeError
 import ssl
 
 from ._constants import DEFAULT_STOMP_PORT, JMS_LOGGER_NAME, \
@@ -397,7 +394,7 @@ class _UpdateListener:
         if noti_type == 'property-change':
             try:
                 msg_obj = json.loads(message)
-            except _JSONDecodeError:
+            except JSONDecodeError:
                 JMS_LOGGER.error(
                     "JMS message for object notification topic '%s' "
                     "has a non-JSON message body (ignored): %r",
@@ -422,7 +419,7 @@ class _UpdateListener:
         elif noti_type == 'status-change':
             try:
                 msg_obj = json.loads(message)
-            except _JSONDecodeError:
+            except JSONDecodeError:
                 JMS_LOGGER.error(
                     "JMS message for object notification topic '%s' "
                     "has a non-JSON message body (ignored): %r",

--- a/zhmcclient/_auto_updater.py
+++ b/zhmcclient/_auto_updater.py
@@ -46,7 +46,7 @@ __all__ = ['AutoUpdater']
 JMS_LOGGER = logging.getLogger(JMS_LOGGER_NAME)
 
 
-class AutoUpdater(object):
+class AutoUpdater:
     """
     A class that automatically updates
 
@@ -132,7 +132,7 @@ class AutoUpdater(object):
         # Subscription ID. We use some value that allows to identify on the
         # HMC that this is the zhmcclient, but otherwise we are not using
         # this value ourselves.
-        self._sub_id = 'zhmcclient.{}'.format(id(self))
+        self._sub_id = f'zhmcclient.{id(self)}'
 
         # Lazy importing of the stomp module, because the import is slow in some
         # versions.
@@ -157,8 +157,7 @@ class AutoUpdater(object):
         self._conn = self._stomp.Connection(
             [(self._session.actual_host, DEFAULT_STOMP_PORT)], **rt_kwargs)
         set_kwargs = dict()
-        if sys.version_info >= (3, 6):
-            set_kwargs['ssl_version'] = ssl.PROTOCOL_TLS_CLIENT
+        set_kwargs['ssl_version'] = ssl.PROTOCOL_TLS_CLIENT
         self._conn.set_ssl(
             for_hosts=[(self._session.actual_host, DEFAULT_STOMP_PORT)],
             **set_kwargs)
@@ -239,8 +238,7 @@ class AutoUpdater(object):
         if uri in self._registered_objects:
             id_dict = self._registered_objects[uri]
             # pylint: disable=use-yield-from
-            for res_obj in id_dict.values():
-                yield res_obj
+            yield from id_dict.values()
 
     def has_objects(self):
         """
@@ -250,7 +248,7 @@ class AutoUpdater(object):
         return bool(self._registered_objects)
 
 
-class _UpdateListener(object):
+class _UpdateListener:
     # pylint: disable=too-few-public-methods
     """
     A notification listener class for use by the Python `stomp` package.
@@ -352,7 +350,7 @@ class _UpdateListener(object):
                     self._session.object_topic, headers)
                 return None
 
-        mgr_uris = ['{}#{}'.format(_uri, res_class) for _uri in parent_uris]
+        mgr_uris = [f'{_uri}#{res_class}' for _uri in parent_uris]
         return mgr_uris
 
     def _get_uri(self, headers):

--- a/zhmcclient/_auto_updater.py
+++ b/zhmcclient/_auto_updater.py
@@ -18,7 +18,7 @@ Support for the :ref:`auto-updating` of Python zhmcclient resource and manager
 objects based on HMC notifications.
 """
 
-import sys
+
 import logging
 import json
 try:

--- a/zhmcclient/_capacity_group.py
+++ b/zhmcclient/_capacity_group.py
@@ -23,7 +23,6 @@ Capacity Group resources are contained in CPC resources.
 Capacity Groups only exist in :term:`CPCs <CPC>` that are in DPM mode.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -56,12 +55,12 @@ class CapacityGroupManager(BaseManager):
         #   cpc (:class:`~zhmcclient.Cpc`):
         #     CPC defining the scope for this manager.
 
-        super(CapacityGroupManager, self).__init__(
+        super().__init__(
             resource_class=CapacityGroup,
             class_name=RC_CAPACITY_GROUP,
             session=cpc.manager.session,
             parent=cpc,
-            base_uri='{}/capacity-groups'.format(cpc.uri),
+            base_uri=f'{cpc.uri}/capacity-groups',
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
@@ -132,7 +131,7 @@ class CapacityGroupManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'capacity-groups'
-        list_uri = '{}/capacity-groups'.format(self.cpc.uri)
+        list_uri = f'{self.cpc.uri}/capacity-groups'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -211,7 +210,7 @@ class CapacityGroup(BaseResource):
         assert isinstance(manager, CapacityGroupManager), \
             "CapacityGroup init: Expected manager type {}, got {}" \
             .format(CapacityGroupManager, type(manager))
-        super(CapacityGroup, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):

--- a/zhmcclient/_certificates.py
+++ b/zhmcclient/_certificates.py
@@ -27,7 +27,6 @@ corresponding entities when doing a "secure boot" load for an LPAR, respectively
 a Partition start.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -68,7 +67,7 @@ class CertificateManager(BaseManager):
             'name', 'parent-name', 'type'
         ]
 
-        super(CertificateManager, self).__init__(
+        super().__init__(
             resource_class=Certificate,
             class_name=RC_CERTIFICATE,
             session=console.manager.session,
@@ -207,7 +206,7 @@ class Certificate(BaseResource):
         assert isinstance(manager, CertificateManager), \
             "Certificate init: Expected manager type {}, got {}" \
             .format(CertificateManager, type(manager))
-        super(Certificate, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
         self._cpc = None
 
     @property
@@ -313,7 +312,7 @@ class Certificate(BaseResource):
         """
         # pylint: disable=protected-access
         return self.manager.session.get(
-            '{}/operations/get-encoded'.format(self.uri), resource=self)
+            f'{self.uri}/operations/get-encoded', resource=self)
 
     def dump(self):
         """
@@ -332,6 +331,6 @@ class Certificate(BaseResource):
         """
 
         # Dump the resource properties
-        resource_dict = super(Certificate, self).dump()
+        resource_dict = super().dump()
 
         return resource_dict

--- a/zhmcclient/_client.py
+++ b/zhmcclient/_client.py
@@ -16,7 +16,6 @@
 Client class: A client to an HMC.
 """
 
-from __future__ import absolute_import
 
 import time
 try:
@@ -35,7 +34,7 @@ from ._exceptions import Error, OperationTimeout
 __all__ = ['Client']
 
 
-class Client(object):
+class Client:
     """
     A client to an HMC.
 

--- a/zhmcclient/_client.py
+++ b/zhmcclient/_client.py
@@ -18,10 +18,7 @@ Client class: A client to an HMC.
 
 
 import time
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 import yaml
 import yamlloader
 

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -19,7 +19,6 @@ In a paired setup with primary and alternate HMC, each HMC is represented as
 a separate :term:`Console` resource.
 """
 
-from __future__ import absolute_import
 
 import time
 import six
@@ -69,7 +68,7 @@ class ConsoleManager(BaseManager):
         #   client (:class:`~zhmcclient.Client`):
         #      Client object for the HMC to be used.
 
-        super(ConsoleManager, self).__init__(
+        super().__init__(
             resource_class=Console,
             class_name=RC_CONSOLE,
             session=client.session,
@@ -196,7 +195,7 @@ class Console(BaseResource):
         assert isinstance(manager, ConsoleManager), \
             "Console init: Expected manager type {}, got {}" \
             .format(ConsoleManager, type(manager))
-        super(Console, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
         # The manager objects for child resources (with lazy initialization):
         self._storage_groups = None
@@ -455,11 +454,11 @@ class Console(BaseResource):
         query_parms = []
         if begin_time is not None:
             begin_ts = timestamp_from_datetime(begin_time)
-            qp = 'begin-time={}'.format(begin_ts)
+            qp = f'begin-time={begin_ts}'
             query_parms.append(qp)
         if end_time is not None:
             end_ts = timestamp_from_datetime(end_time)
-            qp = 'end-time={}'.format(end_ts)
+            qp = f'end-time={end_ts}'
             query_parms.append(qp)
         query_parms_str = '&'.join(query_parms)
         if query_parms_str:
@@ -1243,7 +1242,7 @@ class Console(BaseResource):
         # 'ftp_host' after that, so we detect the passing of
         # 'wait_for_completion' as a positional argument.
         assert ftp_host is None or \
-            isinstance(ftp_host, six.string_types)
+            isinstance(ftp_host, str)
 
         body = {
             'backup-location-type': backup_location_type,
@@ -1378,7 +1377,7 @@ class Console(BaseResource):
         """
 
         # Dump the resource properties
-        resource_dict = super(Console, self).dump()
+        resource_dict = super().dump()
 
         # Dump the child resources
         users = self.users.dump()

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -21,7 +21,6 @@ a separate :term:`Console` resource.
 
 
 import time
-import six
 
 from ._manager import BaseManager
 from ._resource import BaseResource

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -54,7 +54,6 @@ try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
-import six
 
 from ._manager import BaseManager
 from ._resource import BaseResource

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -46,7 +46,6 @@ particular functionality is available only in a specific mode, that is
 indicated in the description of the functionality.
 """
 
-from __future__ import absolute_import
 
 import warnings
 import copy
@@ -80,7 +79,7 @@ from ._utils import get_features, \
 __all__ = ['STPNode', 'CpcManager', 'Cpc']
 
 
-class STPNode(object):
+class STPNode:
     # pylint: disable=too-few-public-methods
     """
     Data structure defining a CPC that is referenced by an STP configuration.
@@ -163,7 +162,7 @@ class CpcManager(BaseManager):
             'name',
         ]
 
-        super(CpcManager, self).__init__(
+        super().__init__(
             resource_class=Cpc,
             class_name=RC_CPC,
             session=client.session,
@@ -291,7 +290,7 @@ class Cpc(BaseResource):
         assert isinstance(manager, CpcManager), \
             "Cpc init: Expected manager type {}, got {}" \
             .format(CpcManager, type(manager))
-        super(Cpc, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
         # The manager objects for child resources (with lazy initialization):
         self._lpars = None
@@ -553,7 +552,7 @@ class Cpc(BaseResource):
         """
 
         # Dump the resource properties
-        resource_dict = super(Cpc, self).dump()
+        resource_dict = super().dump()
 
         # Dump the child resources
         capacity_groups = self.capacity_groups.dump()
@@ -2177,7 +2176,7 @@ class Cpc(BaseResource):
         # 'ftp_host' after that, so we detect the passing of
         # 'wait_for_completion' as a positional argument.
         assert ftp_host is None or \
-            isinstance(ftp_host, six.string_types)
+            isinstance(ftp_host, str)
 
         body = {
             'accept-firmware': accept_firmware,

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -50,10 +50,7 @@ indicated in the description of the functionality.
 import warnings
 import copy
 import json
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
 from ._manager import BaseManager
 from ._resource import BaseResource

--- a/zhmcclient/_debug_info.py
+++ b/zhmcclient/_debug_info.py
@@ -27,7 +27,6 @@ Command line usage:
     python -c "import zhmcclient; print(zhmcclient.debuginfo())"
 """
 
-from __future__ import print_function, absolute_import
 
 import sys
 import platform
@@ -46,9 +45,9 @@ def _version_string(version_info):
         "1.2.3.alpha.42"  # if version_info[3] != 'final'
     """
     major, minor, micro, releaselevel, serial = version_info
-    version_str = '{}.{}.{}'.format(major, minor, micro)
+    version_str = f'{major}.{minor}.{micro}'
     if releaselevel != 'final':
-        version_str = '{}.{}.{}'.format(version_str, releaselevel, serial)
+        version_str = f'{version_str}.{releaselevel}.{serial}'
     return version_str
 
 
@@ -59,7 +58,7 @@ def debuginfo():
     di_dict = debuginfo_dict()
     ret = ""
     for k, v in di_dict.items():
-        ret += "{}: {}\n".format(k, v)
+        ret += f"{k}: {v}\n"
     return ret
 
 

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -82,7 +82,7 @@ class ConnectionError(Error):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(ConnectionError, self).__init__(msg)
+        super().__init__(msg)
         self._details = details
 
     @property
@@ -150,7 +150,7 @@ class ConnectTimeout(ConnectionError):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(ConnectTimeout, self).__init__(msg, details)
+        super().__init__(msg, details)
         self._connect_timeout = connect_timeout
         self._connect_retries = connect_retries
 
@@ -224,7 +224,7 @@ class ReadTimeout(ConnectionError):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(ReadTimeout, self).__init__(msg, details)
+        super().__init__(msg, details)
         self._read_timeout = read_timeout
         self._read_retries = read_retries
 
@@ -296,7 +296,7 @@ class RetriesExceeded(ConnectionError):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(RetriesExceeded, self).__init__(msg, details)
+        super().__init__(msg, details)
         self._connect_retries = connect_retries
 
     @property
@@ -359,7 +359,7 @@ class ClientAuthError(AuthError):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(ClientAuthError, self).__init__(msg)
+        super().__init__(msg)
 
     def __repr__(self):
         """
@@ -402,7 +402,7 @@ class ServerAuthError(AuthError):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(ServerAuthError, self).__init__(msg)
+        super().__init__(msg)
         assert isinstance(details, HTTPError)
         self._details = details
 
@@ -474,7 +474,7 @@ class ParseError(Error):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(ParseError, self).__init__(msg)
+        super().__init__(msg)
         self._line = None
         self._column = None
         if msg:
@@ -550,7 +550,7 @@ class VersionError(Error):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(VersionError, self).__init__(msg)
+        super().__init__(msg)
         self._min_api_version = min_api_version
         self._api_version = api_version
 
@@ -613,7 +613,7 @@ class HTTPError(Error):
         if not present.
         """
         msg = body.get('message', None)
-        super(HTTPError, self).__init__(msg)
+        super().__init__(msg)
         self._body = body
 
     @property
@@ -767,7 +767,7 @@ class HTTPError(Error):
         """
         Return a human readable string representation of this exception object.
         """
-        stack_txt = ' stack={!r}'.format(self.stack) if self.stack else ''
+        stack_txt = f' stack={self.stack!r}' if self.stack else ''
         return "{},{}: {} [{} {}]{}".\
                format(self.http_status, self.reason, self.message,
                       self.request_method, self.request_uri, stack_txt)
@@ -821,7 +821,7 @@ class OperationTimeout(Error):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(OperationTimeout, self).__init__(msg)
+        super().__init__(msg)
         self._operation_timeout = operation_timeout
 
     @property
@@ -895,7 +895,7 @@ class StatusTimeout(Error):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(StatusTimeout, self).__init__(msg)
+        super().__init__(msg)
         self._actual_status = actual_status
         self._desired_statuses = desired_statuses
         self._status_timeout = status_timeout
@@ -992,7 +992,7 @@ class NoUniqueMatch(Error):
             "URIs: {!r}". \
             format(manager.resource_class.__name__, filter_args, in_str,
                    resource_uris)
-        super(NoUniqueMatch, self).__init__(msg)
+        super().__init__(msg)
         self._filter_args = filter_args
         self._manager = manager
         self._resources = list(resources)
@@ -1125,7 +1125,7 @@ class NotFound(Error):
             else:
                 msg = "Could not find {} using filter arguments {!r}{}.".\
                     format(manager.resource_class.__name__, filter_args, in_str)
-        super(NotFound, self).__init__(msg)
+        super().__init__(msg)
         self._filter_args = filter_args
         self._manager = manager
 
@@ -1213,7 +1213,7 @@ class MetricsResourceNotFound(Error):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(MetricsResourceNotFound, self).__init__(msg)
+        super().__init__(msg)
         self._resource_class = resource_class
         self._managers = managers
 
@@ -1304,7 +1304,7 @@ class NotificationJMSError(NotificationError):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(NotificationJMSError, self).__init__(msg)
+        super().__init__(msg)
         self._jms_headers = jms_headers
         self._jms_message = jms_message
 
@@ -1364,7 +1364,7 @@ class NotificationParseError(NotificationError):
 
         ``args[0]`` will be set to the ``msg`` parameter.
         """
-        super(NotificationParseError, self).__init__(msg)
+        super().__init__(msg)
         self._jms_message = jms_message
 
     @property
@@ -1412,7 +1412,7 @@ class NotificationConnectionError(NotificationError):
         ``args[0]`` will be set to the ``msg`` parameter.
         """
         # pylint: disable=useless-super-delegation
-        super(NotificationConnectionError, self).__init__(msg)
+        super().__init__(msg)
 
     def str_def(self):
         """
@@ -1445,7 +1445,7 @@ class NotificationSubscriptionError(NotificationError):
         ``args[0]`` will be set to the ``msg`` parameter.
         """
         # pylint: disable=useless-super-delegation
-        super(NotificationSubscriptionError, self).__init__(msg)
+        super().__init__(msg)
 
     def str_def(self):
         """
@@ -1477,7 +1477,7 @@ class SubscriptionNotFound(NotificationError):
         ``args[0]`` will be set to the ``msg`` parameter.
         """
         # pylint: disable=useless-super-delegation
-        super(SubscriptionNotFound, self).__init__(msg)
+        super().__init__(msg)
 
     def str_def(self):
         """
@@ -1526,8 +1526,8 @@ class CeasedExistence(Error):
 
         ``args[0]`` will be set to a default message.
         """
-        msg = "Resource no longer exists: {}".format(resource_uri)
-        super(CeasedExistence, self).__init__(msg)
+        msg = f"Resource no longer exists: {resource_uri}"
+        super().__init__(msg)
         self._resource_uri = resource_uri
 
     @property

--- a/zhmcclient/_group.py
+++ b/zhmcclient/_group.py
@@ -28,7 +28,6 @@ Groups can be one of two kinds:
   :meth:`Group.add_member` and :meth:`Group.remove_member` methods.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -61,7 +60,7 @@ class GroupManager(BaseManager):
             'name',
         ]
 
-        super(GroupManager, self).__init__(
+        super().__init__(
             resource_class=Group,
             class_name=RC_GROUP,
             session=console.manager.session,
@@ -190,7 +189,7 @@ class Group(BaseResource):
         assert isinstance(manager, GroupManager), \
             "Group init: Expected manager type {}, got {}" \
             .format(GroupManager, type(manager))
-        super(Group, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     def dump(self):
         """
@@ -208,7 +207,7 @@ class Group(BaseResource):
         """
 
         # Dump the resource properties
-        resource_dict = super(Group, self).dump()
+        resource_dict = super().dump()
 
         return resource_dict
 

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -27,7 +27,6 @@ enabled, :term:`virtual HBAs <HBA>` are represented as
 :term:`Virtual Storage Resource` resources.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -63,12 +62,12 @@ class HbaManager(BaseManager):
         #   partition (:class:`~zhmcclient.Partition`):
         #     Partition defining the scope for this manager.
 
-        super(HbaManager, self).__init__(
+        super().__init__(
             resource_class=Hba,
             class_name=RC_HBA,
             session=partition.manager.session,
             parent=partition,
-            base_uri='{}/hbas'.format(partition.uri),
+            base_uri=f'{partition.uri}/hbas',
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
@@ -238,7 +237,7 @@ class Hba(BaseResource):
         assert isinstance(manager, HbaManager), \
             "Hba init: Expected manager type {}, got {}" \
             .format(HbaManager, type(manager))
-        super(Hba, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):

--- a/zhmcclient/_ldap_server_definition.py
+++ b/zhmcclient/_ldap_server_definition.py
@@ -18,7 +18,6 @@ information about an LDAP server that may be used for HMC user authentication
 purposes.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -61,7 +60,7 @@ class LdapServerDefinitionManager(BaseManager):
             'name',
         ]
 
-        super(LdapServerDefinitionManager, self).__init__(
+        super().__init__(
             resource_class=LdapServerDefinition,
             class_name=RC_LDAP_SERVER_DEFINITION,
             session=console.manager.session,
@@ -140,7 +139,7 @@ class LdapServerDefinitionManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'ldap-server-definitions'
-        list_uri = '{}/ldap-server-definitions'.format(self.console.uri)
+        list_uri = f'{self.console.uri}/ldap-server-definitions'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -213,7 +212,7 @@ class LdapServerDefinition(BaseResource):
         assert isinstance(manager, LdapServerDefinitionManager), \
             "Console init: Expected manager type {}, got {}" \
             .format(LdapServerDefinitionManager, type(manager))
-        super(LdapServerDefinition, self).__init__(
+        super().__init__(
             manager, uri, name, properties)
 
     @logged_api_call

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -157,7 +157,7 @@ def logged_api_call(func):
 
     if apifunc_owner == '<module>':
         # The decorated API function is defined globally (at module level)
-        apifunc_str = '{func}()'.format(func=func.__name__)
+        apifunc_str = f'{func.__name__}()'
     else:
         # The decorated API function is defined in a class or in a function
         apifunc_str = '{owner}.{func}()'.format(owner=apifunc_owner,

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -25,7 +25,6 @@ LPAR resources only exist in CPCs that are in classic mode (or ensemble mode).
 CPCs in DPM mode have :term:`Partition` resources, instead.
 """
 
-from __future__ import absolute_import
 
 import time
 import copy
@@ -72,7 +71,7 @@ class LparManager(BaseManager):
             'name',
         ]
 
-        super(LparManager, self).__init__(
+        super().__init__(
             resource_class=Lpar,
             class_name=RC_LOGICAL_PARTITION,
             session=cpc.manager.session,
@@ -149,7 +148,7 @@ class LparManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'logical-partitions'
-        list_uri = '{}/logical-partitions'.format(self.cpc.uri)
+        list_uri = f'{self.cpc.uri}/logical-partitions'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -180,7 +179,7 @@ class Lpar(BaseResource):
         assert isinstance(manager, LparManager), \
             "Lpar init: Expected manager type {}, got {}" \
             .format(LparManager, type(manager))
-        super(Lpar, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def update_properties(self, properties):
@@ -1926,19 +1925,19 @@ class Lpar(BaseResource):
         """
         query_parms = []
         if begin is not None:
-            query_parms.append('begin-sequence-number={}'.format(begin))
+            query_parms.append(f'begin-sequence-number={begin}')
         if end is not None:
-            query_parms.append('end-sequence-number={}'.format(end))
+            query_parms.append(f'end-sequence-number={end}')
         if is_held is not None:
-            query_parms.append('is-held={}'.format(str(is_held).lower()))
+            query_parms.append(f'is-held={str(is_held).lower()}')
         if is_priority is not None:
             query_parms.append(
-                'is-priority={}'.format(str(is_priority).lower()))
+                f'is-priority={str(is_priority).lower()}')
         if max_messages > 0:
-            query_parms.append('max-messages={}'.format(max_messages))
+            query_parms.append(f'max-messages={max_messages}')
         query_str = make_query_str(query_parms)
         result = self.manager.session.get(
-            '{}/operations/list-os-messages{}'.format(self.uri, query_str),
+            f'{self.uri}/operations/list-os-messages{query_str}',
             resource=self)
         return result
 

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -25,7 +25,6 @@ resource object scope of each LPAR manager object is the set of LPARs in that
 CPC.
 """
 
-from __future__ import absolute_import
 
 import re
 from datetime import datetime, timedelta
@@ -46,7 +45,7 @@ __all__ = ['BaseManager']
 REGEXP_SPECIAL_CHAR = re.compile(r'[\^\$\.\+\*\?\(\)\[\]\{\}\|\\]')
 
 
-class _NameUriCache(object):
+class _NameUriCache:
     """
     A Name-URI cache, that caches the mapping between resource names and
     resource URIs. It supports looking up resource URIs by resource names.
@@ -186,7 +185,7 @@ class _NameUriCache(object):
                 pass
 
 
-class _ResourceList(object):
+class _ResourceList:
     """
     A list of resources, for use by resource manager objects for auto-updating.
 
@@ -363,7 +362,7 @@ class _ResourceList(object):
                 pass
 
 
-class BaseManager(object):
+class BaseManager:
     """
     Abstract base class for manager classes (e.g.
     :class:`~zhmcclient.CpcManager`).
@@ -574,7 +573,7 @@ class BaseManager(object):
         if self._name_prop in filter_args:
 
             name_match = filter_args[self._name_prop]
-            if not isinstance(name_match, six.string_types) or \
+            if not isinstance(name_match, str) or \
                     REGEXP_SPECIAL_CHAR.search(name_match):
                 return None
 
@@ -588,7 +587,7 @@ class BaseManager(object):
         if self._oid_prop in filter_args:
 
             oid_match = filter_args[self._oid_prop]
-            if not isinstance(oid_match, six.string_types) or \
+            if not isinstance(oid_match, str) or \
                     REGEXP_SPECIAL_CHAR.search(oid_match):
                 return None
 
@@ -679,7 +678,7 @@ class BaseManager(object):
                 parent_uri = self._parent.uri
             else:
                 parent_uri = '/'  # top-level resource
-            self._uri = '{}#{}'.format(parent_uri, self._class_name)
+            self._uri = f'{parent_uri}#{self._class_name}'
         return self._uri
 
     @property
@@ -775,7 +774,7 @@ class BaseManager(object):
                     ','.join(additional_properties))
                 query_parms.append(ap_parm)
             query_parms_str = make_query_str(query_parms)
-            uri = '{}{}'.format(list_uri, query_parms_str)
+            uri = f'{list_uri}{query_parms_str}'
 
             try:
                 result = self.session.get(uri)
@@ -1114,7 +1113,7 @@ class BaseManager(object):
         else:
             assert '/' not in uri_or_oid
             oid = uri_or_oid
-            uri = '{}/{}'.format(self._base_uri, oid)
+            uri = f'{self._base_uri}/{oid}'
         res_props = {
             'parent': self.parent.uri if self.parent is not None else None,
             'class': self.class_name,

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -31,7 +31,6 @@ from datetime import datetime, timedelta
 import time
 import warnings
 import threading
-import six
 from nocasedict import NocaseDict
 
 from ._logging import logged_api_call

--- a/zhmcclient/_metrics.py
+++ b/zhmcclient/_metrics.py
@@ -63,7 +63,6 @@ The basic usage of the metrics API is shown in this example:
     mc.delete()
 """
 
-from __future__ import absolute_import
 
 try:
     from collections.abc import namedtuple
@@ -112,7 +111,7 @@ class MetricsContextManager(BaseManager):
         # Parameters:
         #   client (:class:`~zhmcclient.Client`):
         #      Client object for the HMC to be used.
-        super(MetricsContextManager, self).__init__(
+        super().__init__(
             resource_class=MetricsContext,
             class_name='',
             session=client.session,
@@ -278,7 +277,7 @@ class MetricsContext(BaseResource):
             raise AssertionError(
                 "MetricsContext init: Expected manager type {}, got {}"
                 .format(MetricsContextManager, type(manager)))
-        super(MetricsContext, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
         self._metric_group_definitions = self._setup_metric_group_definitions()
 
@@ -394,7 +393,7 @@ class MetricGroupDefinition(_MetricGroupDefinitionTuple):
 
         All these parameters are also available as same-named attributes.
         """
-        self = super(MetricGroupDefinition, cls).__new__(
+        self = super().__new__(
             cls, name, resource_class, metric_definitions)
         return self
 
@@ -458,7 +457,7 @@ class MetricDefinition(_MetricDefinitionTuple):
 
         All these parameters are also available as same-named attributes.
         """
-        self = super(MetricDefinition, cls).__new__(
+        self = super().__new__(
             cls, index, name, type, unit)
         return self
 
@@ -492,7 +491,7 @@ _METRIC_TYPES_BY_NAME = {
     'integer-metric': int,
     'long-metric': int,
     'double-metric': float,
-    'string-metric': six.text_type,
+    'string-metric': str,
 }
 
 
@@ -509,7 +508,7 @@ def _metric_value(value_str, metric_type):
                 format(metric_type.__class__.__name__, value_str))
             new_exc.__cause__ = None
             raise new_exc  # ValueError
-    elif metric_type is six.text_type:
+    elif metric_type is str:
         # In Python 3, decode('unicode_escape) requires bytes, so we need
         # to encode to bytes. This also works in Python 2.
         return value_str.strip('"').encode('utf-8').decode('unicode_escape')
@@ -520,7 +519,7 @@ def _metric_value(value_str, metric_type):
             return True
         if lower_str == 'false':
             return False
-        raise ValueError("Invalid boolean metric value: {!r}".format(value_str))
+        raise ValueError(f"Invalid boolean metric value: {value_str!r}")
 
 
 def _metric_unit_from_name(metric_name):
@@ -539,36 +538,36 @@ def _metric_unit_from_name(metric_name):
 
 _USE_UNICODE = True
 if _USE_UNICODE:
-    MICROSECONDS = u"\u00b5s"  # U+00B5 = Micro Sign
-    CELSIUS = u"\u00B0C"  # U+00B0 = Degree Sign
+    MICROSECONDS = "\u00b5s"  # U+00B5 = Micro Sign
+    CELSIUS = "\u00B0C"  # U+00B0 = Degree Sign
     # Note: Use of U+2103 (Degree Celsius) is discouraged by Unicode standard
 else:
-    MICROSECONDS = u"us"
-    CELSIUS = u"degree Celsius"  # Official SI unit when not using degree sign
+    MICROSECONDS = "us"
+    CELSIUS = "degree Celsius"  # Official SI unit when not using degree sign
 
 
 _PATTERN_UNIT_LIST = {
     # End patterns:
-    (re.compile(r".+-usage$"), u"%"),
+    (re.compile(r".+-usage$"), "%"),
     (re.compile(r".+-time$"), MICROSECONDS),
     (re.compile(r".+-time-used$"), MICROSECONDS),
     (re.compile(r".+-celsius$"), CELSIUS),
-    (re.compile(r".+-watts$"), u"W"),
-    (re.compile(r".+-paging-rate$"), u"pages/s"),
-    (re.compile(r".+-sampling-rate$"), u"samples/s"),
+    (re.compile(r".+-watts$"), "W"),
+    (re.compile(r".+-paging-rate$"), "pages/s"),
+    (re.compile(r".+-sampling-rate$"), "samples/s"),
     # Begin patterns:
-    (re.compile(r"^bytes-.+"), u"B"),
-    (re.compile(r"^heat-load.+"), u"BTU/h"),  # Note: No trailing hyphen
-    (re.compile(r"^interval-bytes-.+"), u"B"),
-    (re.compile(r"^bytes-per-second-.+"), u"B/s"),
+    (re.compile(r"^bytes-.+"), "B"),
+    (re.compile(r"^heat-load.+"), "BTU/h"),  # Note: No trailing hyphen
+    (re.compile(r"^interval-bytes-.+"), "B"),
+    (re.compile(r"^bytes-per-second-.+"), "B/s"),
     # Special cases:
-    (re.compile(r"^storage-rate$"), u"kB/s"),
-    (re.compile(r"^humidity$"), u"%"),
-    (re.compile(r"^memory-used$"), u"MiB"),
-    (re.compile(r"^policy-activation-time$"), u""),  # timestamp
+    (re.compile(r"^storage-rate$"), "kB/s"),
+    (re.compile(r"^humidity$"), "%"),
+    (re.compile(r"^memory-used$"), "MiB"),
+    (re.compile(r"^policy-activation-time$"), ""),  # timestamp
     (re.compile(r"^velocity-numerator$"), MICROSECONDS),
     (re.compile(r"^velocity-denominator$"), MICROSECONDS),
-    (re.compile(r"^utilization$"), u"%"),
+    (re.compile(r"^utilization$"), "%"),
 }
 
 
@@ -604,7 +603,7 @@ CLASS_FROM_GROUP = {
 }
 
 
-class MetricsResponse(object):
+class MetricsResponse:
     """
     Represents the metric values returned by one call to the
     :meth:`~zhmcclient.MetricsContext.get_metrics` method, and provides
@@ -744,7 +743,7 @@ class MetricsResponse(object):
         return self._metric_group_values
 
 
-class MetricGroupValues(object):
+class MetricGroupValues:
     """
     Represents the metric values for a metric group in a MetricsResponse
     string.
@@ -782,7 +781,7 @@ class MetricGroupValues(object):
         return self._object_values
 
 
-class MetricObjectValues(object):
+class MetricObjectValues:
     """
     Represents the metric values for a single resource at a single point in
     time.
@@ -953,7 +952,7 @@ class MetricObjectValues(object):
                     Nic, nic_managers)
         else:
             raise ValueError(
-                "Invalid resource class: {!r}".format(resource_class))
+                f"Invalid resource class: {resource_class!r}")
 
         self._resource = resource
         return self._resource

--- a/zhmcclient/_metrics.py
+++ b/zhmcclient/_metrics.py
@@ -64,14 +64,7 @@ The basic usage of the metrics API is shown in this example:
 """
 
 
-try:
-    from collections.abc import namedtuple
-except ImportError:
-    from collections import namedtuple
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict, namedtuple
 import re
 from datetime import datetime
 import pytz

--- a/zhmcclient/_metrics.py
+++ b/zhmcclient/_metrics.py
@@ -75,7 +75,6 @@ except ImportError:
 import re
 from datetime import datetime
 import pytz
-import six
 
 from ._manager import BaseManager
 from ._resource import BaseResource

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -24,7 +24,6 @@ NIC resources are contained in Partition resources.
 NICs only exist in :term:`CPCs <CPC>` that are in DPM mode.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -58,12 +57,12 @@ class NicManager(BaseManager):
         #   partition (:class:`~zhmcclient.Partition`):
         #     Partition defining the scope for this manager.
 
-        super(NicManager, self).__init__(
+        super().__init__(
             resource_class=Nic,
             class_name=RC_NIC,
             session=partition.manager.session,
             parent=partition,
-            base_uri='{}/nics'.format(partition.uri),
+            base_uri=f'{partition.uri}/nics',
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
@@ -269,7 +268,7 @@ class Nic(BaseResource):
         assert isinstance(manager, NicManager), \
             "Nic init: Expected manager type {}, got {}" \
             .format(NicManager, type(manager))
-        super(Nic, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -75,7 +75,7 @@ messages issued by the operating system. The following commands use the
     $ zhmc partition start {cpc-name} {partition-name}
 """
 
-import sys
+
 import os
 import json
 import ssl

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -79,10 +79,7 @@ messages issued by the operating system. The following commands use the
 import os
 import json
 import ssl
-try:
-    import queue
-except ImportError:
-    import Queue as queue  # Python 2.7
+import queue
 from collections import namedtuple
 import logging
 import uuid

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -108,7 +108,7 @@ DEBUG_HEARTBEATS = False
 JMS_LOGGER = logging.getLogger(JMS_LOGGER_NAME)
 
 
-class StompRetryTimeoutConfig(object):
+class StompRetryTimeoutConfig:
     # pylint: disable=too-few-public-methods
     """
     A configuration setting that specifies various retry and timeout related
@@ -232,7 +232,7 @@ class StompRetryTimeoutConfig(object):
         return ret
 
 
-class NotificationReceiver(object):
+class NotificationReceiver:
     """
     A class for receiving HMC notifications that are published to particular
     HMC notification topics.
@@ -385,8 +385,7 @@ class NotificationReceiver(object):
         self._conn = self._stomp.Connection(
             [(self._host, self._port)], **rt_kwargs)
         set_kwargs = dict()
-        if sys.version_info >= (3, 6):
-            set_kwargs['ssl_version'] = ssl.PROTOCOL_TLS_CLIENT
+        set_kwargs['ssl_version'] = ssl.PROTOCOL_TLS_CLIENT
         self._conn.set_ssl(for_hosts=[(self._host, self._port)], **set_kwargs)
         listener = _NotificationListener(self._handover_queue)
         self._conn.set_listener('', listener)
@@ -651,7 +650,7 @@ class NotificationReceiver(object):
                 else:
                     details = ""
                 raise NotificationJMSError(
-                    "Received JMS error from HMC{}".format(details),
+                    f"Received JMS error from HMC{details}",
                     item.headers, item.message)
             elif item.msgtype in ('disconnected', 'heartbeat_timeout'):
                 # Get all contiguous such entries to handle them just once
@@ -685,7 +684,7 @@ class NotificationReceiver(object):
                     "{} disconnect messages".format(num_hbto, num_disc))
             else:
                 raise RuntimeError(
-                    "Invalid handover item: {}".format(item.msgtype))
+                    f"Invalid handover item: {item.msgtype}")
 
             yield item.headers, msg_obj
 
@@ -717,7 +716,7 @@ _NotificationItem = namedtuple(
 )
 
 
-class _NotificationListener(object):
+class _NotificationListener:
     """
     A notification listener class for use by the Python `stomp-py` package.
 
@@ -779,12 +778,12 @@ class _NotificationListener(object):
         if can_send == 0:
             can_send_str = "cannot send heartbeats"
         else:
-            can_send_str = "can send heartbeats every {} msec".format(can_send)
+            can_send_str = f"can send heartbeats every {can_send} msec"
         if want_receive == 0:
             want_receive_str = "does not want to receive heartbeats"
         else:
             want_receive_str = \
-                "wants to receive heartbeats every {} msec".format(want_receive)
+                f"wants to receive heartbeats every {want_receive} msec"
         JMS_LOGGER.info(
             "Connected. The HMC %s and %s", can_send_str, want_receive_str)
 

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -29,7 +29,6 @@ Partition resources only exist in CPCs that are in DPM mode. CPCs in classic
 mode (or ensemble mode) have :term:`LPAR` resources, instead.
 """
 
-from __future__ import absolute_import
 
 import time
 import copy
@@ -78,7 +77,7 @@ class PartitionManager(BaseManager):
             'status',
         ]
 
-        super(PartitionManager, self).__init__(
+        super().__init__(
             resource_class=Partition,
             class_name=RC_PARTITION,
             session=cpc.manager.session,
@@ -164,7 +163,7 @@ class PartitionManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'partitions'
-        list_uri = '{}/partitions'.format(self.cpc.uri)
+        list_uri = f'{self.cpc.uri}/partitions'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args,
             additional_properties)
@@ -238,7 +237,7 @@ class Partition(BaseResource):
         assert isinstance(manager, PartitionManager), \
             "Partition init: Expected manager type {}, got {}" \
             .format(PartitionManager, type(manager))
-        super(Partition, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
         # The manager objects for child resources (with lazy initialization):
         self._nics = None
         self._hbas = None
@@ -996,12 +995,12 @@ class Partition(BaseResource):
         """
         query_parms = []
         if begin is not None:
-            query_parms.append('begin-sequence-number={}'.format(begin))
+            query_parms.append(f'begin-sequence-number={begin}')
         if end is not None:
-            query_parms.append('end-sequence-number={}'.format(end))
+            query_parms.append(f'end-sequence-number={end}')
         query_str = make_query_str(query_parms)
         result = self.manager.session.get(
-            '{}/operations/list-os-messages{}'.format(self.uri, query_str),
+            f'{self.uri}/operations/list-os-messages{query_str}',
             resource=self)
         return result
 
@@ -1477,7 +1476,7 @@ class Partition(BaseResource):
         """
 
         # Dump the resource properties
-        resource_dict = super(Partition, self).dump()
+        resource_dict = super().dump()
 
         # Dump the child resources
         nics = self.nics.dump()

--- a/zhmcclient/_password_rule.py
+++ b/zhmcclient/_password_rule.py
@@ -19,7 +19,6 @@ authentication (i.e. not LDAP) is assigned a password rule. There are certain
 system-defined password rules available for use.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -62,7 +61,7 @@ class PasswordRuleManager(BaseManager):
             'type',
         ]
 
-        super(PasswordRuleManager, self).__init__(
+        super().__init__(
             resource_class=PasswordRule,
             class_name=RC_PASSWORD_RULE,
             session=console.manager.session,
@@ -141,7 +140,7 @@ class PasswordRuleManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'password-rules'
-        list_uri = '{}/password-rules'.format(self.console.uri)
+        list_uri = f'{self.console.uri}/password-rules'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -213,7 +212,7 @@ class PasswordRule(BaseResource):
         assert isinstance(manager, PasswordRuleManager), \
             "Console init: Expected manager type {}, got {}" \
             .format(PasswordRuleManager, type(manager))
-        super(PasswordRule, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -22,10 +22,7 @@ Ports only exist in :term:`CPCs <CPC>` that are in DPM mode.
 
 
 import copy
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
 from ._manager import BaseManager
 from ._resource import BaseResource

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -20,7 +20,6 @@ Port resources are contained in Adapter resources.
 Ports only exist in :term:`CPCs <CPC>` that are in DPM mode.
 """
 
-from __future__ import absolute_import
 
 import copy
 try:
@@ -70,9 +69,9 @@ class PortManager(BaseManager):
         try:
             port_class = PORT_CLASSES[port_type]
         except KeyError:
-            raise ValueError("Unknown port type: {}".format(port_type))
+            raise ValueError(f"Unknown port type: {port_type}")
 
-        super(PortManager, self).__init__(
+        super().__init__(
             resource_class=Port,
             session=adapter.manager.session,
             class_name=port_class,
@@ -203,7 +202,7 @@ class Port(BaseResource):
         assert isinstance(manager, PortManager), \
             "Port init: Expected manager type {}, got {}" \
             .format(PortManager, type(manager))
-        super(Port, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def update_properties(self, properties):

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -19,7 +19,6 @@ Resource objects represent the real manageable resources in the systems managed
 by the HMC.
 """
 
-from __future__ import absolute_import
 import time
 import threading
 try:
@@ -36,7 +35,7 @@ from ._exceptions import CeasedExistence, HTTPError
 __all__ = ['BaseResource']
 
 
-class BaseResource(object):
+class BaseResource:
     """
     Abstract base class for resource classes (e.g. :class:`~zhmcclient.Cpc`)
     representing manageable resources.
@@ -635,9 +634,9 @@ class BaseResource(object):
                            'type', 'class']
             sorted_keys = sorted([k for k in properties_keys
                                   if k in search_keys])
-            info = ", ".join("{}={!r}".format(k, self._properties[k])
+            info = ", ".join(f"{k}={self._properties[k]!r}"
                              for k in sorted_keys)
-            return "{}({})".format(self.__class__.__name__, info)
+            return f"{self.__class__.__name__}({info})"
 
     def __repr__(self):
         """

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -21,10 +21,7 @@ by the HMC.
 
 import time
 import threading
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 # import contextlib
 from immutable_views import DictView
 

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -17,20 +17,12 @@ Session class: A session to the HMC, optionally in context of an HMC user.
 """
 
 
-import sys
 import json
 import time
 import re
 from copy import copy
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
-try:
-    from collections.abc import Iterable
-except ImportError:
-    # pylint: disable=deprecated-class
-    from collections.abc import Iterable
+from collections import OrderedDict
+from collections.abc import Iterable
 import requests
 import urllib3
 
@@ -2113,10 +2105,6 @@ def json2dict(json_str):
     Raises:
       ValueError: Cannot parse JSON string
     """
-    # In Python 3 up to 3.5, json.loads() requires unicode strings.
-    if sys.version_info[0] == 3 and sys.version_info[1] in (4, 5) and \
-            isinstance(json_str, bytes):
-        json_str = json_str.decode('utf-8')
     json_dict = json.loads(json_str)  # May raise ValueError
     return json_dict
 

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -16,7 +16,6 @@
 Session class: A session to the HMC, optionally in context of an HMC user.
 """
 
-from __future__ import absolute_import
 
 import sys
 import json
@@ -31,7 +30,7 @@ try:
     from collections.abc import Iterable
 except ImportError:
     # pylint: disable=deprecated-class
-    from collections import Iterable
+    from collections.abc import Iterable
 import six
 import requests
 import urllib3
@@ -58,7 +57,7 @@ HMC_LOGGER = get_logger(HMC_LOGGER_NAME)
 
 _HMC_SCHEME = "https"
 _STD_HEADERS = {
-    'User-Agent': 'python-zhmcclient/{}'.format(__version__),
+    'User-Agent': f'python-zhmcclient/{__version__}',
     'Content-type': 'application/json',
     'Accept': '*/*'
 }
@@ -119,7 +118,7 @@ def _request_exc_message(exc):
         if isinstance(arg, Exception):
             org_exc = arg
             if isinstance(org_exc, urllib3.exceptions.MaxRetryError):
-                message = "{}, reason: {}".format(org_exc, org_exc.reason)
+                message = f"{org_exc}, reason: {org_exc.reason}"
             else:
                 message = str(org_exc)
         else:
@@ -135,7 +134,7 @@ def _request_exc_message(exc):
     return ", ".join(messages)
 
 
-class RetryTimeoutConfig(object):
+class RetryTimeoutConfig:
     # pylint: disable=too-few-public-methods
     """
     A configuration setting that specifies verious retry counts and timeout
@@ -270,7 +269,7 @@ def _headers_for_logging(headers):
     return headers
 
 
-class Session(object):
+class Session:
     """
     A session to the HMC, optionally in context of an HMC user.
 
@@ -412,7 +411,7 @@ class Session(object):
         """  # noqa: E501
         # pylint: enable=line-too-long
 
-        if isinstance(host, six.string_types):
+        if isinstance(host, str):
             self._hosts = [host]
         else:
             self._hosts = list(host)
@@ -952,9 +951,9 @@ class Session(object):
 
         content_msg = None
         if content is not None:
-            if isinstance(content, six.binary_type):
+            if isinstance(content, bytes):
                 content = content.decode('utf-8', errors='ignore')
-            assert isinstance(content, six.text_type)
+            assert isinstance(content, str)
             if content_len is None:
                 content_len = len(content)  # may change after JSON conversion
             try:
@@ -973,7 +972,7 @@ class Session(object):
                     format(trunc, content_len)
                 content_msg = content[0:trunc] + '...(truncated)'
             else:
-                content_label = 'content({} B)'.format(content_len)
+                content_label = f'content({content_len} B)'
                 content_msg = content
         else:
             content_label = 'content'
@@ -1019,9 +1018,9 @@ class Session(object):
         """
 
         if content is not None:
-            if isinstance(content, six.binary_type):
+            if isinstance(content, bytes):
                 content = content.decode('utf-8')
-            assert isinstance(content, six.text_type)
+            assert isinstance(content, str)
             content_len = len(content)  # may change after JSON conversion
             try:
                 content_dict = json2dict(content)
@@ -1050,7 +1049,7 @@ class Session(object):
                         format(trunc, content_len)
                     content_msg = content[0:trunc] + '...(truncated)'
                 else:
-                    content_label = 'content({} B)'.format(len(content))
+                    content_label = f'content({len(content)} B)'
                     content_msg = content
         else:
             content_label = 'content'
@@ -1135,7 +1134,7 @@ class Session(object):
                              timeout=req_timeout)
         # Note: The requests method may raise OSError/IOError in case of
         # HMC certificate validation issues (e.g. incorrect cert path)
-        except (requests.exceptions.RequestException, IOError, OSError) as exc:
+        except (requests.exceptions.RequestException, OSError) as exc:
             _handle_request_exc(exc, self.retry_timeout_config)
         finally:
             stats.end()
@@ -1320,16 +1319,16 @@ class Session(object):
             # Produces unicode string on py3, and unicode or byte string on py2.
             # Content-type is already set to 'application/json' in standard
             # headers.
-            if isinstance(data, six.text_type):
+            if isinstance(data, str):
                 log_data = data
                 data = data.encode('utf-8')
             else:
                 log_data = data
-        elif isinstance(body, six.text_type):
+        elif isinstance(body, str):
             data = body.encode('utf-8')
             log_data = body
             headers['Content-type'] = 'application/octet-stream'
-        elif isinstance(body, six.binary_type):
+        elif isinstance(body, bytes):
             data = body
             log_data = body
             headers['Content-type'] = 'application/octet-stream'
@@ -1341,11 +1340,11 @@ class Session(object):
                 mode = body.mode
             except AttributeError:
                 mode = 'unknown'
-            log_data = u"<file-like object with mode {}>".format(mode)
+            log_data = f"<file-like object with mode {mode}>"
             log_len = -1
             headers['Content-type'] = 'application/octet-stream'
         else:
-            raise TypeError("Body has invalid type: {}".format(type(body)))
+            raise TypeError(f"Body has invalid type: {type(body)}")
 
         self._log_http_request('POST', url, resource=resource, headers=headers,
                                content=log_data, content_len=log_len)
@@ -1370,7 +1369,7 @@ class Session(object):
                                       timeout=req_timeout)
             # Note: The requests method may raise OSError/IOError in case of
             # HMC certificate validation issues (e.g. incorrect cert path)
-            except (requests.exceptions.RequestException, IOError, OSError) \
+            except (requests.exceptions.RequestException, OSError) \
                     as exc:
                 _handle_request_exc(exc, self.retry_timeout_config)
             finally:
@@ -1497,7 +1496,7 @@ class Session(object):
                                 verify=self.verify_cert, timeout=req_timeout)
         # Note: The requests method may raise OSError/IOError in case of
         # HMC certificate validation issues (e.g. incorrect cert path)
-        except (requests.exceptions.RequestException, IOError, OSError) as exc:
+        except (requests.exceptions.RequestException, OSError) as exc:
             _handle_request_exc(exc, self.retry_timeout_config)
         finally:
             stats.end()
@@ -1612,7 +1611,7 @@ class Session(object):
             self._auto_updater.close()
 
 
-class Job(object):
+class Job:
     """
     A job on the HMC that performs an asynchronous HMC operation.
 
@@ -1981,7 +1980,7 @@ class Job(object):
           :exc:`~zhmcclient.ServerAuthError`
           :exc:`~zhmcclient.ConnectionError`
         """
-        uri = '{}/operations/cancel'.format(self.uri)
+        uri = f'{self.uri}/operations/cancel'
         try:
             self.session.post(uri)
         except Error as exc:
@@ -2071,9 +2070,9 @@ def _result_object(result):
                     replace('<br>', '\\n').replace('\\n\\n', '\\n').strip()
             else:
                 html_title = "Console Internal Error"
-                html_details = "Response body: {!r}".format(html_uni)
+                html_details = f"Response body: {html_uni!r}"
             html_reason = HTML_REASON_OTHER
-        message = "{}: {}".format(html_title, html_details)
+        message = f"{html_title}: {html_details}"
 
         # We create a minimal JSON error object (to the extent we use it
         # when processing it):
@@ -2088,7 +2087,7 @@ def _result_object(result):
 
     if content_type.startswith('application/vnd.ibm-z-zmanager-metrics'):
         content_bytes = result.content
-        assert isinstance(content_bytes, six.binary_type)
+        assert isinstance(content_bytes, bytes)
         return content_bytes.decode('utf-8')  # as a unicode object
 
     raise ParseError(
@@ -2117,7 +2116,7 @@ def json2dict(json_str):
     """
     # In Python 3 up to 3.5, json.loads() requires unicode strings.
     if sys.version_info[0] == 3 and sys.version_info[1] in (4, 5) and \
-            isinstance(json_str, six.binary_type):
+            isinstance(json_str, bytes):
         json_str = json_str.decode('utf-8')
     json_dict = json.loads(json_str)  # May raise ValueError
     return json_dict

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -31,7 +31,6 @@ try:
 except ImportError:
     # pylint: disable=deprecated-class
     from collections.abc import Iterable
-import six
 import requests
 import urllib3
 

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -78,7 +78,6 @@ Storage groups can only be associated with CPCs that have the
 "dpm-storage-management" feature enabled.
 """
 
-from __future__ import absolute_import
 
 import copy
 import re
@@ -125,7 +124,7 @@ class StorageGroupManager(BaseManager):
             'fulfillment-state',
         ]
 
-        super(StorageGroupManager, self).__init__(
+        super().__init__(
             resource_class=StorageGroup,
             class_name=RC_STORAGE_GROUP,
             session=console.manager.session,
@@ -317,7 +316,7 @@ class StorageGroup(BaseResource):
         assert isinstance(manager, StorageGroupManager), \
             "StorageGroup init: Expected manager type {}, got {}"  \
             .format(StorageGroupManager, type(manager))
-        super(StorageGroup, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
         # The manager objects for child resources (with lazy initialization):
         self._storage_volumes = None
         self._virtual_storage_resources = None
@@ -406,7 +405,7 @@ class StorageGroup(BaseResource):
             append_query_parms(query_parms, 'status', status)
         query_parms_str = '&'.join(query_parms)
         if query_parms_str:
-            query_parms_str = '?{}'.format(query_parms_str)
+            query_parms_str = f'?{query_parms_str}'
 
         uri = '{}/operations/get-partitions{}'.format(
             self.uri, query_parms_str)
@@ -528,7 +527,7 @@ class StorageGroup(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         # pylint: disable=protected-access
-        uri = '{}/operations/modify'.format(self.uri)
+        uri = f'{self.uri}/operations/modify'
         self.manager.session.post(uri, resource=self, body=properties)
         is_rename = self.manager._name_prop in properties
         if is_rename:
@@ -837,7 +836,7 @@ class StorageGroup(BaseResource):
         """
 
         # Dump the resource properties
-        resource_dict = super(StorageGroup, self).dump()
+        resource_dict = super().dump()
 
         # Dump the child resources
         storage_volumes = self.storage_volumes.dump()

--- a/zhmcclient/_storage_group_template.py
+++ b/zhmcclient/_storage_group_template.py
@@ -25,7 +25,6 @@ Storage group template objects can only be defined in CPCs that are in
 DPM mode and that have the "dpm-storage-management" feature enabled.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -69,7 +68,7 @@ class StorageGroupTemplateManager(BaseManager):
             'type',
         ]
 
-        super(StorageGroupTemplateManager, self).__init__(
+        super().__init__(
             resource_class=StorageGroupTemplate,
             class_name=RC_STORAGE_TEMPLATE,
             session=console.manager.session,
@@ -230,7 +229,7 @@ class StorageGroupTemplate(BaseResource):
         assert isinstance(manager, StorageGroupTemplateManager), \
             "StorageGroupTemplate init: Expected manager type {}, got {}" \
             .format(StorageGroupTemplateManager, type(manager))
-        super(StorageGroupTemplate, self).__init__(
+        super().__init__(
             manager, uri, name, properties)
         # The manager objects for child resources (with lazy initialization):
         self._storage_volume_templates = None
@@ -329,7 +328,7 @@ class StorageGroupTemplate(BaseResource):
           :exc:`~zhmcclient.ConnectionError`
         """
         # pylint: disable=protected-access
-        uri = '{}/operations/modify'.format(self.uri)
+        uri = f'{self.uri}/operations/modify'
         self.manager.session.post(uri, resource=self, body=properties)
         is_rename = self.manager._name_prop in properties
         if is_rename:

--- a/zhmcclient/_storage_volume.py
+++ b/zhmcclient/_storage_volume.py
@@ -36,7 +36,6 @@ Storage groups and storage volumes only can be defined in CPCs that are in
 DPM mode and that have the "dpm-storage-management" feature enabled.
 """
 
-from __future__ import absolute_import
 
 import re
 import copy
@@ -83,12 +82,12 @@ class StorageVolumeManager(BaseManager):
             'usage',
         ]
 
-        super(StorageVolumeManager, self).__init__(
+        super().__init__(
             resource_class=StorageVolume,
             class_name=RC_STORAGE_VOLUME,
             session=storage_group.manager.session,
             parent=storage_group,
-            base_uri='{}/storage-volumes'.format(storage_group.uri),
+            base_uri=f'{storage_group.uri}/storage-volumes',
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
@@ -159,7 +158,7 @@ class StorageVolumeManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'storage-volumes'
-        list_uri = '{}/storage-volumes'.format(self.storage_group.uri)
+        list_uri = f'{self.storage_group.uri}/storage-volumes'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -306,7 +305,7 @@ class StorageVolume(BaseResource):
         assert isinstance(manager, StorageVolumeManager), \
             "StorageVolume init: Expected manager type {}, got {}" \
             .format(StorageVolumeManager, type(manager))
-        super(StorageVolume, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @property
     def oid(self):

--- a/zhmcclient/_storage_volume_template.py
+++ b/zhmcclient/_storage_volume_template.py
@@ -32,7 +32,6 @@ CPCs that are in DPM mode and that have the "dpm-storage-management" feature
 enabled.
 """
 
-from __future__ import absolute_import
 
 import copy
 # from requests.utils import quote
@@ -78,7 +77,7 @@ class StorageVolumeTemplateManager(BaseManager):
             'usage',
         ]
 
-        super(StorageVolumeTemplateManager, self).__init__(
+        super().__init__(
             resource_class=StorageVolumeTemplate,
             class_name=RC_STORAGE_TEMPLATE_VOLUME,
             session=storage_group_template.manager.session,
@@ -259,7 +258,7 @@ class StorageVolumeTemplate(BaseResource):
         assert isinstance(manager, StorageVolumeTemplateManager), \
             "StorageVolumeTemplate init: Expected manager type {}, got {}" \
             .format(StorageVolumeTemplateManager, type(manager))
-        super(StorageVolumeTemplate, self).__init__(
+        super().__init__(
             manager, uri, name, properties)
 
     @logged_api_call

--- a/zhmcclient/_task.py
+++ b/zhmcclient/_task.py
@@ -20,7 +20,6 @@ user interface, the Web Services APIs or both.
 Tasks are predefined by the HMC and cannot be created, modified or deleted.
 """
 
-from __future__ import absolute_import
 
 from ._manager import BaseManager
 from ._resource import BaseResource
@@ -58,7 +57,7 @@ class TaskManager(BaseManager):
             'name',
         ]
 
-        super(TaskManager, self).__init__(
+        super().__init__(
             resource_class=Task,
             class_name=RC_TASK,
             session=console.manager.session,
@@ -134,7 +133,7 @@ class TaskManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'tasks'
-        list_uri = '{}/tasks'.format(self.console.uri)
+        list_uri = f'{self.console.uri}/tasks'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -165,4 +164,4 @@ class Task(BaseResource):
         assert isinstance(manager, TaskManager), \
             "Console init: Expected manager type {}, got {}" \
             .format(TaskManager, type(manager))
-        super(Task, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)

--- a/zhmcclient/_timestats.py
+++ b/zhmcclient/_timestats.py
@@ -38,7 +38,6 @@ Example::
     print(session.time_stats_keeper)
 """
 
-from __future__ import absolute_import
 
 import time
 import copy
@@ -48,7 +47,7 @@ from ._logging import logged_api_call
 __all__ = ['TimeStatsKeeper', 'TimeStats']
 
 
-class TimeStats(object):
+class TimeStats:
     """
     Elapsed time statistics for all invocations of a particular named
     operation.
@@ -207,7 +206,7 @@ class TimeStats(object):
                    self.name)
 
 
-class TimeStatsKeeper(object):
+class TimeStatsKeeper:
     """
     Statistics keeper for elapsed times.
 

--- a/zhmcclient/_unmanaged_cpc.py
+++ b/zhmcclient/_unmanaged_cpc.py
@@ -25,7 +25,6 @@ This section describes the interface for *unmanaged* CPCs using resource class
 :class:`~zhmcclient.UnmanagedCpcManager`.
 """
 
-from __future__ import absolute_import
 
 from ._manager import BaseManager
 from ._resource import BaseResource
@@ -63,7 +62,7 @@ class UnmanagedCpcManager(BaseManager):
             'name',
         ]
 
-        super(UnmanagedCpcManager, self).__init__(
+        super().__init__(
             resource_class=UnmanagedCpc,
             class_name=RC_CPC,
             session=console.manager.session,
@@ -143,7 +142,7 @@ class UnmanagedCpcManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'cpcs'
-        list_uri = '{}/operations/list-unmanaged-cpcs'.format(self.parent.uri)
+        list_uri = f'{self.parent.uri}/operations/list-unmanaged-cpcs'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -174,4 +173,4 @@ class UnmanagedCpc(BaseResource):
         assert isinstance(manager, UnmanagedCpcManager), \
             "UnmanagedCpc init: Expected manager type {}, got {}" \
             .format(UnmanagedCpcManager, type(manager))
-        super(UnmanagedCpc, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -16,7 +16,6 @@
 A :term:`User` resource represents a user configured in the HMC.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -59,7 +58,7 @@ class UserManager(BaseManager):
             'type',
         ]
 
-        super(UserManager, self).__init__(
+        super().__init__(
             resource_class=User,
             class_name=RC_USER,
             session=console.manager.session,
@@ -138,7 +137,7 @@ class UserManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'users'
-        list_uri = '{}/users'.format(self.console.uri)
+        list_uri = f'{self.console.uri}/users'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -212,7 +211,7 @@ class User(BaseResource):
         assert isinstance(manager, UserManager), \
             "Console init: Expected manager type {}, got {}" \
             .format(UserManager, type(manager))
-        super(User, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):

--- a/zhmcclient/_user_pattern.py
+++ b/zhmcclient/_user_pattern.py
@@ -30,7 +30,6 @@ order can be customized through the
 :meth:`~zhmcclient.UserPatternManager.reorder` method.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -73,7 +72,7 @@ class UserPatternManager(BaseManager):
             'type',
         ]
 
-        super(UserPatternManager, self).__init__(
+        super().__init__(
             resource_class=UserPattern,
             class_name=RC_USER_PATTERN,
             session=console.manager.session,
@@ -151,7 +150,7 @@ class UserPatternManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'user-patterns'
-        list_uri = '{}/user-patterns'.format(self.console.uri)
+        list_uri = f'{self.console.uri}/user-patterns'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -256,7 +255,7 @@ class UserPattern(BaseResource):
         assert isinstance(manager, UserPatternManager), \
             "Console init: Expected manager type {}, got {}" \
             .format(UserPatternManager, type(manager))
-        super(UserPattern, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):

--- a/zhmcclient/_user_role.py
+++ b/zhmcclient/_user_role.py
@@ -25,7 +25,6 @@ with the HMC.
 
 
 import copy
-import six
 
 from ._manager import BaseManager
 from ._resource import BaseResource

--- a/zhmcclient/_user_role.py
+++ b/zhmcclient/_user_role.py
@@ -23,7 +23,6 @@ the system-defined User Roles are pre-defined, standard User Roles supplied
 with the HMC.
 """
 
-from __future__ import absolute_import
 
 import copy
 import six
@@ -67,7 +66,7 @@ class UserRoleManager(BaseManager):
             'type',
         ]
 
-        super(UserRoleManager, self).__init__(
+        super().__init__(
             resource_class=UserRole,
             class_name=RC_USER_ROLE,
             session=console.manager.session,
@@ -145,7 +144,7 @@ class UserRoleManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'user-roles'
-        list_uri = '{}/user-roles'.format(self.console.uri)
+        list_uri = f'{self.console.uri}/user-roles'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -217,7 +216,7 @@ class UserRole(BaseResource):
         assert isinstance(manager, UserRoleManager), \
             "Console init: Expected manager type {}, got {}" \
             .format(UserRoleManager, type(manager))
-        super(UserRole, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):
@@ -344,7 +343,7 @@ class UserRole(BaseResource):
         if isinstance(permitted_object, BaseResource):
             perm_obj = permitted_object.uri
             perm_type = 'object'
-        elif isinstance(permitted_object, six.string_types):
+        elif isinstance(permitted_object, str):
             perm_obj = permitted_object
             perm_type = 'object-class'
         else:
@@ -425,7 +424,7 @@ class UserRole(BaseResource):
         if isinstance(permitted_object, BaseResource):
             perm_obj = permitted_object.uri
             perm_type = 'object'
-        elif isinstance(permitted_object, six.string_types):
+        elif isinstance(permitted_object, str):
             perm_obj = permitted_object
             perm_type = 'object-class'
         else:

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -28,7 +28,6 @@ from datetime import datetime
 import warnings
 
 from dateutil import parser
-import six
 import pytz
 from requests.utils import quote
 

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -19,11 +19,7 @@ Utility functions.
 
 import re
 from collections import OrderedDict
-try:
-    from collections.abc import Mapping, MutableSequence, Iterable
-except ImportError:
-    # pylint: disable=deprecated-class
-    from collections.abc import Mapping, MutableSequence, Iterable
+from collections.abc import Mapping, MutableSequence, Iterable
 from datetime import datetime
 import warnings
 

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -16,7 +16,6 @@
 Utility functions.
 """
 
-from __future__ import absolute_import
 
 import re
 from collections import OrderedDict
@@ -24,7 +23,7 @@ try:
     from collections.abc import Mapping, MutableSequence, Iterable
 except ImportError:
     # pylint: disable=deprecated-class
-    from collections import Mapping, MutableSequence, Iterable
+    from collections.abc import Mapping, MutableSequence, Iterable
 from datetime import datetime
 import warnings
 
@@ -191,7 +190,7 @@ def repr_list(lst, indent):
                         .format(type(lst)))
     ret = bm + '\n'
     for value in lst:
-        ret += _indent('{!r},\n'.format(value), 2)
+        ret += _indent(f'{value!r},\n', 2)
     ret += em
     ret = repr_text(ret, indent=indent)
     return ret.lstrip(' ')
@@ -209,15 +208,15 @@ def repr_dict(dct, indent):
     if isinstance(dct, OrderedDict):
         kind = 'ordered'
         ret = '%s {\n' % kind  # non standard syntax for the kind indicator
-        for key in six.iterkeys(dct):
+        for key in dct.keys():
             value = dct[key]
-            ret += _indent('{!r}: {!r},\n'.format(key, value), 2)
+            ret += _indent(f'{key!r}: {value!r},\n', 2)
     else:  # dict
         kind = 'sorted'
         ret = '%s {\n' % kind  # non standard syntax for the kind indicator
-        for key in sorted(six.iterkeys(dct)):
+        for key in sorted(dct.keys()):
             value = dct[key]
-            ret += _indent('{!r}: {!r},\n'.format(key, value), 2)
+            ret += _indent(f'{key!r}: {value!r},\n', 2)
     ret += '}'
     ret = repr_text(ret, indent=indent)
     return ret.lstrip(' ')
@@ -374,7 +373,7 @@ def append_query_parms(query_parms, prop_name, prop_match):
         # Just in case, we also escape the property name
         parm_name = quote(prop_name, safe='')
         parm_value = quote(str(prop_match), safe='')
-        qp = '{}={}'.format(parm_name, parm_value)
+        qp = f'{parm_name}={parm_value}'
         query_parms.append(qp)
 
 
@@ -442,7 +441,7 @@ def make_query_str(query_parms):
     """
     query_parms_str = '&'.join(query_parms)
     if query_parms_str:
-        query_parms_str = '?{}'.format(query_parms_str)
+        query_parms_str = f'?{query_parms_str}'
     return query_parms_str
 
 
@@ -534,7 +533,7 @@ def matches_prop(obj, prop_name, prop_match, case_insensitive):
             prop_value = obj.get_property(prop_name)
         except KeyError:
             return False
-        if isinstance(prop_value, six.string_types):
+        if isinstance(prop_value, str):
             # HMC resource property is Enum String or (non-enum) String,
             # and is both matched by regexp matching. Ideally, regexp
             # matching should only be done for non-enum strings, but
@@ -609,9 +608,9 @@ def get_features(session, base_uri, name):
     404/Not Found is caught and turned into an empty list result.
     """
     try:
-        uri = '{}/operations/list-features'.format(base_uri)
+        uri = f'{base_uri}/operations/list-features'
         if name is not None:
-            uri = '{}?name={}'.format(uri, name)
+            uri = f'{uri}?name={name}'
         return session.get(uri)
     except HTTPError as e:
         # API features are introduced with WS API version 4.10.

--- a/zhmcclient/_version.py
+++ b/zhmcclient/_version.py
@@ -33,9 +33,5 @@ __version__ = '1.17.0.dev1'
 # Keep these Python versions in sync with:
 # - python_requires and classifiers in setup.py
 # - Section "Supported environments" in docs/intro.rst
-_PYTHON_M = sys.version_info[0]
-_PYTHON_N = sys.version_info[1]
-if _PYTHON_M == 2 and _PYTHON_N < 7:
-    raise RuntimeError('On Python 2, zhcmclient requires Python 2.7')
-if _PYTHON_M == 3 and _PYTHON_N < 5:
-    raise RuntimeError('On Python 3, zhmcclient requires Python 3.5 or higher')
+if sys.version_info[0:2] < (3, 8):
+    raise RuntimeError('zhmcclient requires Python 3.8 or higher')

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -22,7 +22,6 @@ Virtual Function resources are contained in Partition resources.
 Virtual Functions only exist in :term:`CPCs <CPC>` that are in DPM mode.
 """
 
-from __future__ import absolute_import
 
 import copy
 
@@ -55,12 +54,12 @@ class VirtualFunctionManager(BaseManager):
         # Parameters:
         #   partition (:class:`~zhmcclient.Partition`):
         #     Partition defining the scope for this manager.
-        super(VirtualFunctionManager, self).__init__(
+        super().__init__(
             resource_class=VirtualFunction,
             class_name=RC_VIRTUAL_FUNCTION,
             session=partition.manager.session,
             parent=partition,
-            base_uri='{}/virtual-functions'.format(partition.uri),
+            base_uri=f'{partition.uri}/virtual-functions',
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
@@ -207,7 +206,7 @@ class VirtualFunction(BaseResource):
         assert isinstance(manager, VirtualFunctionManager), \
             "VirtualFunction init: Expected manager type {}, got {}" \
             .format(VirtualFunctionManager, type(manager))
-        super(VirtualFunction, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def delete(self):

--- a/zhmcclient/_virtual_storage_resource.py
+++ b/zhmcclient/_virtual_storage_resource.py
@@ -46,7 +46,6 @@ Storage groups and storage volumes only can be defined in CPCs that are in
 DPM mode and that have the "dpm-storage-management" feature enabled.
 """
 
-from __future__ import absolute_import
 
 import re
 import copy
@@ -92,12 +91,12 @@ class VirtualStorageResourceManager(BaseManager):
             'partition-uri',
         ]
 
-        super(VirtualStorageResourceManager, self).__init__(
+        super().__init__(
             resource_class=VirtualStorageResource,
             class_name=RC_VIRTUAL_STORAGE_RESOURCE,
             session=storage_group.manager.session,
             parent=storage_group,
-            base_uri='{}/virtual-storage-resources'.format(storage_group.uri),
+            base_uri=f'{storage_group.uri}/virtual-storage-resources',
             oid_prop='element-id',
             uri_prop='element-uri',
             name_prop='name',
@@ -168,7 +167,7 @@ class VirtualStorageResourceManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'virtual-storage-resources'
-        list_uri = '{}/virtual-storage-resources'.format(self.storage_group.uri)
+        list_uri = f'{self.storage_group.uri}/virtual-storage-resources'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
@@ -199,7 +198,7 @@ class VirtualStorageResource(BaseResource):
         assert isinstance(manager, VirtualStorageResourceManager), \
             "VirtualStorageResource init: Expected manager type {}, got {}" \
             .format(VirtualStorageResourceManager, type(manager))
-        super(VirtualStorageResource, self).__init__(
+        super().__init__(
             manager, uri, name, properties)
         self._attached_partition = None
         self._adapter_port = None

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -24,7 +24,6 @@ Virtual Switch resources are contained in :term:`CPC` resources.
 Virtual Switches only exist in CPCs that are in DPM mode.
 """
 
-from __future__ import absolute_import
 
 import re
 import copy
@@ -67,7 +66,7 @@ class VirtualSwitchManager(BaseManager):
             'type',
         ]
 
-        super(VirtualSwitchManager, self).__init__(
+        super().__init__(
             resource_class=VirtualSwitch,
             class_name=RC_VIRTUAL_SWITCH,
             session=cpc.manager.session,
@@ -152,7 +151,7 @@ class VirtualSwitchManager(BaseManager):
           :exc:`~zhmcclient.ConnectionError`
         """
         result_prop = 'virtual-switches'
-        list_uri = '{}/virtual-switches'.format(self.cpc.uri)
+        list_uri = f'{self.cpc.uri}/virtual-switches'
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args,
             additional_properties)
@@ -187,7 +186,7 @@ class VirtualSwitch(BaseResource):
         assert isinstance(manager, VirtualSwitchManager), \
             "VirtualSwitch init: Expected manager type {}, got {}" \
             .format(VirtualSwitchManager, type(manager))
-        super(VirtualSwitch, self).__init__(manager, uri, name, properties)
+        super().__init__(manager, uri, name, properties)
 
     @logged_api_call
     def get_connected_nics(self):

--- a/zhmcclient/testutils/__init__.py
+++ b/zhmcclient/testutils/__init__.py
@@ -16,7 +16,6 @@
 zhmcclient.testutils - Utilities for testing against real or mocked HMCs.
 """
 
-from __future__ import absolute_import
 
 from ._hmc_inventory_file import *         # noqa: F401
 from ._hmc_vault_file import *             # noqa: F401

--- a/zhmcclient/testutils/_cpc_fixtures.py
+++ b/zhmcclient/testutils/_cpc_fixtures.py
@@ -16,7 +16,6 @@
 Pytest fixtures for CPCs.
 """
 
-from __future__ import absolute_import
 
 import warnings
 import pytest
@@ -41,7 +40,7 @@ def fixtureid_cpcs(fixture_value):
         return None  # Use pytest auto-generated ID
     cpc_list = fixture_value
     cpcs_str = ','.join([cpc.name for cpc in cpc_list])
-    return "CPCs={}".format(cpcs_str)
+    return f"CPCs={cpcs_str}"
 
 
 @pytest.fixture(

--- a/zhmcclient/testutils/_hmc_definition.py
+++ b/zhmcclient/testutils/_hmc_definition.py
@@ -16,14 +16,13 @@
 HMC definition for zhmcclient end2end tests.
 """
 
-from __future__ import absolute_import
 
 import six
 
 __all__ = ['HMCDefinition']
 
 
-class HMCDefinition(object):
+class HMCDefinition:
     """
     A single HMC definition.
 
@@ -95,7 +94,7 @@ class HMCDefinition(object):
         self._mock_file = mock_file
         if host is None:
             self._hosts = None
-        elif isinstance(host, six.string_types):
+        elif isinstance(host, str):
             self._hosts = [host]
         else:
             self._hosts = list(host)
@@ -190,7 +189,7 @@ class HMCDefinition(object):
         # pylint: disable=attribute-defined-outside-init
         if host is None:
             self._hosts = None
-        elif isinstance(host, six.string_types):
+        elif isinstance(host, str):
             self._hosts = [host]
         else:
             self._hosts = list(host)

--- a/zhmcclient/testutils/_hmc_definition.py
+++ b/zhmcclient/testutils/_hmc_definition.py
@@ -17,8 +17,6 @@ HMC definition for zhmcclient end2end tests.
 """
 
 
-import six
-
 __all__ = ['HMCDefinition']
 
 

--- a/zhmcclient/testutils/_hmc_definition_fixtures.py
+++ b/zhmcclient/testutils/_hmc_definition_fixtures.py
@@ -16,7 +16,6 @@
 Pytest fixtures for mocked HMCs.
 """
 
-from __future__ import absolute_import
 
 import os
 import logging
@@ -55,11 +54,11 @@ def fixtureid_hmc_definition(fixture_value):
     if not show_hmc:
         hmc_str = ""
     elif hd.mock_file:
-        hmc_str = "(mock_file={f})".format(f=hd.mock_file)
+        hmc_str = f"(mock_file={hd.mock_file})"
     else:
         hmc_str = "(host={h}, userid={u})".format(
             h=hd.host, u=hd.userid)
-    ret_str = "hmc_definition={n}{v}".format(n=hd.nickname, v=hmc_str)
+    ret_str = f"hmc_definition={hd.nickname}{hmc_str}"
     return ret_str
 
 
@@ -124,7 +123,7 @@ def setup_hmc_session(hd):
     # We use the cached skip reason from previous attempts
     skip_msg = getattr(hd, 'skip_msg', None)
     if skip_msg:
-        pytest.skip("Skip reason from earlier attempt: {0}".format(skip_msg))
+        pytest.skip(f"Skip reason from earlier attempt: {skip_msg}")
 
     if hd.mock_file:
         # A mocked HMC

--- a/zhmcclient/testutils/_hmc_definitions.py
+++ b/zhmcclient/testutils/_hmc_definitions.py
@@ -16,7 +16,6 @@
 HMC definitions for zhmcclient end2end tests.
 """
 
-from __future__ import absolute_import
 
 import os
 
@@ -69,9 +68,9 @@ def print_hmc_definitions():
     hmcdefs = HMCDefinitions()
     print("\nHMC definitions for end2end tests:")
 
-    print("\nHMC inventory file: {}".format(hmcdefs.inventory_file))
-    print("HMC vault file: {}".format(hmcdefs.vault_file))
-    print("Default test group/nickname: {}".format(hmcdefs.testhmc))
+    print(f"\nHMC inventory file: {hmcdefs.inventory_file}")
+    print(f"HMC vault file: {hmcdefs.vault_file}")
+    print(f"Default test group/nickname: {hmcdefs.testhmc}")
 
     print("\nHMCs in inventory file:")
     print("{:20s} {:24s} {:}".
@@ -80,14 +79,14 @@ def print_hmc_definitions():
         host = hd.mock_file or hd.host
         if isinstance(host, list):
             host = ','.join(host)
-        print("{:20s} {:24s} {}".format(hd.nickname, str(host), hd.description))
+        print(f"{hd.nickname:20s} {str(host):24s} {hd.description}")
 
     print("\nGroups in inventory file:")
     print("{:20s} {}".format("Group name", "HMCs in the group"))
     for group_name in hmcdefs.list_all_group_names():
         hmc_names = ', '.join(
             [hd.nickname for hd in hmcdefs.list_hmcs(group_name)])
-        print("{:20s} {}".format(group_name, hmc_names))
+        print(f"{group_name:20s} {hmc_names}")
 
 
 def _default(vars_tuple, key, default):
@@ -114,7 +113,7 @@ class HMCNotFound(Exception):
     pass
 
 
-class HMCDefinitions(object):
+class HMCDefinitions:
     """
     The HMC definitions in the :ref:`HMC inventory file` and their credentials
     in the :ref:`HMC vault file`.

--- a/zhmcclient/testutils/_hmc_inventory_file.py
+++ b/zhmcclient/testutils/_hmc_inventory_file.py
@@ -19,7 +19,6 @@ HMC inventory files conform to the format of HMC inventory files in YAML
 format and define specific additional variables for HMCs.
 """
 
-from __future__ import absolute_import
 
 try:
     from collections import OrderedDict
@@ -232,7 +231,7 @@ class HMCInventoryFileError(Exception):
     pass
 
 
-class HMCInventoryFile(object):
+class HMCInventoryFile:
     """
     Encapsulation of an :ref:`HMC inventory file` in YAML format.
     """
@@ -259,7 +258,7 @@ class HMCInventoryFile(object):
                         format(self._filepath, exc.__class__.__name__, exc))
                     new_exc.__cause__ = None
                     raise new_exc  # HMCInventoryFileError
-        except IOError as exc:
+        except OSError as exc:
             if exc.errno == errno.ENOENT:
                 new_exc = HMCInventoryFileError(
                     "The HMC inventory file {0!r} was not found".

--- a/zhmcclient/testutils/_hmc_inventory_file.py
+++ b/zhmcclient/testutils/_hmc_inventory_file.py
@@ -20,10 +20,7 @@ format and define specific additional variables for HMCs.
 """
 
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 import errno
 import yaml
 import yamlloader

--- a/zhmcclient/testutils/_hmc_vault_file.py
+++ b/zhmcclient/testutils/_hmc_vault_file.py
@@ -19,7 +19,6 @@ HMC vault files conform to the format of Ansible vault files in YAML
 format and define specific variables for HMC authentication.
 """
 
-from __future__ import absolute_import
 
 try:
     from collections import OrderedDict
@@ -135,7 +134,7 @@ class HMCVaultFileError(Exception):
     pass
 
 
-class HMCVaultFile(object):
+class HMCVaultFile:
     """
     Encapsulation of an :ref:`HMC vault file` in YAML format.
     """
@@ -162,7 +161,7 @@ class HMCVaultFile(object):
                         format(self._filepath, exc.__class__.__name__, exc))
                     new_exc.__cause__ = None
                     raise new_exc  # HMCVaultFileError
-        except IOError as exc:
+        except OSError as exc:
             if exc.errno == errno.ENOENT:
                 new_exc = HMCVaultFileError(
                     "The HMC vault file {0!r} was not found".

--- a/zhmcclient/testutils/_hmc_vault_file.py
+++ b/zhmcclient/testutils/_hmc_vault_file.py
@@ -20,10 +20,7 @@ format and define specific variables for HMC authentication.
 """
 
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 import errno
 import yaml
 import yamlloader

--- a/zhmcclient_mock/__init__.py
+++ b/zhmcclient_mock/__init__.py
@@ -16,7 +16,6 @@
 zhmcclient_mock - Unit test support for users of the zhmcclient package.
 """
 
-from __future__ import absolute_import
 
 from ._session import *       # noqa: F401 pylint: disable=redefined-builtin
 from ._urihandler import *    # noqa: F401

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -19,10 +19,7 @@ local Python object and maintains its resource state across operations.
 """
 
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 import re
 import copy
 from dateutil import tz

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -26,7 +26,6 @@ except ImportError:
 import re
 import copy
 from dateutil import tz
-import six
 from immutable_views import DictView
 
 from zhmcclient._utils import repr_dict, repr_manager, repr_list, \

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -18,7 +18,6 @@ relevant for the `zhmcclient` package. The faked HMC is implemented as a
 local Python object and maintains its resource state across operations.
 """
 
-from __future__ import absolute_import
 
 try:
     from collections import OrderedDict
@@ -310,10 +309,10 @@ class InputError(Exception):
 
     def __init__(self, message):
         # pylint: disable=useless-super-delegation
-        super(InputError, self).__init__(message)
+        super().__init__(message)
 
 
-class FakedBaseResource(object):
+class FakedBaseResource:
     """
     A base class for faked resource classes in the faked HMC.
     """
@@ -562,7 +561,7 @@ class FakedBaseResource(object):
                                          grandchild_list)
 
 
-class FakedBaseManager(object):
+class FakedBaseManager:
     """
     A base class for manager classes for faked resources in the faked HMC.
     """
@@ -700,7 +699,7 @@ class FakedBaseManager(object):
             if prop_name not in obj.properties:
                 return False
             prop_value = obj.properties[prop_name]
-            if isinstance(prop_value, six.string_types):
+            if isinstance(prop_value, str):
                 # HMC resource property is Enum String or (non-enum) String,
                 # and is both matched by regexp matching. Ideally, regexp
                 # matching should only be done for non-enum strings, but
@@ -884,7 +883,7 @@ class FakedHmc(FakedBaseResource):
     """
 
     def __init__(self, session, hmc_name, hmc_version, api_version):
-        super(FakedHmc, self).__init__(manager=None, properties=None)
+        super().__init__(manager=None, properties=None)
         self._session = session
         self.hmc_name = hmc_name
         self.hmc_version = hmc_version
@@ -1032,7 +1031,7 @@ class FakedHmc(FakedBaseResource):
         """
         if session_id in self._valid_session_ids:
             raise ValueError(
-                "Session ID {} already exists".format(session_id))
+                f"Session ID {session_id} already exists")
 
         self._valid_session_ids.add(session_id)
 
@@ -1053,7 +1052,7 @@ class FakedHmc(FakedBaseResource):
         try:
             self._valid_session_ids.remove(session_id)
         except KeyError:
-            raise ValueError("Session ID {} does not exist".format(session_id))
+            raise ValueError(f"Session ID {session_id} does not exist")
 
     def lookup_by_uri(self, uri):
         """
@@ -1104,7 +1103,7 @@ class FakedConsoleManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, client):
-        super(FakedConsoleManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=client,
             resource_class=FakedConsole,
@@ -1145,7 +1144,7 @@ class FakedConsoleManager(FakedBaseManager):
         Returns:
           :class:`~zhmcclient_mock.FakedConsole`: The faked Console resource.
         """
-        return super(FakedConsoleManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedConsole(FakedBaseResource):
@@ -1158,7 +1157,7 @@ class FakedConsole(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedConsole, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         self._storage_groups = FakedStorageGroupManager(
@@ -1300,7 +1299,7 @@ class FakedUserManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedUserManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedUser,
@@ -1335,7 +1334,7 @@ class FakedUserManager(FakedBaseManager):
         Returns:
           :class:`~zhmcclient_mock.FakedUser`: The faked User resource.
         """
-        new_user = super(FakedUserManager, self).add(properties)
+        new_user = super().add(properties)
 
         # Resource type specific default values
         if 'disabled' not in new_user.properties:
@@ -1354,7 +1353,7 @@ class FakedUser(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedUser, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -1369,7 +1368,7 @@ class FakedUserRoleManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedUserRoleManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedUserRole,
@@ -1407,7 +1406,7 @@ class FakedUserRoleManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedUserRole`: The faked User Role
           resource.
         """
-        new_user_role = super(FakedUserRoleManager, self).add(properties)
+        new_user_role = super().add(properties)
 
         # Resource type specific default values
         if 'type' not in new_user_role.properties:
@@ -1428,7 +1427,7 @@ class FakedUserRole(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedUserRole, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -1443,7 +1442,7 @@ class FakedUserPatternManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedUserPatternManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedUserPattern,
@@ -1477,7 +1476,7 @@ class FakedUserPatternManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedUserPattern`: The faked User Pattern
           resource.
         """
-        return super(FakedUserPatternManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedUserPattern(FakedBaseResource):
@@ -1490,7 +1489,7 @@ class FakedUserPattern(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedUserPattern, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -1505,7 +1504,7 @@ class FakedPasswordRuleManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedPasswordRuleManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedPasswordRule,
@@ -1543,7 +1542,7 @@ class FakedPasswordRuleManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedPasswordRule`: The faked Password Rule
           resource.
         """
-        new_pwrule = super(FakedPasswordRuleManager, self).add(properties)
+        new_pwrule = super().add(properties)
 
         # Resource type specific default values
         if 'min-length' not in new_pwrule.properties:
@@ -1564,7 +1563,7 @@ class FakedPasswordRule(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedPasswordRule, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -1579,7 +1578,7 @@ class FakedTaskManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedTaskManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedTask,
@@ -1611,7 +1610,7 @@ class FakedTaskManager(FakedBaseManager):
         Returns:
           :class:`~zhmcclient_mock.FakedTask`: The faked Task resource.
         """
-        return super(FakedTaskManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedTask(FakedBaseResource):
@@ -1624,7 +1623,7 @@ class FakedTask(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedTask, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -1639,7 +1638,7 @@ class FakedLdapServerDefinitionManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedLdapServerDefinitionManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedLdapServerDefinition,
@@ -1675,7 +1674,7 @@ class FakedLdapServerDefinitionManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedLdapServerDefinition`: The faked
           LdapServerDefinition resource.
         """
-        new_lsd = super(FakedLdapServerDefinitionManager, self).add(properties)
+        new_lsd = super().add(properties)
 
         # Resource type specific default values
         new_lsd.properties.setdefault('description', '')
@@ -1704,7 +1703,7 @@ class FakedLdapServerDefinition(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedLdapServerDefinition, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -1721,7 +1720,7 @@ class FakedActivationProfileManager(FakedBaseManager):
     def __init__(self, hmc, cpc, profile_type):
         ap_uri_segment = profile_type + '-activation-profiles'
         ap_class_value = profile_type + '-activation-profile'
-        super(FakedActivationProfileManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=cpc,
             resource_class=FakedActivationProfile,
@@ -1756,7 +1755,7 @@ class FakedActivationProfileManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedActivationProfile`: The faked
             Activation Profile resource.
         """
-        return super(FakedActivationProfileManager, self).add(properties)
+        return super().add(properties)
 
     @property
     def profile_type(self):
@@ -1776,7 +1775,7 @@ class FakedActivationProfile(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedActivationProfile, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -1791,7 +1790,7 @@ class FakedAdapterManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, cpc):
-        super(FakedAdapterManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=cpc,
             resource_class=FakedAdapter,
@@ -1835,7 +1834,7 @@ class FakedAdapterManager(FakedBaseManager):
           :exc:`zhmcclient_mock.InputError`: Some issue with the input
             properties.
         """
-        return super(FakedAdapterManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedAdapter(FakedBaseResource):
@@ -1848,7 +1847,7 @@ class FakedAdapter(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedAdapter, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         # Initial values to be prepared for raising InputError
@@ -1964,7 +1963,7 @@ class FakedCpcManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, client):
-        super(FakedCpcManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=client,
             resource_class=FakedCpc,
@@ -2001,7 +2000,7 @@ class FakedCpcManager(FakedBaseManager):
         Returns:
           :class:`~zhmcclient_mock.FakedCpc`: The faked CPC resource.
         """
-        return super(FakedCpcManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedCpc(FakedBaseResource):
@@ -2014,7 +2013,7 @@ class FakedCpc(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedCpc, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         self._lpars = FakedLparManager(hmc=manager.hmc, cpc=self)
@@ -2168,7 +2167,7 @@ class FakedUnmanagedCpcManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedUnmanagedCpcManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedUnmanagedCpc,
@@ -2199,7 +2198,7 @@ class FakedUnmanagedCpcManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedUnmanagedCpc`: The faked unmanaged CPC
           resource.
         """
-        return super(FakedUnmanagedCpcManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedUnmanagedCpc(FakedBaseResource):
@@ -2212,7 +2211,7 @@ class FakedUnmanagedCpc(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedUnmanagedCpc, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -2249,7 +2248,7 @@ class FakedGroupManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedGroupManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedGroup,
@@ -2281,7 +2280,7 @@ class FakedGroupManager(FakedBaseManager):
         Returns:
           :class:`~zhmcclient_mock.FakedGroup`: The faked Group resource.
         """
-        new_group = super(FakedGroupManager, self).add(properties)
+        new_group = super().add(properties)
 
         # Set optional properties to their defaults
         new_group.properties.setdefault('description', '')
@@ -2300,7 +2299,7 @@ class FakedGroup(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedGroup, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -2337,7 +2336,7 @@ class FakedHbaManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, partition):
-        super(FakedHbaManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=partition,
             resource_class=FakedHba,
@@ -2381,7 +2380,7 @@ class FakedHbaManager(FakedBaseManager):
           :exc:`zhmcclient_mock.InputError`: Some issue with the input
             properties.
         """
-        new_hba = super(FakedHbaManager, self).add(properties)
+        new_hba = super().add(properties)
 
         partition = self.parent
 
@@ -2424,7 +2423,7 @@ class FakedHbaManager(FakedBaseManager):
         assert 'hba-uris' in partition.properties
         hba_uris = partition.properties['hba-uris']
         hba_uris.remove(hba.uri)
-        super(FakedHbaManager, self).remove(oid)  # deletes the resource
+        super().remove(oid)  # deletes the resource
 
 
 class FakedHba(FakedBaseResource):
@@ -2437,7 +2436,7 @@ class FakedHba(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedHba, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -2452,7 +2451,7 @@ class FakedLparManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, cpc):
-        super(FakedLparManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=cpc,
             resource_class=FakedLpar,
@@ -2485,7 +2484,7 @@ class FakedLparManager(FakedBaseManager):
         Returns:
           :class:`~zhmcclient_mock.FakedLpar`: The faked LPAR resource.
         """
-        return super(FakedLparManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedLpar(FakedBaseResource):
@@ -2498,7 +2497,7 @@ class FakedLpar(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedLpar, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         if 'status' not in self._properties:
@@ -2515,7 +2514,7 @@ class FakedNicManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, partition):
-        super(FakedNicManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=partition,
             resource_class=FakedNic,
@@ -2567,7 +2566,7 @@ class FakedNicManager(FakedBaseManager):
           :exc:`zhmcclient_mock.InputError`: Some issue with the input
             properties.
         """
-        new_nic = super(FakedNicManager, self).add(properties)
+        new_nic = super().add(properties)
 
         partition = self.parent
 
@@ -2627,7 +2626,7 @@ class FakedNicManager(FakedBaseManager):
         assert 'nic-uris' in partition.properties
         nic_uris = partition.properties['nic-uris']
         nic_uris.remove(nic.uri)
-        super(FakedNicManager, self).remove(oid)  # deletes the resource
+        super().remove(oid)  # deletes the resource
 
 
 class FakedNic(FakedBaseResource):
@@ -2640,7 +2639,7 @@ class FakedNic(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedNic, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -2655,7 +2654,7 @@ class FakedPartitionManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, cpc):
-        super(FakedPartitionManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=cpc,
             resource_class=FakedPartition,
@@ -2701,7 +2700,7 @@ class FakedPartitionManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedPartition`: The faked Partition
             resource.
         """
-        return super(FakedPartitionManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedPartition(FakedBaseResource):
@@ -2719,7 +2718,7 @@ class FakedPartition(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedPartition, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         if 'hba-uris' not in self._properties:
@@ -2808,7 +2807,7 @@ class FakedPartition(FakedBaseResource):
           ValueError: No more device numbers available in that range.
         """
         devno_int = self._devno_pool.alloc()
-        devno = "{:04X}".format(devno_int)
+        devno = f"{devno_int:04X}"
         return devno
 
     def devno_free(self, devno):
@@ -2852,7 +2851,7 @@ class FakedPartition(FakedBaseResource):
           ValueError: No more WWPNs available in that range.
         """
         wwpn_int = self._wwpn_pool.alloc()
-        wwpn = "AFFEAFFE0000" + "{:04X}".format(wwpn_int)
+        wwpn = "AFFEAFFE0000" + f"{wwpn_int:04X}"
         return wwpn
 
     def wwpn_free(self, wwpn):
@@ -2906,7 +2905,7 @@ class FakedPortManager(FakedBaseManager):
             raise AssertionError("FakedAdapter with object-id={} must be a "
                                  "storage or network adapter to have ports."
                                  .format(adapter.oid))
-        super(FakedPortManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=adapter,
             resource_class=FakedPort,
@@ -2941,7 +2940,7 @@ class FakedPortManager(FakedBaseManager):
         Returns:
           :class:`zhmcclient_mock.FakedPort`: The faked Port resource.
         """
-        new_port = super(FakedPortManager, self).add(properties)
+        new_port = super().add(properties)
         adapter = self.parent
         if 'network-port-uris' in adapter.properties:
             adapter.properties['network-port-uris'].append(new_port.uri)
@@ -2970,7 +2969,7 @@ class FakedPortManager(FakedBaseManager):
         if 'storage-port-uris' in adapter.properties:
             port_uris = adapter.properties['storage-port-uris']
             port_uris.remove(port.uri)
-        super(FakedPortManager, self).remove(oid)  # deletes the resource
+        super().remove(oid)  # deletes the resource
 
 
 class FakedPort(FakedBaseResource):
@@ -2983,7 +2982,7 @@ class FakedPort(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedPort, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -2998,7 +2997,7 @@ class FakedVirtualFunctionManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, partition):
-        super(FakedVirtualFunctionManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=partition,
             resource_class=FakedVirtualFunction,
@@ -3037,7 +3036,7 @@ class FakedVirtualFunctionManager(FakedBaseManager):
           :class:`zhmcclient_mock.FakedVirtualFunction`: The faked Virtual
             Function resource.
         """
-        new_vf = super(FakedVirtualFunctionManager, self).add(properties)
+        new_vf = super().add(properties)
         partition = self.parent
         assert 'virtual-function-uris' in partition.properties
         partition.properties['virtual-function-uris'].append(new_vf.uri)
@@ -3067,7 +3066,7 @@ class FakedVirtualFunctionManager(FakedBaseManager):
         assert 'virtual-function-uris' in partition.properties
         vf_uris = partition.properties['virtual-function-uris']
         vf_uris.remove(virtual_function.uri)
-        super(FakedVirtualFunctionManager, self).remove(oid)  # deletes res.
+        super().remove(oid)  # deletes res.
 
 
 class FakedVirtualFunction(FakedBaseResource):
@@ -3080,7 +3079,7 @@ class FakedVirtualFunction(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedVirtualFunction, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -3095,7 +3094,7 @@ class FakedVirtualSwitchManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, cpc):
-        super(FakedVirtualSwitchManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=cpc,
             resource_class=FakedVirtualSwitch,
@@ -3130,7 +3129,7 @@ class FakedVirtualSwitchManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedVirtualSwitch`: The faked Virtual
             Switch resource.
         """
-        return super(FakedVirtualSwitchManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedVirtualSwitch(FakedBaseResource):
@@ -3143,7 +3142,7 @@ class FakedVirtualSwitch(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedVirtualSwitch, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         if 'connected-vnic-uris' not in self._properties:
@@ -3160,7 +3159,7 @@ class FakedStorageGroupManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, console):
-        super(FakedStorageGroupManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=console,
             resource_class=FakedStorageGroup,
@@ -3196,7 +3195,7 @@ class FakedStorageGroupManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedStorageGroup`: The faked StorageGroup
             resource.
         """
-        return super(FakedStorageGroupManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedStorageGroup(FakedBaseResource):
@@ -3209,7 +3208,7 @@ class FakedStorageGroup(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedStorageGroup, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         if 'storage-volume-uris' not in self._properties:
@@ -3262,7 +3261,7 @@ class FakedStorageVolumeManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, storage_group):
-        super(FakedStorageVolumeManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=storage_group,
             resource_class=FakedStorageVolume,
@@ -3297,7 +3296,7 @@ class FakedStorageVolumeManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedStorageVolume`: The faked StorageVolume
             resource.
         """
-        stovol = super(FakedStorageVolumeManager, self).add(properties)
+        stovol = super().add(properties)
         stogrp = stovol.manager.parent
         if stovol.uri not in stogrp.properties['storage-volume-uris']:
             stogrp.properties['storage-volume-uris'].append(stovol.uri)
@@ -3314,7 +3313,7 @@ class FakedStorageVolume(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedStorageVolume, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
 
@@ -3351,7 +3350,7 @@ class FakedCapacityGroupManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, cpc):
-        super(FakedCapacityGroupManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=cpc,
             resource_class=FakedCapacityGroup,
@@ -3386,7 +3385,7 @@ class FakedCapacityGroupManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedCapacityGroup`: The faked CapacityGroup
             resource.
         """
-        return super(FakedCapacityGroupManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedCapacityGroup(FakedBaseResource):
@@ -3399,7 +3398,7 @@ class FakedCapacityGroup(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedCapacityGroup, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         if 'capping-enabled' not in self._properties:
@@ -3490,7 +3489,7 @@ class FakedMetricsContextManager(FakedBaseManager):
     """
 
     def __init__(self, hmc, client):
-        super(FakedMetricsContextManager, self).__init__(
+        super().__init__(
             hmc=hmc,
             parent=client,
             resource_class=FakedMetricsContext,
@@ -3522,7 +3521,7 @@ class FakedMetricsContextManager(FakedBaseManager):
           :class:`~zhmcclient_mock.FakedMetricsContext`: The faked Metrics
           Context resource.
         """
-        return super(FakedMetricsContextManager, self).add(properties)
+        return super().add(properties)
 
 
 class FakedMetricsContext(FakedBaseResource):
@@ -3568,7 +3567,7 @@ class FakedMetricsContext(FakedBaseResource):
     """
 
     def __init__(self, manager, properties):
-        super(FakedMetricsContext, self).__init__(
+        super().__init__(
             manager=manager,
             properties=properties)
         assert 'anticipated-frequency-seconds' in properties
@@ -3670,16 +3669,16 @@ class FakedMetricsContext(FakedBaseResource):
         resp_lines = []
         for mv in mv_list:
             group_name = mv[0]
-            resp_lines.append('"{}"'.format(group_name))
+            resp_lines.append(f'"{group_name}"')
             mo_vals = mv[1]
             for mo_val in mo_vals:
-                resp_lines.append('"{}"'.format(mo_val.resource_uri))
+                resp_lines.append(f'"{mo_val.resource_uri}"')
                 resp_lines.append(
                     str(timestamp_from_datetime(mo_val.timestamp)))
                 v_list = []
                 for _, v in mo_val.values:
-                    if isinstance(v, six.string_types):
-                        v_str = '"{}"'.format(v)
+                    if isinstance(v, str):
+                        v_str = f'"{v}"'
                     else:
                         v_str = str(v)
                     v_list.append(v_str)
@@ -3691,7 +3690,7 @@ class FakedMetricsContext(FakedBaseResource):
         return '\n'.join(resp_lines) + '\n'
 
 
-class FakedMetricGroupDefinition(object):
+class FakedMetricGroupDefinition:
     # pylint: disable=too-few-public-methods
     """
     A faked metric group definition (of one metric group).
@@ -3746,7 +3745,7 @@ class FakedMetricGroupDefinition(object):
         return ret
 
 
-class FakedMetricObjectValues(object):
+class FakedMetricObjectValues:
     # pylint: disable=too-few-public-methods
     """
     Faked metric values for one resource and one metric group.

--- a/zhmcclient_mock/_idpool.py
+++ b/zhmcclient_mock/_idpool.py
@@ -18,12 +18,11 @@ from a defined value range. This is used for example to manage automatically
 allocated device numbers.
 """
 
-from __future__ import absolute_import
 
 __all__ = ['IdPool']
 
 
-class IdPool(object):
+class IdPool:
     """
     A pool of integer ID values from a defined value range.
 

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -16,7 +16,6 @@
 A faked Session class for the zhmcclient package.
 """
 
-from __future__ import absolute_import
 
 try:
     from collections import OrderedDict
@@ -649,7 +648,7 @@ class HmcDefinitionYamlError(Exception):
 
     def __init__(self, message):
         # pylint: disable=useless-super-delegation
-        super(HmcDefinitionYamlError, self).__init__(message)
+        super().__init__(message)
 
 
 class HmcDefinitionSchemaError(Exception):
@@ -662,7 +661,7 @@ class HmcDefinitionSchemaError(Exception):
 
     def __init__(self, message):
         # pylint: disable=useless-super-delegation
-        super(HmcDefinitionSchemaError, self).__init__(message)
+        super().__init__(message)
 
 
 class FakedSession(zhmcclient.Session):
@@ -713,7 +712,7 @@ class FakedSession(zhmcclient.Session):
           password (:term:`string`):
             HMC password for logging in to the mocked HMC.
         """
-        super(FakedSession, self).__init__(
+        super().__init__(
             host, userid=userid, password=password)
         self._hmc = FakedHmc(self, hmc_name, hmc_version, api_version)
         self._urihandler = UriHandler(URIS)
@@ -839,7 +838,7 @@ class FakedSession(zhmcclient.Session):
             hmc_dict = yaml.load(hmc_yaml, Loader=yamlloader.ordereddict.Loader)
         except (yaml.parser.ParserError, yaml.scanner.ScannerError) as exc:
             if filepath:
-                file_str = " in file {f}".format(f=filepath)
+                file_str = f" in file {filepath}"
             else:
                 file_str = ""
             new_exc = HmcDefinitionYamlError(
@@ -890,7 +889,7 @@ class FakedSession(zhmcclient.Session):
             jsonschema.validate(hmc_dict, FAKED_HMC_DEFINITION_SCHEMA)
         except jsonschema.exceptions.ValidationError as exc:
             if filepath:
-                file_str = " in file {f}".format(f=filepath)
+                file_str = f" in file {filepath}"
             else:
                 file_str = ""
             new_exc = HmcDefinitionSchemaError(

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -17,10 +17,7 @@ A faked Session class for the zhmcclient package.
 """
 
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 import yaml
 import yamlloader
 import jsonschema

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -23,7 +23,6 @@ methods that can be mocked in order to provoke non-standard behavior in
 the handling of the HTTP methods.
 """
 
-from __future__ import absolute_import
 
 import re
 import time
@@ -64,7 +63,7 @@ class HTTPError(Exception):
     """
 
     def __init__(self, method, uri, http_status, reason, message):
-        super(HTTPError, self).__init__()
+        super().__init__()
         self.method = method
         self.uri = uri
         self.http_status = http_status
@@ -92,7 +91,7 @@ class ConnectionError(Exception):
     """
 
     def __init__(self, message):
-        super(ConnectionError, self).__init__()
+        super().__init__()
         self.message = message
 
 
@@ -104,12 +103,12 @@ class InvalidResourceError(HTTPError):
     def __init__(self, method, uri, handler_class=None, reason=1,
                  resource_uri=None):
         if handler_class is not None:
-            handler_txt = " (handler class {})".format(handler_class.__name__)
+            handler_txt = f" (handler class {handler_class.__name__})"
         else:
             handler_txt = ""
         if not resource_uri:
             resource_uri = uri
-        super(InvalidResourceError, self).__init__(
+        super().__init__(
             method, uri,
             http_status=404,
             reason=reason,
@@ -124,10 +123,10 @@ class InvalidMethodError(HTTPError):
 
     def __init__(self, method, uri, handler_class=None):
         if handler_class is not None:
-            handler_txt = "handler class {}".format(handler_class.__name__)
+            handler_txt = f"handler class {handler_class.__name__}"
         else:
             handler_txt = "no handler class"
-        super(InvalidMethodError, self).__init__(
+        super().__init__(
             method, uri,
             http_status=404,
             reason=1,
@@ -141,7 +140,7 @@ class BadRequestError(HTTPError):
     """
 
     def __init__(self, method, uri, reason, message):
-        super(BadRequestError, self).__init__(
+        super().__init__(
             method, uri,
             http_status=400,
             reason=reason,
@@ -154,7 +153,7 @@ class ConflictError(HTTPError):
     """
 
     def __init__(self, method, uri, reason, message):
-        super(ConflictError, self).__init__(
+        super().__init__(
             method, uri,
             http_status=409,
             reason=reason,
@@ -177,9 +176,9 @@ class CpcNotInDpmError(ConflictError):
     """
 
     def __init__(self, method, uri, cpc):
-        super(CpcNotInDpmError, self).__init__(
+        super().__init__(
             method, uri, reason=5,
-            message="CPC is not in DPM mode: {}".format(cpc.uri))
+            message=f"CPC is not in DPM mode: {cpc.uri}")
 
 
 class CpcInDpmError(ConflictError):
@@ -197,9 +196,9 @@ class CpcInDpmError(ConflictError):
     """
 
     def __init__(self, method, uri, cpc):
-        super(CpcInDpmError, self).__init__(
+        super().__init__(
             method, uri, reason=4,
-            message="CPC is in DPM mode: {}".format(cpc.uri))
+            message=f"CPC is in DPM mode: {cpc.uri}")
 
 
 class ServerError(HTTPError):
@@ -208,7 +207,7 @@ class ServerError(HTTPError):
     """
 
     def __init__(self, method, uri, reason, message):
-        super(ServerError, self).__init__(
+        super().__init__(
             method, uri,
             http_status=500,
             reason=reason,
@@ -221,7 +220,7 @@ class MockedResourceError(Exception):
     """
 
     def __init__(self, message):
-        super(MockedResourceError, self).__init__()
+        super().__init__()
         self.message = message
 
 
@@ -405,7 +404,7 @@ def check_writable(method, uri, body, writeable):
         if prop not in writeable:
             raise BadRequestError(
                 method, uri, reason=6,
-                message="Property is not writable: {!r}".format(prop))
+                message=f"Property is not writable: {prop!r}")
 
 
 def check_set_noninput(method, uri, properties, prop_name, prop_value):
@@ -444,7 +443,7 @@ def check_invalid_query_parms(method, uri, query_parms, valid_query_parms):
         raise new_exc  # zhmcclient_mock.BadRequestError
 
 
-class UriHandler(object):
+class UriHandler:
     """
     Handle HTTP methods against a set of known URIs and invoke respective
     handlers.
@@ -505,7 +504,7 @@ class UriHandler(object):
         handler_class.delete('DELETE', hmc, uri, uri_parms, logon_required)
 
 
-class GenericGetPropertiesHandler(object):
+class GenericGetPropertiesHandler:
     """
     Handler class for generic get of resource properties.
     """
@@ -552,7 +551,7 @@ class GenericGetPropertiesHandler(object):
         return dict(resource.properties)
 
 
-class GenericUpdatePropertiesHandler(object):
+class GenericUpdatePropertiesHandler:
     """
     Handler class for generic update of resource properties.
     """
@@ -572,7 +571,7 @@ class GenericUpdatePropertiesHandler(object):
         resource.update(body)
 
 
-class GenericDeleteHandler(object):
+class GenericDeleteHandler:
     """
     Handler class for generic delete of a resource.
     """
@@ -590,7 +589,7 @@ class GenericDeleteHandler(object):
         resource.manager.remove(resource.oid)
 
 
-class VersionHandler(object):
+class VersionHandler:
     """
     Handler class for operation: Get version.
     """
@@ -608,7 +607,7 @@ class VersionHandler(object):
         }
 
 
-class SessionsHandler(object):
+class SessionsHandler:
     """
     Handler class for session operations.
     """
@@ -636,7 +635,7 @@ class SessionsHandler(object):
         return result
 
 
-class ThisSessionHandler(object):
+class ThisSessionHandler:
     """
     Handler class for session operations.
     """
@@ -659,7 +658,7 @@ class ConsoleHandler(GenericGetPropertiesHandler):
     valid_query_parms_get = ['properties']
 
 
-class ConsoleRestartHandler(object):
+class ConsoleRestartHandler:
     """
     Handler class for Console operation: Restart Console.
     """
@@ -684,7 +683,7 @@ class ConsoleRestartHandler(object):
         # not visible for the caller of FakedSession (or Session).
 
 
-class ConsoleShutdownHandler(object):
+class ConsoleShutdownHandler:
     """
     Handler class for Console operation: Shutdown Console.
     """
@@ -707,7 +706,7 @@ class ConsoleShutdownHandler(object):
         # not visible for the caller of FakedSession (or Session).
 
 
-class ConsoleMakePrimaryHandler(object):
+class ConsoleMakePrimaryHandler:
     """
     Handler class for Console operation: Make Console Primary.
     """
@@ -729,7 +728,7 @@ class ConsoleMakePrimaryHandler(object):
         # it is primary or alternate.
 
 
-class ConsoleReorderUserPatternsHandler(object):
+class ConsoleReorderUserPatternsHandler:
     """
     Handler class for Console operation: Reorder User Patterns.
     """
@@ -760,7 +759,7 @@ class ConsoleReorderUserPatternsHandler(object):
             console.user_patterns.add(obj.properties)  # append to end
 
 
-class ConsoleGetAuditLogHandler(object):
+class ConsoleGetAuditLogHandler:
     """
     Handler class for Console operation: Get Console Audit Log.
     """
@@ -781,7 +780,7 @@ class ConsoleGetAuditLogHandler(object):
         return resp
 
 
-class ConsoleGetSecurityLogHandler(object):
+class ConsoleGetSecurityLogHandler:
     """
     Handler class for Console operation: Get Console Security Log.
     """
@@ -802,7 +801,7 @@ class ConsoleGetSecurityLogHandler(object):
         return resp
 
 
-class ConsoleListUnmanagedCpcsHandler(object):
+class ConsoleListUnmanagedCpcsHandler:
     """
     Handler class for Console operation: List Unmanaged CPCs.
     """
@@ -834,7 +833,7 @@ class ConsoleListUnmanagedCpcsHandler(object):
         return {'cpcs': result_ucpcs}
 
 
-class ConsoleListPermittedPartitionsHandler(object):
+class ConsoleListPermittedPartitionsHandler:
     """
     Handler class for Console operation: List Permitted Partitions (DPM).
     """
@@ -883,7 +882,7 @@ class ConsoleListPermittedPartitionsHandler(object):
         return {'partitions': result_partitions}
 
 
-class ConsoleListPermittedLparsHandler(object):
+class ConsoleListPermittedLparsHandler:
     """
     Handler class for Console operation: List Permitted LPARs (classic).
     """
@@ -941,7 +940,7 @@ class ConsoleListPermittedLparsHandler(object):
         return {'logical-partitions': result_lpars}
 
 
-class UsersHandler(object):
+class UsersHandler:
     """
     Handler class for HTTP methods on set of User resources.
     """
@@ -1025,7 +1024,7 @@ class UsersHandler(object):
         else:
             raise BadRequestError(
                 method, uri, reason=4,
-                message="Invalid authentication-type: {!r}".format(auth_type))
+                message=f"Invalid authentication-type: {auth_type!r}")
 
         user_type = properties['type']
         if user_type == 'standard':
@@ -1042,7 +1041,7 @@ class UsersHandler(object):
         else:
             raise BadRequestError(
                 method, uri, reason=4,
-                message="Invalid user type: {!r}".format(user_type))
+                message=f"Invalid user type: {user_type!r}")
 
         new_user = console.users.add(properties)
         return {'object-uri': new_user.uri}
@@ -1124,7 +1123,7 @@ class UserHandler(GenericGetPropertiesHandler):
         user.manager.remove(user.oid)
 
 
-class UserAddUserRoleHandler(object):
+class UserAddUserRoleHandler:
     """
     Handler class for operation: Add User Role to User.
     """
@@ -1162,7 +1161,7 @@ class UserAddUserRoleHandler(object):
         user.properties['user-roles'].append(user_role_uri)
 
 
-class UserRemoveUserRoleHandler(object):
+class UserRemoveUserRoleHandler:
     """
     Handler class for operation: Remove User Role from User.
     """
@@ -1204,7 +1203,7 @@ class UserRemoveUserRoleHandler(object):
         user.properties['user-roles'].remove(user_role_uri)
 
 
-class UserRolesHandler(object):
+class UserRolesHandler:
     """
     Handler class for HTTP methods on set of UserRole resources.
     """
@@ -1309,7 +1308,7 @@ class UserRoleHandler(GenericGetPropertiesHandler,
     # TODO: Add delete() for Delete UserRole that rejects system-defined type
 
 
-class UserRoleAddPermissionHandler(object):
+class UserRoleAddPermissionHandler:
     """
     Handler class for operation: Add Permission to User Role.
     """
@@ -1347,7 +1346,7 @@ class UserRoleAddPermissionHandler(object):
         user_role.properties['permissions'].append(permission)
 
 
-class UserRoleRemovePermissionHandler(object):
+class UserRoleRemovePermissionHandler:
     """
     Handler class for operation: Remove Permission from User Role.
     """
@@ -1384,7 +1383,7 @@ class UserRoleRemovePermissionHandler(object):
             user_role.properties['permissions'].remove(permission)
 
 
-class TasksHandler(object):
+class TasksHandler:
     """
     Handler class for HTTP methods on set of Task resources.
     """
@@ -1423,7 +1422,7 @@ class TaskHandler(GenericGetPropertiesHandler):
     pass
 
 
-class UserPatternsHandler(object):
+class UserPatternsHandler:
     """
     Handler class for HTTP methods on set of UserPattern resources.
     """
@@ -1482,7 +1481,7 @@ class UserPatternHandler(GenericGetPropertiesHandler,
     pass
 
 
-class PasswordRulesHandler(object):
+class PasswordRulesHandler:
     """
     Handler class for HTTP methods on set of PasswordRule resources.
     """
@@ -1580,7 +1579,7 @@ class PasswordRuleHandler(GenericGetPropertiesHandler,
         pw_rule.update(body)
 
 
-class LdapServerDefinitionsHandler(object):
+class LdapServerDefinitionsHandler:
     """
     Handler class for HTTP methods on set of LdapServerDefinition resources.
     """
@@ -1668,7 +1667,7 @@ class LdapServerDefinitionHandler(GenericGetPropertiesHandler,
         lsd.update(body)
 
 
-class CpcsHandler(object):
+class CpcsHandler:
     """
     Handler class for HTTP methods on set of Cpc resources.
     """
@@ -1703,7 +1702,7 @@ class CpcHandler(GenericGetPropertiesHandler,
     valid_query_parms_get = ['properties', 'cached-acceptable', 'group-uri']
 
 
-class CpcSetPowerSaveHandler(object):
+class CpcSetPowerSaveHandler:
     """
     Handler class for operation: Set CPC Power Save.
     """
@@ -1735,7 +1734,7 @@ class CpcSetPowerSaveHandler(object):
         cpc.properties['zcpc-power-saving-state'] = power_saving
 
 
-class CpcSetPowerCappingHandler(object):
+class CpcSetPowerCappingHandler:
     """
     Handler class for operation: Set CPC Power Capping.
     """
@@ -1774,7 +1773,7 @@ class CpcSetPowerCappingHandler(object):
         cpc.properties['zcpc-power-cap-current'] = power_cap_current
 
 
-class CpcGetEnergyManagementDataHandler(object):
+class CpcGetEnergyManagementDataHandler:
     """
     Handler class for operation: Get CPC Energy Management Data.
     """
@@ -1863,7 +1862,7 @@ class CpcGetEnergyManagementDataHandler(object):
         return result
 
 
-class CpcStartHandler(object):
+class CpcStartHandler:
     """
     Handler class for operation: Start CPC (DPM mode).
     """
@@ -1886,7 +1885,7 @@ class CpcStartHandler(object):
         cpc.properties['status'] = 'active'
 
 
-class CpcStopHandler(object):
+class CpcStopHandler:
     """
     Handler class for operation: Stop CPC (DPM mode).
     """
@@ -1909,7 +1908,7 @@ class CpcStopHandler(object):
         cpc.properties['status'] = 'not-operating'
 
 
-class CpcActivateHandler(object):
+class CpcActivateHandler:
     """
     Handler class for operation: Activate CPC (classic mode)
     """
@@ -1950,7 +1949,7 @@ class CpcActivateHandler(object):
         # TODO: Set last-used-iocds from profile
 
 
-class CpcDeactivateHandler(object):
+class CpcDeactivateHandler:
     """
     Handler class for operation: Deactivate CPC (classic mode).
     """
@@ -1987,7 +1986,7 @@ class CpcDeactivateHandler(object):
         cpc.properties['status'] = 'no-power'
 
 
-class CpcImportProfilesHandler(object):
+class CpcImportProfilesHandler:
     """
     Handler class for operation: Import Profiles.
     """
@@ -2011,7 +2010,7 @@ class CpcImportProfilesHandler(object):
         # TODO: Import the CPC profiles from a simulated profile area
 
 
-class CpcExportProfilesHandler(object):
+class CpcExportProfilesHandler:
     """
     Handler class for operation: Export Profiles.
     """
@@ -2035,7 +2034,7 @@ class CpcExportProfilesHandler(object):
         # TODO: Export the CPC profiles to a simulated profile area
 
 
-class CpcExportPortNamesListHandler(object):
+class CpcExportPortNamesListHandler:
     """
     Handler class for operation: Export WWPN List.
     """
@@ -2099,7 +2098,7 @@ CPC_PROPNAME_FROM_PROCTYPE = {
 }
 
 
-class CpcAddTempCapacityHandler(object):
+class CpcAddTempCapacityHandler:
     """
     Handler class for operation: Add Temporary Capacity.
     """
@@ -2163,7 +2162,7 @@ class CpcAddTempCapacityHandler(object):
                     cpc.properties[pname] += psteps
 
 
-class CpcRemoveTempCapacityHandler(object):
+class CpcRemoveTempCapacityHandler:
     """
     Handler class for operation: Remove Temporary Capacity.
     """
@@ -2230,7 +2229,7 @@ class CpcRemoveTempCapacityHandler(object):
                     cpc.properties[pname] -= psteps
 
 
-class CpcSetAutoStartListHandler(object):
+class CpcSetAutoStartListHandler:
     """
     Handler class for operation: Set Auto-start List.
     """
@@ -2254,7 +2253,7 @@ class CpcSetAutoStartListHandler(object):
         cpc.properties['auto-start-list'] = auto_start_list
 
 
-class GroupsHandler(object):
+class GroupsHandler:
     """
     Handler class for HTTP methods on set of Group resources.
     """
@@ -2334,7 +2333,7 @@ class GroupHandler(GenericGetPropertiesHandler):
         group.manager.remove(group.oid)
 
 
-class GroupAddMemberHandler(object):
+class GroupAddMemberHandler:
     """
     Handler class for operation: Add Member to Custom Group.
     """
@@ -2366,7 +2365,7 @@ class GroupAddMemberHandler(object):
         group.properties['members'].append(object_uri)
 
 
-class GroupRemoveMemberHandler(object):
+class GroupRemoveMemberHandler:
     """
     Handler class for operation: Remove Member from Custom Group.
     """
@@ -2398,7 +2397,7 @@ class GroupRemoveMemberHandler(object):
         group.properties['members'].remove(object_uri)
 
 
-class GroupMembersHandler(object):
+class GroupMembersHandler:
     """
     Handler class for operation: List Custom Group Members.
     """
@@ -2437,7 +2436,7 @@ class GroupMembersHandler(object):
         return result
 
 
-class MetricsContextsHandler(object):
+class MetricsContextsHandler:
     """
     Handler class for HTTP methods on set of MetricsContext resources.
     """
@@ -2458,7 +2457,7 @@ class MetricsContextsHandler(object):
         return result
 
 
-class MetricsContextHandler(object):
+class MetricsContextHandler:
     """
     Handler class for HTTP methods on single MetricsContext resource.
     """
@@ -2489,7 +2488,7 @@ class MetricsContextHandler(object):
         return result
 
 
-class AdaptersHandler(object):
+class AdaptersHandler:
     """
     Handler class for HTTP methods on set of Adapter resources.
     """
@@ -2620,7 +2619,7 @@ class AdapterHandler(GenericGetPropertiesHandler,
         adapter.manager.remove(adapter.oid)
 
 
-class AdapterChangeCryptoTypeHandler(object):
+class AdapterChangeCryptoTypeHandler:
     """
     Handler class for operation: Change Crypto Type.
     """
@@ -2656,7 +2655,7 @@ class AdapterChangeCryptoTypeHandler(object):
         adapter.properties['crypto-type'] = crypto_type
 
 
-class AdapterChangeAdapterTypeHandler(object):
+class AdapterChangeAdapterTypeHandler:
     """
     Handler class for operation: Change Adapter Type.
     """
@@ -2769,7 +2768,7 @@ class StoragePortHandler(GenericGetPropertiesHandler):
         storage_port.update(body)
 
 
-class PartitionsHandler(object):
+class PartitionsHandler:
     """
     Handler class for HTTP methods on set of Partition resources.
     """
@@ -2831,7 +2830,7 @@ class PartitionsHandler(object):
             Note: Does not guarantee to be reproducable.
             Note: Has a chance to not be unique.
             """
-            return "{:02X}".format(randrange(80))
+            return f"{randrange(80):02X}"
 
         assert wait_for_completion is True  # async not supported yet
         cpc_oid = uri_parms[0]
@@ -3054,7 +3053,7 @@ class PartitionHandler(GenericGetPropertiesHandler,
         partition.manager.remove(partition.oid)
 
 
-class PartitionStartHandler(object):
+class PartitionStartHandler:
     """
     Handler class for operation: Start Partition.
     """
@@ -3085,7 +3084,7 @@ class PartitionStartHandler(object):
         return {}
 
 
-class PartitionStopHandler(object):
+class PartitionStopHandler:
     """
     Handler class for operation: Stop Partition.
     """
@@ -3120,7 +3119,7 @@ class PartitionStopHandler(object):
         return {}
 
 
-class PartitionScsiDumpHandler(object):
+class PartitionScsiDumpHandler:
     """
     Handler class for operation: Dump Partition.
     """
@@ -3155,7 +3154,7 @@ class PartitionScsiDumpHandler(object):
         return {}
 
 
-class PartitionStartDumpProgramHandler(object):
+class PartitionStartDumpProgramHandler:
     """
     Handler class for operation: Start Dump Program.
     """
@@ -3189,7 +3188,7 @@ class PartitionStartDumpProgramHandler(object):
         return {}
 
 
-class PartitionPswRestartHandler(object):
+class PartitionPswRestartHandler:
     """
     Handler class for operation: Perform PSW Restart.
     """
@@ -3220,7 +3219,7 @@ class PartitionPswRestartHandler(object):
         return {}
 
 
-class PartitionMountIsoImageHandler(object):
+class PartitionMountIsoImageHandler:
     """
     Handler class for operation: Mount ISO Image.
     """
@@ -3276,7 +3275,7 @@ class PartitionMountIsoImageHandler(object):
         return {}
 
 
-class PartitionUnmountIsoImageHandler(object):
+class PartitionUnmountIsoImageHandler:
     """
     Handler class for operation: Unmount ISO Image.
     """
@@ -3332,7 +3331,7 @@ def ensure_crypto_config(partition):
     return adapter_uris, domain_configs
 
 
-class PartitionIncreaseCryptoConfigHandler(object):
+class PartitionIncreaseCryptoConfigHandler:
     """
     Handler class for operation: Increase Crypto Configuration.
     """
@@ -3376,7 +3375,7 @@ class PartitionIncreaseCryptoConfigHandler(object):
                 domain_configs.append(dc)
 
 
-class PartitionDecreaseCryptoConfigHandler(object):
+class PartitionDecreaseCryptoConfigHandler:
     """
     Handler class for operation: Decrease Crypto Configuration.
     """
@@ -3421,7 +3420,7 @@ class PartitionDecreaseCryptoConfigHandler(object):
                     del domain_configs[i]
 
 
-class PartitionChangeCryptoConfigHandler(object):
+class PartitionChangeCryptoConfigHandler:
     """
     Handler class for operation: Change Crypto Configuration.
     """
@@ -3463,7 +3462,7 @@ class PartitionChangeCryptoConfigHandler(object):
                 dc['access-mode'] = change_access_mode
 
 
-class HbasHandler(object):
+class HbasHandler:
     """
     Handler class for HTTP methods on set of Hba resources.
     """
@@ -3547,7 +3546,7 @@ class HbaHandler(GenericGetPropertiesHandler,
         partition.hbas.remove(hba.oid)
 
 
-class HbaReassignPortHandler(object):
+class HbaReassignPortHandler:
     """
     Handler class for operation: Reassign Storage Adapter Port.
     """
@@ -3582,7 +3581,7 @@ class HbaReassignPortHandler(object):
         hba.properties['adapter-port-uri'] = new_port_uri
 
 
-class NicsHandler(object):
+class NicsHandler:
     """
     Handler class for HTTP methods on set of Nic resources.
     """
@@ -3721,7 +3720,7 @@ class NicHandler(GenericGetPropertiesHandler):
         partition.nics.remove(nic.oid)
 
 
-class VirtualFunctionsHandler(object):
+class VirtualFunctionsHandler:
     """
     Handler class for HTTP methods on set of VirtualFunction resources.
     """
@@ -3781,7 +3780,7 @@ class VirtualFunctionHandler(GenericGetPropertiesHandler,
         partition.virtual_functions.remove(vf.oid)
 
 
-class VirtualSwitchesHandler(object):
+class VirtualSwitchesHandler:
     """
     Handler class for HTTP methods on set of VirtualSwitch resources.
     """
@@ -3827,7 +3826,7 @@ class VirtualSwitchHandler(GenericGetPropertiesHandler,
     pass
 
 
-class VirtualSwitchGetVnicsHandler(object):
+class VirtualSwitchGetVnicsHandler:
     """
     Handler class for operation: Get Connected VNICs of a Virtual Switch.
     """
@@ -3855,7 +3854,7 @@ class VirtualSwitchGetVnicsHandler(object):
         return {'connected-vnic-uris': connected_vnic_uris}
 
 
-class StorageGroupsHandler(object):
+class StorageGroupsHandler:
     """
     Handler class for HTTP methods on set of StorageGroup resources.
     """
@@ -3939,7 +3938,7 @@ class StorageGroupHandler(GenericGetPropertiesHandler):
     pass
 
 
-class StorageGroupModifyHandler(object):
+class StorageGroupModifyHandler:
     """
     Handler class for operation: Modify Storage Group Properties.
     """
@@ -4002,7 +4001,7 @@ class StorageGroupModifyHandler(object):
         }
 
 
-class StorageGroupDeleteHandler(object):
+class StorageGroupDeleteHandler:
     """
     Handler class for operation: Delete Storage Group.
     """
@@ -4029,7 +4028,7 @@ class StorageGroupDeleteHandler(object):
         storage_group.manager.remove(storage_group.oid)
 
 
-class StorageGroupRequestFulfillmentHandler(object):
+class StorageGroupRequestFulfillmentHandler:
     """
     Handler class for operation: Request Storage Group Fulfillment.
     """
@@ -4054,7 +4053,7 @@ class StorageGroupRequestFulfillmentHandler(object):
         pass
 
 
-class StorageGroupAddCandidatePortsHandler(object):
+class StorageGroupAddCandidatePortsHandler:
     """
     Handler class for operation: Add Candidate Adapter Ports to an FCP Storage
     Group.
@@ -4092,7 +4091,7 @@ class StorageGroupAddCandidatePortsHandler(object):
             candidate_adapter_port_uris.append(ap_uri)
 
 
-class StorageGroupRemoveCandidatePortsHandler(object):
+class StorageGroupRemoveCandidatePortsHandler:
     """
     Handler class for operation: Remove Candidate Adapter Ports from an FCP
     Storage Group.
@@ -4131,7 +4130,7 @@ class StorageGroupRemoveCandidatePortsHandler(object):
             candidate_adapter_port_uris.remove(ap_uri)
 
 
-class StorageVolumesHandler(object):
+class StorageVolumesHandler:
     """
     Handler class for HTTP methods on set of StorageVolume resources.
     """
@@ -4173,7 +4172,7 @@ class StorageVolumeHandler(GenericGetPropertiesHandler):
     pass
 
 
-class CapacityGroupsHandler(object):
+class CapacityGroupsHandler:
     """
     Handler class for HTTP methods on set of CapacityGroup resources.
     """
@@ -4264,7 +4263,7 @@ class CapacityGroupHandler(GenericGetPropertiesHandler,
         capacity_group.manager.remove(capacity_group.oid)
 
 
-class CapacityGroupAddPartitionHandler(object):
+class CapacityGroupAddPartitionHandler:
     """
     Handler class for operation: Add Partition to Capacity Group.
     """
@@ -4333,7 +4332,7 @@ class CapacityGroupAddPartitionHandler(object):
         capacity_group.properties['partition-uris'].append(partition.uri)
 
 
-class CapacityGroupRemovePartitionHandler(object):
+class CapacityGroupRemovePartitionHandler:
     """
     Handler class for operation: Remove Partition from Capacity Group.
     """
@@ -4387,7 +4386,7 @@ class CapacityGroupRemovePartitionHandler(object):
         capacity_group.properties['partition-uris'].remove(partition.uri)
 
 
-class LparsHandler(object):
+class LparsHandler:
     """
     Handler class for HTTP methods on set of Lpar resources.
     """
@@ -4450,14 +4449,14 @@ class LparHandler(GenericGetPropertiesHandler):
             # LPAR permits property updates only when a active
             new_exc = ConflictError(
                 method, uri, 1,
-                "Cannot update LPAR properties in status {}".format(status))
+                f"Cannot update LPAR properties in status {status}")
             new_exc.__cause__ = None
             raise new_exc  # zhmcclient_mock.ConflictError
         # TODO: Add check whether requested properties are modifiable
         lpar.update(body)
 
 
-class LparActivateHandler(object):
+class LparActivateHandler:
     """
     A handler class for the "Activate Logical Partition" operation.
     """
@@ -4522,7 +4521,7 @@ class LparActivateHandler(object):
         lpar.properties['last-used-activation-profile'] = act_profile_name
 
 
-class LparDeactivateHandler(object):
+class LparDeactivateHandler:
     """
     A handler class for the "Deactivate Logical Partition" operation.
     """
@@ -4578,7 +4577,7 @@ class LparDeactivateHandler(object):
         lpar.properties['status'] = LparDeactivateHandler.get_status()
 
 
-class LparLoadHandler(object):
+class LparLoadHandler:
     """
     A handler class for the "Load Logical Partition" operation.
     """
@@ -4665,7 +4664,7 @@ class LparLoadHandler(object):
         lpar.properties['last-used-load-parameter'] = load_parameter
 
 
-class LparScsiLoadHandler(object):
+class LparScsiLoadHandler:
     """
     A handler class for the "SCSI Load" operation.
     """
@@ -4759,7 +4758,7 @@ class LparScsiLoadHandler(object):
             lpar.properties['last-used-clear-indicator'] = clear_indicator
 
 
-class LparScsiDumpHandler(object):
+class LparScsiDumpHandler:
     """
     A handler class for the "SCSI Dump" operation.
     """
@@ -4852,7 +4851,7 @@ class LparScsiDumpHandler(object):
         # does not have a corresponding parameter.
 
 
-class LparNvmeLoadHandler(object):
+class LparNvmeLoadHandler:
     """
     A handler class for the "NVME Load" operation.
     """
@@ -4940,7 +4939,7 @@ class LparNvmeLoadHandler(object):
             lpar.properties['last-used-clear-indicator'] = clear_indicator
 
 
-class LparNvmeDumpHandler(object):
+class LparNvmeDumpHandler:
     """
     A handler class for the "NVME Dump" operation.
     """
@@ -5027,7 +5026,7 @@ class LparNvmeDumpHandler(object):
         # does not have a corresponding parameter.
 
 
-class ResetActProfilesHandler(object):
+class ResetActProfilesHandler:
     """
     Handler class for HTTP methods on set of Reset ActivationProfile resources.
     """
@@ -5073,7 +5072,7 @@ class ResetActProfileHandler(GenericGetPropertiesHandler,
     valid_query_parms_get = ['properties', 'cached-acceptable']
 
 
-class ImageActProfilesHandler(object):
+class ImageActProfilesHandler:
     """
     Handler class for HTTP methods on set of Image ActivationProfile resources.
     """
@@ -5122,7 +5121,7 @@ class ImageActProfileHandler(GenericGetPropertiesHandler,
     valid_query_parms_get = ['properties', 'cached-acceptable']
 
 
-class LoadActProfilesHandler(object):
+class LoadActProfilesHandler:
     """
     Handler class for HTTP methods on set of Load ActivationProfile resources.
     """
@@ -5168,7 +5167,7 @@ class LoadActProfileHandler(GenericGetPropertiesHandler,
     valid_query_parms_get = ['properties', 'cached-acceptable']
 
 
-class SubmitRequestsHandler(object):
+class SubmitRequestsHandler:
     """
     Handler class for "Submit Requests" operation (= aggregation service).
     """


### PR DESCRIPTION
The different activities to drop Python < 3.8 have been kept separate in this PR.