### PR TITLE
1.20: Fixed use of list_permitted_adapters(); Added caching for list_api_features()

### DIFF
--- a/changes/1803.feature.rst
+++ b/changes/1803.feature.rst
@@ -1,0 +1,2 @@
+Added support for caching the API features returned by
+'Console.list_api_features()' and 'Cpc.list_api_features()'.

--- a/changes/1803.fix.rst
+++ b/changes/1803.fix.rst
@@ -1,0 +1,3 @@
+Fixed that 'Console.list_permitted_adapters()' was used in the metrics support
+by incorrectly checking for the API version 4.1. The code now checks for
+availability of the API feature 'adapter-network-information', instead.

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -218,6 +218,7 @@ class Console(BaseResource):
         self._unmanaged_cpcs = None
         self._groups = None
         self._certificates = None
+        self._api_features = None
 
     @property
     def storage_groups(self):
@@ -1139,10 +1140,14 @@ class Console(BaseResource):
         return adapter_obj_list
 
     @logged_api_call
-    def list_api_features(self, name=None):
+    def list_api_features(self, name=None, force=False):
         """
-        Returns information about the :ref:`API features` available on
-        this console.
+        Returns the :ref:`API features` available on this console.
+
+        The result is cached in this object.
+
+        The list of API features for the console can be found in section
+        "API features" in the :term:`HMC API` book, starting with 2.16.0.
 
         HMC/SE version requirements:
 
@@ -1152,18 +1157,24 @@ class Console(BaseResource):
 
         Parameters:
 
-          name:
-            A regular expression used to limit returned objects to those that
-            have a matching name field.
+          name (string):
+            A regular expression used to limit the result to matching API
+            features. If `None`, no such filtering takes place.
+
+          force (bool):
+            Boolean controlling whether to retrieve the API feature list from
+            the console even when cached.
 
         Returns:
 
           list of strings: The list of API features that are available on this
-          client. For HMC API versions prior to 4.10, an empty list is returned.
-
+          console. For HMC API versions prior to 4.10, an empty list is
+          returned.
         """
-        # TODO: add reference to WSAPI book chapter regarding API features
-        return get_features(self.manager.session, '/api/console', name)
+        if self._api_features is None or force:
+            self._api_features = get_features(
+                self.manager.session, '/api/console', name)
+        return self._api_features
 
     @property
     def certificates(self):

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -310,6 +310,7 @@ class Cpc(BaseResource):
         self._reset_activation_profiles = None
         self._image_activation_profiles = None
         self._load_activation_profiles = None
+        self._api_features = None
 
     @property
     def lpars(self):
@@ -2115,10 +2116,14 @@ class Cpc(BaseResource):
         return config_dict
 
     @logged_api_call
-    def list_api_features(self, name=None):
+    def list_api_features(self, name=None, force=False):
         """
-        Returns information about the Web Services API features available on
-        the CPC, see :ref:`Feature enablement`.
+        Returns the :ref:`API features` available on this CPC.
+
+        The result is cached in this object.
+
+        The list of API features for the CPC can be found in section
+        "API features" in the :term:`HMC API` book, starting with 2.16.0.
 
         HMC/SE version requirements:
 
@@ -2130,16 +2135,23 @@ class Cpc(BaseResource):
 
         Parameters:
 
-          name:
-            A regular expression used to limit returned objects to those that
-            have a matching name field.
+          name (string):
+            A regular expression used to limit the result to matching API
+            features. If `None`, no such filtering takes place.
+
+          force (bool):
+            Boolean controlling whether to retrieve the API feature list from
+            the console even when cached.
 
         Returns:
 
           list of strings: The list of API features that are available on this
-          CPC. Below the required HMC version, an empty list is returned.
+          CPC. For HMC API versions prior to 4.10, an empty list is returned.
         """
-        return get_features(self.manager.session, self.uri, name)
+        if self._api_features is None or force:
+            self._api_features = get_features(
+                self.manager.session, self.uri, name)
+        return self._api_features
 
     @logged_api_call
     def single_step_install(

--- a/zhmcclient/_metrics.py
+++ b/zhmcclient/_metrics.py
@@ -85,9 +85,11 @@ __all__ = ['MetricsContextManager', 'MetricsContext', 'MetricGroupDefinition',
            'MetricDefinition', 'MetricsResponse', 'MetricGroupValues',
            'MetricObjectValues']
 
-# HMC API version for certain HMC versions
+# Initial HMC API version for certain HMC versions
 API_VERSION_HMC_2_14_0 = (2, 20)
-API_VERSION_HMC_2_16_0 = (4, 1)
+
+# List of API features we check for (since HMC 2.16 and API version 4.10)
+API_FEATURE_ADAPTER_NETWORK_INFORMATION = 'adapter-network-information'
 
 
 class MetricsContextManager(BaseManager):
@@ -939,10 +941,12 @@ class MetricObjectValues:
         elif resource_class == 'adapter':
             filter_args = {'object-uri': resource_uri}
             fallback = False
-            if self.client.version_info() >= API_VERSION_HMC_2_16_0:
+            if self.client.consoles.console.list_api_features(
+                    API_FEATURE_ADAPTER_NETWORK_INFORMATION):
                 adapters = self.client.consoles.console.list_permitted_adapters(
                     filter_args=filter_args)
-                # The method does not return adapters of CPCs with SE < 2.16.0
+                # The method does not return adapters of classic mode CPCs with
+                # SE < 2.16.0
                 if len(adapters) < 1:
                     fallback = True
                 else:


### PR DESCRIPTION
Rolls back PR #1803 into 1.20.