### PR TITLE
Support for Console / CPC Hardware Messages (using resource class)

### DIFF
--- a/changes/1672.feature.1.rst
+++ b/changes/1672.feature.1.rst
@@ -1,0 +1,7 @@
+Added a resource class 'zhmcclient.HwMessage' and corresponding manager
+class 'zhmcclient.HwMessageManager' to support hardware messages. The
+hardware messages are accessible for CPC and Console via a new property
+'hw_messages'. A HwMessage object supports list() and find..() methods,
+property retrieval, 'delete()', 'request_service()',
+'get_service_information()' and 'decline_service()'. Added end2end and unit
+tests.

--- a/changes/1672.feature.2.rst
+++ b/changes/1672.feature.2.rst
@@ -1,0 +1,2 @@
+Added zhmcclient mock support for all operations related to hardware
+messages for Console and CPC.

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -382,9 +382,10 @@ Resources scoped to the HMC
      A user-defined group of resources.
 
   Hardware Message
-     TBD - Not yet supported.
+     A message describing a problem with the hardware that the system has
+     detected.
 
-     Also scoped to CPCs in any mode.
+     Hardware messages can exist for the Console and for CPCs in any mode.
 
   Job
      The execution of an asynchronous HMC operation.

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -616,3 +616,23 @@ Certificates
    :autosummary:
    :autosummary-inherited-members:
    :special-members: __str__
+
+
+.. _`Hardware Message`:
+
+Hardware Message
+----------------
+
+.. automodule:: zhmcclient._hw_message
+
+.. autoclass:: zhmcclient.HwMessageManager
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.HwMessage
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__

--- a/tests/end2end/mocked_hmc_z14.yaml
+++ b/tests/end2end/mocked_hmc_z14.yaml
@@ -356,6 +356,16 @@ hmc_definition:
                 adapter-port-uri: /api/adapters/fcp1
                 partition-uri: /api/partitions/part1
 
+      hw_messages:
+        - properties:
+            # class: created automatically
+            # parent: created automatically
+            # element-uri: created automatically
+            element-id: a
+            text: foo
+            timestamp: 1744826146533
+            service-supported: true
+
   cpcs:
     - properties:
         # class: created automatically
@@ -602,6 +612,15 @@ hmc_definition:
             name: "LPAR2"
             description: "Image activation profile LPAR2"
             # TODO: Add more properties
+      hw_messages:
+        - properties:
+            # class: created automatically
+            # parent: created automatically
+            # element-uri: created automatically
+            element-id: a
+            text: foo
+            timestamp: 1744826146533
+            service-supported: true
     - properties:
         # class: created automatically
         # parent: created automatically
@@ -1062,3 +1081,13 @@ hmc_definition:
                 type: osd
                 device-number: '0010'
                 virtual-switch-uri: /api/virtual-switches/vs-osa1
+
+      hw_messages:
+        - properties:
+            # class: created automatically
+            # parent: created automatically
+            # element-uri: created automatically
+            element-id: a
+            text: foo
+            timestamp: 1744826146533
+            service-supported: true

--- a/tests/end2end/mocked_hmc_z16.yaml
+++ b/tests/end2end/mocked_hmc_z16.yaml
@@ -356,6 +356,16 @@ hmc_definition:
                 adapter-port-uri: /api/adapters/fcp1
                 partition-uri: /api/partitions/part1
 
+      hw_messages:
+        - properties:
+            # class: created automatically
+            # parent: created automatically
+            # element-uri: created automatically
+            element-id: a
+            text: foo
+            timestamp: 1744826146533
+            service-supported: true
+
   cpcs:
     - properties:
         # class: created automatically
@@ -602,6 +612,16 @@ hmc_definition:
             name: "LPAR2"
             description: "Image activation profile LPAR2"
             # TODO: Add more properties
+      hw_messages:
+        - properties:
+            # class: created automatically
+            # parent: created automatically
+            # element-uri: created automatically
+            element-id: a
+            text: foo
+            timestamp: 1744826146533
+            service-supported: true
+
     - properties:
         # class: created automatically
         # parent: created automatically
@@ -1062,3 +1082,12 @@ hmc_definition:
                 type: osd
                 device-number: '0010'
                 virtual-switch-uri: /api/virtual-switches/vs-osa1
+      hw_messages:
+        - properties:
+            # class: created automatically
+            # parent: created automatically
+            # element-uri: created automatically
+            element-id: a
+            text: foo
+            timestamp: 1744826146533
+            service-supported: true

