### PR TITLE
release_pr: changed to use github-token parameter

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -64,6 +64,7 @@ jobs:
     - name: Create PR on Github for the pushed release branch
       uses: actions/github-script@v7
       with:
+        github-token: ${{ secrets.PAT_ZHMCCLIENT_CREATE_PR }}
         script: |
           github.rest.pulls.create({
             owner: context.repo.owner,
@@ -73,5 +74,3 @@ jobs:
             head: "${{ github.ref_name }}",
             base: "${{ steps.set-target-branch.outputs.result }}",
           });
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAT_ZHMCCLIENT_CREATE_PR }}


### PR DESCRIPTION
Following the recommendation in https://github.com/actions/github-script/issues/484.
No review needed.