### PR TITLE
1.19: Fix broken adapter removal; Drop storage/network ports for removed adapters

### DIFF
--- a/changes/1764.fix.1.rst
+++ b/changes/1764.fix.1.rst
@@ -1,0 +1,1 @@
+Remove unused network and storage port objects from export data, too.

--- a/changes/1764.fix.rst
+++ b/changes/1764.fix.rst
@@ -1,0 +1,1 @@
+Ensure proper detection of all unreferenced adapters.

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -2046,8 +2046,9 @@ class Cpc(BaseResource):
         capacity groups, various storage and tape related resources, and
         certificate objects.
 
-        By default, only those adapters of the CPC are exported that are
-        referenced by other DPM specific objects.
+        By default, only those adapters and virtual switches of the CPC are
+        exported that are referenced by other DPM specific configuration
+        objects.
 
         This method performs the "Get Inventory" HMC operation and extracts
         the relevant elements into the result.
@@ -2929,7 +2930,7 @@ class Cpc(BaseResource):
             config_dict['certificates'] = certificates
 
         if not include_unused_adapters:
-            _remove_unreferenced_adapters(config_dict)
+            _drop_unused_adapters_and_switches(config_dict)
 
         sort_lists(config_dict)
 
@@ -3152,22 +3153,34 @@ def _add_encoded(console, certificates):
         cert_dict.update(cert.get_encoded())
 
 
-def _remove_unreferenced_adapters(dpm_config):
+def _drop_unused_adapters_and_switches(dpm_config):
     """
-    Creates a string representation of the given config, EXCLUDING
-    adapters AND network-ports. Then iterates the list of adapters,
-    to collect those that are referenced by their object-id within that
-    string representation. Updates dpm_config in place to use the refined
-    adapter list.
+    Removes all adapters and virtual switch objects from dpm_config in place
+    that aren't referenced by actual DPM configuration elements.
     """
-    config_without_adapters_as_str = str(
+    _remove_unreferenced_elements(dpm_config,
+                                  'virtual-switches', ['adapters'])
+    _remove_unreferenced_elements(dpm_config, 'adapters',
+                                  ['network-ports', 'storage-ports'])
+
+
+def _remove_unreferenced_elements(dpm_config, key_to_update, keys_to_ignore):
+    """
+    Creates a string representation of dpm_config, EXCLUDING keys key_to_update
+    and keys_to_ignore. Then iterates the list of key_to_update
+    entries within dpm_config to collect those that are referenced by their
+    object-id within that string representation. Then updates dpm_config
+    for key_to_update in place to that list of elements that are actually
+    referenced.
+    """
+    config = str(
         {key: dpm_config[key] for key in dpm_config
-         if (key not in ('adapters', 'network-ports'))})
-    referenced_adapters = []
-    for adapter in dpm_config['adapters']:
-        if adapter['object-id'] in config_without_adapters_as_str:
-            referenced_adapters.append(adapter)
-    dpm_config['adapters'] = referenced_adapters
+         if (key != key_to_update and key not in keys_to_ignore)})
+    referenced = []
+    for elem in dpm_config[key_to_update]:
+        if elem['object-id'] in config:
+            referenced.append(elem)
+    dpm_config[key_to_update] = referenced
 
 
 def sort_lists(dpm_config):


### PR DESCRIPTION
Rolls back PRs #1765 and #1770 into 1.19.
No review needed.