### PR TITLE
Reimplemented direct Hipersocket creation and deletion based on partition links

### DIFF
--- a/changes/1934.2.feature.rst
+++ b/changes/1934.2.feature.rst
@@ -1,0 +1,2 @@
+Extended the 'zhmcclient.NoUniqueMatch' exception to now also accept a
+user-provided exception message.

--- a/changes/1934.feature.rst
+++ b/changes/1934.feature.rst
@@ -1,0 +1,6 @@
+Reimplemented direct Hipersocket creation and deletion (i.e. the
+methods 'AdapterManager.create_hipersocket()' and 'Adapter.delete()') using
+partition links when the CPC is z16 or later. The interface of the methods
+remains the same for z16 and later CPCs, except that the 'port-description'
+input property is ignored, and additional exceptions 'zhmcclient.NotFound'
+and 'zhmcclient.NoUniqueMatch' can be raised.

--- a/tests/end2end/test_adapter.py
+++ b/tests/end2end/test_adapter.py
@@ -168,46 +168,48 @@ def test_adapter_hs_crud(dpm_mode_cpcs):  # noqa: F811
         # The code to be tested
         adapter = cpc.adapters.create_hipersocket(adapter_input_props)
 
-        for pn, exp_value in adapter_input_props.items():
-            assert adapter.properties[pn] == exp_value, \
-                f"Unexpected value for property {pn!r}"
-        adapter.pull_full_properties()
-        for pn, exp_value in adapter_input_props.items():
-            assert adapter.properties[pn] == exp_value, \
-                f"Unexpected value for property {pn!r}"
-        for pn, exp_value in adapter_auto_props.items():
-            assert adapter.properties[pn] == exp_value, \
-                f"Unexpected value for property {pn!r}"
+        try:
+            for pn, exp_value in adapter_input_props.items():
+                assert adapter.properties[pn] == exp_value, \
+                    f"Unexpected value for property {pn!r}"
+            adapter.pull_full_properties()
+            for pn, exp_value in adapter_input_props.items():
+                assert adapter.properties[pn] == exp_value, \
+                    f"Unexpected value for property {pn!r}"
+            for pn, exp_value in adapter_auto_props.items():
+                assert adapter.properties[pn] == exp_value, \
+                    f"Unexpected value for property {pn!r}"
 
-        # Test updating a property of the adapter
+            # Test updating a property of the adapter
 
-        new_desc = "Updated adapter description."
+            new_desc = "Updated adapter description."
 
-        # The code to be tested
-        adapter.update_properties(dict(description=new_desc))
+            # The code to be tested
+            adapter.update_properties(dict(description=new_desc))
 
-        assert adapter.properties['description'] == new_desc
-        adapter.pull_full_properties()
-        assert adapter.properties['description'] == new_desc
+            assert adapter.properties['description'] == new_desc
+            adapter.pull_full_properties()
+            assert adapter.properties['description'] == new_desc
 
-        # Test renaming the adapter
+            # Test renaming the adapter
 
-        # The code to be tested
-        adapter.update_properties(dict(name=adapter_name_new))
+            # The code to be tested
+            adapter.update_properties(dict(name=adapter_name_new))
 
-        assert adapter.properties['name'] == adapter_name_new
-        adapter.pull_full_properties()
-        assert adapter.properties['name'] == adapter_name_new
-        with pytest.raises(zhmcclient.NotFound):
-            cpc.adapters.find(name=adapter_name)
+            assert adapter.properties['name'] == adapter_name_new
+            adapter.pull_full_properties()
+            assert adapter.properties['name'] == adapter_name_new
+            with pytest.raises(zhmcclient.NotFound):
+                cpc.adapters.find(name=adapter_name)
 
-        # Test deleting the adapter
+        finally:
+            # Test deleting the adapter
 
-        # The code to be tested
-        adapter.delete()
+            # The code to be tested
+            adapter.delete()
 
-        with pytest.raises(zhmcclient.NotFound):
-            cpc.adapters.find(name=adapter_name_new)
+            with pytest.raises(zhmcclient.NotFound):
+                cpc.adapters.find(name=adapter_name_new)
 
 
 def test_adapter_list_assigned_part(dpm_mode_cpcs):  # noqa: F811

--- a/zhmcclient/_exceptions.py
+++ b/zhmcclient/_exceptions.py
@@ -973,7 +973,8 @@ class NoUniqueMatch(Error):
     Derived from :exc:`~zhmcclient.Error`.
     """
 
-    def __init__(self, filter_args, manager, resources):
+    def __init__(self, filter_args=None, manager=None, resources=None,
+                 message=None):
         """
         Parameters:
 
@@ -982,30 +983,50 @@ class NoUniqueMatch(Error):
             to be found. Keys are the resource property names, values are
             the match values for that property.
 
+            May be `None` if the `message` parameter is `None`.
+            Will be ignored if the `message` parameter is not `None`.
+
           manager (:class:`~zhmcclient.BaseManager`):
             The manager of the resource, in whose scope the resource was
             attempted to be found.
 
-            Must not be `None`.
+            Must not be `None` if the `message` parameter is `None`.
+            Will be ignored if the `message` parameter is not `None`.
 
           resources (:term:`iterable` of :class:`~zhmcclient.BaseResource`):
             The resources that did match the filter.
 
-            Must not be `None`.
+            Must not be `None` if the `message` parameter is `None`.
+            Will be ignored if the `message` parameter is not `None`.
+
+          message (string):
+            The exception message.
+
+            If `None`, the message will be automatically created from the
+            `filter_args`, `manager` and `resources` parameters.
 
         ``args[0]`` will be set to an exception message that is automatically
         constructed from the input parameters.
         """
-        parent = manager.parent
-        if parent:
-            in_str = f" in {parent.__class__.__name__} {parent.name!r}"
+        if message is not None:
+            msg = message
+            filter_args = None
+            manager = None
+            resources = []
+            resource_uris = []
         else:
-            in_str = ""
-        resource_uris = [r.uri for r in resources]
-        msg = (
-            f"Found more than one {manager.resource_class.__name__} using "
-            f"filter arguments {filter_args!r}{in_str}, with "
-            f"URIs: {resource_uris!r}")
+            assert manager is not None
+            assert resources is not None
+            parent = manager.parent
+            if parent:
+                in_str = f" in {parent.__class__.__name__} {parent.name!r}"
+            else:
+                in_str = ""
+            resource_uris = [r.uri for r in resources]
+            msg = (
+                f"Found more than one {manager.resource_class.__name__} using "
+                f"filter arguments {filter_args!r}{in_str}, with "
+                f"URIs: {resource_uris!r}")
         super().__init__(msg)
         self._filter_args = filter_args
         self._manager = manager


### PR DESCRIPTION
For details, see the commit message.

I ran the end2end tests for test_adapter.py on A224, and the HS create/delete methods passed.