### PR TITLE
Dev: Added AUTHORS.md to build dependencies again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,14 +244,11 @@ pytest_cov_files := .coveragerc
 build_files := $(bdist_file) $(sdist_file)
 
 # Files the distribution archives depend upon.
-# AUTHORS.md is intentionally not in that list even though it is included in the
-# binary distribution archive, because we don't want it to change during the
-# 'make build' that is run in the publish workflow (that would lead to an
-# attempt to release a development version).
 dist_dependent_files := \
     pyproject.toml \
     LICENSE \
     README.md \
+    AUTHORS.md \
     requirements.txt \
     extra-testutils-requirements.txt \
     $(package_py_files) \


### PR DESCRIPTION
It had been removed in PR #1622 because it was updated in the publish workflow. PR #1694 provided a better circumvention by making the AUTHORS.md file creation check for whether the git shortlog command returned any authors.

With the better circumvention in place, the previous circumvention is now removed.