### PR TITLE
1.18: Accomodated rollout of Ubuntu 24.04 on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,31 @@ jobs:
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
             \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\", \"3.13\" ], \
-            \"package_level\": [ \"minimum\", \"latest\" ] \
+            \"package_level\": [ \"minimum\", \"latest\" ], \
+            \"exclude\": [ \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.8\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.8\", \
+                \"package_level\": \"latest\" \
+              } \
+            ], \
+            \"include\": [ \
+              { \
+                \"os\": \"ubuntu-22.04\", \
+                \"python-version\": \"3.8\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-22.04\", \
+                \"python-version\": \"3.8\", \
+                \"package_level\": \"latest\" \
+              } \
+            ] \
           }" >> $GITHUB_OUTPUT; \
         else \
           echo "matrix={ \
@@ -45,7 +69,7 @@ jobs:
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
-                \"os\": \"ubuntu-latest\", \
+                \"os\": \"ubuntu-22.04\", \
                 \"python-version\": \"3.8\", \
                 \"package_level\": \"minimum\" \
               }, \

--- a/changes/noissue.1.cleanup.rst
+++ b/changes/noissue.1.cleanup.rst
@@ -1,0 +1,2 @@
+Accommodated rollout of Ubuntu 24.04 on GitHub Actions by using ubuntu-22.04
+as the OS image for Python 3.8 based test runs.


### PR DESCRIPTION
Rolls back PR #1726 into 1.18.3.