### PR TITLE
1.23: Increased max size of notification handover queue

### DIFF
--- a/changes/1982.fix.rst
+++ b/changes/1982.fix.rst
@@ -1,0 +1,2 @@
+Increased the max size of the internal handover queue for notifications
+from 10 to 1000, in order to better handle spikes of notifications.

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -372,7 +372,7 @@ class NotificationReceiver:
 
         # Thread-safe handover queue between listener thread and receiver
         # thread
-        self._handover_queue = queue.Queue(10)
+        self._handover_queue = queue.Queue(1000)
 
         # STOMP connection
         self._conn = None


### PR DESCRIPTION
Rolls back PR #1982 into 1.23.