### PR TITLE
1.21: Changed default read retries from 0 to 3

### DIFF
--- a/changes/1888.fix.rst
+++ b/changes/1888.fix.rst
@@ -1,0 +1,2 @@
+Changed the default for HTTP read retries from 0 to 3. This applies only to
+the HTTP "GET" method. This should help when using unstable networks.

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -85,12 +85,10 @@ DEFAULT_STOMP_PORT = 61612
 #: if not specified in the ``retry_timeout_config`` init argument to
 #: :class:`~zhmcclient.Session`.
 #:
-#: Note: The default value for this parameter has been set to 0 in order to
-#: mitigate the behavior of the 'requests' module to retry HTTP methods even if
-#: they are not idempotent (e.g. DELETE).
-#: See zhmcclient `issue #249
+#: Note: The HTTP methods for which retries are performed are restricted to
+#: only "GET". For more background, see zhmcclient `issue #249
 #: <https://github.com/zhmcclient/python-zhmcclient/issues/249>`_.
-DEFAULT_READ_RETRIES = 0
+DEFAULT_READ_RETRIES = 3
 
 #: Default max. number of HTTP redirects,
 #: if not specified in the ``retry_timeout_config`` init argument to


### PR DESCRIPTION
Rolls back PR #1889 into 1.21.