### PR TITLE
Pinned Python 3.13 to 3.13.0 - change entry

### DIFF
--- a/changes/1728.fix.rst
+++ b/changes/1728.fix.rst
@@ -1,0 +1,2 @@
+Test: Python 3.13 was pinned to 3.13.0 to work around a pylint issue on
+Python 3.13.1.


### PR DESCRIPTION
The change entry was missing in PR #1729.
No review needed.