### PR TITLE
Migrated safety to use 'safety scan'

### DIFF
--- a/.safety-policy-develop.yml
+++ b/.safety-policy-develop.yml
@@ -1,33 +1,62 @@
 # Safety policy file for packages needed for development.
-# For documentation, see https://docs.pyup.io/docs/safety-20-policy-file
+# For documentation, see https://docs.safetycli.com/safety-docs/administration/safety-policy-files
 
 # Note: This policy file is used against the versions in minimum-constraints-develop.txt.
 
-# Configuration for the 'safety check' command
-security:
+version: '3.0'
 
-    # Ignore certain severities.
-    # A number between 0 and 10, with the following significant values:
-    # - 9: ignore all vulnerabilities except CRITICAL severity
-    # - 7: ignore all vulnerabilities except CRITICAL & HIGH severity
-    # - 4: ignore all vulnerabilities except CRITICAL, HIGH & MEDIUM severity
-    ignore-cvss-severity-below: 0
+scanning-settings:
+  max-depth: 6
+  exclude: []
+  include-files: []
+  system:
+    targets: []
 
-    # Ignore unknown severities.
-    # Should be set to False.
-    ignore-cvss-unknown-severity: False
+report:
+  dependency-vulnerabilities:
+    enabled: true
+    auto-ignore-in-report:
+      python:
+        environment-results: true
+        unpinned-requirements: true
+      cvss-severity: []
+      vulnerabilities:
+          # List of specific vulnerabilities to ignore.
+          # {id}:                 # vulnerability ID
+          #     reason: {text}    # optional: Reason for ignoring it
+          #     expires: {date}   # optional: Date when this ignore will expire
+          70612:
+              reason: Disputed issue in jinja2 version 3.1.3 - No known fix
 
-    # Ignore unpinned requirements.
-    # Should be set to False.
-    ignore-unpinned-requirements: False
+fail-scan-with-exit-code:
+  dependency-vulnerabilities:
+    enabled: true
+    fail-on-any-of:
+      cvss-severity:
+        - high
+        - medium
+        - critical
+      exploitability:
+        - high
+        - medium
+        - critical
 
-    # List of specific vulnerabilities to ignore.
-    # {id}:                 # vulnerability ID
-    #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports
-    #     expires: {date}   # optional: Date when this ignore will expire
-    ignore-vulnerabilities:
-        70612:
-            reason: Disputed issue in jinja2 version 3.1.3 - No known fix
+security-updates:
+  dependency-vulnerabilities:
+    auto-security-updates-limit:
+      - patch
 
-    # Continue with exit code 0 when vulnerabilities are found.
-    continue-on-vulnerability-error: False
+installation:
+  default-action: allow
+  audit-logging:
+    enabled: true
+  allow:
+    packages: []
+    vulnerabilities: {}
+  deny:
+    packages: {}
+    vulnerabilities:
+      warning-on-any-of:
+        cvss-severity: []
+      block-on-any-of:
+        cvss-severity: []

--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -1,31 +1,60 @@
 # Safety policy file for packages needed for installation.
-# For documentation, see https://docs.pyup.io/docs/safety-20-policy-file
+# For documentation, see https://docs.safetycli.com/safety-docs/administration/safety-policy-files
 
 # Note: This policy file is used against the versions in minimum-constraints-install.txt.
 
-# Configuration for the 'safety check' command
-security:
+version: '3.0'
 
-    # Ignore certain severities.
-    # A number between 0 and 10, with the following significant values:
-    # - 9: ignore all vulnerabilities except CRITICAL severity
-    # - 7: ignore all vulnerabilities except CRITICAL & HIGH severity
-    # - 4: ignore all vulnerabilities except CRITICAL, HIGH & MEDIUM severity
-    ignore-cvss-severity-below: 0
+scanning-settings:
+  max-depth: 6
+  exclude: []
+  include-files: []
+  system:
+    targets: []
 
-    # Ignore unknown severities.
-    # Should be set to False.
-    ignore-cvss-unknown-severity: False
+report:
+  dependency-vulnerabilities:
+    enabled: true
+    auto-ignore-in-report:
+      python:
+        environment-results: true
+        unpinned-requirements: true
+      cvss-severity: []
+      vulnerabilities:
+          # List of specific vulnerabilities to ignore.
+          # {id}:                 # vulnerability ID
+          #     reason: {text}    # optional: Reason for ignoring it
+          #     expires: {date}   # optional: Date when this ignore will expire
 
-    # Ignore unpinned requirements.
-    # Should be set to False.
-    ignore-unpinned-requirements: False
+fail-scan-with-exit-code:
+  dependency-vulnerabilities:
+    enabled: true
+    fail-on-any-of:
+      cvss-severity:
+        - high
+        - medium
+        - critical
+      exploitability:
+        - high
+        - medium
+        - critical
 
-    # List of specific vulnerabilities to ignore.
-    # {id}:                 # vulnerability ID
-    #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports
-    #     expires: {date}   # optional: Date when this ignore will expire
-    ignore-vulnerabilities:
+security-updates:
+  dependency-vulnerabilities:
+    auto-security-updates-limit:
+      - patch
 
