### PR TITLE
1.20: Increased safety to 3.4.0 and updated its dependencies

### DIFF
--- a/changes/noissue.marshmallow.fix.rst
+++ b/changes/noissue.marshmallow.fix.rst
@@ -1,1 +1,0 @@
-Dev: Pinned marshmallow to <4.0 because it breaks safety.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -44,23 +44,22 @@ coveralls>=3.3.0
 # PyYAML: covered in direct deps for development
 
 # Safety CI by pyup.io
-# Safety 3.0.0 requires exact versions of authlib==1.2.0 and jwt==1.3.1.
-# Safety 3.0.x pins pydantic to <2.0, preventing bug fixes.
+# safety 3.4.0 supports marshmallow>=4.0.0, see https://github.com/pyupio/safety/issues/715
+# safety 3.4.0 started using httpx and tenacity
 # pydantic 2.8.0 fixes an install issue on Python 3.13.
-safety>=3.1.0
-safety-schemas>=0.0.2,!=0.0.7
-# TODO: Change to dparse 0.6.4 once released
-dparse>=0.6.4b0
+safety>=3.4.0
+safety-schemas>=0.0.14
+dparse>=0.6.4
 ruamel.yaml>=0.17.21
 click>=8.0.2
-Authlib>=1.2.0
-# marshmallow 4.0.0 breaks safety, see https://github.com/pyupio/safety/issues/715
-marshmallow>=3.15.0,<4.0
+Authlib>=1.3.1
+marshmallow>=3.15.0
 pydantic>=2.8.0
-typer>=0.12.0
-typer-cli>=0.12.0
-typer-slim>=0.12.0
-psutil>=6.0.0
+typer>=0.12.1
+typer-cli>=0.12.1
+typer-slim>=0.12.1
+# safety 3.4.0 depends on psutil~=6.1.0
+psutil~=6.1.0
 
 # Bandit checker
 bandit>=1.7.8

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -42,19 +42,18 @@ pytest-cov==2.7.0
 coveralls==3.3.0
 
 # Safety CI by pyup.io
-safety==3.1.0
-safety-schemas==0.0.2
-# TODO: Change to dparse 0.6.4 once released
-dparse==0.6.4b0
+safety==3.4.0
+safety-schemas==0.0.14
+dparse==0.6.4
 ruamel.yaml==0.17.21
 click==8.0.2
 Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
-typer==0.12.0
-typer-cli==0.12.0
-typer-slim==0.12.0
-psutil==6.0.0
+typer==0.12.1
+typer-cli==0.12.1
+typer-slim==0.12.1
+psutil==6.1.0
 
 # Bandit checker
 bandit==1.7.8
@@ -168,10 +167,12 @@ configparser==4.0.2
 dataclasses==0.8
 defusedxml==0.7.1
 distlib==0.3.7
-filelock==3.13.1
+# safety 3.4.0 depends on filelock~=3.16.1
+filelock==3.16.1
 gitdb==4.0.8
 gitdb2==2.0.0
 html5lib==1.1
+httpx==0.28.1
 imagesize==1.3.0
 importlib-resources==1.4.0
 jedi==0.17.2
@@ -206,6 +207,7 @@ smmap2==2.0.1
 sniffio==1.3.0
 snowballstemmer==2.0.0
 stevedore==5.2.0
+tenacity==8.5.0
 terminado==0.8.3
 testpath==0.3
 toml==0.10.0


### PR DESCRIPTION
Rolls back PR #1841 into 1.20.