### PR TITLE
1.19: Fixed name of change log file

### DIFF
--- a/changes/1755.fix.rst
+++ b/changes/1755.fix.rst
@@ -1,0 +1,2 @@
+Fixed a datetime conversion error by excluding pytz 2025.1
+(already shipped in version 1.19.1).

--- a/changes/fix.1755.rst
+++ b/changes/fix.1755.rst
@@ -1,1 +1,0 @@
-Fixed a datetime conversion error by excluding pytz 2025.1.


### PR DESCRIPTION
Rolls back PR #1777 into 1.19.