### PR TITLE
Made order of names in AUTHORS.md reliable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,4 +21,5 @@ Simon Spinner <sspinner@de.ibm.com>
 Sreeram Venkateswaran <sree@192.168.1.100>
 Viktor Mihajlovski <mihajlov@linux.vnet.ibm.com>
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
 ```

--- a/Makefile
+++ b/Makefile
@@ -699,7 +699,7 @@ AUTHORS.md: _always
 	echo "" >>AUTHORS.md.tmp
 	echo "Sorted list of authors derived from git commit history:" >>AUTHORS.md.tmp
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "git shortlog --summary --email HEAD | cut -f 2 | sort >>AUTHORS.md.tmp"
+	sh -c "git shortlog --summary --email HEAD | cut -f 2 | LC_ALL=C.UTF-8 sort >>AUTHORS.md.tmp"
 	echo '```' >>AUTHORS.md.tmp
 	sh -c "if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; rm AUTHORS.md.tmp; fi"
 

--- a/changes/1897.fix.rst
+++ b/changes/1897.fix.rst
@@ -1,0 +1,1 @@
+Dev: Made order of names in AUTHORS.md reliable.


### PR DESCRIPTION
For details, see the commit message.
No review needed.