### PR TITLE
1.16: Fixed new issues reported by new flake8 7.0.0

### DIFF
--- a/changes/noissue.1.cleanup.rst
+++ b/changes/noissue.1.cleanup.rst
@@ -1,0 +1,1 @@
+Fixed new issues reported by new flake8 7.0.0.

--- a/tests/unit/zhmcclient/test_utils.py
+++ b/tests/unit/zhmcclient/test_utils.py
@@ -67,8 +67,8 @@ DATETIME_TIMESTAMP_TESTCASES = [
     ((3001, 1, 1, 8, 0, 0, 0), TS_3001_LIMIT + 1000),
     ((MAXYEAR - 1, 12, 31, 0, 0, 0, 0), TS_MAX + 1 - DAY_MS - 365 * DAY_MS),
     ((MAXYEAR, 12, 30, 0, 0, 0, 0), TS_MAX + 1 - 2 * DAY_MS),
-    ((MAXYEAR, 12, 30, 23, 59, 59, 0), TS_MAX + 1 - 2 * DAY_MS + \
-     23 * HOUR_MS + 59 * MIN_MS + 59 * SEC_MS),
+    ((MAXYEAR, 12, 30, 23, 59, 59, 0),
+     TS_MAX + 1 - 2 * DAY_MS + 23 * HOUR_MS + 59 * MIN_MS + 59 * SEC_MS),
 
     # The following testcases would be in range but are too close to the max
     # for pytz due to an implementation limitation: pytz.localize() checks the

--- a/zhmcclient_mock/_urihandler.py
+++ b/zhmcclient_mock/_urihandler.py
@@ -5390,7 +5390,7 @@ URIS = (
 
     (r'/api/partitions/([^/]+)/hbas(?:\?(.*))?', HbasHandler),
     (r'/api/partitions/([^/]+)/hbas/([^?/]+)(?:\?(.*))?', HbaHandler),
-    (r'/api/partitions/([^/]+)/hbas/([^/]+)/operations/'\
+    (r'/api/partitions/([^/]+)/hbas/([^/]+)/operations/'
      'reassign-storage-adapter-port', HbaReassignPortHandler),
 
     (r'/api/partitions/([^/]+)/nics(?:\?(.*))?', NicsHandler),


### PR DESCRIPTION
Rolls back PR #1524 into 1.16.2.