### PR TITLE
1.18: Dev: Added AUTHORS.md to build dependencies again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,14 +244,11 @@ pytest_cov_files := .coveragerc
 build_files := $(bdist_file) $(sdist_file)
 
 # Files the distribution archives depend upon.
-# AUTHORS.md is intentionally not in that list even though it is included in the
-# binary distribution archive, because we don't want it to change during the
-# 'make build' that is run in the publish workflow (that would lead to an
-# attempt to release a development version).
 dist_dependent_files := \
     pyproject.toml \
     LICENSE \
     README.md \
+    AUTHORS.md \
     requirements.txt \
     extra-testutils-requirements.txt \
     $(package_py_files) \


### PR DESCRIPTION
Rolls back PR #1702 into 1.18.1.