### PR TITLE
1.23: Removed dependency to "decorator" package

### DIFF
--- a/changes/noissue.63.cleanup.rst
+++ b/changes/noissue.63.cleanup.rst
@@ -1,0 +1,2 @@
+Install: Removed dependency to the Python package "decorator", which was not
+used anymore.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -172,6 +172,7 @@ clint==0.5.1
 configparser==4.0.2
 cryptography==44.0.1  # used by Authlib, which is used by safety
 dataclasses==0.8
+decorator==4.0.11
 defusedxml==0.7.1
 distlib==0.3.7
 # safety 3.4.0 depends on filelock~=3.16.1

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -16,7 +16,6 @@ wheel==0.41.3
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-decorator==4.0.11
 requests==2.32.4
 stomp-py==8.1.1
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@
 
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
-decorator>=4.0.11
-
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six
 requests>=2.32.4


### PR DESCRIPTION
Rolls back PR #1978 into 1.23.