### PR TITLE
Eliminated dependency to 'pyrsistent' package.

### DIFF
--- a/changes/1970.cleanup.rst
+++ b/changes/1970.cleanup.rst
@@ -1,0 +1,4 @@
+Install: Removed dependency to the Python package "pyrsistent", which was used
+indirectly by the zhmcclient package via the "jsonschema" package, in order
+to get security issues addressed. The minimum version of jsonschema 4.18 that
+we now use, no longer uses "pyrsistent".

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -199,6 +199,7 @@ pexpect==4.3.1
 pickleshare==0.7.4
 pkginfo==1.4.2
 pyproject-api==1.6.1  # used by tox since its 4.0.0
+pyrsistent==0.20.0  # used by jsonschema>3.0,<4.18
 prometheus-client==0.13.1
 ptyprocess==0.5.1
 pyparsing==3.0.7

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -48,8 +48,6 @@ pytest==6.2.5
 urllib3==2.2.3; python_version == '3.8'
 urllib3==2.5.0; python_version >= '3.9'
 
-pyrsistent==0.20.0
-
 
 # All other indirect dependencies for install that are not in requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,10 +53,6 @@ jsonschema>=4.18.0
 urllib3>=2.2.3; python_version == '3.8'
 urllib3>=2.5.0; python_version >= '3.9'
 
-# pyrsistent is used by jsonschema>=3.0
-# pyrsistent 0.20.0 has official support for Python 3.12
-pyrsistent>=0.20.0
-
 # websocket-client is also used by stomp-py 8.0 and notebook(?) 6.4
 websocket-client>=1.8.0
 


### PR DESCRIPTION
For details, see the commit message.
No review needed.