### PR TITLE
1.17: Fixed creation of release start tag when starting a new version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,8 +526,6 @@ start:
 	git add changes/noissue.$(VERSION).notshown.rst
 	git commit -asm "Start $(VERSION)"
 	git push --set-upstream origin start_$(VERSION)
-	git tag $(VERSION)a0
-	git push --tags
 	@echo "Done: Pushed the start branch to GitHub - now go there and create a PR."
 	@echo "Makefile: $@ done."
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1046,7 +1046,7 @@ local clone of the python-zhmcclient Git repo.
     have succeeded, merge the Pull Request (no review is needed). This
     automatically deletes the branch on GitHub.
 
-7.  Update and clean up the local repo:
+7.  Create the release start tag and clean up the start branch:
 
     .. code-block:: sh
 
@@ -1054,3 +1054,5 @@ local clone of the python-zhmcclient Git repo.
         git pull
         git branch -D start_${MNU}
         git branch -D -r origin/start_${MNU}
+        git tag -f ${MNU}a0
+      	git push -f --tags


### PR DESCRIPTION
Rolls back PR #1619 into 1.17.2.