### PR TITLE
Fixed expected properties in partition link end2end tests

### DIFF
--- a/tests/end2end/test_partition_link.py
+++ b/tests/end2end/test_partition_link.py
@@ -370,7 +370,6 @@ PARTLINK_CREATE_DELETE_TESTCASES = [
             ],
         },
         {
-            'partitions': ['partition_1.uri', 'partition_2.uri'],
             'paths': [
                 {
                     'starting-device-number': '4000',


### PR DESCRIPTION
Another fix for PR #1685 
No review needed.