### PR TITLE
1.17: Circumvented an issue with pytz by excluding pytz version 2024.2

### DIFF
--- a/changes/1660.fix.rst
+++ b/changes/1660.fix.rst
@@ -1,0 +1,1 @@
+Circumvented an issue with pytz by excluding pytz version 2024.2.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -168,3 +168,9 @@ pip-check-reqs>=2.5.1; python_version >= '3.9'
 # pywinpty <1.1.1 does not have metadata for required Python or dependent packages.
 # pywinpty 1.0 requires maturin which fails installation on py>=3.7
 pywinpty>=0.5,<1.0; os_name == "nt"
+
+# pytz is actually covered in requirements.txt, but we need to repeat it here
+# because development packages pull it in, so the exclusion of 2024.2 is active
+# for development as well.
+# pytz 2024.2 introduced an issue that causes our tests to fail.
+pytz>=2019.1,!=2024.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@
 decorator>=4.0.11
 
 # pytz 2019.1 fixes an ImportError for collections.Mapping on Python 3.10
-pytz>=2019.1
+# pytz 2024.2 introduced an issue that causes our tests to fail.
+pytz>=2019.1,!=2024.2
 
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six


### PR DESCRIPTION
Rolls back PR #1659 into 1.17.2.