### PR TITLE
Mock: Fixed the incorrect YAML syntax and swapped CPCs in z16 mock files

### DIFF
--- a/changes/noissue.4.notshown.rst
+++ b/changes/noissue.4.notshown.rst
@@ -1,0 +1,1 @@
+Mock: Fixed the incorrect YAML syntax and swapped CPCs in z16 mock files.

--- a/tests/end2end/mocked_hmc_z16.yaml
+++ b/tests/end2end/mocked_hmc_z16.yaml
@@ -3,8 +3,8 @@
 # zhmcclient_mock/_session.py of the python-zhmcclient project.
 #
 # This mocked HMC manages two CPCs:
-* - CPC_CLA: A z16 in DPM mode
-* - CPC_DPM: A z16 in classic mode
+# - CPC_CLA: A z16 in classic mode
+# - CPC_DPM: A z16 in DPM mode
 
 hmc_definition:
   host: hmc_z16

--- a/tests/end2end/mocked_inventory.yaml
+++ b/tests/end2end/mocked_inventory.yaml
@@ -37,10 +37,10 @@ all:
       description: "Mocked HMC with z16 in classic mode and z16 in DPM mode"
       mock_file: "mocked_hmc_z16.yaml"
       cpcs:
-        CPC_DPM:
+        CPC_CLA:
           machine_type: "3932"
           dpm_enabled: false
-        CPC_CLA:
+        CPC_DPM:
           machine_type: "3932"
           dpm_enabled: true
   children:


### PR DESCRIPTION
No review needed.

For the prior errors that are now fixed, see https://github.com/zhmcclient/python-zhmcclient/actions/runs/9581883161/job/26419661424#step:18:26