### PR TITLE
Test: Added tests for Python 3.13 (final version)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,13 +35,13 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\", \"3.13.0-rc.1\" ], \
+            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\", \"3.13\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ] \
           }" >> $GITHUB_OUTPUT; \
         else \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\" ], \
-            \"python-version\": [ \"3.12\" ], \
+            \"python-version\": [ \"3.13\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
@@ -52,16 +52,6 @@ jobs:
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.9\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.13.0-rc.1\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.13.0-rc.1\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -76,18 +66,8 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-latest\", \
-                \"python-version\": \"3.12\", \
+                \"python-version\": \"3.13\", \
                 \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.13.0-rc.1\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.13.0-rc.1\", \
-                \"package_level\": \"latest\" \
               }, \
               { \
                 \"os\": \"windows-latest\", \
@@ -96,17 +76,7 @@ jobs:
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.12\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"windows-latest\", \
-                \"python-version\": \"3.13.0-rc.1\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"windows-latest\", \
-                \"python-version\": \"3.13.0-rc.1\", \
+                \"python-version\": \"3.13\", \
                 \"package_level\": \"latest\" \
               } \
             ] \

--- a/changes/1506.feature.rst
+++ b/changes/1506.feature.rst
@@ -1,0 +1,1 @@
+Test: Added tests for Python 3.13 (final version).

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -89,8 +89,10 @@ autodocsumm>=0.2.12
 Babel>=2.11.0
 
 # PyLint (no imports, invoked via pylint script)
-pylint>=3.0.1
-astroid>=3.0.1
+pylint>=3.0.1; python_version == '3.8'
+pylint>=3.3.1; python_version >= '3.9'
+astroid>=3.0.1; python_version == '3.8'
+astroid>=3.3.5; python_version >= '3.9'
 lazy-object-proxy>=1.4.3
 wrapt>=1.14
 # platformdirs is also used by tox

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -83,8 +83,10 @@ autodocsumm==0.2.12
 Babel==2.11.0
 
 # PyLint (no imports, invoked via pylint script)
-pylint==3.0.1
-astroid==3.0.1
+pylint==3.0.1; python_version == '3.8'
+pylint==3.3.1; python_version >= '3.9'
+astroid==3.0.1; python_version == '3.8'
+astroid==3.3.5; python_version >= '3.9'
 lazy-object-proxy==1.4.3
 wrapt==1.14
 platformdirs==4.1.0


### PR DESCRIPTION
No review needed.

Will be restarted daily until Python 3.13.0 GA becomes available.

Status:
* Python 3.13.0 has been released
* GitHub Actions has a PR for picking it up: https://github.com/actions/python-versions/pull/312