### PR TITLE
1.17: Addressed safety issues; Added missing psutil dependency to dev

### DIFF
--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,1 +1,1 @@
-Addressed safety issues up to 2024-07-21.
+Addressed safety issues up to 2024-08-16.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -57,6 +57,7 @@ pydantic>=1.10.13
 typer>=0.12.0
 typer-cli>=0.12.0
 typer-slim>=0.12.0
+psutil>=6.0.0
 
 # Bandit checker
 bandit>=1.7.8

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -54,6 +54,7 @@ pydantic==1.10.13
 typer==0.12.0
 typer-cli==0.12.0
 typer-slim==0.12.0
+psutil==6.0.0
 
 # Bandit checker
 bandit==1.7.8

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -51,7 +51,7 @@ pyrsistent==0.15.1
 # All other indirect dependencies for install that are not in requirements.txt
 
 attrs==19.2.0
-certifi==2023.07.22
+certifi==2024.07.04
 chardet==5.2.0
 docopt==0.6.2
 # idna>3 requires using requests >=2.26.0


### PR DESCRIPTION
Rolls back PR #1601 into 1.17.1.