### PR TITLE
Added boolean parm 'always' to 'zhmcclient.Session.logon()'

### DIFF
--- a/changes/noissue.2.feature.rst
+++ b/changes/noissue.2.feature.rst
@@ -1,0 +1,3 @@
+Added a boolean parameter 'always' to the 'zhmcclient.Session.logon()' method,
+which causes the session to always be logged on, regardless of an existing
+session ID.

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -679,7 +679,7 @@ class Session:
         return self._auto_updater
 
     @logged_api_call
-    def logon(self, verify=False):
+    def logon(self, verify=False, always=False):
         """
         Make sure this session object is logged on to the HMC.
 
@@ -708,6 +708,9 @@ class Session:
 
           verify (bool): Verify the validity of an existing session ID.
 
+          always (bool): Unconditionally log on, regardless of an existing
+            session ID.
+
         Raises:
 
           :exc:`~zhmcclient.HTTPError`
@@ -717,7 +720,7 @@ class Session:
           :exc:`~zhmcclient.ConnectionError`
         """
         need_logon = False
-        if self._session_id is None:
+        if self._session_id is None or always:
             need_logon = True
         elif verify:
             try:


### PR DESCRIPTION
This is needed for the new 'zhmccli session logon' command.