### PR TITLE
Split 'Submit Requests' operation when request body limit is exceeded

### DIFF
--- a/changes/1836.feature.rst
+++ b/changes/1836.feature.rst
@@ -1,0 +1,7 @@
+When a 'list()' method specific full_properties=True, the retrieval of the
+resource properties in the list result is implemented using the bulk operation
+"Submit Requests". That operation has a limit for the request size of 256 kB.
+So far, that limit could not possibly be reached. The support for hardware
+messages made it necessary to improve that implementation by splitting the
+bulk operation into multiple operations when the request size limit is
+exceeded.


### PR DESCRIPTION
For details, see the commit message.

I tested the PR with end2end tests for test_cpc.py and test_adapter.py on T224. These resources do not exceed the bulk request limit, but this verifies that it works as before.

Together with PR #1834, I tested this PR with end2end tests for test_hw_message.py on T224. This test exceeded the bulk request limit for the console hardware messages and caused two bulk operations to be sent.

This PR is not rolled back into the fix stream, because before the introduction of HW messages, there is no resource type that can possibly exceed the bulk request maximum: The maximum number of the kind GET requests we use in bulk operations is between 1500 and 3000 (dependent on the length of the resource URIs), and there is no resource type that can have such a large number of items in a list result.