### PR TITLE
1.17: Fixed RTD build requirements by adding base-requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,4 +22,5 @@ sphinx:
 python:
    install:
      - requirements: requirements.txt
+     - requirements: base-requirements.txt
      - requirements: dev-requirements.txt


### PR DESCRIPTION
Rolls back PR #1599 into 1.17.1.