### PR TITLE
1.20: Clarified that Cpc.get_wwpns() is no longer supported

### DIFF
--- a/changes/1713.fix.rst
+++ b/changes/1713.fix.rst
@@ -1,0 +1,3 @@
+Docs: Clarified that 'Cpc.get_wwpns()' is only supported for SE version 2.13.1,
+because the underlying HMC operation "Export WWPN List" was no longer supported
+since z14.

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -1099,14 +1099,16 @@ class Cpc(BaseResource):
         Return the WWPNs of the host ports (of the :term:`HBAs <HBA>`) of the
         specified :term:`Partitions <Partition>` of this CPC.
 
-        This method performs the HMC operation "Export WWPN List".
+        This method performs the HMC operation "Export WWPN List". That
+        operation is no longer supported since the introduction of the
+        'dpm-storage-management' firmware feature with z14.
 
         The CPC must be set for DPM operational mode (i.e. its 'dpm-enabled'
         property is True) and must currently be active.
 
         HMC/SE version requirements:
 
-        * SE version >= 2.13.1
+        * SE version == 2.13.1
 
         Authorization requirements:
 


### PR DESCRIPTION
Rolls back PR #1832 into 1.20.