### PR TITLE
1.21: Safety issues up to 2025-05-11

### DIFF
--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,0 +1,1 @@
+Fixed safety issues up to 2025-05-11.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -165,6 +165,7 @@ cachetools==5.3.2
 Click==8.0.2
 clint==0.5.1
 configparser==4.0.2
+cryptography==44.0.1  # used by Authlib, which is used by safety
 dataclasses==0.8
 defusedxml==0.7.1
 distlib==0.3.7


### PR DESCRIPTION
Rolls back PR #1864 into 1.21.