### PR TITLE
1.20: Dev: Fixed permissions for creating GitHub release when releasing a version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
     environment: pypi  # For Pypi trusted publishing
     permissions:
       id-token: write  # For Pypi trusted publishing
+      content: write   # For creating GitHub release
     steps:
 
     #-------- Info gathering and checks

--- a/changes/noissue.2.fix.rst
+++ b/changes/noissue.2.fix.rst
@@ -1,0 +1,1 @@
+Dev: Fixed permissions for creating GitHub release when releasing a version


### PR DESCRIPTION
Rolls back PR #1798 into 1.20.
