### PR TITLE
Test: Transitioned to label 'no change log' for PRs without need for change log

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,9 +112,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Make sure this change adds or changes at least one change fragment file
-      run: |
-        bash -c "! git diff --exit-code origin/${{ github.base_ref }} changes/*.rst >/dev/null || (echo 'Please add or modify a change fragment file in the changes directory - for details read the Making a change section in the docs'; exit 1)"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/changes/1573.notshown.rst
+++ b/changes/1573.notshown.rst
@@ -1,0 +1,2 @@
+Test: Removed the checking for change fragment files from the test workflow
+again.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -636,12 +636,8 @@ For changes that have no corresponding issue:
 
     towncrier create noissue.<number>.<type>.rst --edit
 
-For changes where you do not want to create a change log entry:
-
-.. code-block:: sh
-
-    towncrier create noissue.<number>.notshown.rst --edit
-    # The file content will be ignored - it can also be empty
+For changes where you do not want to create or modify a change log entry,
+simply don't provide a change fragment file.
 
 where:
 
@@ -680,8 +676,6 @@ where:
   - ``cleanup`` - A cleanup in the code, documentation or development
     environment, that does not fix a bug and is not an enhanced functionality.
     This will show up in the "Cleanup" section of the change log.
-
-  - ``notshown`` - The change will not be shown in the change log.
 
 This command will create a new change fragment file in the ``changes``
 directory and will bring up your editor (usually vim).


### PR DESCRIPTION
For details, see the commit message.

Particular review points:
* With this approach, the label needs to be set while creating the PR. If that is forgotten, the check fails and then after adding the label, a dummy push is needed to trigger the test workflow again. The question is, is that too cumbersome in the handling.