### PR TITLE
1.18: Fixed clear-text logging of all password-like properties in API/HMC log

### DIFF
--- a/changes/noissue.1.feature.rst
+++ b/changes/noissue.1.feature.rst
@@ -1,0 +1,3 @@
+Dev: Enhanced the zhmcclient API logging code so that in the debugger,
+zhmcclient API functions now have less logging steps to go through until the
+actual API function is reached.

--- a/changes/noissue.4.fix.rst
+++ b/changes/noissue.4.fix.rst
@@ -1,0 +1,4 @@
+Fixed that all password-like properties are no longer written in clear text to
+the Python loggers "zhmcclient.api" and "zhmcclient.hmc", but are now blanked
+out. Previously, that was done only for the "zhmcclient.hmc" logger for creation
+and update of HMC users.

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -502,3 +502,21 @@ def timestamp_aware(dt):
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=tz.tzlocal())  # new object
     return dt
+
+
+def assert_blanked_in_message(message, properties, blanked_properties):
+    """
+    Assert that a message containing a string representation of a properties
+    dict has the desired properties blanked out.
+
+    Parameters:
+        message (str): The message to be checked.
+        properties (dict): Properties that can possibly be in the message
+          (with hyphened names).
+        blanked_properties (list of str): The names of the properties that
+          need to be blanked out in the message (with hyphened names).
+    """
+    for pname in blanked_properties:
+        if pname in properties:
+            exp_str = f"'{pname}': '{zhmcclient.BLANKED_OUT_STRING}'"
+            assert message.find(exp_str) > 0

--- a/tests/unit/zhmcclient/test_activation_profile.py
+++ b/tests/unit/zhmcclient/test_activation_profile.py
@@ -22,9 +22,9 @@ import re
 import logging
 import pytest
 
-from zhmcclient import Client, ActivationProfile, BLANKED_OUT_STRING
+from zhmcclient import Client, ActivationProfile
 from zhmcclient_mock import FakedSession
-from tests.common.utils import assert_resources
+from tests.common.utils import assert_resources, assert_blanked_in_message
 
 
 class TestActivationProfile:
@@ -386,9 +386,6 @@ class TestActivationProfile:
             assert prop_value == exp_prop_value
 
         # Verify the API call log record for blanked-out properties.
-        if 'ssc-master-pw' in input_props:
-            exp_str = f"'ssc-master-pw': '{BLANKED_OUT_STRING}'"
-            assert call_record.message.find(exp_str) > 0
-        if 'zaware-master-pw' in input_props:
-            exp_str = f"'zaware-master-pw': '{BLANKED_OUT_STRING}'"
-            assert call_record.message.find(exp_str) > 0
+        assert_blanked_in_message(
+            call_record.message, input_props,
+            ['ssc-master-pw', 'zaware-master-pw'])

--- a/tests/unit/zhmcclient/test_ldap_server_definition.py
+++ b/tests/unit/zhmcclient/test_ldap_server_definition.py
@@ -22,10 +22,9 @@ import copy
 import logging
 import pytest
 
-from zhmcclient import Client, HTTPError, NotFound, LdapServerDefinition, \
-    BLANKED_OUT_STRING
+from zhmcclient import Client, HTTPError, NotFound, LdapServerDefinition
 from zhmcclient_mock import FakedSession
-from tests.common.utils import assert_resources
+from tests.common.utils import assert_resources, assert_blanked_in_message
 
 
 class TestLdapServerDefinition:
@@ -206,9 +205,9 @@ class TestLdapServerDefinition:
                     assert value == exp_value
 
             # Verify the API call log record for blanked-out properties.
-            if 'bind-password' in input_props:
-                exp_str = f"'bind-password': '{BLANKED_OUT_STRING}'"
-                assert call_record.message.find(exp_str) > 0
+            assert_blanked_in_message(
+                call_record.message, input_props,
+                ['bind-password'])
 
     def test_ldap_srv_def_repr(self):
         """Test LdapServerDefinition.__repr__()."""
@@ -357,6 +356,6 @@ class TestLdapServerDefinition:
             assert prop_value == exp_prop_value
 
         # Verify the API call log record for blanked-out properties.
