### PR TITLE
Increased minimum version of urllib3 to 2.2.3

### DIFF
--- a/changes/1888.2.fix.rst
+++ b/changes/1888.2.fix.rst
@@ -1,0 +1,4 @@
+Increased minimum version of "urllib3" to 2.2.3 in order to pick up changes
+that help when using unstable networks. Specifically, enabling
+enforce_content_length by default and distinguishing too much from not enough
+response data.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -45,7 +45,7 @@ pytest==6.2.5
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with requirements.txt)
 
-urllib3==1.26.19
+urllib3==2.2.3
 
 pyrsistent==0.20.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,10 +45,12 @@ jsonschema>=4.18.0
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with minimum-constraints-install.txt)
 
-# Since we changed to use the allowed_methods attribute introduced in urllib3
-# 1.26.0, and our minimum version of requests (2.25.0) only requires
-# urllib3>=1.21.0, we need to require a minimum version of urllib3.
-urllib3>=1.26.19
+# Functional dependencies on urllib3 versions:
+# - Use of the 'allowed_methods' attribute requires >=1.26.0
+# - Enabling enforce_content_length by default requires >=2.0.0
+# - IncompleteRead fix: Distinguishing too much from not enough response data
+#   requires >=2.2.1
+urllib3>=2.2.3
 
 # pyrsistent is used by jsonschema>=3.0
 # pyrsistent 0.20.0 has official support for Python 3.12


### PR DESCRIPTION
For details, see the commit message.
No review needed.