### PR TITLE
Fixed incorrect blanked-out password-like properties

### DIFF
--- a/changes/noissue.5.fix.rst
+++ b/changes/noissue.5.fix.rst
@@ -1,0 +1,2 @@
+Fixed that incorrect password-like properties were added with blanked-out values
+to the API and HMC log.

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -255,11 +255,9 @@ def logged_api_call(
             # properties may also be a DictView (subclass of Mapping)
             assert isinstance(properties, Mapping)
             copied_properties = dict(properties)
-            for pn in blanked_properties:
-                try:
-                    copied_properties[pn] = BLANKED_OUT_STRING
-                except KeyError:
-                    pass
+            for pname in blanked_properties:
+                if pname in copied_properties:
+                    copied_properties[pname] = BLANKED_OUT_STRING
             return copied_properties
 
         def blanked_args(args, kwargs):

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -967,11 +967,9 @@ class Session:
                 # structured data such as a password or session IDs.
                 pass
             else:
-                for prop in BLANKED_OUT_PROPERTIES:
-                    try:
-                        content_dict[prop] = BLANKED_OUT_STRING
-                    except KeyError:
-                        pass
+                for pname in BLANKED_OUT_PROPERTIES:
+                    if pname in content_dict:
+                        content_dict[pname] = BLANKED_OUT_STRING
                 content = dict2json(content_dict)
             trunc = 30000
             if content_len > trunc:


### PR DESCRIPTION
For details, see the commit message.
No review needed.