### PR TITLE
Revert "Release 1.20.0"

### DIFF
--- a/changes/1738.feature.rst
+++ b/changes/1738.feature.rst
@@ -1,0 +1,2 @@
+Dev: Started using the trusted publisher concept of Pypi in order to avoid
+dealing with Pypi access tokens.

--- a/changes/1755.fix.rst
+++ b/changes/1755.fix.rst
@@ -1,0 +1,1 @@
+Fixed a datetime conversion error by excluding pytz 2025.1.

--- a/changes/1760.fix.rst
+++ b/changes/1760.fix.rst
@@ -1,0 +1,2 @@
+When handling inventory errors during "Export DPM configuration", only access
+field "inventory-error-details" if "inventory-error-code" is 5.

--- a/changes/1764.fix.1.rst
+++ b/changes/1764.fix.1.rst
@@ -1,0 +1,1 @@
+Remove unused network and storage port objects from export data, too.

--- a/changes/1764.fix.rst
+++ b/changes/1764.fix.rst
@@ -1,0 +1,1 @@
+Ensure proper detection of all unreferenced adapters.

--- a/changes/1775.feature.1.rst
+++ b/changes/1775.feature.1.rst
@@ -1,0 +1,1 @@
+Improved performance of looking up LPARs and adapters in metrics processing.

--- a/changes/1775.feature.2.rst
+++ b/changes/1775.feature.2.rst
@@ -1,0 +1,2 @@
+Docs: Clarified in 'Console.list_permitted_adapters()' that the method does
+not return adapters of Z systems before SE version 2.16.0.

--- a/changes/1775.fix.1.rst
+++ b/changes/1775.fix.1.rst
@@ -1,0 +1,2 @@
+Fixed incorrect CPC name in exception message when a NIC could not be found
+during metrics processing.

--- a/changes/1775.fix.2.rst
+++ b/changes/1775.fix.2.rst
@@ -1,0 +1,2 @@
+Fixed that metrics processing for partition metrics failed on HMC versions older
+than 2.14.0.

--- a/changes/noissue.1.20.0.notshown.rst
+++ b/changes/noissue.1.20.0.notshown.rst
@@ -1,0 +1,1 @@
+Dummy change for starting new version 1.20.0

--- a/changes/noissue.1.fix.rst
+++ b/changes/noissue.1.fix.rst
@@ -1,0 +1,7 @@
+Added support for busy retries to 'Session.post()' and 'Session.delete()'
+when the HTTP request returns HTTP status 409 with reason codes 1 or 2.
+The waiting time between retries can also be specified. This can be used
+by resource class methods that need that.
+By default, no retries are performed.
+Changed 'PartitionLink.update_properties()' and 'PartitionLink.delete()' to
+specify busy retries.

--- a/changes/noissue.4.feature.rst
+++ b/changes/noissue.4.feature.rst
@@ -1,0 +1,4 @@
+Added support for waiting for partition links to reach one of a specified set
+of states with a new 'zhmcclient.PartitionLink.wait_for_states()' method.
+This can be used to ensure that a partition link is in a stable state before
+proceeding with other operations on it.

--- a/changes/noissue.checkreqs-dev.fix.rst
+++ b/changes/noissue.checkreqs-dev.fix.rst
@@ -1,0 +1,1 @@
+Fixed missing package dependencies for development.

--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,0 +1,1 @@
+Fixed safety issues up to 2025-02-26.

--- a/changes/noissue.tc.feature.rst
+++ b/changes/noissue.tc.feature.rst
@@ -1,0 +1,1 @@
+Added check for incorrectly named towncrier change fragment files.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,58 +20,6 @@ Change log
 ----------
 
 .. towncrier start
-Version 1.20.0
-^^^^^^^^^^^^^^
-
-Released: 2025-03-23
-
-**Bug fixes:**
-
-* Fixed missing package dependencies for development.
-
-* Fixed safety issues up to 2025-02-26.
-
-* Added support for busy retries to 'Session.post()' and 'Session.delete()'
-  when the HTTP request returns HTTP status 409 with reason codes 1 or 2.
-  The waiting time between retries can also be specified. This can be used
-  by resource class methods that need that.
-  By default, no retries are performed.
-  Changed 'PartitionLink.update_properties()' and 'PartitionLink.delete()' to
-  specify busy retries.
-
-* Fixed a datetime conversion error by excluding pytz 2025.1. (`#1755 <https://github.com/zhmcclient/python-zhmcclient/issues/1755>`_)
-
-* When handling inventory errors during "Export DPM configuration", only access
-  field "inventory-error-details" if "inventory-error-code" is 5. (`#1760 <https://github.com/zhmcclient/python-zhmcclient/issues/1760>`_)
-
-* Remove unused network and storage port objects from export data, too. (`#1764 <https://github.com/zhmcclient/python-zhmcclient/issues/1764>`_)
-
-* Ensure proper detection of all unreferenced adapters. (`#1764 <https://github.com/zhmcclient/python-zhmcclient/issues/1764>`_)
-
-* Fixed incorrect CPC name in exception message when a NIC could not be found
-  during metrics processing. (`#1775 <https://github.com/zhmcclient/python-zhmcclient/issues/1775>`_)
-
-* Fixed that metrics processing for partition metrics failed on HMC versions older
-  than 2.14.0. (`#1775 <https://github.com/zhmcclient/python-zhmcclient/issues/1775>`_)
-
-**Enhancements:**
-
-* Added check for incorrectly named towncrier change fragment files.
-
-* Added support for waiting for partition links to reach one of a specified set
-  of states with a new 'zhmcclient.PartitionLink.wait_for_states()' method.
-  This can be used to ensure that a partition link is in a stable state before
-  proceeding with other operations on it.
-
-* Dev: Started using the trusted publisher concept of Pypi in order to avoid
-  dealing with Pypi access tokens. (`#1738 <https://github.com/zhmcclient/python-zhmcclient/issues/1738>`_)
-
-* Improved performance of looking up LPARs and adapters in metrics processing. (`#1775 <https://github.com/zhmcclient/python-zhmcclient/issues/1775>`_)
-
-* Docs: Clarified in 'Console.list_permitted_adapters()' that the method does
-  not return adapters of Z systems before SE version 2.16.0. (`#1775 <https://github.com/zhmcclient/python-zhmcclient/issues/1775>`_)
-
-
 Version 1.19.0
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This reverts PR #1783 which was used to test the release process using Pypi trusted publishing.