### PR TITLE
Improved performance of LPAR/adapter lookup during metrics; Fixed exception msg

### DIFF
--- a/changes/1775.feature.1.rst
+++ b/changes/1775.feature.1.rst
@@ -1,0 +1,1 @@
+Improved performance of looking up LPARs and adapters in metrics processing.

--- a/changes/1775.feature.2.rst
+++ b/changes/1775.feature.2.rst
@@ -1,0 +1,2 @@
+Docs: Clarified in 'Console.list_permitted_adapters()' that the method does
+not return adapters of Z systems before SE version 2.16.0.

--- a/changes/1775.fix.1.rst
+++ b/changes/1775.fix.1.rst
@@ -1,0 +1,2 @@
+Fixed incorrect CPC name in exception message when a NIC could not be found
+during metrics processing.

--- a/changes/1775.fix.2.rst
+++ b/changes/1775.fix.2.rst
@@ -1,0 +1,2 @@
+Fixed that metrics processing for partition metrics failed on HMC versions older
+than 2.14.0.

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -990,6 +990,8 @@ class Console(BaseResource):
         HMC/SE version requirements:
 
         * HMC version >= 2.16.0
+        * The adapters of CPCs with SE version < 2.16.0 that are not enabled
+          for DPM are not included in the result.
 
         Authorization requirements:
 


### PR DESCRIPTION
For details, see the commit message.

I tested the performance improvement using the zhmc prometheus exporter: On the HMC of T28 which manages 7 CPCs all in classic mode with a total of 44 LPARs, the elapsed time for the first data collection (where the resource lookup is performed) went down from 59 sec to 12 sec.