### PR TITLE
Fixed RTD build requirements by adding base-requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,4 +22,5 @@ sphinx:
 python:
    install:
      - requirements: requirements.txt
+     - requirements: base-requirements.txt
      - requirements: dev-requirements.txt


### PR DESCRIPTION
No review needed.
For the RTD build failure this fixes, see https://readthedocs.org/projects/python-zhmcclient/builds/25209635/