-        if 'bind-password' in input_props:
-            exp_str = f"'bind-password': '{BLANKED_OUT_STRING}'"
-            assert call_record.message.find(exp_str) > 0
+        assert_blanked_in_message(
+            call_record.message, input_props,
+            ['bind-password'])

--- a/tests/unit/zhmcclient/test_lpar.py
+++ b/tests/unit/zhmcclient/test_lpar.py
@@ -24,11 +24,10 @@ from unittest import mock
 import pytest
 import requests_mock
 
-from zhmcclient import Client, Lpar, HTTPError, StatusTimeout, Job, \
-    BLANKED_OUT_STRING
+from zhmcclient import Client, Lpar, HTTPError, StatusTimeout, Job
 from zhmcclient_mock import FakedSession, LparActivateHandler, \
     LparDeactivateHandler, LparLoadHandler
-from tests.common.utils import assert_resources
+from tests.common.utils import assert_resources, assert_blanked_in_message
 
 # pylint: disable=unused-import,line-too-long
 from tests.common.http_mocked_fixtures import http_mocked_session  # noqa: F401
@@ -373,12 +372,9 @@ class TestLpar:
             assert prop_value == exp_prop_value
 
         # Verify the API call log record for blanked-out properties.
-        if 'ssc-master-pw' in input_props:
-            exp_str = f"'ssc-master-pw': '{BLANKED_OUT_STRING}'"
-            assert call_record.message.find(exp_str) > 0
-        if 'zaware-master-pw' in input_props:
-            exp_str = f"'zaware-master-pw': '{BLANKED_OUT_STRING}'"
-            assert call_record.message.find(exp_str) > 0
+        assert_blanked_in_message(
+            call_record.message, input_props,
+            ['ssc-master-pw', 'zaware-master-pw'])
 
     @pytest.mark.parametrize(
         "initial_profile, profile_kwargs, exp_profile, exp_profile_exc", [

--- a/tests/unit/zhmcclient/test_partition.py
+++ b/tests/unit/zhmcclient/test_partition.py
@@ -22,10 +22,9 @@ import copy
 import logging
 import pytest
 
-from zhmcclient import Client, Partition, HTTPError, NotFound, \
-    BLANKED_OUT_STRING
+from zhmcclient import Client, Partition, HTTPError, NotFound
 from zhmcclient_mock import FakedSession
-from tests.common.utils import assert_resources
+from tests.common.utils import assert_resources, assert_blanked_in_message
 
 # Object IDs and names of our faked partitions:
 PART1_OID = 'part1-oid'
@@ -388,12 +387,9 @@ class TestPartition:
                     assert value == exp_value
 
             # Verify the API call log record for blanked-out properties.
-            if 'boot-ftp-password' in input_props:
-                exp_str = f"'boot-ftp-password': '{BLANKED_OUT_STRING}'"
-                assert call_record.message.find(exp_str) > 0
-            if 'ssc-master-pw' in input_props:
-                exp_str = f"'ssc-master-pw': '{BLANKED_OUT_STRING}'"
-                assert call_record.message.find(exp_str) > 0
+            assert_blanked_in_message(
+                call_record.message, input_props,
+                ['boot-ftp-password', 'ssc-master-pw'])
 
     def test_pm_resource_object(self):
         """
@@ -753,12 +749,9 @@ class TestPartition:
             assert prop_value == exp_prop_value
 
         # Verify the API call log record for blanked-out properties.
-        if 'boot-ftp-password' in input_props:
-            exp_str = f"'boot-ftp-password': '{BLANKED_OUT_STRING}'"
-            assert call_record.message.find(exp_str) > 0
-        if 'ssc-master-pw' in input_props:
-            exp_str = f"'ssc-master-pw': '{BLANKED_OUT_STRING}'"
-            assert call_record.message.find(exp_str) > 0
+        assert_blanked_in_message(
+            call_record.message, input_props,
+            ['boot-ftp-password', 'ssc-master-pw'])
 
     def test_partition_update_name(self):
         """

--- a/tests/unit/zhmcclient/test_user.py
+++ b/tests/unit/zhmcclient/test_user.py
@@ -22,9 +22,9 @@ import copy
 import logging
 import pytest
 
-from zhmcclient import Client, HTTPError, NotFound, User, BLANKED_OUT_STRING
+from zhmcclient import Client, HTTPError, NotFound, User
 from zhmcclient_mock import FakedSession
-from tests.common.utils import assert_resources
+from tests.common.utils import assert_resources, assert_blanked_in_message
 
 
 class TestUser:
@@ -228,9 +228,9 @@ class TestUser:
                     assert value == exp_value
 
             # Verify the API call log record for blanked-out properties.
-            if 'password' in input_props:
-                exp_str = f"'password': '{BLANKED_OUT_STRING}'"
-                assert call_record.message.find(exp_str) > 0
+            assert_blanked_in_message(
+                call_record.message, input_props,
+                ['password'])
 
     def test_user_repr(self):
         """Test User.__repr__()."""

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -224,7 +224,8 @@ class ActivationProfileManager(BaseManager):
             list_uri, result_prop, full_properties, filter_args,
             additional_properties)
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['ssc-master-pw', 'zaware-master-pw'],
+                     properties_pos=1)
     def create(self, properties):
         """
         Create and configure an Activation Profiles on this CPC, of the profile
@@ -344,7 +345,8 @@ class ActivationProfile(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['ssc-master-pw', 'zaware-master-pw'],
+                     properties_pos=1)
     def update_properties(self, properties):
         """
         Update writeable properties of this Activation Profile.

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -50,7 +50,8 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'HTML_REASON_WEB_SERVICES_DISABLED',
            'HTML_REASON_OTHER',
            'STOMP_MIN_CONNECTION_CHECK_TIME',
