### PR TITLE
1.23: Added missing zhmcclient exceptions to the documentation

### DIFF
--- a/changes/noissue.39.rst
+++ b/changes/noissue.39.rst
@@ -1,0 +1,1 @@
+Docs: Added missing zhmcclient exceptions to the documentation.

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -244,13 +244,73 @@ Exceptions
    :autosummary-inherited-members:
    :special-members: __str__
 
+.. autoclass:: zhmcclient.NoUniqueMatch
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
 .. autoclass:: zhmcclient.NotFound
    :members:
    :autosummary:
    :autosummary-inherited-members:
    :special-members: __str__
 
-.. autoclass:: zhmcclient.NoUniqueMatch
+.. autoclass:: zhmcclient.MetricsResourceNotFound
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.NotificationError
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.NotificationJMSError
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.NotificationParseError
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.NotificationConnectionError
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.NotificationSubscriptionError
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.SubscriptionNotFound
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.ConsistencyError
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.PartitionLinkError
+   :members:
+   :autosummary:
+   :autosummary-inherited-members:
+   :special-members: __str__
+
+.. autoclass:: zhmcclient.FilterConversionError
    :members:
    :autosummary:
    :autosummary-inherited-members:


### PR DESCRIPTION
Rolls back PR #1994 into 1.23.