### PR TITLE
1.18: Circumvented issue with installing pywinpty on py38; Added py38/win/latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,11 @@ jobs:
               }, \
               { \
                 \"os\": \"windows-latest\", \
+                \"python-version\": \"3.8\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
                 \"python-version\": \"3.13.0\", \
                 \"package_level\": \"latest\" \
               } \

--- a/changes/noissue.6.fix.rst
+++ b/changes/noissue.6.fix.rst
@@ -1,0 +1,2 @@
+Circumvented an issue when installing pywinpty 2.0.14 with latest version of
+maturin on Python 3.8, by excluding pywinpty 2.0.14.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -175,7 +175,11 @@ pip-check-reqs>=2.5.1; python_version >= '3.9'
 
 # pywinpty is used by terminado <- notebook <- jupyter
 # pywinpty>=1.0 requires maturin to build. Meanwhile, it works.
-pywinpty>=2.0.12; os_name == "nt"
+# pywinpty 2.0.14 has an issue with latest maturin on Python 3.8, see https://github.com/andfoy/pywinpty/issues/486
+# pywinpty 2.0.12/13 has the above issue on Python 3.13
+pywinpty>=2.0.12,!=2.0.14; os_name == "nt" and python_version == '3.8'
+pywinpty>=2.0.12; os_name == "nt" and python_version >= '3.9' and python_version <= '3.12'
+pywinpty>=2.0.14; os_name == "nt" and python_version >= '3.13'
 
 # pytz is actually covered in requirements.txt, but we need to repeat it here
 # because development packages pull it in, so the exclusion of 2024.2 is active

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -145,7 +145,8 @@ pip-check-reqs==2.4.3; python_version <= '3.8'
 pip-check-reqs==2.5.1; python_version >= '3.9'
 
 # pywinpty is used by terminado <- notebook <- jupyter
-pywinpty==2.0.12; os_name == "nt"
+pywinpty==2.0.12; os_name == "nt" and python_version >= '3.8' and python_version <= '3.12'
+pywinpty==2.0.14; os_name == "nt" and python_version >= '3.13'
 
 # Indirect dependencies for development that are not in dev-requirements.txt
 


### PR DESCRIPTION
Rolls back PR #1730 into 1.18.3.