### PR TITLE
Changed RTD versions shown in docs to be master instead of latest

### DIFF
--- a/changes/1567.cleanup.rst
+++ b/changes/1567.cleanup.rst
@@ -1,2 +1,2 @@
 Docs: Reduced number of versions shown in generated documentation to only
-the latest fix version of each minor version.
+the latest fix version of each minor version, and the master version.


### PR DESCRIPTION
No review needed - merging it in order to get RTD updated.

The actual change is in the RTD version settings:
- set "latest" to be hidden
- activated "master"