### PR TITLE
1.22: Support removal of vswitches and addition of network express adapters on z17

### DIFF
--- a/changes/1929.fix.rst
+++ b/changes/1929.fix.rst
@@ -1,0 +1,2 @@
+Documented that virtual switch objects have been removed in z17 CPCs.
+Adjusted code in the zhmcclient mock support for that.

--- a/zhmcclient/_adapter.py
+++ b/zhmcclient/_adapter.py
@@ -286,6 +286,8 @@ class Adapter(BaseResource):
         'hipersockets': 'network-port-uris',
         'cna': 'network-port-uris',
         'cloud-network': 'network-port-uris',  # for preliminary driver
+        'network-express': 'network-port-uris',
+        'networking': 'network-port-uris',
     }
 
     # URI segment for port URIs, dependent on adapter family
@@ -296,6 +298,8 @@ class Adapter(BaseResource):
         'hipersockets': 'network-ports',
         'cna': 'network-ports',
         'cloud-network': 'network-ports',  # for preliminary driver
+        'network-express': 'network-ports',
+        'networking': 'network-ports',
     }
 
     # Port type, dependent on adapter family
@@ -306,6 +310,8 @@ class Adapter(BaseResource):
         'hipersockets': 'network',
         'cna': 'network',
         'cloud-network': 'network',  # for preliminary driver
+        'network-express': 'network',
+        'networking': 'network',
     }
 
     def __init__(self, manager, uri, name=None, properties=None):

--- a/zhmcclient/_virtual_switch.py
+++ b/zhmcclient/_virtual_switch.py
@@ -21,7 +21,9 @@ Virtual Switches are generated automatically every time a new
 
 Virtual Switch resources are contained in :term:`CPC` resources.
 
-Virtual Switches only exist in CPCs that are in DPM mode.
+Virtual Switches only exist in CPCs up to z16.
+Support for them has been removed with the introduction of the
+"network-express-support" feature in z17 CPCs.
 """
 
 
@@ -95,6 +97,10 @@ class VirtualSwitchManager(BaseManager):
              additional_properties=None):
         """
         List the Virtual Switches in this CPC.
+
+        With the introduction of the "network-express-support" feature in z17
+        CPCs, support for virtual switches has been removed. This method will
+        succeed but return no objects on such systems.
 
         Any resource property may be specified in a filter argument. For
         details about filter arguments, see :ref:`Filtering`.
@@ -179,6 +185,10 @@ class VirtualSwitch(BaseResource):
     Objects of this class are not directly created by the user; they are
     returned from creation or list functions on their manager object
     (in this case, :class:`~zhmcclient.VirtualSwitchManager`).
+
+    With the introduction of the "network-express-support" feature in z17
+    CPCs, support for virtual switches has been removed. VirtualSwitch objects
+    will not be obtainable on such systems.
 
     HMC/SE version requirements:
 


### PR DESCRIPTION
Rolls back PR #1929 into 1.22.