-           'DEFAULT_WS_TIMEOUT']
+           'DEFAULT_WS_TIMEOUT',
+           'BLANKED_OUT_STRING']
 
 
 #: Default HTTP connect timeout in seconds,
@@ -187,3 +188,7 @@ STOMP_MIN_CONNECTION_CHECK_TIME = 5.0
 #: Default WebSocket connect and receive timeout in seconds, for interacting
 #: with the :class:`zhmcclient.OSConsole` class.
 DEFAULT_WS_TIMEOUT = 5
+
+#: Replacement string for blanked out sensitive values in log entries, such as
+#: passwords or session tokens.
+BLANKED_OUT_STRING = '********'

--- a/zhmcclient/_ldap_server_definition.py
+++ b/zhmcclient/_ldap_server_definition.py
@@ -151,7 +151,7 @@ class LdapServerDefinitionManager(BaseManager):
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['bind-password'], properties_pos=1)
     def create(self, properties):
         """
         Create a new LDAP Server Definition in this HMC.
@@ -257,7 +257,7 @@ class LdapServerDefinition(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['bind-password'], properties_pos=1)
     def update_properties(self, properties):
         """
         Update writeable properties of this LDAP Server Definitions.

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -187,7 +187,8 @@ class Lpar(BaseResource):
             f"got {type(manager)}")
         super().__init__(manager, uri, name, properties)
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['ssc-master-pw', 'zaware-master-pw'],
+                     properties_pos=1)
     def update_properties(self, properties):
         """
         Update writeable properties of this LPAR.

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -176,7 +176,8 @@ class PartitionManager(BaseManager):
             list_uri, result_prop, full_properties, filter_args,
             additional_properties)
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['boot-ftp-password', 'ssc-master-pw'],
+                     properties_pos=1)
     def create(self, properties):
         """
         Create and configure a Partition in this CPC.
@@ -591,7 +592,8 @@ class Partition(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['boot-ftp-password', 'ssc-master-pw'],
+                     properties_pos=1)
     def update_properties(self, properties):
         """
         Update writeable properties of this Partition.

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -149,7 +149,7 @@ class UserManager(BaseManager):
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['password'], properties_pos=1)
     def create(self, properties):
         """
         Create a new User in this HMC.
@@ -256,7 +256,7 @@ class User(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call
+    @logged_api_call(blanked_properties=['password'], properties_pos=1)
     def update_properties(self, properties):
         """
         Update writeable properties of this User.


### PR DESCRIPTION
Rolls back PR #1714 into 1.18.1.