-    # Continue with exit code 0 when vulnerabilities are found.
-    continue-on-vulnerability-error: False
+installation:
+  default-action: allow
+  audit-logging:
+    enabled: true
+  allow:
+    packages: []
+    vulnerabilities: {}
+  deny:
+    packages: {}
+    vulnerabilities:
+      warning-on-any-of:
+        cvss-severity: []
+      block-on-any-of:
+        cvss-severity: []

--- a/Makefile
+++ b/Makefile
@@ -596,14 +596,14 @@ $(done_dir)/pylint_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(
 $(done_dir)/safety_develop_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(safety_develop_policy_file) minimum-constraints-develop.txt minimum-constraints-install.txt
 	@echo "Makefile: Running Safety for development packages (and tolerate safety issues when RUN_TYPE is normal or scheduled)"
 	-$(call RM_FUNC,$@)
-	bash -c "safety check --policy-file $(safety_develop_policy_file) -r minimum-constraints-develop.txt --full-report || test '$(RUN_TYPE)' == 'normal' || test '$(RUN_TYPE)' == 'scheduled' || exit 1"
+	bash -c "safety scan --policy-file $(safety_develop_policy_file) -r minimum-constraints-develop.txt --full-report || test '$(RUN_TYPE)' == 'normal' || test '$(RUN_TYPE)' == 'scheduled' || exit 1"
 	echo "done" >$@
 	@echo "Makefile: Done running Safety for development packages"
 
 $(done_dir)/safety_install_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(safety_install_policy_file) minimum-constraints-install.txt
 	@echo "Makefile: Running Safety for install packages (and tolerate safety issues when RUN_TYPE is normal)"
 	-$(call RM_FUNC,$@)
-	bash -c "safety check --policy-file $(safety_install_policy_file) -r minimum-constraints-install.txt --full-report || test '$(RUN_TYPE)' == 'normal' || exit 1"
+	bash -c "safety scan --policy-file $(safety_install_policy_file) -r minimum-constraints-install.txt --full-report || test '$(RUN_TYPE)' == 'normal' || exit 1"
 	echo "done" >$@
 	@echo "Makefile: Done running Safety for install packages"
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,19 +47,18 @@ coveralls>=3.3.0
 # Safety 3.0.0 requires exact versions of authlib==1.2.0 and jwt==1.3.1.
 # Safety 3.0.x pins pydantic to <2.0, preventing bug fixes.
 # pydantic 2.8.0 fixes an install issue on Python 3.13.
-safety>=3.1.0
-safety-schemas>=0.0.2,!=0.0.7
-# TODO: Change to dparse 0.6.4 once released
-dparse>=0.6.4b0
+safety>=3.2.14
+safety-schemas>=0.0.10
+dparse>=0.6.4
 ruamel.yaml>=0.17.21
 click>=8.0.2
 Authlib>=1.2.0
 marshmallow>=3.15.0
 pydantic>=2.8.0
-typer>=0.12.0
-typer-cli>=0.12.0
-typer-slim>=0.12.0
-psutil>=6.0.0
+typer>=0.13.0
+typer-cli>=0.13.0
+typer-slim>=0.13.0
+psutil>=6.1.0
 
 # Bandit checker
 bandit>=1.7.8

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -42,19 +42,18 @@ pytest-cov==2.7.0
 coveralls==3.3.0
 
 # Safety CI by pyup.io
-safety==3.1.0
-safety-schemas==0.0.2
-# TODO: Change to dparse 0.6.4 once released
-dparse==0.6.4b0
+safety==3.2.14
+safety-schemas==0.0.10
+dparse==0.6.4
 ruamel.yaml==0.17.21
 click==8.0.2
 Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
-typer==0.12.0
-typer-cli==0.12.0
-typer-slim==0.12.0
-psutil==6.0.0
+typer==0.13.0
+typer-cli==0.13.0
+typer-slim==0.13.0
+psutil==6.1.0
 
 # Bandit checker
 bandit==1.7.8
@@ -168,7 +167,7 @@ configparser==4.0.2
 dataclasses==0.8
 defusedxml==0.7.1
 distlib==0.3.7
-filelock==3.13.1
+filelock==3.16.1
 gitdb==4.0.8
 gitdb2==2.0.0
 html5lib==1.1


### PR DESCRIPTION
In this PR, the safety tool is not running. It prompts for creating an account and then terminates without returning an error:
```
Makefile: Running Safety for install packages (and tolerate safety issues when RUN_TYPE is normal)
rm -f done/safety_install_py3.9_latest.done
bash -c "safety scan --policy-file .safety-policy-install.yml -r minimum-constraints-install.txt --full-report || test 'normal' == 'normal' || exit 1"
Please login or register Safety CLI (free forever) to scan and secure your 
projects with Safety
(R)egister for a free account in 30 seconds, or (L)ogin with an existing account
Unhandled exception happened: EOF when reading a line
to continue (R/L): echo "done" >done/safety_install_py3.9_latest.done
Makefile: Done running Safety for install packages
```