### PR TITLE
1.23: Removed dependency on python-dateutil

### DIFF
--- a/changes/1975.cleanup.rst
+++ b/changes/1975.cleanup.rst
@@ -1,0 +1,2 @@
+Install: Removed dependency to the Python package "python-dateutil" and
+replaced its use with the "datetime" module of standard Python.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -499,7 +499,6 @@ intersphinx_mapping = {
     'py2': ('https://docs.python.org/2', None), # specific to Python 2
     'py3': ('https://docs.python.org/3', None), # specific to Python 3
     'iv': ('https://immutable-views.readthedocs.io/en/latest/', None),
-    'dateutil': ('https://dateutil.readthedocs.io/en/stable/', None),
 }
 
 intersphinx_cache_limit = 5

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -202,6 +202,7 @@ pickleshare==0.7.4
 pkginfo==1.4.2
 pyproject-api==1.6.1  # used by tox since its 4.0.0
 pyrsistent==0.20.0  # used by jsonschema>3.0,<4.18
+python-dateutil==2.8.2
 prometheus-client==0.13.1
 ptyprocess==0.5.1
 pyparsing==3.0.7

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -18,7 +18,6 @@ wheel==0.41.3
 
 requests==2.32.4
 stomp-py==8.1.1
-python-dateutil==2.8.2
 immutable-views==0.6.0
 nocasedict==1.0.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ requests>=2.32.4
 
 stomp-py>=8.1.1
 
-python-dateutil>=2.8.2
 immutable-views>=0.6.0
 nocasedict>=1.0.2
 

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -19,9 +19,9 @@ Utility functions for tests.
 import sys
 import os
 import logging
-from dateutil import tz
 
 import zhmcclient
+from zhmcclient._utils import tzlocal
 from zhmcclient_mock._hmc import FakedBaseResource, \
     FakedMetricGroupDefinition, FakedMetricObjectValues
 
@@ -500,7 +500,7 @@ def timestamp_aware(dt):
     added to a copy of the input object and that copy is returned.
     """
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=tz.tzlocal())  # new object
+        dt = dt.replace(tzinfo=tzlocal())  # new object
     return dt
 
 

--- a/tests/unit/zhmcclient_mock/test_hmc.py
+++ b/tests/unit/zhmcclient_mock/test_hmc.py
@@ -18,16 +18,15 @@
 Unit tests for _hmc module of the zhmcclient_mock package.
 """
 
-
 import re
 from datetime import datetime, timezone
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
     ZoneInfo = None
-from dateutil import tz
 import pytest
 
+from zhmcclient._utils import tzlocal
 from zhmcclient_mock._session import FakedSession
 from zhmcclient_mock._hmc import \
     FakedBaseManager, FakedBaseResource, \
@@ -2143,7 +2142,7 @@ class TestFakedMetricsContext:
         mg_name2 = 'dpm-system-usage-overview'
 
         ts3_input = datetime(2017, 9, 5, 12, 13, 30, 0)  # timezone-naive
