### PR TITLE
Fixed that incorrect type in filter arguments no longer raises TypeError

### DIFF
--- a/changes/1850.fix.rst
+++ b/changes/1850.fix.rst
@@ -1,0 +1,12 @@
+Fixed that incorrect type in filter arguments of 'list()', etc. no longer
+results in TypeError. For client-side filtering, the filter arguments are now
+converted to the type of the property value, before matching the filter, for
+property types bool, int, float, and str. For bool, the string values 'TRUE' and
+'FALSE' are interpreted (case insensitively) as the corresponding boolean values.
+This provides more flexibility in environments such as the command line or
+Ansible. Match values that cannot be converted cause a new exception
+'zhmcclient.FilterConversionError' to be raised, in order to provide the user
+with a way to catch such situations. Note that for server-side filtering,
+the provided filter arguments were already converted to string because they
+are passed as URI query parameters, so a type tolerance already existed for
+such filter arguments.

--- a/changes/1850.incompatible.rst
+++ b/changes/1850.incompatible.rst
@@ -1,0 +1,9 @@
+The fix that incorrect types of match values in filter arguments of 'list()',
+'findall()' and 'find()' no longer result in 'TypeError' has the implication
+that providing such incorrect types is now treated differently, resulting
+in an incompatibility: If possible the match value gets its type converted to
+the type of the property value. Otherwise, a new exception
+'zhmcclient.FilterConversionError' is raised.
+Note that this incompatibility only applies when the types of match values in
+filter arguments are incorrect for the property values. If they are correct,
+there is no incompatibility.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -303,12 +303,10 @@ object.
 
 The match value specifies how the corresponding resource property matches:
 
-* For resource properties of type String (as per the resource's data model in
-  the :term:`HMC API`), the match value is interpreted as a regular
-  expression that must match the actual resource property value. The regular
-  expression syntax used is the same as that used by the Java programming
-  language, as specified for the ``java.util.regex.Pattern`` class (see
-  http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html).
+* For resource properties of type String, the match value is interpreted as a
+  case sensitive regular expression that must match the actual resource property
+  value with exact begin and end matching. For resource types that have a case
+  insensitive name, matching of the name is performed case insensitively.
 
 * For resource properties of type String Enum, the match value is interpreted
   as an exact string that must be equal to the actual resource property value.
@@ -318,6 +316,31 @@ The match value specifies how the corresponding resource property matches:
 
 * If the match value is a list or a tuple, a resource matches if any item in
   the list or tuple matches (i.e. this is a logical OR between the list items).
+
+There are some subtle differences between matching on the HMC and matching
+on the client side:
+
+* For properties that are matched on the HMC, the type is determined by the
+  resource's data model as defined in the :term:`HMC API`. The regular
+  expression syntax used for string matching is the one used by the Java
+  programming language, as specified for the ``java.util.regex.Pattern`` class
+  (see http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html).
+
+* For properties that are matched on the client side, the type is determined by
+  the actual property value. For property values of type bool, int, float and
+  str, the match value is converted to that type before matching the value.
+  The regular expression syntax used for string matching is from
+  `Python's 're' module <https://docs.python.org/3/library/re.html#regular-expression-syntax>`_.
+
+* For resource properties of type String Enum, the matching actually depends on
+  whether the property is matched in the HMC or on the client side: When
+  matching on the HMC, the match value is interpreted as an exact string that
+  must be equal to the actual resource property value. When matching on the
+  client side, regular expression matching is used, because the client side only
+  sees the type of the property value, and not the type definition on the HMC.
+  However, in order to tolerate future improvements where more properties could
+  be matched on the HMC, you should not rely on regular expression matching for
+  properties of type String Enum.
 
 If a property that is specified in filter arguments does not exist on all
 resources that are subject to be searched, those resources that do not have the

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -213,6 +213,7 @@ class ActivationProfileManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = self._profile_type + '-activation-profiles'
         list_uri = f'{self.cpc.uri}/{result_prop}'

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -205,6 +205,7 @@ class AdapterManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'adapters'
         list_uri = f'{self.cpc.uri}/adapters'

--- a/zhmcclient/_capacity_group.py
+++ b/zhmcclient/_capacity_group.py
@@ -137,6 +137,7 @@ class CapacityGroupManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'capacity-groups'
         list_uri = f'{self.cpc.uri}/capacity-groups'

--- a/zhmcclient/_certificates.py
+++ b/zhmcclient/_certificates.py
@@ -134,6 +134,7 @@ class CertificateManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'certificates'
         list_uri = '/api/certificates'

