### PR TITLE
Dev: Pinned marshmallow to <4.0 because it breaks safety; Fixed safety issues

### DIFF
--- a/changes/noissue.marshmallow.fix.rst
+++ b/changes/noissue.marshmallow.fix.rst
@@ -1,0 +1,1 @@
+Dev: Pinned marshmallow to <4.0 because it breaks safety.

--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,0 +1,1 @@
+Fixed safety issues up to 2025-04-21.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -54,7 +54,8 @@ dparse>=0.6.4b0
 ruamel.yaml>=0.17.21
 click>=8.0.2
 Authlib>=1.2.0
-marshmallow>=3.15.0
+# marshmallow 4.0.0 breaks safety, see https://github.com/pyupio/safety/issues/715
+marshmallow>=3.15.0,<4.0
 pydantic>=2.8.0
 typer>=0.12.0
 typer-cli>=0.12.0

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -175,7 +175,7 @@ html5lib==1.1
 imagesize==1.3.0
 importlib-resources==1.4.0
 jedi==0.17.2
-Jinja2==3.1.5
+Jinja2==3.1.6
 keyring==18.0.0
 levenshtein==0.25.1
 lxml==4.9.3


### PR DESCRIPTION
No review needed.