### PR TITLE
Added bibliography entries for HMC API books 2.11 - 2.12 back in

### DIFF
--- a/changes/1560.fix.rst
+++ b/changes/1560.fix.rst
@@ -1,0 +1,2 @@
+Docs: Added bibliography entries for HMC API books 2.11 - 2.12 back in,
+without links (they are not downloadable anymore).

--- a/changes/noissue.7.notshown.rst
+++ b/changes/noissue.7.notshown.rst
@@ -1,0 +1,1 @@
+Added bibliography entries for HMC API books 2.11 - 2.13 back in.

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -620,6 +620,15 @@ Bibliography
    HMC API
        The Web Services API of the z Systems Hardware Management Console, described in the following books:
 
+   HMC API 2.11.1
+       IBM SC27-2616, System z Hardware Management Console Web Services API (Version 2.11.1) (no longer available for download)
+
+   HMC API 2.12.0
+       IBM SC27-2617, System z Hardware Management Console Web Services API (Version 2.12.0) (no longer available for download)
+
+   HMC API 2.12.1
+       IBM SC27-2626, System z Hardware Management Console Web Services API (Version 2.12.1) (no longer available for download)
+
    HMC API 2.13.0
        `IBM SC27-2627-00a, z Systems Hardware Management Console Web Services API (Version 2.13.0) <https://www.ibm.com/docs/en/module_1707928542006/pdf/SC27-2627-00a.pdf>`_
 


### PR DESCRIPTION
This implements one of the options listed in issue #1560 - please consider both options when reviewing this PR.