### PR TITLE
Support for "Get ASCII Console WebSocket URI" operation

### DIFF
--- a/changes/618.feature.rst
+++ b/changes/618.feature.rst
@@ -1,0 +1,5 @@
+Added support for using the integrated ASCII console of operating systems
+running in partitions in DPM mode via the WebSocket protocol, by adding a new
+method 'zhmcclient.Partition.create_os_websocket()'.
+Added a new documentation section "Using WebSocket to access OS console" that
+documents how to interact with the integrated ASCII console from Python code.

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -286,3 +286,176 @@ Utilities
 .. autofunction:: zhmcclient.datetime_from_timestamp
 
 .. autofunction:: zhmcclient.timestamp_from_datetime
+
+
+
+.. _`Using WebSocket to access OS console`:
+
+Using WebSocket to access OS console
+------------------------------------
+
+Starting with HMC version 2.14, it supports the WebSocket protocol for
+accessing the console of the operating system running in partitions on
+CPCs in DPM mode.
+
+The zhmcclient method
+:meth:`zhmcclient.Partition.create_os_websocket` is used to create a WebSocket
+for a particular partition and to return its URI.
+
+This section describes how to use that returned WebSocket URI and how to
+interact with the OS console using Python code.
+
+The WebSocket URI returned by the above method is a URI path without scheme and
+server, e.g.
+``/api/websock/4a4f1hj12hldmm26brcpfnydk663gt6gtyxq4iwto26g2r6wq1/1``.
+That URI is used on the IP address of the HMC that created it using the Web
+Services port of the HMC (port 6794).
+
+Depending on which WebSocket client is used, a full URI needs to be constructed
+from the returned URI path by prepending the secure WebSocket URI scheme
+``wss`` and the HMC's IP address and port, e.g.
+``wss://9.10.11.12:6794/api/websock/4a4f1hj12hldmm26brcpfnydk663gt6gtyxq4iwto26g2r6wq1/1``.
+
+The data returned by the WebSocket are the lines on the OS console, and the
+data sent to the WebSocket are the commands executed on the console, and any
+login data.
+
+Since the integrated ASCII console is supported only on Z systems in DPM mode,
+the operating system running there will be one of:
+
+* some sort of Linux (in a partition with type "linux" or "ssc")
+* z/VM (in a partition with type "zvm")
+
+The OS console of z/VM does not require a login procedure, and any lines sent to
+the WebSocket are interpreted as CP commands.
+
+The OS console of Linux requires a login procedure, so the data sent by the
+WebSocket represents a login prompt that needs to be responded by sending lines
+with the Linux userid and password. After that, any further lines sent are
+interpreted as Linux console commands.
+
+Here is an example Python script that uses the
+`websocket-client <https://pypi.org/project/websocket-client>`_ Python package
+and performs a login to a Linux OS and then executes the 'uname' command and
+prints its output:
+
+.. code-block:: python
+
+    #!/usr/bin/env python
+    # Use WebSocket to console of a partition, login to Linux and execute 'uname'
+
+    import sys
+    import re
+    import ssl
+    import time
+    import websocket
+    import certifi
+    import requests.packages.urllib3
+    import zhmcclient
+
+    WS_TIMEOUT = 5  # WebSocket receive timeout in seconds
+
+    HMC_HOST = '...'  # HMC IP address
+    HMC_USERID = '...'  # HMC user name
+    HMC_PASSWORD = '...'  # HMC password
+    HMC_VERIFY_CERT = False  # or path to CA certificate file/dir
+
+    CPC_NAME = '...'  # CPC name
+    PARTITION_NAME = '...'  # partition name
+
+    LINUX_USERNAME = '...'  # Linux user name for the partition
+    LINUX_PASSWORD = '...'  # Linux password for the partition
+
+
+    def recv_all(ws):
+        """Receive all lines on console"""
+        lines = []
+        while True:
+            try:
+                line = ws.recv()
+            except websocket.WebSocketTimeoutException:
+                return ''.join(lines)
+            lines.append(line)
+
+
+    def linux_login(ws, username, password):
+        """Login to a Linux OS"""
+        while True:
+            lines = recv_all(ws)
+            if lines and re.search(r"login:$", lines.strip(), flags=re.I+re.M):
+                ws.send(username + '\n')
+                lines = recv_all(ws)
+                if lines and re.search(r"password:$", lines.strip(), flags=re.I+re.M):
+                    ws.send(password + '\n')
+                    lines = recv_all(ws)
+                    if lines and re.search(r"login incorrect", lines, flags=re.I+re.M):
+                        msg = lines.replace('\r\n', '\n')
+                        msg = re.sub(r"\n+", "\n", msg, flags=re.M)
+                        msg = re.sub(r"\n[^\n]*login:", "", msg, flags=re.I+re.M)
+                        msg = msg.strip().replace('\n', ' ')
+                        raise Exception(msg)
+                    break
+            else:
+                # Sending empty line to get to login prompt
+                ws.send('\n')
+
+
+    def main():
+
+        requests.packages.urllib3.disable_warnings()
+
+        session = zhmcclient.Session(
+            host=HMC_HOST,
+            userid=HMC_USERID,
+            password=HMC_PASSWORD,
+            verify_cert=HMC_VERIFY_CERT)
+
+        client = zhmcclient.Client(session)
+        cpc = client.cpcs.find(name=CPC_NAME)
+        partition = cpc.partitions.find(name=PARTITION_NAME)
+
+        session = partition.manager.session
+        sslopt = {}
+        if isinstance(session.verify_cert, str):
+            sslopt["cert_reqs"] = ssl.CERT_REQUIRED
+            sslopt["ca_cert_path"] = session.verify_cert
+        elif session.verify_cert is True:
+            sslopt["cert_reqs"] = ssl.CERT_REQUIRED
+            sslopt["ca_cert_path"] = certifi.where()
+        else:
+            sslopt["cert_reqs"] = ssl.CERT_NONE
+
+        ws_uri = partition.create_os_websocket()
+
+        ws = websocket.WebSocket(sslopt=sslopt)
+
+        try:
+            print(f"Connecting to WebSocket for partition {cpc.name}.{partition.name}")
+            ws.connect(f"wss://{session.actual_host}:6794{ws_uri}", timeout=WS_TIMEOUT)
+
+            print("Logging in to Linux")
+            try:
+                linux_login(ws, LINUX_USERNAME, LINUX_PASSWORD)
+            except Exception as exc:
+                print(f"Error: Cannot login: {exc}")
+                return 1
+
+            print("Executing 'uname -a' command")
+            try:
+                ws.send('uname -a\n')
+                uname_out = recv_all(ws)
+            except Exception as exc:
+                print(f"Error: Cannot execute uname: {exc}")
+                return 1
+
+            print(f"Output: {uname_out}")
+
+        finally:
+            print("Closing WebSocket")
+            ws.close()
+            return 0
+
+
+    if __name__ == '__main__':
+        rc = main()
+        sys.exit(rc)