--- a/tests/end2end/test_hw_message.py
+++ b/tests/end2end/test_hw_message.py
@@ -1,0 +1,145 @@
+# Copyright 2025 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for hw_messages.
+
+These tests do not delete any existing hardware messages.
+"""
+
+
+import random
+import pytest
+from requests.packages import urllib3
+
+import zhmcclient
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from .utils import runtest_find_list, skip_warn, pick_test_resources
+
+urllib3.disable_warnings()
+
+# Properties in minimalistic objects (e.g. find_by_name())
+HW_MESSAGE_MINIMAL_PROPS = ['element-uri']
+
+# Properties in objects returned by list() without full props
+# Note: 'element-id' is added by the list() method.
+HW_MESSAGE_LIST_PROPS = ['element-uri', 'element-id', 'text', 'timestamp']
+
+# Properties whose values can change between retrievals of objects
+HW_MESSAGE_VOLATILE_PROPS = []
+
+
+@pytest.mark.parametrize(
+    "parent", ['cpc', 'console']
+)
+def test_hw_message_find_list(hmc_session, parent):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test list(), find(), findall().
+    """
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+    hd = hmc_session.hmc_definition
+
+    if parent == 'cpc':
+        parent_obj = random.choice(client.cpcs.list())
+        parent_str = f"CPC {parent_obj.name!r}"
+    else:
+        assert parent == 'console'
+        parent_obj = console
+        parent_str = "Console"
+
+    # Compare items returned by list() with/without full_properties
+    hw_message_list = parent_obj.hw_messages.list()
+    hw_message_list_full = parent_obj.hw_messages.list(full_properties=True)
+    assert len(hw_message_list) == len(hw_message_list_full)
+    hw_message_full_by_id = {}
+    for hw_message in hw_message_list_full:
+        element_id = hw_message.properties['element-id']
+        hw_message_full_by_id[element_id] = hw_message
+    for hw_message in hw_message_list:
+        element_id = hw_message.properties['element-id']
+        assert element_id in hw_message_full_by_id
+        hw_message_full = hw_message_full_by_id[element_id]
+        for prop_name in HW_MESSAGE_LIST_PROPS:
+            assert prop_name in hw_message.properties, (
+                f"Property {prop_name!r} not found in hardware-message "
+                f"object {element_id!r} returned by list()")
+            assert prop_name in hw_message_full.properties, (
+                f"Property {prop_name!r} not found in hardware-message "
+                f"object {element_id!r} returned by list(full_properties=True)")
+
+    # Pick the hw_messages to test with
+    if not hw_message_list:
+        skip_warn(f"No hardware messages for {parent_str} on HMC {hd.host}")
+    hw_message_list = pick_test_resources(hw_message_list)
+
+    for hw_message in hw_message_list:
+        element_id = hw_message.properties['element-id']
+        print(f"Testing with hardware message {element_id!r} on {parent_str}")
+        runtest_find_list(
+            hmc_session, parent_obj.hw_messages, element_id, 'element-id',
+            'timestamp', HW_MESSAGE_VOLATILE_PROPS, HW_MESSAGE_MINIMAL_PROPS,
+            HW_MESSAGE_LIST_PROPS)
+
+
+@pytest.mark.parametrize(
+    "parent", ['cpc', 'console']
+)
+def test_hw_message_list_filtered(hmc_session, parent):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test list() with timestamp filtering.
+    """
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+
+    if parent == 'cpc':
+        parent_obj = random.choice(client.cpcs.list())
+    else:
+        assert parent == 'console'
+        parent_obj = console
+
+    # Test timestamp filtering
+    all_message_list = parent_obj.hw_messages.list()
+    sorted_message_list = sorted(all_message_list,
+                                 key=lambda m: m.prop('timestamp'))
+    begin_index = -3
+    end_index = -1
+    exp_number = end_index - begin_index + 1
+    min_number = exp_number + 2
+    if len(sorted_message_list) < min_number:
+        skip_warn(f"Not enough hardware messages ({len(sorted_message_list)}) "
+                  "for timestamp filtering for {parent_str} on HMC {hd.host}")
+    begin_msg = sorted_message_list[begin_index]
+    end_msg = sorted_message_list[end_index]
+    begin_time = zhmcclient.datetime_from_timestamp(begin_msg.prop('timestamp'))
+    end_time = zhmcclient.datetime_from_timestamp(end_msg.prop('timestamp'))
+
+    # The code to be tested.
+    filtered_message_list = parent_obj.hw_messages.list(
+        begin_time=begin_time, end_time=end_time)
+
+    assert len(filtered_message_list) == exp_number, (
+        f"Unexpected number of filtered messages. Begin time: {begin_time}, "
+        f"End time: {end_time}, Expected number: {exp_number}, \n"
+        f"Actual number: {len(filtered_message_list)!r}"
+    )
+    for msg in filtered_message_list:
+        time = zhmcclient.datetime_from_timestamp(msg.prop('timestamp'))
+        assert time >= begin_time
+        assert time <= end_time

--- a/tests/unit/zhmcclient/test_hw_message.py
+++ b/tests/unit/zhmcclient/test_hw_message.py
@@ -1,0 +1,177 @@
+# Copyright 2025 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for _hw_message module.
+"""
+
+
+import re
+from datetime import datetime
+import pytest
+
+from zhmcclient import Client, NotFound, HwMessage, timestamp_from_datetime
+from zhmcclient_mock import FakedSession
+from tests.common.utils import assert_resources
+
+
+class TestHwMessageConsole:
+    """
+    All tests for the HwMessage and HwMessageManager classes for the Console.
+    """
+
+    def setup_method(self):
+        """
+        Setup that is called by pytest before each test method.
+
+        Set up a faked session, and add a faked Console without any
+        child resources.
+        """
+        # pylint: disable=attribute-defined-outside-init
+
+        self.session = FakedSession('fake-host', 'fake-hmc', '2.13.1', '1.8')
+        self.client = Client(self.session)
+
+        self.faked_console = self.session.hmc.consoles.add({
+            'element-id': None,
+            # element-uri will be automatically set
+            'parent': None,
+            'class': 'console',
+            'name': 'fake-console1',
+            'description': 'Console #1',
+        })
+        self.console = self.client.consoles.find(name=self.faked_console.name)
+
+    def add_hw_message(self, element_id, text, timestamp_dt=None):
+        """
+        Add a faked hw_message object to the faked Console and return it.
+        """
+        if timestamp_dt is None:
+            timestamp_dt = datetime.now()
+
+        faked_hw_message = self.faked_console.hw_messages.add({
+            'element-id': element_id,
+            # element-uri will be automatically set
+            'parent': None,
+            'class': 'hardware-message',
+            'text': text,
+            'timestamp': timestamp_from_datetime(timestamp_dt),
+            'service-supported': True,
+            # 'details': ...
+        })
+        return faked_hw_message
+
+    def test_hw_message_manager_repr(self):
+        """Test HwMessageManager.__repr__()."""
+
+        hw_message_mgr = self.console.hw_messages
+
+        # Execute the code to be tested
+        repr_str = repr(hw_message_mgr)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(
+            rf'^{hw_message_mgr.__class__.__name__}\s+at\s+'
+            rf'0x{id(hw_message_mgr):08x}\s+\(\\n.*',
+            repr_str)
+
+    def test_hw_message_manager_initial_attrs(self):
+        """Test initial attributes of HwMessageManager."""
+
+        hw_message_mgr = self.console.hw_messages
+
+        # Verify all public properties of the manager object
+        assert hw_message_mgr.resource_class == HwMessage
+        assert hw_message_mgr.class_name == 'hardware-message'
+        assert hw_message_mgr.session is self.session
+        assert hw_message_mgr.parent is self.console
+
+    @pytest.mark.parametrize(
+        "full_properties_kwargs, exp_prop_names", [
+            (dict(full_properties=False),
+             ['element-uri', 'element-id', 'text', 'timestamp']),
+            (dict(full_properties=True),
+             ['element-uri', 'element-id', 'text', 'timestamp',
+              'service-supported']),
+            ({},  # test default for full_properties (False)
+             ['element-uri', 'element-id', 'text', 'timestamp']),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "filter_args, exp_element_ids", [
+            (None,
+             ['1', '2']),
+            ({},
+             ['1', '2']),
+            ({'element-id': '1'},
+             ['1']),
+            ({'element-uri': '/api/console/hardware-messages/1'},
+             ['1']),
+        ]
+    )
+    def test_hw_message_manager_list(
+            self, filter_args, exp_element_ids, full_properties_kwargs,
+            exp_prop_names):
+        """Test HwMessageManager.list()."""
+
+        faked_hw_message1 = self.add_hw_message(element_id='1', text='foo')
+        faked_hw_message2 = self.add_hw_message(element_id='2', text='bar')
+        faked_hw_messages = [faked_hw_message1, faked_hw_message2]
+        exp_faked_hw_messages = [
+            m for m in faked_hw_messages
+            if m.properties['element-id'] in exp_element_ids]
+        hw_message_mgr = self.console.hw_messages
+
+        # Execute the code to be tested
+        hw_messages = hw_message_mgr.list(filter_args=filter_args,
+                                          **full_properties_kwargs)
+
+        assert_resources(hw_messages, exp_faked_hw_messages, exp_prop_names)
+
+    def test_hw_message_repr(self):
+        """Test HwMessage.__repr__()."""
+
+        faked_hw_message1 = self.add_hw_message(element_id='1', text='foo')
+        hw_message_mgr = self.console.hw_messages
+        hw_message1 = hw_message_mgr.find(
+            **{'element-id': faked_hw_message1.properties['element-id']})
+
+        # Execute the code to be tested
+        repr_str = repr(hw_message1)
+
+        repr_str = repr_str.replace('\n', '\\n')
+        # We check just the begin of the string:
+        assert re.match(
+            rf'^{hw_message1.__class__.__name__}\s+at\s+'
+            rf'0x{id(hw_message1):08x}\s+\(\\n.*',
+            repr_str)
+
+    def test_hw_message_delete(self):
+        """Test HwMessage.delete()."""
+
+        faked_hw_message1 = self.add_hw_message(element_id='1', text='foo')
+        self.add_hw_message(element_id='2', text='bar')
+
+        hw_message_mgr = self.console.hw_messages
+        hw_message1 = hw_message_mgr.find(
+            **{'element-id': faked_hw_message1.properties['element-id']})
+
+        # Execute the code to be tested.
+        hw_message1.delete()
+
+        # Check that the HwMessage no longer exists
+        with pytest.raises(NotFound):
+            hw_message1 = hw_message_mgr.find(
+                **{'element-id': faked_hw_message1.properties['element-id']})

--- a/zhmcclient/__init__.py
+++ b/zhmcclient/__init__.py
@@ -62,4 +62,5 @@ from ._partition_link import *         # noqa: F401
 from ._capacity_group import *         # noqa: F401
 from ._certificates import *         # noqa: F401
 from ._os_console import *         # noqa: F401
+from ._hw_message import *         # noqa: F401
 from ._debug_info import *         # noqa: F401

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -42,6 +42,7 @@ from ._group import GroupManager
 from ._utils import get_api_features
 from ._certificates import CertificateManager
 from ._partition_link import PartitionLinkManager
+from ._hw_message import HwMessageManager
 
 __all__ = ['ConsoleManager', 'Console']
 
@@ -220,6 +221,7 @@ class Console(BaseResource):
         self._groups = None
         self._certificates = None
         self._api_feature_set = None
+        self._hw_messages = None
 
     @property
     def storage_groups(self):
@@ -355,6 +357,17 @@ class Console(BaseResource):
         if not self._groups:
             self._groups = GroupManager(self)
         return self._groups
+
+    @property
+    def hw_messages(self):
+        """
+        :class:`~zhmcclient.HwMessageManager`: Access to
+        :term:`Hardware Messages <Hardware Message>` for this Console.
+        """
+        # We do here some lazy loading.
+        if not self._hw_messages:
+            self._hw_messages = HwMessageManager(self)
+        return self._hw_messages
 
     @logged_api_call
     def restart(self, force=False, wait_for_available=True,

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -59,6 +59,7 @@ from ._activation_profile import ActivationProfileManager
 from ._adapter import AdapterManager
 from ._virtual_switch import VirtualSwitchManager
 from ._capacity_group import CapacityGroupManager
+from ._hw_message import HwMessageManager
 from ._logging import logged_api_call
 from ._exceptions import ParseError, ConsistencyError
 from ._utils import get_api_features, get_firmware_features, \
@@ -311,6 +312,7 @@ class Cpc(BaseResource):
         self._load_activation_profiles = None
         self._api_feature_set = None
         self._firmware_feature_set = None
+        self._hw_messages = None
 
     @property
     def lpars(self):
@@ -421,6 +423,17 @@ class Cpc(BaseResource):
             self._load_activation_profiles = ActivationProfileManager(
                 self, profile_type='load')
         return self._load_activation_profiles
+
+    @property
+    def hw_messages(self):
+        """
+        :class:`~zhmcclient.HwMessageManager`: Access to
+        :term:`Hardware Messages <Hardware Message>` for this CPC.
+        """
+        # We do here some lazy loading.
+        if not self._hw_messages:
+            self._hw_messages = HwMessageManager(self)
+        return self._hw_messages
 
     @property
     @logged_api_call

--- a/zhmcclient/_hw_message.py
+++ b/zhmcclient/_hw_message.py
@@ -1,0 +1,333 @@
+# Copyright 2025 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The hardware messages that belong to the parent resource object (Console or
+CPC).
+"""
+
+
+from ._manager import BaseManager
+from ._resource import BaseResource
+from ._logging import logged_api_call
+from ._utils import RC_HW_MESSAGE, make_query_str, timestamp_from_datetime
+
+
+__all__ = ['HwMessageManager', 'HwMessage']
+
+
+class HwMessageManager(BaseManager):
+    """
+    Manager providing access to the :term:`Hardware Messages <Hardware Message>`
+    of the parent object (Console or CPC), that are exposed by the HMC this
+    client is connected to.
+
+    Derived from :class:`~zhmcclient.BaseManager`; see there for common methods
+    and attributes.
+
+    HMC/SE version requirements: None
+    """
+
+    def __init__(self, parent):
+        # This function should not go into the docs.
+        # Parameters:
+        #   parent (:class:`~zhmcclient.BaseResource`):
+        #      The parent object (Console or CPC).
+
+        # Resource properties that are supported as filter query parameters
+        # (for server-side filtering).
+        query_props = []
+
+        super().__init__(
+            resource_class=HwMessage,
+            class_name=RC_HW_MESSAGE,
+            session=parent.manager.session,
+            parent=parent,
+            base_uri=f'{parent.uri}/hardware-messages',
+            # Console: /api/console/hardware-messages/{hardware-message-id}
+            # CPC: /api/cpcs/{cpc-id}/hardware-messages/{hardware-message-id}
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            name_prop='element-id',
+            query_props=query_props)
+
+    @logged_api_call
+    def list(
+            self, full_properties=False, filter_args=None, begin_time=None,
+            end_time=None):
+        """
+        List the hardware messages for the parent object (Console or CPC).
+
+        HMC/SE version requirements: None
+
+        Authorization requirements:
+
+        * For hardware messages of the CPC: Object-access permission to the CPC.
+        * Task permission to the "Hardware Messages" task at least in view-only
+          mode.
+
+        Parameters:
+
+          full_properties (bool):
+            Controls whether the full set of resource properties should be
+            retrieved, vs. only the short set as returned by the list
+            operation.
+
+          filter_args (dict):
+            Filter arguments that narrow the list of returned messages to those
+            whose properties match the specified filter arguments. For details,
+            see :ref:`Filtering`.
+
+            `None` causes no such filtering to happen.
+
+          begin_time (:class:`~py:datetime.datetime`):
+            Filter that narrows the list of returned messages to those created
+            on or after the specified point in time.
+            The datetime object may be timezone-aware or timezone-naive. If
+            timezone-naive, the UTC timezone is assumed.
+
+            `None` causes no such filtering to happen.
+
+          end_time (:class:`~py:datetime.datetime`):
+            Filter that narrows the list of returned messages to those created
+            on or before the specified point in time.
+            The datetime object may be timezone-aware or timezone-naive. If
+            timezone-naive, the UTC timezone is assumed.
+
+            `None` causes no such filtering to happen.
+
+        Returns:
+
+          list: A list of :class:`~zhmcclient.HwMessage` objects.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        result_prop = 'hardware-messages'
+        if filter_args and 'element-id' in filter_args:
+            # Filter with filter-uri instead, because faster
+            element_id = filter_args['element-id']
+            element_uri = f'{self._base_uri}/{element_id}'
+            filter_args = dict(filter_args)
+            del filter_args['element-id']
+            filter_args['element-uri'] = element_uri
+        query_parms = []
+        if begin_time is not None:
+            begin_time = timestamp_from_datetime(begin_time)
+            query_parms.append(f'begin-time={begin_time}')
+        if end_time is not None:
+            end_time = timestamp_from_datetime(end_time)
+            query_parms.append(f'end-time={end_time}')
+        msg_list = self._list_with_operation(
+            self._base_uri, result_prop, full_properties,
+            filter_args=filter_args, query_parms=query_parms)
+        if not full_properties:
+            # Add the element-id property since that is used as the 'name'.
+            for msg in msg_list:
+                element_id = msg.uri.split('/')[-1]
+                msg.update_properties_local({'element-id': element_id})
+        return msg_list
+
+
+class HwMessage(BaseResource):
+    """
+    Representation of a :term:`Hardware Message`.
+
+    Derived from :class:`~zhmcclient.BaseResource`; see there for common
+    methods and attributes.
+
+    Objects of this class are not directly created by the user; they are
+    returned from list functions on their manager object
+    (in this case, :class:`~zhmcclient.HwMessageManager`).
+
+    Note that HwMessage objects do not have any writeable properties, so they
+    do not have an ``update_properties()`` method.
+
+    HMC/SE version requirements: None
+    """
+
+    def __init__(self, manager, uri, name=None, properties=None):
+        # This function should not go into the docs.
+        #   manager (:class:`~zhmcclient.HwMessageManager`):
+        #     Manager object for this resource object.
+        #   uri (string):
+        #     Canonical URI path of the resource.
+        #   name (string):
+        #     Name of the resource.
+        #   properties (dict):
+        #     Properties to be set for this resource object. May be `None` or
+        #     empty.
+        assert isinstance(manager, HwMessageManager), (
+            f"HwMessage init: Expected manager type {HwMessageManager}, "
+            f"got {type(manager)}")
+        super().__init__(manager, uri, name, properties)
+
+    def dump(self):
+        """
+        Dump this HwMessage resource with its properties as a resource
+        definition.
+
+        The returned resource definition has the following format::
+
+            {
+                # Resource properties:
+                "properties": {...},
+            }
+
+        Returns:
+
+          dict: Resource definition of this resource.
+        """
+
+        # Dump the resource properties
+        resource_dict = super().dump()
+
+        return resource_dict
+
+    # Note: HwMessage resources cannot have their properties updated,
+    #       hence there is no update_properties() method.
+
+    @logged_api_call
+    def delete(self):
+        """
+        Delete this hardware message.
+
+        HMC/SE version requirements: None
+
+        Authorization requirements:
+
+        * For hardware messages of the CPC: Object-access permission to the CPC.
+        * Task permission to the "Hardware Messages" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        # pylint: disable=protected-access
+        self.manager.session.delete(self.uri, resource=self)
+        self.manager._name_uri_cache.delete(
+            self.get_properties_local(self.manager._name_prop, None))
+        self.cease_existence_local()
+
+    @logged_api_call
+    def request_service(self, customer_name=None, customer_phone=None):
+        """
+        Request service from IBM for this hardware message and delete the
+        hardware message.
+
+        The hardware message's ``service-supported`` property must be True.
+
+        HMC/SE version requirements: None
+
+        Authorization requirements:
+
+        * For hardware messages of the CPC: Object-access permission to the CPC.
+        * Task permission to the "Hardware Messages" task.
+
+        Parameters:
+
+          customer_name (:term:`string`): Name of the person that can be
+            contacted about the problem. Optional, default is the customer name
+            registered with IBM for the machine.
+
+          customer_phone (:term:`string`): Telephone number of the person that
+            can be contacted about the problem. Optional, default is the
+            customer telephone number registered with IBM for the machine.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        body = {}
+        if customer_name:
+            body['customer-name'] = customer_name
+        if customer_phone:
+            body['customer-phone'] = customer_phone
+        ops_uri = self.uri + '/operations/request-service'
+        self.manager.session.post(ops_uri, resource=self, body=body)
+
+    @logged_api_call
+    def get_service_information(self, delete=False):
+        """
+        Get problem information and a telephone number for requesting service
+        from IBM for this hardware message and optionally delete the hardware
+        message.
+
+        The hardware message's ``service-supported`` property must be True.
+
+        HMC/SE version requirements: None
+
+        Authorization requirements:
+
+        * For hardware messages of the CPC: Object-access permission to the CPC.
+        * Task permission to the "Hardware Messages" task.
+
+        Parameters:
+
+          delete (bool): Boolean indicating whether the hardware message should
+            be deleted upon successful completion of the operation.
+
+        Returns:
+
+          dict: Response body of the "Get Console Service Request Information"
+          or "Get CPC Service Request Information" operation, as described in
+          the :term:`HMC API` book.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        query_parms = [f'delete={delete}']
+        query_str = make_query_str(query_parms)
+        ops_uri = f'{self.uri}/operations/get-service-information{query_str}'
+        result = self.manager.session.get(ops_uri, resource=self)
+        return result
+
+    @logged_api_call
+    def decline_service(self):
+        """
+        Decline service from IBM for this hardware message and delete the
+        hardware message.
+
+        The hardware message's ``service-supported`` property must be True.
+
+        HMC/SE version requirements: None
+
+        Authorization requirements:
+
+        * For hardware messages of the CPC: Object-access permission to the CPC.
+        * Task permission to the "Hardware Messages" task.
+
+        Raises:
+
+          :exc:`~zhmcclient.HTTPError`
+          :exc:`~zhmcclient.ParseError`
+          :exc:`~zhmcclient.AuthError`
+          :exc:`~zhmcclient.ConnectionError`
+        """
+        ops_uri = self.uri + '/operations/request-service'
+        self.manager.session.post(ops_uri, resource=self)

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -687,8 +687,8 @@ class BaseManager:
         return self._supports_properties
 
     def _list_with_operation(
-            self, list_uri, result_prop, full_properties, filter_args,
-            additional_properties):
+            self, list_uri, result_prop, full_properties, filter_args=None,
+            additional_properties=None, query_parms=None):
         """
         List resource objects by using a List operation.
 
@@ -736,6 +736,10 @@ class BaseManager:
             Must be `None` for resource types whose List operation does not
             support the 'additional-properties' query parameter.
 
+          query_parms (list of str): Additional query parameters. Each list
+            item must be a string (e.g. "key=value") ready to be appended to
+            the URI as a query parameter.
+
         Returns:
 
           : A list of zhmcclient resource objects.
@@ -753,13 +757,15 @@ class BaseManager:
                 if matches_filters(resource_obj, filter_args):
                     resource_obj_list.append(resource_obj)
         else:
-            query_parms, client_filters = divide_filter_args(
+            _query_parms, client_filters = divide_filter_args(
                 self._query_props, filter_args)
             if additional_properties:
                 ap_parm = \
                     f"additional-properties={','.join(additional_properties)}"
-                query_parms.append(ap_parm)
-            query_parms_str = make_query_str(query_parms)
+                _query_parms.append(ap_parm)
+            if query_parms:
+                _query_parms.extend(query_parms)
+            query_parms_str = make_query_str(_query_parms)
             uri = f'{list_uri}{query_parms_str}'
 
             try:

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -80,6 +80,7 @@ RC_USER = 'user'
 RC_GROUP = 'group'
 RC_LDAP_SERVER_DEFINITION = 'ldap-server-definition'
 RC_MFA_SERVER_DEFINITION = 'mfa-server-definition'
+RC_HW_MESSAGE = 'hardware-message'
 
 # Resource classes that are children of zhmcclient.Cpc
 RC_CHILDREN_CPC = (

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -57,6 +57,7 @@ __all__ = ['InputError',
            'FakedMetricsContextManager', 'FakedMetricsContext',
            'FakedMetricGroupDefinition', 'FakedMetricObjectValues',
            'FakedCapacityGroupManager', 'FakedCapacityGroup',
+           'FakedHwMessageManager', 'FakedHwMessage',
            ]
 
 # All currently defined metric groups with their metrics.
@@ -1152,6 +1153,8 @@ class FakedConsole(FakedBaseResource):
         self._unmanaged_cpcs = FakedUnmanagedCpcManager(
             hmc=manager.hmc, console=self)
         self._groups = FakedGroupManager(hmc=manager.hmc, console=self)
+        self._hw_messages = FakedHwMessageManager(
+            hmc=manager.hmc, parent=self)
 
     def __repr__(self):
         """
@@ -1271,6 +1274,14 @@ class FakedConsole(FakedBaseResource):
         group resources of this Console.
         """
         return self._groups
+
+    @property
+    def hw_messages(self):
+        """
+        :class:`~zhmcclient_mock.HwMessageManager`: Access to the
+        faked Hardware Message resources of this Console.
+        """
+        return self._hw_messages
 
 
 class FakedUserManager(FakedBaseManager):
@@ -2090,6 +2101,8 @@ class FakedCpc(FakedBaseResource):
             hmc=manager.hmc, cpc=self, profile_type='image')
         self._load_activation_profiles = FakedActivationProfileManager(
             hmc=manager.hmc, cpc=self, profile_type='load')
+        self._hw_messages = FakedHwMessageManager(
+            hmc=manager.hmc, parent=self)
 
         if 'dpm-enabled' not in self._properties:
             self._properties['dpm-enabled'] = False
@@ -2201,6 +2214,14 @@ class FakedCpc(FakedBaseResource):
         faked Load Activation Profile resources of this CPC.
         """
         return self._load_activation_profiles
+
+    @property
+    def hw_messages(self):
+        """
+        :class:`~zhmcclient_mock.HwMessageManager`: Access to the
+        faked Hardware Message resources of this CPC.
+        """
+        return self._hw_messages
 
 
 class FakedUnmanagedCpcManager(FakedBaseManager):
@@ -4089,5 +4110,83 @@ class FakedMetricObjectValues:
             f"  resource_uri = {self.resource_uri!r}\n"
             f"  timestamp = {self.timestamp!r}\n"
             f"  values = {self.values!r}\n"
+            ")")
+        return ret
+
+
+class FakedHwMessageManager(FakedBaseManager):
+    """
+    A manager for faked HwMessage resources within a faked Console (see
+    :class:`zhmcclient_mock.FakedConsole`) or Cpc (see
+    :class:`zhmcclient_mock.FakedCpc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseManager`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, hmc, parent):
+        super().__init__(
+            hmc=hmc,
+            parent=parent,
+            resource_class=FakedHwMessage,
+            base_uri=parent.uri + '/hardware-messages',
+            oid_prop='element-id',
+            uri_prop='element-uri',
+            class_value='hardware-message',
+            name_prop='element-uri')
+
+    def add(self, properties):
+        # pylint: disable=useless-super-delegation
+        """
+        Add a faked HwMessage resource.
+
+        Parameters:
+
+          properties (dict):
+            Resource properties.
+
+            Special handling and requirements for certain properties:
+
+            * 'element-id' will be auto-generated with a unique value across
+              all instances of this resource type, if not specified.
+            * 'element-uri' will be auto-generated based upon the element ID,
+              if not specified.
+            * 'class' will be auto-generated to 'hardware-message',
+              if not specified.
+
+        Returns:
+
+          :class:`~zhmcclient_mock.FakedHwMessage`: The faked HwMessage
+            resource.
+        """
+        return super().add(properties)
+
+
+class FakedHwMessage(FakedBaseResource):
+    """
+    A faked HwMessage resource within a faked Console (see
+    :class:`zhmcclient_mock.FakedConsole`) or Cpc (see
+    :class:`zhmcclient_mock.FakedCpc`).
+
+    Derived from :class:`zhmcclient_mock.FakedBaseResource`, see there for
+    common methods and attributes.
+    """
+
+    def __init__(self, manager, properties):
+        super().__init__(
+            manager=manager,
+            properties=properties)
+
+    def __repr__(self):
+        """
+        Return a string with the state of this faked HwMessage resource, for
+        debug purposes.
+        """
+        ret = (
+            f"{repr_obj_id(self)} (\n"
+            f"  _manager = {repr_obj_id(self._manager)}\n"
+            f"  _manager._parent._uri = {self._manager.parent.uri!r}\n"
+            f"  _uri = {self._uri!r}\n"
+            f"  _properties = {repr_dict(self._properties, indent=2)}\n"
             ")")
         return ret

--- a/zhmcclient_mock/_session.py
+++ b/zhmcclient_mock/_session.py
@@ -219,6 +219,13 @@ FAKED_HMC_DEFINITION_SCHEMA = {
                         "$ref": "#/definitions/StorageGroup"
                     },
                 },
+                "hw_messages": {
+                    "description": "The hardware mesages for this Console",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/HwMessage"
+                    },
+                },
             },
         },
         "User": {
@@ -366,6 +373,19 @@ FAKED_HMC_DEFINITION_SCHEMA = {
                 },
             },
         },
+        "HwMessage": {
+            "description": "A hardware message (for Console or CPC)",
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "properties",
+            ],
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/Properties"
+                },
+            },
+        },
         "Cpc": {
             "description": "A CPC managed by an HMC",
             "type": "object",
@@ -435,6 +455,13 @@ FAKED_HMC_DEFINITION_SCHEMA = {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/LoadActivationProfile"
+                    },
+                },
+                "hw_messages": {
+                    "description": "The hardware mesages for this CPC",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/HwMessage"
                     },
                 },
             },


### PR DESCRIPTION
For details, see the commit message.

I tested it with the new end2end test test_hw_message.py on T224, and verified that the console hardware messages exceed the request limit for "Submit Requests" and are properly split into two operations.