### PR TITLE
1.18: Fixed safety issues up to 2024-11-28

### DIFF
--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,0 +1,1 @@
+Fixed safety issues up to 2024-11-28.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@
 # PEP517 package builder, used in Makefile
 build>=1.0.0
 # build requires virtualenv.cli_run which was added in virtualenv 20.1
-virtualenv>=20.25.0
+virtualenv>=20.26.6
 pyproject-hooks>=1.1.0
 
 # six (only needed by packages that still support Python 2)

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -14,7 +14,7 @@ six==1.16.0
 # PEP517 package builder, used in Makefile
 build==1.0.0
 # build requires virtualenv.cli_run which was added in virtualenv 20.1
-virtualenv==20.25.0
+virtualenv==20.26.6
 pyproject-hooks==1.1.0
 
 # Change log


### PR DESCRIPTION
Rolls back PR #1716 into 1.18.1.