--- a/tests/end2end/test_partition.py
+++ b/tests/end2end/test_partition.py
@@ -294,6 +294,39 @@ def test_part_list_os_messages(dpm_mode_cpcs):  # noqa: F811
             assert message in all_messages
 
 
+def test_part_create_os_websocket(dpm_mode_cpcs):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test "Get ASCII Console WebSocket URI" operation on partitions
+    """
+    if not dpm_mode_cpcs:
+        pytest.skip("HMC definition does not include any CPCs in DPM mode")
+
+    for cpc in dpm_mode_cpcs:
+        assert cpc.dpm_enabled
+
+        session = cpc.manager.session
+        hd = session.hmc_definition
+
+        if hd.mock_file:
+            skip_warn("zhmcclient mock does not support 'Get ASCII Console "
+                      "WebSocket URI' operation")
+
+        # Pick the partition to test with
+        active_part_list = cpc.partitions.list(filter_args={'status': 'active'})
+        if not active_part_list:
+            skip_warn(
+                f"No partitions on CPC {cpc.name} managed by HMC {hd.host} "
+                "with an active status")
+
+        # Pick a random partition to test with
+        part = random.choice(active_part_list)
+
+        ws_uri = part.create_os_websocket()
+
+        assert ws_uri.startswith('/api/websock/')
+
+
 # Full set of properties that are common on all types of partitions:
 COMMON_PROPS_LIST = ['name', 'object-uri', 'type', 'status',
                      'has-unacceptable-status']

--- a/tests/unit/zhmcclient/test_partition.py
+++ b/tests/unit/zhmcclient/test_partition.py
@@ -1017,6 +1017,8 @@ class TestPartition:
 
     # TODO: Test for Partition.send_os_command()
 
+    # TODO: Test for Partition.create_os_websocket()
+
     # TODO: Test for Partition.wait_for_status()
 
     # TODO: Test for Partition.increase_crypto_config()

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -1009,6 +1009,67 @@ class Partition(BaseResource):
         return result
 
     @logged_api_call
+    def create_os_websocket(self, force_takeover=False):
+        """
+        Create a WebSocket on the HMC, which allows accessing the console of
+        the operating system running in the partition using the integrated
+        ASCII console of the HMC, and return the WebSocket URI for use by a
+        WebSocket client.
+
+        This is done by performing the "Get ASCII Console WebSocket URI"
+        HMC operation.
+
+        For more details on how to use a WebSocket client to interact with the
+        integrated ASCII console, see
+        :ref:`Using WebSocket to access OS console`.
+
+        Authorization requirements:
+
+        * Object-access permission to this Partition.
+        * Task permission to the "Integrated ASCII Console" task.
+
+        Parameters:
+
+          force_takeover (bool):
+            Boolean controlling whether to break any possibly existing
+            WebSockets on other HMCs to the same partition, as follows:
+
+            * If `True`, existing WebSockets are broken up and the operation
+              proceeds.
+
+            * If `False`, existing WebSockets are not broken up and the
+              operation fails.
+
+            Note that only existing WebSockets on *other* HMCs can be taken
+            over, but not existing WebSockets on the current HMC.
+
+        Returns:
+
+          :term:`string`:
+
+            Returns a string representing the canonical URI of the new
+            WebSocket, e.g.
+            ``/api/websock/4a4f1hj12hldmm26brcpfnydk663gt6gtyxq4iwto26g2r6wq1/1``.
+
+            Depending on which WebSocket client is used, a full URI may need to
+            be constructed from the returned string by prepending the secure
+            WebSocket URI scheme ``wss`` and the HMC's IP address and port, e.g.
+            ``wss://9.10.11.12:6794/api/websock/4a4f1hj12hldmm26brcpfnydk663gt6gtyxq4iwto26g2r6wq1/1``.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """  # pylint: disable=line-too-long
+        body = {'force-takeover': force_takeover}
+        result = self.manager.session.post(
+            self.uri + '/operations/get-ascii-console-websocket-uri',
+            resource=self, body=body)
+        return result['websocket-uri']
+
+    @logged_api_call
     def wait_for_status(self, status, status_timeout=None):
         """
         Wait until the status of this partition has a desired value.


### PR DESCRIPTION
This PR contains only the support for a new method that invokes the "Get ASCII Console WebSocket URI" HMC operation. The higher level support for making the interactions with the OS console easier, will be in the separate PR #1648 .