### PR TITLE
1.18: Fix issue that without terminal the AUTHORS.md file was emptied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -683,19 +683,15 @@ authors: AUTHORS.md
 	@echo "Makefile: $@ done."
 
 # Make sure the AUTHORS.md file is up to date but has the old date when it did
-# not change to prevent redoing dependent targets. In GitHub Actions, the
-# 'git shortlog' command does not return authors anymore since around 8/2024.
-# This is tolerated by leaving the file unchanged.
+# not change to prevent redoing dependent targets.
 AUTHORS.md: _always
 	echo "# Authors of this project" >AUTHORS.md.tmp
 	echo "" >>AUTHORS.md.tmp
 	echo "Sorted list of authors derived from git commit history:" >>AUTHORS.md.tmp
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "git shortlog --summary --email | cut -f 2 | sort >log.tmp"
-	sh -c "cat log.tmp >>AUTHORS.md.tmp"
+	sh -c "git shortlog --summary --email HEAD | cut -f 2 | sort >>AUTHORS.md.tmp"
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "if ! grep -q '[^[:space:]]' log.tmp; then echo 'Warning - git shortlog does not display any authors - leaving AUTHORS.md file unchanged'; else if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; fi; fi"
-	sh -c "rm -f log.tmp AUTHORS.md.tmp"
+	sh -c "if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; rm AUTHORS.md.tmp; fi"
 
 .PHONY:	end2end_show
 end2end_show:

--- a/changes/noissue.2.fix.rst
+++ b/changes/noissue.2.fix.rst
@@ -1,3 +1,3 @@
-Dev: Made creation/update of AUTHORS.md tolerant when 'git shortlog' does not
-show any authors - it then issues a warning and leaves the existing file
-unchanged.
+Dev: In the make commands to create/update AUTHORS.md, added a reftag to the
+'git shortlog' command to fix the issue that without a terminal (e.g. in GitHub
+Actions), the command did not display any authors.


### PR DESCRIPTION
Rolls back PR #1706 into 1.18.1.