### PR TITLE
1.19: Filter out non-FCP storage groups in test_virtual_storage_resource.

### DIFF
--- a/tests/end2end/test_virtual_storage_resource.py
+++ b/tests/end2end/test_virtual_storage_resource.py
@@ -63,7 +63,8 @@ def test_vsr_find_list(dpm_mode_cpcs):  # noqa: F811
 
         # Pick the VSRs to test with
         grp_vol_tuples = []
-        stogrp_list = cpc.list_associated_storage_groups()
+        stogrp_list = cpc.list_associated_storage_groups(
+            filter_args={type: 'fcp'})
         for stogrp in stogrp_list:
             vsr_list = stogrp.virtual_storage_resources.list()
             for vsr in vsr_list:
@@ -100,7 +101,8 @@ def test_vsr_property(dpm_mode_cpcs):  # noqa: F811
 
         # Pick the VSRs to test with
         grp_vol_tuples = []
-        stogrp_list = cpc.list_associated_storage_groups()
+        stogrp_list = cpc.list_associated_storage_groups(
+            filter_args={type: 'fcp'})
         for stogrp in stogrp_list:
             vsr_list = stogrp.virtual_storage_resources.list()
             for vsr in vsr_list:


### PR DESCRIPTION
Rolls back PR #1759 into 1.19.
No review needed.