### PR TITLE
Dev: Started using the trusted publisher concept of Pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ jobs:
     name: Build and publish to PyPI
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment: pypi  # GitHub environment that must exist
+    permissions:
+      id-token: write
+      # contents: write
     steps:
 
     #-------- Info gathering and checks
@@ -144,7 +148,9 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: dist
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        repository-url: https://test.pypi.org/legacy/
+        # Pypi has a trusted publisher defined, so we do not need a password:
+        # https://pypi.org/manage/project/zhmcclient/settings/publishing/
 
     #-------- Creation of Github release
     - name: Determine whether release on Github exists for the pushed tag

--- a/changes/1738.feature.rst
+++ b/changes/1738.feature.rst
@@ -1,0 +1,2 @@
+Dev: Started using the trusted publisher concept of Pypi in order to avoid
+dealing with Pypi access tokens.


### PR DESCRIPTION
When trusted publishing was enabled for the exporter, the upload to Pypi worked, but the subsequent step in the publish.yml workflow to create a release failed. GitHub ticket https://support.github.com/ticket/personal/0/3042595 has been opened for that. Need to wait for clarity on that.

The trust of GitHub has already been established on the Pypi side for all zhmcclient repos.

Once trusted publishing works, the PYPI_API_KEY secrets can be removed in GitHub and the corresponding keys in Pypi.