### PR TITLE
Fix broken inventory error handling

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,7 @@ Andreas Maier <maiera@de.ibm.com>
 Andreas Scheuring <andreas.scheuring@de.ibm.com>
 Andrew Brezovsky <abrezov@us.ibm.com>
 Anil Kumar Dakarapu <anil.kumar.dakarapu@ibm.com>
+Edwin Guenthner <edwin.guenthner@de.ibm.com>
 Edwin Günthner <edwin.guenthner@de.ibm.com>
 Juergen Leopold <leopoldj@de.ibm.com>
 Kavin Raj A M <Kavin.Raj.A.M1@ibm.com>

--- a/changes/1760.fix.rst
+++ b/changes/1760.fix.rst
@@ -1,0 +1,2 @@
+When handling inventory errors during "Export DPM configuration", only access
+field "inventory-error-details" if "inventory-error-code" is 5.

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -3128,11 +3128,15 @@ def retrieveInventoryData(client):
     error_msgs = []
     for item in inventory_list:
         if item.get('class') == 'inventory-error':
+            details = ""
+            if item.get('inventory-error-code') == 5:
+                details = \
+                    f" / Details: {dict(item.get('inventory-error-details'))}"
+
             msg = (
                 f"Inventory error {item.get('inventory-error-code')} for "
                 f"resource with URI {item.get('uri')}: "
-                f"{item.get('inventory-error-text')}; "
-                f"Details: {dict(item.get('inventory-error-details'))}")
+                f"{item.get('inventory-error-text')}{details}")
             error_msgs.append(msg)
     if error_msgs:
         msgs = '\n  '.join(error_msgs)


### PR DESCRIPTION
When inventory errors are encountered and logged to the user during "Export DPM configurtion", the field "inventory-error-details" is only be present if "inventory-error-code" is 5. This change adds a corresponding check to avoid failing with a corresponding TypeError.