### PR TITLE
Fixed coveralls not found on MacOS with py39-311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,11 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-latest\", \
+                \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.12\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -228,7 +233,6 @@ jobs:
       run: |
         make end2end_mocked
     - name: Send coverage result to coveralls.io
-      shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ else
   RMDIR_R_FUNC = find . -type d -name '$(1)' | xargs -n 1 rm -rf
   CP_FUNC = cp -r $(1) $(2)
   ENV = env | sort
-  WHICH = which
+  WHICH = which -a
   DEV_NULL = /dev/null
 endif
 

--- a/changes/1665.fix.rst
+++ b/changes/1665.fix.rst
@@ -1,0 +1,3 @@
+Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on
+MacOS to the normal tests.


### PR DESCRIPTION
For the attempt to debug this, see PR #1663.

If any of the reviewers has an idea why the login shell was specified for invoking coveralls, please comment on that during your review.