### PR TITLE
Fixed a datetime conversion error by excluding pytz 2025.2

### DIFF
--- a/changes/1800.fix.rst
+++ b/changes/1800.fix.rst
@@ -1,0 +1,1 @@
+Fixed a datetime conversion error by excluding pytz 2025.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -186,4 +186,5 @@ pywinpty>=2.0.14; os_name == "nt" and python_version >= '3.13'
 # for development as well.
 # pytz 2024.2 introduced an issue that causes our tests to fail.
 # pytz 2025.1 introduced an issue that causes our tests to fail (https://github.com/stub42/pytz/issues/133)
-pytz>=2019.1,!=2024.2,!=2025.1
+# pytz 2025.2 introduced an issue that causes our tests to fail.
+pytz>=2019.1,!=2024.2,!=2025.1,!=2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ decorator>=4.0.11
 # pytz 2019.1 fixes an ImportError for collections.Mapping on Python 3.10
 # pytz 2024.2 introduced an issue that causes our tests to fail.
 # pytz 2025.1 introduced an issue that causes our tests to fail (https://github.com/stub42/pytz/issues/133)
-pytz>=2019.1,!=2024.2,!=2025.1
+# pytz 2025.2 introduced an issue that causes our tests to fail.
+pytz>=2019.1,!=2024.2,!=2025.1,!=2025.2
 
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six


### PR DESCRIPTION
Fixed a datetime conversion error by excluding pytz 2025.2
Signed-off-by: Anil Kumar Dakarapu <anil.kumar.dakarapu@ibm.com>