--- a/zhmcclient/_console.py
+++ b/zhmcclient/_console.py
@@ -159,6 +159,7 @@ class ConsoleManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         uri = self._base_uri  # There is only one console object.
         if full_properties:

--- a/zhmcclient/_cpc.py
+++ b/zhmcclient/_cpc.py
@@ -264,6 +264,7 @@ class CpcManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'cpcs'
         list_uri = '/api/cpcs'

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -29,7 +29,7 @@ __all__ = ['Error', 'ConnectionError', 'ConnectTimeout', 'ReadTimeout',
            'SubscriptionNotFound', 'ConsistencyError', 'CeasedExistence',
            'OSConsoleError', 'OSConsoleConnectedError',
            'OSConsoleNotConnectedError', 'OSConsoleWebSocketError',
-           'OSConsoleAuthError', 'PartitionLinkError']
+           'OSConsoleAuthError', 'PartitionLinkError', 'FilterConversionError']
 
 
 class Error(Exception):
@@ -1718,3 +1718,70 @@ class PartitionLinkError(Error):
             f"classname={self.__class__.__name__!r}; "
             f"message={self.args[0]!r}; "
             f"operation_results={self._operation_results!r}")
+
+
+class FilterConversionError(Error):
+    """
+    This exception indicates that a filter argument cannot be converted to the
+    type of the property value.
+
+    Derived from :exc:`~zhmcclient.Error`.
+    """
+
+    def __init__(self, msg, property_name, match_value):
+        """
+        Parameters:
+
+          msg (:term:`string`):
+            A human readable message describing the problem.
+
+          property_name (:term:`string`):
+            The name of the property that is subject to filtering.
+
+          match_value:
+            The match value for the filtering.
+
+        ``args[0]`` will be set to the ``msg`` parameter.
+        """
+        super().__init__(msg)
+        self._property_name = property_name
+        self._match_value = match_value
+
+    @property
+    def property_name(self):
+        """
+        The name of the property that is subject to filtering.
+        """
+        return self._property_name
+
+    @property
+    def match_value(self):
+        """
+        The match value for the filtering.
+        """
+        return self._match_value
+
+    def __repr__(self):
+        """
+        Return a string with the state of this exception object, for debug
+        purposes.
+        """
+        return (
+            f"{self.__class__.__name__}(message={self.args[0]!r}, "
+            f"property_name={self.property_name}, "
+            f"match_value={self.match_value})")
+
+    def str_def(self):
+        """
+        :term:`string`: The exception as a string in a Python definition-style
+        format, e.g. for parsing by scripts:
+
+        .. code-block:: text
+
+            classname={}; message={}; property_name={}; match_value={}
+        """
+        return (
+            f"classname={self.__class__.__name__!r}; "
+            f"message={self.args[0]!r}; "
+            f"property_name={self.property_name}; "
+            f"match_value={self.match_value})")

--- a/zhmcclient/_group.py
+++ b/zhmcclient/_group.py
@@ -117,6 +117,7 @@ class GroupManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'groups'
         list_uri = '/api/groups'

--- a/zhmcclient/_hba.py
+++ b/zhmcclient/_hba.py
@@ -142,6 +142,7 @@ class HbaManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         return self._list_with_parent_array(
             self.partition, 'hba-uris', full_properties, filter_args)

--- a/zhmcclient/_hw_message.py
+++ b/zhmcclient/_hw_message.py
@@ -117,6 +117,7 @@ class HwMessageManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'hardware-messages'
         if filter_args and 'element-id' in filter_args:

--- a/zhmcclient/_ldap_server_definition.py
+++ b/zhmcclient/_ldap_server_definition.py
@@ -145,6 +145,7 @@ class LdapServerDefinitionManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'ldap-server-definitions'
         list_uri = f'{self.console.uri}/ldap-server-definitions'

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -150,6 +150,7 @@ class LparManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'logical-partitions'
         list_uri = f'{self.cpc.uri}/logical-partitions'

--- a/zhmcclient/_manager.py
+++ b/zhmcclient/_manager.py
@@ -750,6 +750,7 @@ class BaseManager:
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         resource_obj_list = []
         if self.auto_update_enabled() and not self.auto_update_needs_pull():
@@ -837,6 +838,7 @@ class BaseManager:
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
 
         if not props_list:
@@ -964,6 +966,7 @@ class BaseManager:
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         resource_obj_list = []
         if self.auto_update_enabled() and not self.auto_update_needs_pull():

