### PR TITLE
Handled the presence of the @@implementation-errors property in HMC responses

### DIFF
--- a/changes/1820.feature.rst
+++ b/changes/1820.feature.rst
@@ -1,0 +1,5 @@
+The property '@@implementation-errors' can be returned by the HMC to indicate
+internal inconsistencies not severe enough to return an error. Such cases
+should be considered HMC defects.
+When that property is in an HMC result, a warning is now logged and the
+property is removed.


### PR DESCRIPTION
For details, see the commit message.