### PR TITLE
Fixed a datetime conversion error by excluding pytz 2025.1

### DIFF
--- a/changes/fix.1755.rst
+++ b/changes/fix.1755.rst
@@ -1,0 +1,1 @@
+Fixed a datetime conversion error by excluding pytz 2025.1.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -185,4 +185,5 @@ pywinpty>=2.0.14; os_name == "nt" and python_version >= '3.13'
 # because development packages pull it in, so the exclusion of 2024.2 is active
 # for development as well.
 # pytz 2024.2 introduced an issue that causes our tests to fail.
-pytz>=2019.1,!=2024.2
+# pytz 2025.1 introduced an issue that causes our tests to fail (https://github.com/stub42/pytz/issues/133)
+pytz>=2019.1,!=2024.2,!=2025.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ decorator>=4.0.11
 
 # pytz 2019.1 fixes an ImportError for collections.Mapping on Python 3.10
 # pytz 2024.2 introduced an issue that causes our tests to fail.
-pytz>=2019.1,!=2024.2
+# pytz 2025.1 introduced an issue that causes our tests to fail (https://github.com/stub42/pytz/issues/133)
+pytz>=2019.1,!=2024.2,!=2025.1
 
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six


### PR DESCRIPTION
No review needed.