--- a/zhmcclient/_mfa_server_definition.py
+++ b/zhmcclient/_mfa_server_definition.py
@@ -145,6 +145,7 @@ class MfaServerDefinitionManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'mfa-server-definitions'
         list_uri = f'{self.console.uri}/mfa-server-definitions'

--- a/zhmcclient/_nic.py
+++ b/zhmcclient/_nic.py
@@ -138,6 +138,7 @@ class NicManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         return self._list_with_parent_array(
             self.partition, 'nic-uris', full_properties, filter_args)

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -170,6 +170,7 @@ class PartitionManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'partitions'
         list_uri = f'{self.cpc.uri}/partitions'

--- a/zhmcclient/_partition_link.py
+++ b/zhmcclient/_partition_link.py
@@ -207,6 +207,7 @@ class PartitionLinkManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'partition-links'
         list_uri = self._base_uri

--- a/zhmcclient/_password_rule.py
+++ b/zhmcclient/_password_rule.py
@@ -146,6 +146,7 @@ class PasswordRuleManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'password-rules'
         list_uri = f'{self.console.uri}/password-rules'

--- a/zhmcclient/_port.py
+++ b/zhmcclient/_port.py
@@ -166,6 +166,7 @@ class PortManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         uris_prop = self.adapter.port_uris_prop
         if not uris_prop:

--- a/zhmcclient/_storage_group.py
+++ b/zhmcclient/_storage_group.py
@@ -211,6 +211,7 @@ class StorageGroupManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'storage-groups'
         list_uri = self._base_uri

--- a/zhmcclient/_storage_group_template.py
+++ b/zhmcclient/_storage_group_template.py
@@ -152,6 +152,7 @@ class StorageGroupTemplateManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'storage-templates'
         list_uri = self._base_uri

--- a/zhmcclient/_storage_volume.py
+++ b/zhmcclient/_storage_volume.py
@@ -165,6 +165,7 @@ class StorageVolumeManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'storage-volumes'
         list_uri = f'{self.storage_group.uri}/storage-volumes'

--- a/zhmcclient/_storage_volume_template.py
+++ b/zhmcclient/_storage_volume_template.py
@@ -157,6 +157,7 @@ class StorageVolumeTemplateManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'storage-template-volumes'
         list_uri = f'{self.storage_group_template.uri}/storage-template-volumes'

--- a/zhmcclient/_task.py
+++ b/zhmcclient/_task.py
@@ -137,6 +137,7 @@ class TaskManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'tasks'
         list_uri = f'{self.console.uri}/tasks'

--- a/zhmcclient/_unmanaged_cpc.py
+++ b/zhmcclient/_unmanaged_cpc.py
@@ -146,6 +146,7 @@ class UnmanagedCpcManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'cpcs'
         list_uri = f'{self.parent.uri}/operations/list-unmanaged-cpcs'

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -143,6 +143,7 @@ class UserManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'users'
         list_uri = f'{self.console.uri}/users'

--- a/zhmcclient/_user_pattern.py
+++ b/zhmcclient/_user_pattern.py
@@ -156,6 +156,7 @@ class UserPatternManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'user-patterns'
         list_uri = f'{self.console.uri}/user-patterns'

--- a/zhmcclient/_user_role.py
+++ b/zhmcclient/_user_role.py
@@ -149,6 +149,7 @@ class UserRoleManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'user-roles'
         list_uri = f'{self.console.uri}/user-roles'

--- a/zhmcclient/_virtual_function.py
+++ b/zhmcclient/_virtual_function.py
@@ -135,6 +135,7 @@ class VirtualFunctionManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         return self._list_with_parent_array(
             self.partition, 'virtual-function-uris', full_properties,

--- a/zhmcclient/_virtual_storage_resource.py
+++ b/zhmcclient/_virtual_storage_resource.py
@@ -174,6 +174,7 @@ class VirtualStorageResourceManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'virtual-storage-resources'
         list_uri = f'{self.storage_group.uri}/virtual-storage-resources'

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -157,6 +157,7 @@ class VirtualSwitchManager(BaseManager):
           :exc:`~zhmcclient.ParseError`
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
+          :exc:`~zhmcclient.FilterConversionError`
         """
         result_prop = 'virtual-switches'
         list_uri = f'{self.cpc.uri}/virtual-switches'


### PR DESCRIPTION
For details, see the commit message.

This change should not be rolled back into the stable release because it changes the behavior of `list()` etc. for certain filter arguments.