### PR TITLE
1.22: Fixed incorrect package version in build; Increased pipdeptree version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -596,12 +596,14 @@ start_tag:
 # Distribution archives.
 $(sdist_file): Makefile $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(dist_dependent_files)
 	@echo "Makefile: Building the source distribution archive: $(sdist_file)"
-	$(PYTHON_CMD) -m build --sdist --outdir $(dist_dir) .
+	$(PYTHON_CMD) -m build --no-isolation --sdist --outdir $(dist_dir) .
+	bash -c "ls -l $(sdist_file) || ls -l $(dist_dir) && echo package_level=$(package_level) && $(PYTHON_CMD) -m setuptools_scm"
 	@echo "Makefile: Done building the source distribution archive: $(sdist_file)"
 
 $(bdist_file) $(version_file): Makefile $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(dist_dependent_files)
 	@echo "Makefile: Building the wheel distribution archive: $(bdist_file)"
-	$(PYTHON_CMD) -m build --wheel --outdir $(dist_dir) -C--universal .
+	$(PYTHON_CMD) -m build --no-isolation --wheel --outdir $(dist_dir) -C--universal .
+	bash -c "ls -l $(bdist_file) $(version_file) || ls -l $(dist_dir) && echo package_level=$(package_level) && $(PYTHON_CMD) -m setuptools_scm"
 	@echo "Makefile: Done building the wheel distribution archive: $(bdist_file)"
 
 $(done_dir)/pylint_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(pylint_rc_file) $(check_py_files)
@@ -707,9 +709,9 @@ AUTHORS.md: _always
 	echo "" >>AUTHORS.md.tmp
 	echo "Sorted list of authors derived from git commit history:" >>AUTHORS.md.tmp
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "git shortlog --summary --email HEAD | cut -f 2 | LC_ALL=C.UTF-8 sort >>AUTHORS.md.tmp"
+	bash -c "git shortlog --summary --email HEAD | cut -f 2 | LC_ALL=C.UTF-8 sort >>AUTHORS.md.tmp"
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; rm AUTHORS.md.tmp; fi"
+	bash -c "if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; rm AUTHORS.md.tmp; fi"
 
 .PHONY:	end2end_show
 end2end_show:

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -7,5 +7,5 @@
 
 pip>=25.0
 setuptools>=70.0.0
-setuptools-scm[toml]>=8.1.0
+setuptools-scm[toml]>=9.2.0
 wheel>=0.41.3

--- a/changes/noissue.1.fix.rst
+++ b/changes/noissue.1.fix.rst
@@ -1,0 +1,5 @@
+Dev: Fixed issue where the package version used for distribution archive file
+names were generated inconsistently between setuptools_scm (used in Makefile)
+and the 'build' module, by using no build isolation ('--no-isolation' option
+of the 'build' module) and increasing the minimum version of 'setuptools-scm'
+to 9.2.0, which fixes a number of version related issues.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -28,7 +28,7 @@ more-itertools>=4.0.0
 # pytz: covered in requirements.txt
 
 # packaging is used by pytest, pip-check-reqs, sphinx
-packaging>=23.2
+packaging>=24.1
 
 # Unit test (indirect dependencies):
 pluggy>=1.3.0
@@ -176,7 +176,7 @@ tabulate>=0.8.1
 progressbar2>=3.12.0
 
 # Package dependency management tools (not used by any make rules)
-pipdeptree>=2.2.0
+pipdeptree>=2.24.0
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
 # pip-check-reqs 2.5.0 dropped support for py38
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -143,7 +143,7 @@ tabulate==0.8.1
 progressbar2==3.12.0
 
 # Package dependency management tools (not used by any make rules)
-pipdeptree==2.2.0
+pipdeptree==2.24.0
 pip-check-reqs==2.4.3; python_version <= '3.8'
 pip-check-reqs==2.5.1; python_version >= '3.9'
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -10,7 +10,7 @@
 pip==25.0
 setuptools==70.0.0
 # Note on not specifying 'setuptools-scm[toml]': Extras cannot be in constraints files
-setuptools-scm==8.1.0
+setuptools-scm==9.2.0
 wheel==0.41.3
 
 
@@ -61,5 +61,5 @@ idna==3.7
 
 
 # Used by zhmcclient.testutils
-packaging==23.2
+packaging==24.1
 pluggy==1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     # Keep in sync with base-requirements.txt and the base dependencies in
     # minimum-constraints-install.txt
     "setuptools>=70.0.0",
-    "setuptools-scm[toml]>=8.1.0",
+    "setuptools-scm[toml]>=9.2.0",
     "wheel>=0.41.3"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Rolls back PR #1926 into 1.22.