### PR TITLE
Added support for make target 'end2end_check'

### DIFF
--- a/changes/noissue.e2echeck.1.feature.rst
+++ b/changes/noissue.e2echeck.1.feature.rst
@@ -1,0 +1,4 @@
+Test: Added a new make target 'end2end_check' which checks all HMCs defined
+in the HMC inventory file for whether the logon works and for whether they
+specify valid CPCs. This is done by using the existing end2end test function
+'test_hmcdef_check_all_hmcs()'. Improved that test function.

--- a/changes/noissue.e2echeck.2.feature.rst
+++ b/changes/noissue.e2echeck.2.feature.rst
@@ -1,0 +1,4 @@
+Added optional parameters to the :func:`zhmcclient.testutils.setup_hmc_session`
+function: 'rt_config' allows to override the default retry/timeout config for
+the HMC session; 'skip_on_failure' allows to select between pytest skipping and
+raising exceptions if the HMC session cannot be established.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+# Config file for pytest
+
+[pytest]
+markers =
+    check_hmcs: Test function for checking the HMCs (zhmcclient).


### PR DESCRIPTION
For details, see the commit message.

Tested:
* `make end2end_check` with my (updated) HMC inventory/vault files -> detected 2 failures -> OK
* `TESTHMC=A218 make end2end` - with a HMC definition that cannot log on -> first test failed after checking connectivity, all subsequent tests failed due to skip detection -> OK
* `TESTHMC=A28 make end2end` - with a HMC definition that can log on -> same test results as before -> OK
