### PR TITLE
Enabled Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
     "config:recommended"
   ],
   "commitBody": "Signed-off-by: {{{gitAuthor}}}",
-  "constraintsFiltering": "strict"
+  "constraintsFiltering": "strict",
+  "dependencyDashboard": true
 }


### PR DESCRIPTION
No review needed.

This is described in https://docs.renovatebot.com/key-concepts/dashboard/ .

I assume this causes the "Dependency Dashboard" issue to be created and updated. However, we already got this issue created without doing anything for it: https://github.com/zhmcclient/python-zhmcclient/issues/1861.

So it is not really clear what this change does.