### PR TITLE
Increased end2end operations timeout

### DIFF
--- a/changes/noissue.3.feature.rst
+++ b/changes/noissue.3.feature.rst
@@ -1,0 +1,3 @@
+Increased the timeout for HMC operations that is used in end2end tests, from
+300 sec to 1800 sec. Note that this does not change the default timeout for
+users of the zhmcclient library, which continues to be 3600 sec.

--- a/zhmcclient/testutils/_hmc_definition_fixtures.py
+++ b/zhmcclient/testutils/_hmc_definition_fixtures.py
@@ -162,7 +162,7 @@ def setup_hmc_session(hd):
             logger.setLevel(logging.DEBUG)
 
         rt_config = zhmcclient.RetryTimeoutConfig(
-            read_timeout=300,
+            read_timeout=1800,
         )
 
         # Creating a session does not interact with the HMC (logon is deferred)


### PR DESCRIPTION
No review needed.