-        ts3_offset = int(tz.tzlocal().utcoffset(ts3_input).total_seconds())
+        ts3_offset = int(tzlocal().utcoffset(ts3_input).total_seconds())
         ts3_exp = 1504613610000 - 1000 * ts3_offset
         mo_val3_input = FakedMetricObjectValues(
             group_name=mg_name2,

--- a/tests/unit/zhmcclient_mock/test_urihandler.py
+++ b/tests/unit/zhmcclient_mock/test_urihandler.py
@@ -18,7 +18,6 @@
 Unit tests for _urihandler module of the zhmcclient_mock package.
 """
 
-
 from datetime import datetime, timezone
 try:
     from zoneinfo import ZoneInfo
@@ -26,10 +25,10 @@ except ImportError:
     ZoneInfo = None
 # TODO: Migrate mock to zhmcclient_mock
 from unittest.mock import MagicMock
-from dateutil import tz
 from requests.packages import urllib3
 import pytest
 
+from zhmcclient._utils import tzlocal
 from zhmcclient_mock._session import FakedSession
 from zhmcclient_mock._hmc import FakedMetricObjectValues
 from zhmcclient_mock._urihandler import HTTPError, InvalidResourceError, \
@@ -4413,7 +4412,7 @@ class TestMetricsContextHandlers:
         faked_hmc.add_metric_values(mo_val2_input)
 
         ts3_input = datetime(2017, 9, 5, 12, 13, 30, 0)  # timezone-naive
-        ts3_offset = int(tz.tzlocal().utcoffset(ts3_input).total_seconds())
+        ts3_offset = int(tzlocal().utcoffset(ts3_input).total_seconds())
         ts3_exp = 1504613610000 - 1000 * ts3_offset
         mo_val3_input = FakedMetricObjectValues(
             group_name=mg_name2,

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -22,7 +22,6 @@ from collections.abc import Mapping, MutableSequence, Iterable
 from datetime import datetime, timezone
 import warnings
 
-from dateutil import parser
 from requests.utils import quote
 
 from ._exceptions import HTTPError, FilterConversionError
@@ -616,15 +615,16 @@ def datetime_from_isoformat(dt_str):
     This function is used to parse timestamp strings from the externalized
     HMC definition.
 
-    The date time strings are parsed using dateutil.parse.isoparse(), which
-    supports the ISO8601 formats. The separator between the date portion and
-    the time portion can be ' ' or 'T', and the optional timezone portion can
-    be specified as 'shhmm' or 'shh:mm'.
+    The date time strings are parsed using datetime.fromisoformat() (see
+    https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat),
+    which supports the ISO8601 formats. The separator between the date portion
+    and the time portion can be ' ' or 'T', and the optional timezone portion
+    must be specified as 'shh:mm'.
 
     If the date time string specifies a timezone, the returned datetime object
     is timezone-aware. Otherwise, it is timezone-naive.
     """
-    dt = parser.isoparse(dt_str)
+    dt = datetime.fromisoformat(dt_str)
     return dt
 
 
@@ -649,6 +649,15 @@ def datetime_to_isoformat(dt):
     """
     dt_str = dt.isoformat(sep=' ')
     return dt_str
+
+
+def tzlocal():
+    """
+    Return a datetime.tzinfo object for the local timezone.
+    """
+    dt_now = datetime.now()
+    tz = dt_now.astimezone().tzinfo
+    return tz
 
 
 def get_api_features(obj, name=None):

--- a/zhmcclient_mock/_hmc.py
+++ b/zhmcclient_mock/_hmc.py
@@ -20,11 +20,10 @@ local Python object and maintains its resource state across operations.
 
 import re
 import copy
-from dateutil import tz
 from immutable_views import DictView
 
 from zhmcclient._utils import repr_dict, repr_manager, repr_list, \
-    timestamp_from_datetime, repr_obj_id
+    timestamp_from_datetime, repr_obj_id, tzlocal
 
 from ._idpool import IdPool
 
@@ -4083,8 +4082,7 @@ class FakedMetricObjectValues:
 
           timestamp (datetime): Point in time to which these metric values
             apply. Timezone-naive values are converted to timezone-aware values
-            using the local timezone as determined by
-            :class:`dateutil:dateutil.tz.tzlocal`.
+            using the local timezone.
 
           values (list of tuple(name, value)): The metric values, as follows:
 
@@ -4094,7 +4092,7 @@ class FakedMetricObjectValues:
               :class:`~zhmcclient_mock.FakedMetricGroupDefinition`).
         """
         if timestamp.tzinfo is None:
-            timestamp = timestamp.replace(tzinfo=tz.tzlocal())  # new object
+            timestamp = timestamp.replace(tzinfo=tzlocal())  # new object
         self.group_name = group_name
         self.resource_uri = resource_uri
         self.timestamp = timestamp


### PR DESCRIPTION
Rolls back PR #1976 into 1.23.