### PR TITLE
Reduced number of HMC sessions in end2end tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,7 +14,12 @@ branch = False
 relative_files = True
 
 # The following files are omitted in the coverage.
-omit = zhmcclient/_vendor/*
+omit =
+    zhmcclient/_vendor/*
+    tests/*
+
+# Enable to see which for which source files coverage is traced.
+# debug = trace
 
 [report]
 

--- a/Makefile
+++ b/Makefile
@@ -246,8 +246,7 @@ else
   pytest_opts := $(TESTOPTS)
 endif
 
-pytest_cov_opts := --cov $(package_name) --cov $(mock_package_name) --cov-config .coveragerc --cov-append --cov-report=html
-pytest_cov_files := .coveragerc
+coverage_config_file := .coveragerc
 
 # Files to be built
 build_files := $(bdist_file) $(sdist_file)
@@ -672,8 +671,9 @@ endif
 	echo "done" >$@
 
 .PHONY: test
-test: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_unit_py_files) $(test_common_py_files) $(pytest_cov_files)
-	bash -c "PYTHONPATH=. pytest --color=yes $(pytest_no_log_opt) -s $(test_dir)/unit $(pytest_cov_opts) $(pytest_opts)"
+test: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_unit_py_files) $(test_common_py_files) $(coverage_config_file)
+	bash -c "PYTHONPATH=. coverage run --append -m pytest --color=yes $(pytest_no_log_opt) -s $(pytest_opts) $(test_dir)/unit"
+	coverage html
 	@echo "Makefile: $@ done."
 
 .PHONY: installtest
@@ -687,14 +687,16 @@ else
 endif
 
 .PHONY:	end2end
-end2end: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(pytest_cov_files)
-	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true pytest --color=yes $(pytest_no_log_opt) -v -s -m 'not check_hmcs' $(test_dir)/end2end $(pytest_cov_opts) $(pytest_opts)"
+end2end: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(coverage_config_file)
+	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true coverage run --append -m pytest --color=yes $(pytest_no_log_opt) -v -s -m 'not check_hmcs' $(pytest_opts) $(test_dir)/end2end"
+	coverage html
 	@echo "Makefile: $@ done."
 
 # TODO: Enable rc checking again once the remaining issues are resolved
 .PHONY:	end2end_mocked
-end2end_mocked: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(pytest_cov_files) tests/end2end/mocked_inventory.yaml tests/end2end/mocked_vault.yaml tests/end2end/mocked_hmc_z16.yaml
-	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true TESTINVENTORY=tests/end2end/mocked_inventory.yaml TESTVAULT=tests/end2end/mocked_vault.yaml pytest --color=yes $(pytest_no_log_opt) -v -s -m 'not check_hmcs' $(test_dir)/end2end $(pytest_cov_opts) $(pytest_opts)"
+end2end_mocked: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(coverage_config_file) tests/end2end/mocked_inventory.yaml tests/end2end/mocked_vault.yaml tests/end2end/mocked_hmc_z16.yaml
+	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true TESTINVENTORY=tests/end2end/mocked_inventory.yaml TESTVAULT=tests/end2end/mocked_vault.yaml coverage run --append -m pytest --color=yes $(pytest_no_log_opt) -v -s -m 'not check_hmcs' $(pytest_opts) $(test_dir)/end2end"
+	coverage html
 	@echo "Makefile: $@ done."
 
 .PHONY: authors
@@ -717,7 +719,7 @@ end2end_show:
 	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true $(PYTHON_CMD) -c 'from zhmcclient.testutils import print_hmc_definitions; print_hmc_definitions()'"
 
 .PHONY:	end2end_check
-end2end_check: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(pytest_cov_files)
+end2end_check: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(coverage_config_file)
 	-$(call RMDIR_R_FUNC,htmlcov.end2end)
-	bash -c "TESTEND2END_LOAD=true TESTCASES=test_hmcdef_check_all_hmcs pytest --color=yes $(pytest_no_log_opt) -v -m check_hmcs -s $(test_dir)/end2end $(pytest_cov_opts) $(pytest_opts)"
+	bash -c "TESTEND2END_LOAD=true TESTCASES=test_hmcdef_check_all_hmcs coverage run --append -m pytest --color=yes $(pytest_no_log_opt) -v -s -m check_hmcs $(pytest_opts) $(test_dir)/end2end"
 	@echo "Makefile: $@ done."

--- a/changes/2015.feature.1.rst
+++ b/changes/2015.feature.1.rst
@@ -1,0 +1,1 @@
+Test: Reduced number of HMC sessions that are created in end2end tests.

--- a/changes/2015.feature.2.rst
+++ b/changes/2015.feature.2.rst
@@ -1,0 +1,11 @@
+Simplified the way users can write pytest based test programs using the
+pytest fixtures in zhmcclient.testutils: These pytest fixtures no longer need
+to be imported before using them, because they are now delivered as a pytest
+plugin and are thus globally known by pytest. In addition, the scope of these
+pytest fixtures was widened from 'module' to 'session'. This reduces the
+number of HMC sessions that pytest based test programs use, because they now
+are reused across test modules. User-written test programs that import these
+fixtures will still run unchanged, but in order to take advantage of the
+reduced number of HMC sessions, these test programs need to remove the import
+statements for the fixtures, because importing them causes pytest to reduce
+their scope to 'module' again.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -55,7 +55,6 @@ pluggy>=1.5.0
 coverage>=7.6.1,<8.0; python_version == '3.8'
 coverage>=7.8.0,<8.0; python_version >= '3.9' and python_version <= '3.12'
 coverage>=6.5.0,<7.0; python_version >= '3.13'
-pytest-cov>=2.7.0
 coveralls>=4.0.1; python_version <= '3.12'
 coveralls>=3.3.0; python_version >= '3.13'
 # PyYAML: covered in direct deps for development

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -574,7 +574,16 @@ functions to its known fixtures, based upon the parameter name.
 For more details on pytest fixtures in general, see
 `pytest fixtures <https://docs.pytest.org/en/latest/explanation/fixtures.html>`_.
 
-The :mod:`zhmcclient.testutils` module provides the following pytest fixtures:
+The 'zhmcclient' Python package provides a number of pytest fixtures that are
+useful for user-written test programs. They are also used by the end2end tests
+of the zhmcclient project itself.  These fixtures are included in the
+'zhmcclient' package as a pytest plugin, which enables them to be used by test
+programs without first having to import them. The ``pytest --fixtures`` command
+will display them along with a brief description.
+
+The following pytest fixtures are provided. In their descriptions, the return
+value indicates what the fixture resolves to when used as a test function
+parameter:
 
 .. autofunction:: zhmcclient.testutils.hmc_definition
 

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -42,7 +42,6 @@ tzdata==2023.4; sys_platform == 'win32'
 coverage==7.6.1; python_version == '3.8'
 coverage==7.8.0; python_version >= '3.9' and python_version <= '3.12'
 coverage==6.5.0; python_version >= '3.13'
-pytest-cov==2.7.0
 coveralls==4.0.1; python_version <= '3.12'
 coveralls==3.3.0; python_version >= '3.13'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,7 @@ testutils = {file = ['extra-testutils-requirements.txt']}
 [tool.setuptools_scm]
 # Get the version from the Git tag, and write a version file:
 version_file = "zhmcclient/_version_scm.py"
+
+[project.entry-points.pytest11]
+# Pytest plugin with zhmcclient fixtures (required for fixtures with session scope).
+zhmcclient-testutils = "zhmcclient.testutils"

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -1,0 +1,80 @@
+# Copyright 2025 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Pytest fixtures for end2end tests.
+"""
+
+
+import os
+import time
+import logging
+import pytest
+
+
+LOG_FORMAT_STRING = '%(asctime)s %(levelname)s %(name)s: %(message)s'
+
+LOG_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
+
+LOG_DATETIME_TIMEZONE = time.gmtime
+
+
+@pytest.fixture(scope='function')
+def zhmc_logger(request):
+    # Note: The first paragraph is shown by 'pytest --fixtures'
+    """
+    Pytest fixture that provides a logger for an end2end test function.
+
+    This functionm creates a logger named after the test function.
+    Using this fixture as an argument in a test function resolves to that
+    logger.
+
+    Logging is enabled by setting the env var TESTLOGFILE. If logging is
+    enabled, the logger is set to debug level, otherwise the logger is disabled.
+
+    During setup of the fixture, a log entry for entering the test function
+    is written, and during teardown of the fixture, a log entry for leaving
+    the test function is written.
+
+    Because this fixture is called for each invocation of a test
+    function, it ends up being called multiple times within the same Python
+    process. Therefore, the logger is created only when it does not exist yet.
+
+    Returns:
+        logging.Logger: Logger for the test function
+    """
+    log_file = os.getenv('TESTLOGFILE', None)
+    if log_file:
+        logging.Formatter.converter = LOG_DATETIME_TIMEZONE
+        log_formatter = logging.Formatter(
+            LOG_FORMAT_STRING, datefmt=LOG_DATETIME_FORMAT)
+        log_handler = logging.FileHandler(log_file, encoding='utf-8')
+        log_handler.setFormatter(log_formatter)
+
+    testfunc_name = request.function.__name__
+    testfunc_logger = logging.getLogger(testfunc_name)
+
+    if log_file and log_handler not in testfunc_logger.handlers:
+        testfunc_logger.addHandler(log_handler)
+
+    if log_file:
+        testfunc_logger.setLevel(logging.DEBUG)
+    else:
+        testfunc_logger.setLevel(logging.NOTSET)
+
+    testfunc_logger.debug("Entered test function")
+    try:
+        yield testfunc_logger
+    finally:
+        testfunc_logger.debug("Leaving test function")

--- a/tests/end2end/test_activation_profile.py
+++ b/tests/end2end/test_activation_profile.py
@@ -25,11 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
-from .utils import logger  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, runtest_find_list, \
     runtest_get_properties, End2endTestWarning, skip_missing_api_feature
@@ -81,8 +76,7 @@ def standard_activation_profile_props(cpc, profile_name, profile_type):
 @pytest.mark.parametrize(
     "profile_type", ['reset', 'image', 'load']
 )
-def test_actprof_crud(logger, classic_mode_cpcs, profile_type):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_actprof_crud(zhmc_logger, classic_mode_cpcs, profile_type):
     """
     Test create, read, update and delete an activation profile.
     """
@@ -101,7 +95,7 @@ def test_actprof_crud(logger, classic_mode_cpcs, profile_type):  # noqa: F811
 
         msg = f"Testing on CPC {cpc.name}"
         print(msg)
-        logger.debug(msg)
+        zhmc_logger.debug(msg)
 
         actprof_name = f'ZHMC{profile_type[0].upper()}1'
 
@@ -115,15 +109,16 @@ def test_actprof_crud(logger, classic_mode_cpcs, profile_type):  # noqa: F811
                 f"Preparation: Delete {profile_type} activation profile "
                 f"{actprof_name!r} on CPC {cpc.name} from previous run")
             warnings.warn(msg, UserWarning)
-            logger.debug(msg)
+            zhmc_logger.debug(msg)
             _actprof.delete()
 
         # Test creating the activation profile
         actprof_input_props = standard_activation_profile_props(
             cpc, actprof_name, profile_type)
 
-        logger.debug("Create %s activation profile %r on CPC %s",
-                     profile_type, actprof_name, cpc.name)
+        zhmc_logger.debug(
+            "Create %s activation profile %r on CPC %s",
+            profile_type, actprof_name, cpc.name)
 
         # The code to be tested
         actprof = actprof_mgr.create(actprof_input_props)
@@ -143,8 +138,9 @@ def test_actprof_crud(logger, classic_mode_cpcs, profile_type):  # noqa: F811
 
             new_desc = "Updated activation profile description."
 
-            logger.debug("Update a property of %s activation profile "
-                         "%r on CPC %s", profile_type, actprof_name, cpc.name)
+            zhmc_logger.debug(
+                "Update a property of %s activation profile %r on CPC %s",
+                profile_type, actprof_name, cpc.name)
 
             # The code to be tested
             actprof.update_properties(dict(description=new_desc))
@@ -156,8 +152,9 @@ def test_actprof_crud(logger, classic_mode_cpcs, profile_type):  # noqa: F811
         finally:
             # Test deleting the activation profile (also cleanup)
 
-            logger.debug("Delete %s activation profile %r on CPC %s",
-                         profile_type, actprof_name, cpc.name)
+            zhmc_logger.debug(
+                "Delete %s activation profile %r on CPC %s",
+                profile_type, actprof_name, cpc.name)
 
             # The code to be tested
             actprof.delete()
@@ -166,8 +163,7 @@ def test_actprof_crud(logger, classic_mode_cpcs, profile_type):  # noqa: F811
 @pytest.mark.parametrize(
     "profile_type", ['reset', 'image', 'load']
 )
-def test_actprof_find_list(classic_mode_cpcs, profile_type):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_actprof_find_list(classic_mode_cpcs, profile_type):
     """
     Test list(), find(), findall().
     """
@@ -205,8 +201,7 @@ def test_actprof_find_list(classic_mode_cpcs, profile_type):  # noqa: F811
 @pytest.mark.parametrize(
     "profile_type", ['reset', 'image', 'load']
 )
-def test_actprof_property(classic_mode_cpcs, profile_type):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_actprof_property(classic_mode_cpcs, profile_type):
     """
     Test property related methods
     """

--- a/tests/end2end/test_adapter.py
+++ b/tests/end2end/test_adapter.py
@@ -27,10 +27,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs, all_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     standard_partition_props, runtest_find_list, runtest_get_properties
@@ -58,8 +54,7 @@ def se_version_info(cpc):
     return list(map(int, cpc.prop('se-version').split('.')))
 
 
-def test_adapter_find_list(all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_adapter_find_list(all_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -91,8 +86,7 @@ def test_adapter_find_list(all_cpcs):  # noqa: F811
                 ADAPTER_LIST_PROPS, ADAPTER_ADDITIONAL_PROPS)
 
 
-def test_adapter_property(all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_adapter_property(all_cpcs):
     """
     Test property related methods
     """
@@ -125,8 +119,7 @@ def test_adapter_property(all_cpcs):  # noqa: F811
             runtest_get_properties(adapter.manager, non_list_prop)
 
 
-def test_adapter_hs_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_adapter_hs_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a Hipersocket adapter.
     """
@@ -243,8 +236,7 @@ ADAPTER_FAMILIES = [
 @pytest.mark.parametrize(
     "test_family",
     ADAPTER_FAMILIES)
-def test_adapter_list_assigned_part(dpm_mode_cpcs, test_family):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_adapter_list_assigned_part(dpm_mode_cpcs, test_family):
     """
     Test Adapter.list_assigned_partitions().
     """
@@ -568,8 +560,7 @@ def base_adapter_id(adapter_id, family):
     return f'{base_pchid:03x}'
 
 
-def test_adapter_list_sibling_adapters(all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_adapter_list_sibling_adapters(all_cpcs):
     """
     Test Adapter.list_sibling_adapters().
     """
@@ -692,9 +683,8 @@ LIST_PERMITTED_ADAPTERS_TESTCASES = [
     "desc, input_kwargs, exp_props, exp_exc_type, run",
     LIST_PERMITTED_ADAPTERS_TESTCASES)
 def test_adapter_list_permitted(
-        desc, input_kwargs, exp_props, exp_exc_type, run,
-        all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name, unused-argument
+        desc, input_kwargs, exp_props, exp_exc_type, run, all_cpcs):
+    # pylint: disable=unused-argument
     """
     Test Console.list_permitted_adapters() without filtering, but with
     different variations of returned properties.

--- a/tests/end2end/test_auto_update.py
+++ b/tests/end2end/test_auto_update.py
@@ -26,10 +26,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 from zhmcclient.mock import FakedSession
 
 from .utils import TEST_PREFIX, standard_partition_props, skip_warn
@@ -37,8 +33,7 @@ from .utils import TEST_PREFIX, standard_partition_props, skip_warn
 urllib3.disable_warnings()
 
 
-def test_autoupdate_prop(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_autoupdate_prop(dpm_mode_cpcs):
     """
     Test auto-updated partitions when updating a property.
     """
@@ -207,8 +202,7 @@ def test_autoupdate_prop(dpm_mode_cpcs):  # noqa: F811
                     raise
 
 
-def test_autoupdate_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_autoupdate_list(dpm_mode_cpcs):
     """
     Test list() with auto-updated Partition manager.
     """

--- a/tests/end2end/test_capacity_group.py
+++ b/tests/end2end/test_capacity_group.py
@@ -25,10 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     runtest_find_list, runtest_get_properties
@@ -45,8 +41,7 @@ CAPGRP_LIST_PROPS = ['element-uri', 'name']
 CAPGRP_VOLATILE_PROPS = []
 
 
-def test_capgrp_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_capgrp_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -75,8 +70,7 @@ def test_capgrp_find_list(dpm_mode_cpcs):  # noqa: F811
                 CAPGRP_LIST_PROPS)
 
 
-def test_capgrp_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_capgrp_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -106,8 +100,7 @@ def test_capgrp_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(capgrp.manager, non_list_prop)
 
 
-def test_capgrp_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_capgrp_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a capacity group.
     """

--- a/tests/end2end/test_certificates.py
+++ b/tests/end2end/test_certificates.py
@@ -22,10 +22,6 @@ from requests.packages import urllib3
 
 import zhmcclient
 
-# pylint: disable=unused-import
-from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
-# pylint: disable=unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 from .utils import pick_test_resources, runtest_find_list, skip_warn, \
     skipif_no_secure_boot_feature, standard_partition_props, \
     cleanup_and_import_example_certificate
@@ -45,8 +41,7 @@ CERT_ADDITIONAL_PROPS = ['description', 'assigned']
 CERT_VOLATILE_PROPS = []
 
 
-def test_certificates_find_list(all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_certificates_find_list(all_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -76,8 +71,7 @@ def test_certificates_find_list(all_cpcs):  # noqa: F811
                 CERT_ADDITIONAL_PROPS)
 
 
-def test_cert_crud(all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_cert_crud(all_cpcs):
     """
     Test create, read, update and delete a certificate.
     For DPM cpcs, also create a partition and assign/unassign certificates.

--- a/tests/end2end/test_console.py
+++ b/tests/end2end/test_console.py
@@ -22,9 +22,6 @@ These tests do not change the console object.
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, runtest_get_properties, \
     validate_api_features
@@ -41,8 +38,7 @@ CONSOLE_LIST_PROPS = ['object-uri']
 CONSOLE_VOLATILE_PROPS = []
 
 
-def test_console_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_console_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -57,8 +53,7 @@ def test_console_find_list(hmc_session):  # noqa: F811
         CONSOLE_LIST_PROPS)
 
 
-def test_console_property(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_console_property(hmc_session):
     """
     Test property related methods
     """
@@ -70,8 +65,7 @@ def test_console_property(hmc_session):  # noqa: F811
     runtest_get_properties(client.consoles, non_list_prop)
 
 
-def test_console_features(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_console_features(hmc_session):
     """
     Tests Console feature methods:
     - For API features:

--- a/tests/end2end/test_cpc.py
+++ b/tests/end2end/test_cpc.py
@@ -23,10 +23,6 @@ from datetime import timedelta, datetime, timezone
 import pytest
 from requests.packages import urllib3
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import all_cpcs, classic_mode_cpcs, dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, assert_res_prop, runtest_find_list, \
     runtest_get_properties, validate_firmware_features, validate_api_features, \
@@ -86,8 +82,7 @@ MAX_PARTS_BY_TYPE_MODEL = {
 }
 
 
-def test_cpc_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_cpc_find_list(hmc_session):
     """
     Test find/list methods for CPCs (any mode).
     """
@@ -109,8 +104,7 @@ def test_cpc_find_list(hmc_session):  # noqa: F811
             CPC_VOLATILE_PROPS, CPC_MINIMAL_PROPS, cpc_list_props)
 
 
-def test_cpc_property(all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_cpc_property(all_cpcs):
     """
     Test property related methods
     """
@@ -126,8 +120,7 @@ def test_cpc_property(all_cpcs):  # noqa: F811
         runtest_get_properties(cpc.manager, non_list_prop)
 
 
-def test_cpc_features(all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_cpc_features(all_cpcs):
     """
     Test certain "features" of a CPC (any mode):
     - dpm_enabled property
@@ -265,8 +258,7 @@ def test_cpc_features(all_cpcs):  # noqa: F811
             assert enabled is True
 
 
-def test_cpc_export_profiles(classic_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_cpc_export_profiles(classic_mode_cpcs):
     """
     Test for export_profiles(profile_area, wait_for_completion=True,
                              operation_timeout=None)
@@ -300,8 +292,7 @@ def test_cpc_export_profiles(classic_mode_cpcs):  # noqa: F811
         # TODO: Complete this test
 
 
-def test_cpc_export_dpm_config(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_cpc_export_dpm_config(dpm_mode_cpcs):
     """
     Test for export_dpm_configuration()
 
@@ -395,8 +386,8 @@ CPC_METRICS = {
     "tc, input_kwargs, exp_oldest, exp_delta",
     TESTCASES_CPC_GET_SUSTAINABILITY_DATA)
 def test_cpc_get_sustainability_data(
-        tc, input_kwargs, exp_oldest, exp_delta, all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+        tc, input_kwargs, exp_oldest, exp_delta, all_cpcs):
+    # pylint: disable=unused-argument
     """
     Test for Cpc.get_sustainability_data(...)
     """

--- a/tests/end2end/test_group.py
+++ b/tests/end2end/test_group.py
@@ -25,9 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import pick_test_resources, runtest_find_list, TEST_PREFIX, \
     skip_warn, skipif_no_group_support
@@ -44,8 +41,7 @@ GROUP_LIST_PROPS = ['object-uri', 'name']
 GROUP_VOLATILE_PROPS = []
 
 
-def test_group_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_group_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -69,8 +65,7 @@ def test_group_find_list(hmc_session):  # noqa: F811
             GROUP_LIST_PROPS)
 
 
-def test_group_crud(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_group_crud(hmc_session):
     """
     Test create, read, update and delete a group.
     """

--- a/tests/end2end/test_hba.py
+++ b/tests/end2end/test_hba.py
@@ -25,10 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     standard_partition_props, skipif_storage_mgmt_feature, \
@@ -46,8 +42,7 @@ HBA_LIST_PROPS = ['element-uri', 'name', 'description', 'wwpn']
 HBA_VOLATILE_PROPS = []
 
 
-def test_hba_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hba_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -82,8 +77,7 @@ def test_hba_find_list(dpm_mode_cpcs):  # noqa: F811
                 HBA_VOLATILE_PROPS, HBA_MINIMAL_PROPS, HBA_LIST_PROPS)
 
 
-def test_hba_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hba_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -119,8 +113,7 @@ def test_hba_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(hba.manager, non_list_prop)
 
 
-def test_hba_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hba_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a HBA (and a partition).
     """

--- a/tests/end2end/test_hmc_inventory.py
+++ b/tests/end2end/test_hmc_inventory.py
@@ -23,11 +23,7 @@ import pytest
 
 import zhmcclient
 # pylint: disable=unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401
 from zhmcclient.testutils import HMCDefinitions
-from zhmcclient.testutils import all_cpcs  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
 # pylint: enable=unused-import
 from zhmcclient.testutils import setup_hmc_session
 
@@ -41,8 +37,7 @@ def _print_cpc(cpc):
     print(f"Found test CPC {cpc.name} ({mode_str} mode)")
 
 
-def test_hmcdef_all_cpcs(all_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hmcdef_all_cpcs(all_cpcs):
     """
     Display all CPCs to be tested.
     """
@@ -50,8 +45,7 @@ def test_hmcdef_all_cpcs(all_cpcs):  # noqa: F811
         _print_cpc(cpc)
 
 
-def test_hmcdef_dpm_cpcs(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hmcdef_dpm_cpcs(dpm_mode_cpcs):
     """
     Display DPM mode CPCs to be tested.
     """
@@ -59,8 +53,7 @@ def test_hmcdef_dpm_cpcs(dpm_mode_cpcs):  # noqa: F811
         _print_cpc(cpc)
 
 
-def test_hmcdef_classic_cpcs(classic_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hmcdef_classic_cpcs(classic_mode_cpcs):
     """
     Display classic mode CPCs to be tested.
     """
@@ -68,8 +61,7 @@ def test_hmcdef_classic_cpcs(classic_mode_cpcs):  # noqa: F811
         _print_cpc(cpc)
 
 
-def test_hmcdef_cpcs(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hmcdef_cpcs(hmc_session):
     """
     Test that the HMC actually manages the CPCs defined in its inventory file
     and that these CPCs actually have the properties defined there.

--- a/tests/end2end/test_hw_message.py
+++ b/tests/end2end/test_hw_message.py
@@ -24,9 +24,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import runtest_find_list, skip_warn, pick_test_resources
 
@@ -46,8 +43,7 @@ HW_MESSAGE_VOLATILE_PROPS = []
 @pytest.mark.parametrize(
     "parent", ['cpc', 'console']
 )
-def test_hw_message_find_list(hmc_session, parent):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hw_message_find_list(hmc_session, parent):
     """
     Test list(), find(), findall().
     """
@@ -100,8 +96,7 @@ def test_hw_message_find_list(hmc_session, parent):  # noqa: F811
 @pytest.mark.parametrize(
     "parent", ['cpc', 'console']
 )
-def test_hw_message_list_filtered(hmc_session, parent):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_hw_message_list_filtered(hmc_session, parent):
     """
     Test list() with timestamp filtering.
     """

--- a/tests/end2end/test_ldap_server_definition.py
+++ b/tests/end2end/test_ldap_server_definition.py
@@ -25,9 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     runtest_find_list, runtest_get_properties
@@ -46,8 +43,7 @@ LDAPSRVDEF_LIST_PROPS = ['element-uri', 'name']
 LDAPSRVDEF_VOLATILE_PROPS = []
 
 
-def test_ldapsrvdef_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_ldapsrvdef_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -76,8 +72,7 @@ def test_ldapsrvdef_find_list(hmc_session):  # noqa: F811
             LDAPSRVDEF_MINIMAL_PROPS, LDAPSRVDEF_LIST_PROPS)
 
 
-def test_ldapsrvdef_property(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_ldapsrvdef_property(hmc_session):
     """
     Test property related methods
     """
@@ -107,8 +102,7 @@ def test_ldapsrvdef_property(hmc_session):  # noqa: F811
         runtest_get_properties(ldapsrvdef.manager, non_list_prop)
 
 
-def test_ldapsrvdef_crud(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_ldapsrvdef_crud(hmc_session):
     """
     Test create, read, update and delete a LDAP server definition.
     """

--- a/tests/end2end/test_lpar.py
+++ b/tests/end2end/test_lpar.py
@@ -27,11 +27,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
-from .utils import logger  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, runtest_find_list, \
     runtest_get_properties, ensure_lpar_inactive, set_resource_property
@@ -56,8 +51,7 @@ LPAR_LIST_PERMITTED_PROPS = [
 LPAR_VOLATILE_PROPS = []
 
 
-def test_lpar_find_list(classic_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_lpar_find_list(classic_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -83,8 +77,7 @@ def test_lpar_find_list(classic_mode_cpcs):  # noqa: F811
                 LPAR_VOLATILE_PROPS, LPAR_MINIMAL_PROPS, LPAR_LIST_PROPS)
 
 
-def test_lpar_property(classic_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_lpar_property(classic_mode_cpcs):
     """
     Test property related methods
     """
@@ -175,33 +168,34 @@ TESTCASES_CONSOLE_LIST_PERMITTED_LPARS = [
     "desc, input_kwargs, exp_prop_names",
     TESTCASES_CONSOLE_LIST_PERMITTED_LPARS)
 def test_console_list_permitted_lpars(
-        logger, classic_mode_cpcs,  # noqa: F811
-        desc, input_kwargs, exp_prop_names):
-    # pylint: disable=redefined-outer-name
+        zhmc_logger, classic_mode_cpcs, desc, input_kwargs,
+        exp_prop_names):
     """
     Test Console.list_permitted_lpars() method
     """
     if not classic_mode_cpcs:
         pytest.skip("HMC definition does not include any CPCs in classic mode")
 
-    logger.debug("Arguments: desc=%r, input_kwargs=%r, exp_prop_names=%r",
-                 desc, input_kwargs, exp_prop_names)
+    zhmc_logger.debug(
+        "Arguments: desc=%r, input_kwargs=%r, exp_prop_names=%r",
+        desc, input_kwargs, exp_prop_names)
 
     for cpc in classic_mode_cpcs:
         assert not cpc.dpm_enabled
 
-        logger.debug("Testing with CPC %s", cpc.name)
+        zhmc_logger.debug("Testing with CPC %s", cpc.name)
 
         client = cpc.manager.client
         console = client.consoles.console
 
-        logger.debug("Calling list_permitted_lpars() with kwargs: %r",
-                     input_kwargs)
+        zhmc_logger.debug(
+            "Calling list_permitted_lpars() with kwargs: %r", input_kwargs)
 
         # Execute the code to be tested
         lpars = console.list_permitted_lpars(**input_kwargs)
 
-        logger.debug("list_permitted_lpars() returned %d LPARs", len(lpars))
+        zhmc_logger.debug(
+            "list_permitted_lpars() returned %d LPARs", len(lpars))
 
         for lpar in lpars:
             lpar_props = dict(lpar.properties)
@@ -211,8 +205,8 @@ def test_console_list_permitted_lpars(
                     f"properties, got: {lpar_props!r}")
 
 
-def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_lpar_list_os_messages(
+        zhmc_logger, classic_mode_cpcs):
     """
     Test "List OS Messages" operation on LPARs
     """
@@ -239,7 +233,7 @@ def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
 
             # Test: List all messages (without begin or end)
             try:
-                logger.debug(
+                zhmc_logger.debug(
                     "Listing OS messages of LPAR %s with no begin/end",
                     lpar.name)
                 result = lpar.list_os_messages()
@@ -247,7 +241,7 @@ def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
                 if exc.http_status == 409 and exc.reason == 332:
                     # Meaning: The messages interface for the LPAR is not
                     # available
-                    logger.debug(
+                    zhmc_logger.debug(
                         "LPAR %s cannot list OS messages", lpar.name)
                     continue
                 raise
@@ -257,7 +251,7 @@ def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
                 test_lpar = lpar
                 break
 
-            logger.debug(
+            zhmc_logger.debug(
                 "LPAR %s has only %d OS messages",
                 lpar.name, len(all_messages))
 
@@ -268,7 +262,7 @@ def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
         # Test with begin/end selecting the full set of messages
         all_begin = all_messages[0]['sequence-number']
         all_end = all_messages[-1]['sequence-number']
-        logger.debug(
+        zhmc_logger.debug(
             "Listing OS messages of LPAR %s with begin=%s, end=%s",
             test_lpar.name, all_begin, all_end)
         result = test_lpar.list_os_messages(begin=all_begin, end=all_end)
@@ -287,7 +281,7 @@ def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
                 break
         begin = min(seq1, seq2)
         end = max(seq1, seq2)
-        logger.debug(
+        zhmc_logger.debug(
             "Listing OS messages of LPAR %s with begin=%s, end=%s",
             test_lpar.name, begin, end)
         result = test_lpar.list_os_messages(begin=begin, end=end)
@@ -298,7 +292,7 @@ def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
 
         # Test with begin/end and maximum messages
         max_messages = random.randint(0, end - begin + 1)
-        logger.debug(
+        zhmc_logger.debug(
             "Listing OS messages of LPAR %s with begin=%s, end=%s, "
             "max_messages=%d", test_lpar.name, begin, end, max_messages)
         result = test_lpar.list_os_messages(
@@ -310,7 +304,7 @@ def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
 
         # Test with is_held
         for is_held in (False, True):
-            logger.debug(
+            zhmc_logger.debug(
                 "Listing OS messages of LPAR %s with is_held=%s",
                 test_lpar.name, is_held)
             result = test_lpar.list_os_messages(is_held=is_held)
@@ -320,7 +314,7 @@ def test_lpar_list_os_messages(logger, classic_mode_cpcs):  # noqa: F811
 
         # Test with is_priority
         for is_priority in (False, True):
-            logger.debug(
+            zhmc_logger.debug(
                 "Listing OS messages of LPAR %s with is_priority=%s",
                 test_lpar.name, is_priority)
             result = test_lpar.list_os_messages(is_priority=is_priority)
@@ -513,10 +507,10 @@ LPAR_ACTIVATE_TESTCASES = [
     "exp_props, exp_exc_type, run",
     LPAR_ACTIVATE_TESTCASES)
 def test_lpar_activate(
-        logger, classic_mode_cpcs,  # noqa: F811
+        zhmc_logger, classic_mode_cpcs,
         desc, lpar_mode, ap_type, nap_type, auto_load, input_kwargs,
         exp_props, exp_exc_type, run):
-    # pylint: disable=redefined-outer-name, unused-argument
+    # pylint: disable=unused-argument
     """
     Test Lpar.activate().
 
@@ -656,29 +650,32 @@ def test_lpar_activate(
 
         msg = f"Testing on CPC {cpc.name} with LPAR {lpar.name!r}"
         print(msg)
-        logger.debug(msg)
+        zhmc_logger.debug(msg)
 
         if run == 'pdb':
             # pylint: disable=forgotten-debug-statement
             pdb.set_trace()
 
-        logger.debug("Preparation: Ensuring that LPAR %r is inactive",
-                     lpar.name)
+        zhmc_logger.debug(
+            "Preparation: Ensuring that LPAR %r is inactive", lpar.name)
         ensure_lpar_inactive(lpar)
 
-        logger.debug("Preparation: Setting 'next-activation-profile-name' = %r "
-                     "in LPAR %r", nap_name, lpar.name)
+        zhmc_logger.debug(
+            "Preparation: Setting 'next-activation-profile-name' = %r "
+            "in LPAR %r", nap_name, lpar.name)
         saved_nap_name = set_resource_property(
             lpar, 'next-activation-profile-name', nap_name)
 
-        logger.debug("Preparation: Setting 'load-at-activation' = %r in image "
-                     "profile %r", auto_load, iap.name)
+        zhmc_logger.debug(
+            "Preparation: Setting 'load-at-activation' = %r in image "
+            "profile %r", auto_load, iap.name)
         saved_auto_load = set_resource_property(
             iap, 'load-at-activation', auto_load)
 
         try:
-            logger.debug("Activating LPAR %r (profile arg: %r, add. args: %r)",
-                         lpar.name, ap_name, input_kwargs)
+            zhmc_logger.debug(
+                "Activating LPAR %r (profile arg: %r, add. args: %r)",
+                lpar.name, ap_name, input_kwargs)
 
             if exp_exc_type:
 
@@ -701,8 +698,9 @@ def test_lpar_activate(
                 # Check the expected properties
                 lpar.pull_full_properties()
                 lpar_props = dict(lpar.properties)
-                logger.debug("Status of LPAR %r is %r after test",
-                             lpar.name, lpar_props['status'])
+                zhmc_logger.debug(
+                    "Status of LPAR %r is %r after test",
+                    lpar.name, lpar_props['status'])
                 for pname, exp_value in exp_props.items():
                     assert pname in lpar_props, (
                         f"Expected property {pname!r} does not exist in "
@@ -712,17 +710,20 @@ def test_lpar_activate(
                         f"Property {pname!r} has unexpected value "
                         f"{act_value!r}; expected value: {exp_value!r}")
         finally:
-            logger.debug("Cleanup: Ensuring that LPAR %r is inactive",
-                         lpar.name)
+            zhmc_logger.debug(
+                "Cleanup: Ensuring that LPAR %r is inactive",
+                lpar.name)
             ensure_lpar_inactive(lpar)
 
-            logger.debug("Cleanup: Setting 'next-activation-profile-name' = %r "
-                         "in LPAR %r", saved_nap_name, lpar.name)
+            zhmc_logger.debug(
+                "Cleanup: Setting 'next-activation-profile-name' = %r "
+                "in LPAR %r", saved_nap_name, lpar.name)
             set_resource_property(
                 lpar, 'next-activation-profile-name', saved_nap_name)
 
-            logger.debug("Cleanup: Setting 'load-at-activation' = %r in image "
-                         "profile %r", saved_auto_load, iap.name)
+            zhmc_logger.debug(
+                "Cleanup: Setting 'load-at-activation' = %r in image "
+                "profile %r", saved_auto_load, iap.name)
             set_resource_property(iap, 'load-at-activation', saved_auto_load)
 
 
@@ -774,9 +775,8 @@ LPAR_METRICS = {
     "tc, input_kwargs, exp_oldest, exp_delta",
     TESTCASES_LPAR_GET_SUSTAINABILITY_DATA)
 def test_lpar_get_sustainability_data(
-        tc, input_kwargs, exp_oldest, exp_delta,
-        classic_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+        tc, input_kwargs, exp_oldest, exp_delta, classic_mode_cpcs):
+    # pylint: disable=unused-argument
     """
     Test for Lpar.get_sustainability_data(...)
     """

--- a/tests/end2end/test_mfa_server_definition.py
+++ b/tests/end2end/test_mfa_server_definition.py
@@ -25,9 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     runtest_find_list, runtest_get_properties
@@ -46,8 +43,7 @@ MFASRVDEF_LIST_PROPS = ['element-uri', 'name']
 MFASRVDEF_VOLATILE_PROPS = []
 
 
-def test_mfasrvdef_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_mfasrvdef_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -76,8 +72,7 @@ def test_mfasrvdef_find_list(hmc_session):  # noqa: F811
             MFASRVDEF_MINIMAL_PROPS, MFASRVDEF_LIST_PROPS)
 
 
-def test_mfasrvdef_property(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_mfasrvdef_property(hmc_session):
     """
     Test property related methods
     """
@@ -107,8 +102,7 @@ def test_mfasrvdef_property(hmc_session):  # noqa: F811
         runtest_get_properties(mfasrvdef.manager, non_list_prop)
 
 
-def test_mfasrvdef_crud(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_mfasrvdef_crud(hmc_session):
     """
     Test create, read, update and delete a MFA server definition.
     """

--- a/tests/end2end/test_nic.py
+++ b/tests/end2end/test_nic.py
@@ -26,11 +26,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-from .utils import logger  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     standard_partition_props, runtest_find_list, runtest_get_properties
@@ -54,8 +49,7 @@ def se_version_info(cpc):
     return list(map(int, cpc.prop('se-version').split('.')))
 
 
-def test_nic_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_nic_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -89,8 +83,7 @@ def test_nic_find_list(dpm_mode_cpcs):  # noqa: F811
                 NIC_VOLATILE_PROPS, NIC_MINIMAL_PROPS, NIC_LIST_PROPS)
 
 
-def test_nic_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_nic_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -125,8 +118,7 @@ def test_nic_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(nic.manager, non_list_prop)
 
 
-def test_nic_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_nic_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a NIC (and a partition).
     """
@@ -256,8 +248,7 @@ def test_nic_crud(dpm_mode_cpcs):  # noqa: F811
                 adapter.delete()
 
 
-def test_nic_backing_port_port_based(logger, dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_nic_backing_port_port_based(zhmc_logger, dpm_mode_cpcs):
     """
     Test Nic.backing_port() for port-based NICs (e.g. RoCE, CNA).
     """
@@ -265,7 +256,7 @@ def test_nic_backing_port_port_based(logger, dpm_mode_cpcs):  # noqa: F811
         pytest.skip("HMC definition does not include any CPCs in DPM mode")
 
     cpc = random.choice(dpm_mode_cpcs)
-    logger.debug("Testing with CPC %s", cpc.name)
+    zhmc_logger.debug("Testing with CPC %s", cpc.name)
     client = cpc.manager.client
 
     port_nics = []
@@ -279,7 +270,7 @@ def test_nic_backing_port_port_based(logger, dpm_mode_cpcs):  # noqa: F811
                 pass
             else:
                 # port-based NIC (e.g. RoCE, CNA before z17, or z17)
-                logger.debug("Found port-based NIC %s", nic.name)
+                zhmc_logger.debug("Found port-based NIC %s", nic.name)
                 port_nics.append(nic)
         if len(port_nics) >= 5:
             break
@@ -291,8 +282,8 @@ def test_nic_backing_port_port_based(logger, dpm_mode_cpcs):  # noqa: F811
     # Pick the port-based NIC to test with
     nic = random.choice(port_nics)
     partition = nic.manager.parent
-    logger.debug("Testing with NIC %r in partition %r",
-                 nic.name, partition.name)
+    zhmc_logger.debug(
+        "Testing with NIC %r in partition %r", nic.name, partition.name)
 
     port_uri = nic.get_property('network-adapter-port-uri')
     port_props = client.session.get(port_uri)
@@ -300,12 +291,12 @@ def test_nic_backing_port_port_based(logger, dpm_mode_cpcs):  # noqa: F811
     adapter = cpc.adapters.resource_object(adapter_uri)
     port = adapter.ports.resource_object(port_uri)
 
-    logger.debug("Calling Nic.backing_port()")
+    zhmc_logger.debug("Calling Nic.backing_port()")
 
     # The code to be tested
     result_port = nic.backing_port()
 
-    logger.debug("Returned from Nic.backing_port()")
+    zhmc_logger.debug("Returned from Nic.backing_port()")
 
     assert isinstance(result_port, zhmcclient.Port)
     assert result_port.uri == port.uri
@@ -317,8 +308,7 @@ def test_nic_backing_port_port_based(logger, dpm_mode_cpcs):  # noqa: F811
     assert result_cpc.uri == cpc.uri
 
 
-def test_nic_backing_port_vswitch_based(logger, dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_nic_backing_port_vswitch_based(zhmc_logger, dpm_mode_cpcs):
     """
     Test Nic.backing_port() for vswitch-based NICs (e.g. OSA, HS).
     """
@@ -326,7 +316,7 @@ def test_nic_backing_port_vswitch_based(logger, dpm_mode_cpcs):  # noqa: F811
         pytest.skip("HMC definition does not include any CPCs in DPM mode")
 
     cpc = random.choice(dpm_mode_cpcs)
-    logger.debug("Testing with CPC %s", cpc.name)
+    zhmc_logger.debug("Testing with CPC %s", cpc.name)
     client = cpc.manager.client
 
     vswitch_nics = []
@@ -340,7 +330,7 @@ def test_nic_backing_port_vswitch_based(logger, dpm_mode_cpcs):  # noqa: F811
                 pass
             else:
                 # vswitch-based NIC (e.g. OSA, HS before z17)
-                logger.debug("Found vswitch-based NIC %s", nic.name)
+                zhmc_logger.debug("Found vswitch-based NIC %s", nic.name)
                 vswitch_nics.append(nic)
         if len(vswitch_nics) >= 5:
             break
@@ -352,8 +342,8 @@ def test_nic_backing_port_vswitch_based(logger, dpm_mode_cpcs):  # noqa: F811
     # Pick the vswitch-based NIC to test with
     nic = random.choice(vswitch_nics)
     partition = nic.manager.parent
-    logger.debug("Testing with NIC %r in partition %r",
-                 nic.name, partition.name)
+    zhmc_logger.debug(
+        "Testing with NIC %r in partition %r", nic.name, partition.name)
 
     vswitch_uri = nic.get_property('virtual-switch-uri')
     vswitch_props = client.session.get(vswitch_uri)
@@ -369,12 +359,12 @@ def test_nic_backing_port_vswitch_based(logger, dpm_mode_cpcs):  # noqa: F811
     else:
         raise AssertionError  # Would be an HMC inconsistency
 
-    logger.debug("Calling Nic.backing_port()")
+    zhmc_logger.debug("Calling Nic.backing_port()")
 
     # The code to be tested
     result_port = nic.backing_port()
 
-    logger.debug("Returned from Nic.backing_port()")
+    zhmc_logger.debug("Returned from Nic.backing_port()")
 
     assert isinstance(result_port, zhmcclient.Port)
     assert result_port.uri == port.uri

--- a/tests/end2end/test_partition.py
+++ b/tests/end2end/test_partition.py
@@ -28,11 +28,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-from .utils import logger  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     standard_partition_props, runtest_find_list, runtest_get_properties, \
@@ -84,8 +79,7 @@ def assert_ctc_partition_link(partlink, num_paths, num_partitions):
             f"{pformat_as_dict(partlink.properties)}")
 
 
-def test_part_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_part_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -113,8 +107,7 @@ def test_part_find_list(dpm_mode_cpcs):  # noqa: F811
                 PART_ADDITIONAL_PROPS)
 
 
-def test_part_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_part_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -143,8 +136,7 @@ def test_part_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(part.manager, non_list_prop)
 
 
-def test_part_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_part_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a partition.
     """
@@ -237,8 +229,7 @@ def test_part_crud(dpm_mode_cpcs):  # noqa: F811
             cpc.partitions.find(name=part_name_new)
 
 
-def test_partition_features(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_partition_features(dpm_mode_cpcs):
     """
     Test features of the CPC of a partition:
     - For firmware features:
@@ -344,8 +335,7 @@ def test_partition_features(dpm_mode_cpcs):  # noqa: F811
         validate_firmware_features(api_version_info, fw_features)
 
 
-def test_part_list_os_messages(logger, dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_part_list_os_messages(zhmc_logger, dpm_mode_cpcs):
     """
     Test "List OS Messages" operation on partitions
     """
@@ -373,7 +363,7 @@ def test_part_list_os_messages(logger, dpm_mode_cpcs):  # noqa: F811
 
             # Test: List all messages (without begin or end)
             try:
-                logger.debug(
+                zhmc_logger.debug(
                     "Listing OS messages of partition %s with no begin/end",
                     part.name)
                 result = part.list_os_messages()
@@ -381,7 +371,7 @@ def test_part_list_os_messages(logger, dpm_mode_cpcs):  # noqa: F811
                 if exc.http_status == 409 and exc.reason == 332:
                     # Meaning: The messages interface for the partition is not
                     # available
-                    logger.debug(
+                    zhmc_logger.debug(
                         "Partition %s cannot list OS messages", part.name)
                     continue
                 raise
@@ -391,7 +381,7 @@ def test_part_list_os_messages(logger, dpm_mode_cpcs):  # noqa: F811
                 test_part = part
                 break
 
-            logger.debug(
+            zhmc_logger.debug(
                 "Partition %s has only %d OS messages",
                 part.name, len(all_messages))
 
@@ -402,7 +392,7 @@ def test_part_list_os_messages(logger, dpm_mode_cpcs):  # noqa: F811
         # Test with begin/end selecting the full set of messages
         all_begin = all_messages[0]['sequence-number']
         all_end = all_messages[-1]['sequence-number']
-        logger.debug(
+        zhmc_logger.debug(
             "Listing OS messages of partition %s with begin=%s, end=%s",
             test_part.name, all_begin, all_end)
         result = test_part.list_os_messages(begin=all_begin, end=all_end)
@@ -421,7 +411,7 @@ def test_part_list_os_messages(logger, dpm_mode_cpcs):  # noqa: F811
                 break
         begin = min(seq1, seq2)
         end = max(seq1, seq2)
-        logger.debug(
+        zhmc_logger.debug(
             "Listing OS messages of partition %s with begin=%s, end=%s",
             test_part.name, begin, end)
         result = test_part.list_os_messages(begin=begin, end=end)
@@ -431,8 +421,7 @@ def test_part_list_os_messages(logger, dpm_mode_cpcs):  # noqa: F811
             assert message in all_messages
 
 
-def test_part_create_os_websocket(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_part_create_os_websocket(dpm_mode_cpcs):
     """
     Test "Get ASCII Console WebSocket URI" operation on partitions
     """
@@ -519,9 +508,9 @@ LIST_PERMITTED_PARTITION_TESTCASES = [
 @pytest.mark.parametrize(
     "desc, input_kwargs, exp_props",
     LIST_PERMITTED_PARTITION_TESTCASES)
-def test_console_list_permitted_partitions(desc, input_kwargs, exp_props,
-                                           dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name, unused-argument
+def test_console_list_permitted_partitions(
+        desc, input_kwargs, exp_props, dpm_mode_cpcs):
+    # pylint: disable=unused-argument
     """
     Test list permitted partitions on a cpc
     """
@@ -616,9 +605,8 @@ PART_METRICS = {
     "tc, input_kwargs, exp_oldest, exp_delta",
     TESTCASES_PART_GET_SUSTAINABILITY_DATA)
 def test_part_get_sustainability_data(
-        tc, input_kwargs, exp_oldest, exp_delta,
-        dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+        tc, input_kwargs, exp_oldest, exp_delta, dpm_mode_cpcs):
+    # pylint: disable=unused-argument
     """
     Test for Partition.get_sustainability_data(...)
     """
@@ -805,9 +793,8 @@ TESTCASES_PART_ATTACH_DETACH_NETWORK_LINK = [
     "desc, type, number_of_nics, nic_property_list",
     TESTCASES_PART_ATTACH_DETACH_NETWORK_LINK)
 def test_part_attach_detach_network_link(
-        desc, type, number_of_nics, nic_property_list,
-        dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument,redefined-builtin
+        desc, type, number_of_nics, nic_property_list, dpm_mode_cpcs):
+    # pylint: disable=unused-argument,redefined-builtin
     """
     Test for Partition.attach/detach_network_link()
     """
@@ -927,9 +914,8 @@ TESTCASES_PART_ATTACH_DETACH_CTC_LINK = [
     "desc, num_partitions, num_paths",
     TESTCASES_PART_ATTACH_DETACH_CTC_LINK)
 def test_part_attach_detach_ctc_link(
-        logger, dpm_mode_cpcs,  # noqa: F811
-        desc, num_partitions, num_paths):
-    # pylint: disable=redefined-outer-name,unused-argument,redefined-builtin
+        zhmc_logger, dpm_mode_cpcs, desc, num_partitions, num_paths):
+    # pylint: disable=unused-argument
     """
     Test for Partition.attach/detach_ctc_link()
     """
@@ -939,7 +925,7 @@ def test_part_attach_detach_ctc_link(
     for cpc in dpm_mode_cpcs:
         assert cpc.dpm_enabled
 
-        logger.debug("Testing with CPC %s", cpc.name)
+        zhmc_logger.debug("Testing with CPC %s", cpc.name)
 
         console = cpc.manager.client.consoles.console
         session = cpc.manager.session
@@ -969,10 +955,12 @@ def test_part_attach_detach_ctc_link(
             # Create the initial partitions for the partition link
             for i in range(0, num_partitions):
                 part_name = f"{TEST_PREFIX}_{i}_{uuid.uuid4().hex}"
-                logger.debug("Preparing properties for creation of initial "
-                             "PL partition %s", part_name)
+                zhmc_logger.debug(
+                    "Preparing properties for creation of initial "
+                    "PL partition %s", part_name)
                 part_props = standard_partition_props(cpc, part_name)
-                logger.debug("Creating initial PL partition %s", part_name)
+                zhmc_logger.debug(
+                    "Creating initial PL partition %s", part_name)
                 part = cpc.partitions.create(part_props)
                 pl_parts.append(part)
 
@@ -992,22 +980,27 @@ def test_part_attach_detach_ctc_link(
                 "partitions": [p.uri for p in pl_parts],
                 "paths": paths,
             }
-            logger.debug("Creating partition link %s", partlink_name)
+            zhmc_logger.debug(
+                "Creating partition link %s", partlink_name)
             partlink = console.partition_links.create(partlink_input_props)
 
-            logger.debug("Partition link after creation (default properties):\n"
-                         "%s", pformat_as_dict(partlink.properties))
+            zhmc_logger.debug(
+                "Partition link after creation (default properties):\n%s",
+                pformat_as_dict(partlink.properties))
             partlink.pull_full_properties()
-            logger.debug("Partition link after creation (full properties):\n"
-                         "%s", pformat_as_dict(partlink.properties))
+            zhmc_logger.debug(
+                "Partition link after creation (full properties):\n%s",
+                pformat_as_dict(partlink.properties))
             assert_ctc_partition_link(partlink, num_paths, num_partitions)
 
             # Create the test partition (to which the PL is attached)
             test_part_name = f"{TEST_PREFIX}_{uuid.uuid4().hex}"
-            logger.debug("Preparing properties for creation of "
-                         "test partition %s", test_part_name)
+            zhmc_logger.debug(
+                "Preparing properties for creation of test partition %s",
+                test_part_name)
             test_part_props = standard_partition_props(cpc, test_part_name)
-            logger.debug("Creating test partition %s", test_part_name)
+            zhmc_logger.debug(
+                "Creating test partition %s", test_part_name)
             test_part = cpc.partitions.create(test_part_props)
 
             # Verify the partition link is not attached.
@@ -1015,15 +1008,17 @@ def test_part_attach_detach_ctc_link(
             attached_pls = test_part.list_attached_partition_links()
             assert len(attached_pls) == 0
 
-            logger.debug("Attaching partition link to test partition")
+            zhmc_logger.debug(
+                "Attaching partition link to test partition")
 
             # The code to be tested
             test_part.attach_ctc_link(partlink)
             num_partitions += 1
 
             partlink.pull_full_properties()
-            logger.debug("Partition link after attach (full properties):\n"
-                         "%s", pformat_as_dict(partlink.properties))
+            zhmc_logger.debug(
+                "Partition link after attach (full properties):\n%s",
+                pformat_as_dict(partlink.properties))
             assert_ctc_partition_link(partlink, num_paths, num_partitions)
 
             # Verify the partition link is now attached.
@@ -1033,15 +1028,17 @@ def test_part_attach_detach_ctc_link(
             attached_pl = attached_pls[0]
             assert attached_pl.uri == partlink.uri
 
-            logger.debug("Detaching partition link from test partition")
+            zhmc_logger.debug(
+                "Detaching partition link from test partition")
 
             # The code to be tested
             test_part.detach_ctc_link(partlink)
             num_partitions -= 1
 
             partlink.pull_full_properties()
-            logger.debug("Partition link after detach (full properties):\n"
-                         "%s", pformat_as_dict(partlink.properties))
+            zhmc_logger.debug(
+                "Partition link after detach (full properties):\n%s",
+                pformat_as_dict(partlink.properties))
             assert_ctc_partition_link(partlink, num_paths, num_partitions)
 
             # Verify the partition link is no longer attached.
@@ -1051,11 +1048,14 @@ def test_part_attach_detach_ctc_link(
 
         finally:
             if partlink:
-                logger.debug("Deleting partition link %s", partlink.name)
+                zhmc_logger.debug(
+                    "Deleting partition link %s", partlink.name)
                 partlink.delete()
             if test_part:
-                logger.debug("Deleting test partition %s", test_part.name)
+                zhmc_logger.debug(
+                    "Deleting test partition %s", test_part.name)
                 test_part.delete()
             for part in pl_parts:
-                logger.debug("Deleting initial PL partition %s", part.name)
+                zhmc_logger.debug(
+                    "Deleting initial PL partition %s", part.name)
                 part.delete()

--- a/tests/end2end/test_partition_link.py
+++ b/tests/end2end/test_partition_link.py
@@ -28,10 +28,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     skipif_no_partition_link_feature, runtest_find_list, \
@@ -96,8 +92,7 @@ def replace_expressions(obj, replacements):
         'smc-d',
         'ctc'
     ])
-def test_partlink_find_list(dpm_mode_cpcs, pl_type):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_partlink_find_list(dpm_mode_cpcs, pl_type):
     """
     Test list(), find(), findall().
     """
@@ -138,8 +133,7 @@ def test_partlink_find_list(dpm_mode_cpcs, pl_type):  # noqa: F811
         'smc-d',
         'ctc'
     ])
-def test_partlink_property(dpm_mode_cpcs, pl_type):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_partlink_property(dpm_mode_cpcs, pl_type):
     """
     Test property related methods
     """
@@ -181,8 +175,7 @@ def test_partlink_property(dpm_mode_cpcs, pl_type):  # noqa: F811
         'smc-d',
         'ctc'
     ])
-def test_partlink_crud(dpm_mode_cpcs, pl_type):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_partlink_crud(dpm_mode_cpcs, pl_type):
     """
     Test create, read, update and delete a partition link.
     """
@@ -386,9 +379,9 @@ PARTLINK_CREATE_DELETE_TESTCASES = [
     "desc, pl_type, input_props, exp_props, exp_exc_type",
     PARTLINK_CREATE_DELETE_TESTCASES)
 def test_partlink_create_delete(
-        dpm_mode_cpcs,  # noqa: F811
+        dpm_mode_cpcs,
         desc, pl_type, input_props, exp_props, exp_exc_type):
-    # pylint: disable=redefined-outer-name, exec-used, unused-argument
+    # pylint: disable=unused-argument
     """
     Test creation of a partition link (and deletion, for cleanup)
     """
@@ -500,8 +493,7 @@ def test_partlink_create_delete(
                 console.partition_links.find(name=partlink_name)
 
 
-def test_partlink_zzz_cleanup(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name, exec-used, unused-argument
+def test_partlink_zzz_cleanup(dpm_mode_cpcs):
     """
     Cleanup any created partitions and partition links that may have not been
     cleaned up by the other testcase functions.

--- a/tests/end2end/test_password_rule.py
+++ b/tests/end2end/test_password_rule.py
@@ -25,9 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     runtest_find_list, runtest_get_properties
@@ -44,8 +41,7 @@ PWRULE_LIST_PROPS = ['element-uri', 'name', 'type']
 PWRULE_VOLATILE_PROPS = []
 
 
-def test_pwrule_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_pwrule_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -75,8 +71,7 @@ def test_pwrule_find_list(hmc_session):  # noqa: F811
             PWRULE_LIST_PROPS)
 
 
-def test_pwrule_property(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_pwrule_property(hmc_session):
     """
     Test property related methods
     """
@@ -107,8 +102,7 @@ def test_pwrule_property(hmc_session):  # noqa: F811
         runtest_get_properties(pwrule.manager, non_list_prop)
 
 
-def test_pwrule_crud(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_pwrule_crud(hmc_session):
     """
     Test create, read, update and delete a password rule.
     """

--- a/tests/end2end/test_port.py
+++ b/tests/end2end/test_port.py
@@ -25,10 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     runtest_find_list, runtest_get_properties
@@ -45,8 +41,7 @@ PORT_LIST_PROPS = ['element-uri', 'name', 'description']
 PORT_VOLATILE_PROPS = []
 
 
-def test_port_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_port_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -80,8 +75,7 @@ def test_port_find_list(dpm_mode_cpcs):  # noqa: F811
                 PORT_VOLATILE_PROPS, PORT_MINIMAL_PROPS, PORT_LIST_PROPS)
 
 
-def test_port_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_port_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -117,8 +111,7 @@ def test_port_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(port.manager, non_list_prop)
 
 
-def test_port_update(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_port_update(dpm_mode_cpcs):
     """
     Test updating the port of a Hipersocket adapter.
     """
@@ -130,7 +123,7 @@ def test_port_update(dpm_mode_cpcs):  # noqa: F811
 
         print(f"Testing on CPC {cpc.name}")
 
-        adapter_name = TEST_PREFIX + ' test_adapter_crud adapter1'
+        adapter_name = TEST_PREFIX + ' test_port_update adapter1'
 
         # Ensure a clean starting point for this test
         try:

--- a/tests/end2end/test_storage_group.py
+++ b/tests/end2end/test_storage_group.py
@@ -25,10 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     skipif_no_storage_mgmt_feature, runtest_find_list, runtest_get_properties
@@ -46,8 +42,7 @@ STOGRP_LIST_PROPS = ['object-uri', 'cpc-uri', 'name', 'fulfillment-state',
 STOGRP_VOLATILE_PROPS = []
 
 
-def test_stogrp_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stogrp_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -78,8 +73,7 @@ def test_stogrp_find_list(dpm_mode_cpcs):  # noqa: F811
                 STOGRP_LIST_PROPS)
 
 
-def test_stogrp_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stogrp_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -110,8 +104,7 @@ def test_stogrp_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(stogrp.manager, non_list_prop)
 
 
-def test_stogrp_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stogrp_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a storage group.
     """

--- a/tests/end2end/test_storage_group_template.py
+++ b/tests/end2end/test_storage_group_template.py
@@ -25,10 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     skipif_no_storage_mgmt_feature, runtest_find_list, runtest_get_properties
@@ -47,8 +43,7 @@ STOGRPTPL_LIST_PROPS = ['object-uri', 'cpc-uri', 'name', 'type']
 STOGRPTPL_VOLATILE_PROPS = []
 
 
-def test_stogrptpl_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stogrptpl_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -80,8 +75,7 @@ def test_stogrptpl_find_list(dpm_mode_cpcs):  # noqa: F811
                 STOGRPTPL_MINIMAL_PROPS, STOGRPTPL_LIST_PROPS)
 
 
-def test_stogrptpl_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stogrptpl_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -114,8 +108,7 @@ def test_stogrptpl_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(stogrptpl.manager, non_list_prop)
 
 
-def test_stogrptpl_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stogrptpl_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a storage group template.
     """

--- a/tests/end2end/test_storage_volume.py
+++ b/tests/end2end/test_storage_volume.py
@@ -25,10 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     skipif_no_storage_mgmt_feature, runtest_find_list, runtest_get_properties
@@ -46,8 +42,7 @@ STOVOL_LIST_PROPS = ['element-uri', 'name', 'fulfillment-state', 'size',
 STOVOL_VOLATILE_PROPS = []
 
 
-def test_stovol_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stovol_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -93,8 +88,7 @@ def test_stovol_find_list(dpm_mode_cpcs):  # noqa: F811
                 unique_name=unique_name)
 
 
-def test_stovol_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stovol_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -141,8 +135,7 @@ def test_stovol_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(stovol.manager, non_list_prop)
 
 
-def test_stovol_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stovol_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a storage volume in a storage group.
     """

--- a/tests/end2end/test_storage_volume_template.py
+++ b/tests/end2end/test_storage_volume_template.py
@@ -25,10 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     skipif_no_storage_mgmt_feature, runtest_find_list, runtest_get_properties
@@ -45,8 +41,7 @@ STOVOLTPL_LIST_PROPS = ['element-uri', 'name', 'size', 'usage']
 STOVOLTPL_VOLATILE_PROPS = []
 
 
-def test_stovoltpl_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stovoltpl_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -85,8 +80,7 @@ def test_stovoltpl_find_list(dpm_mode_cpcs):  # noqa: F811
                 STOVOLTPL_MINIMAL_PROPS, STOVOLTPL_LIST_PROPS)
 
 
-def test_stovoltpl_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stovoltpl_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -126,8 +120,7 @@ def test_stovoltpl_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(stovoltpl.manager, non_list_prop)
 
 
-def test_stovoltpl_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_stovoltpl_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a storage volume template in a storage
     group template.

--- a/tests/end2end/test_task.py
+++ b/tests/end2end/test_task.py
@@ -22,9 +22,6 @@ These tests do not change any existing tasks.
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, runtest_find_list, \
     runtest_get_properties
@@ -41,8 +38,7 @@ TASK_LIST_PROPS = ['element-uri', 'name']
 TASK_VOLATILE_PROPS = []
 
 
-def test_task_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_task_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -70,8 +66,7 @@ def test_task_find_list(hmc_session):  # noqa: F811
             TASK_VOLATILE_PROPS, TASK_MINIMAL_PROPS, TASK_LIST_PROPS)
 
 
-def test_task_property(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_task_property(hmc_session):
     """
     Test property related methods
     """

--- a/tests/end2end/test_user.py
+++ b/tests/end2end/test_user.py
@@ -25,9 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     runtest_find_list, runtest_get_properties
@@ -44,8 +41,7 @@ USER_LIST_PROPS = ['object-uri', 'name', 'type']
 USER_VOLATILE_PROPS = []
 
 
-def test_user_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_user_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -75,8 +71,7 @@ def test_user_find_list(hmc_session):  # noqa: F811
             USER_LIST_PROPS)
 
 
-def test_user_property(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_user_property(hmc_session):
     """
     Test property related methods
     """
@@ -107,8 +102,7 @@ def test_user_property(hmc_session):  # noqa: F811
         runtest_get_properties(user.manager, non_list_prop)
 
 
-def test_user_crud(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_user_crud(hmc_session):
     """
     Test create, read, update and delete a user.
     """

--- a/tests/end2end/test_user_pattern.py
+++ b/tests/end2end/test_user_pattern.py
@@ -25,9 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     runtest_find_list, runtest_get_properties
@@ -44,8 +41,7 @@ UPATT_LIST_PROPS = ['element-uri', 'name', 'type']
 UPATT_VOLATILE_PROPS = []
 
 
-def test_upatt_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_upatt_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -75,8 +71,7 @@ def test_upatt_find_list(hmc_session):  # noqa: F811
             UPATT_LIST_PROPS)
 
 
-def test_upatt_property(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_upatt_property(hmc_session):
     """
     Test property related methods
     """
@@ -107,8 +102,7 @@ def test_upatt_property(hmc_session):  # noqa: F811
         runtest_get_properties(upatt.manager, non_list_prop)
 
 
-def test_upatt_crud(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_upatt_crud(hmc_session):
     """
     Test create, read, update and delete a user pattern.
     """

--- a/tests/end2end/test_user_role.py
+++ b/tests/end2end/test_user_role.py
@@ -25,9 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     runtest_find_list, runtest_get_properties
@@ -44,8 +41,7 @@ UROLE_LIST_PROPS = ['object-uri', 'name', 'type']
 UROLE_VOLATILE_PROPS = []
 
 
-def test_urole_find_list(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_urole_find_list(hmc_session):
     """
     Test list(), find(), findall().
     """
@@ -75,8 +71,7 @@ def test_urole_find_list(hmc_session):  # noqa: F811
             UROLE_LIST_PROPS)
 
 
-def test_urole_property(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_urole_property(hmc_session):
     """
     Test property related methods
     """
@@ -107,8 +102,7 @@ def test_urole_property(hmc_session):  # noqa: F811
         runtest_get_properties(urole.manager, non_list_prop)
 
 
-def test_urole_crud(hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_urole_crud(hmc_session):
     """
     Test create, read, update and delete a user role.
     """

--- a/tests/end2end/test_virtual_function.py
+++ b/tests/end2end/test_virtual_function.py
@@ -25,10 +25,6 @@ import pytest
 from requests.packages import urllib3
 
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 
 from .utils import skip_warn, pick_test_resources, TEST_PREFIX, \
     standard_partition_props, runtest_find_list, runtest_get_properties
@@ -46,8 +42,7 @@ VFUNC_LIST_PROPS = ['element-uri', 'name', 'description']
 VFUNC_VOLATILE_PROPS = []
 
 
-def test_vfunc_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_vfunc_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -82,8 +77,7 @@ def test_vfunc_find_list(dpm_mode_cpcs):  # noqa: F811
                 VFUNC_LIST_PROPS)
 
 
-def test_vfunc_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_vfunc_property(dpm_mode_cpcs):
     """
     Test property related methods
     """
@@ -119,8 +113,7 @@ def test_vfunc_property(dpm_mode_cpcs):  # noqa: F811
             runtest_get_properties(vfunc.manager, non_list_prop)
 
 
-def test_vfunc_crud(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_vfunc_crud(dpm_mode_cpcs):
     """
     Test create, read, update and delete a virtual function (and a partition).
     """

--- a/tests/end2end/test_virtual_storage_resource.py
+++ b/tests/end2end/test_virtual_storage_resource.py
@@ -22,11 +22,6 @@ These tests do not change any existing VSRs.
 import pytest
 from requests.packages import urllib3
 
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
-
 from .utils import skip_warn, pick_test_resources, \
     skipif_no_storage_mgmt_feature, runtest_find_list, runtest_get_properties
 
@@ -46,8 +41,7 @@ VSR_LIST_PROPS = ['element-uri', 'name', 'device-number', 'adapter-port-uri',
 VSR_VOLATILE_PROPS = []
 
 
-def test_vsr_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_vsr_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -84,8 +78,7 @@ def test_vsr_find_list(dpm_mode_cpcs):  # noqa: F811
                 unique_name=True)
 
 
-def test_vsr_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_vsr_property(dpm_mode_cpcs):
     """
     Test property related methods
     """

--- a/tests/end2end/test_virtual_switch.py
+++ b/tests/end2end/test_virtual_switch.py
@@ -22,11 +22,6 @@ These tests do not change any existing virtual switches.
 import pytest
 from requests.packages import urllib3
 
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
-from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
-
 from .utils import skip_warn, pick_test_resources, runtest_find_list, \
     runtest_get_properties
 
@@ -45,8 +40,7 @@ VSWITCH_ADDITIONAL_PROPS = ['description', 'port']
 VSWITCH_VOLATILE_PROPS = []
 
 
-def test_vswitch_find_list(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_vswitch_find_list(dpm_mode_cpcs):
     """
     Test list(), find(), findall().
     """
@@ -76,8 +70,7 @@ def test_vswitch_find_list(dpm_mode_cpcs):  # noqa: F811
                 VSWITCH_LIST_PROPS, VSWITCH_ADDITIONAL_PROPS)
 
 
-def test_vswitch_property(dpm_mode_cpcs):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_vswitch_property(dpm_mode_cpcs):
     """
     Test property related methods
     """

--- a/tests/end2end/testutils/test_hmc_session_functions.py
+++ b/tests/end2end/testutils/test_hmc_session_functions.py
@@ -21,9 +21,6 @@ from requests.packages import urllib3
 import zhmcclient
 import zhmcclient.mock
 
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
 from zhmcclient.testutils import setup_hmc_session, teardown_hmc_session_id, \
     teardown_hmc_session, is_valid_hmc_session_id
 
@@ -33,8 +30,7 @@ urllib3.disable_warnings()
 @pytest.mark.parametrize(
     "teardown", ['session', 'session_id']
 )
-def test_session_setup(hmc_definition, teardown):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_session_setup(hmc_definition, teardown):
     """
     Test setup_hmc_session().
     """
@@ -59,8 +55,7 @@ def test_session_setup(hmc_definition, teardown):  # noqa: F811
 @pytest.mark.parametrize(
     "teardown", ['session', 'session_id']
 )
-def test_session_valid_session(hmc_definition, teardown):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_session_valid_session(hmc_definition, teardown):
     """
     Test is_valid_hmc_session_id() with a valid session.
     """
@@ -80,8 +75,7 @@ def test_session_valid_session(hmc_definition, teardown):  # noqa: F811
             teardown_hmc_session_id(hmc_definition, session.session_id)
 
 
-def test_session_invalid_session(hmc_definition):  # noqa: F811
-    # pylint: disable=redefined-outer-name
+def test_session_invalid_session(hmc_definition):
     """
     Test is_valid_hmc_session_id() with an invalid session.
     """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,10 +24,6 @@ Example use in a pytest test function that invokes a (hypothetical) method
 
 .. code-block:: python
 
-    from tests.common.http_mocked_fixtures import http_mocked_session
-    from tests.common.http_mocked_fixtures import http_mocked_cpc_dpm
-
-
     def test_cpc_xyz(http_mocked_cpc_dpm):
 
         uri = http_mocked_cpc_dpm.uri + '/operations/xyz'
@@ -45,16 +41,21 @@ Example use in a pytest test function that invokes a (hypothetical) method
             assert result == ...
 """
 
+import logging
+
 import pytest
 import requests_mock
+from testfixtures import LogCapture
+
 import zhmcclient
 
 
 @pytest.fixture(
     scope='module'
 )
-def http_mocked_session(request):  # noqa: F811
+def http_mocked_session(request):
     # pylint: disable=unused-argument
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
     Pytest fixture representing a HTTP-mocked zhmcclient session that is logged
     on.
@@ -97,8 +98,9 @@ def http_mocked_session(request):  # noqa: F811
 @pytest.fixture(
     scope='module'
 )
-def http_mocked_cpc_dpm(request, http_mocked_session):  # noqa: F811
+def http_mocked_cpc_dpm(request, http_mocked_session):
     # pylint: disable=unused-argument,redefined-outer-name
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
     Pytest fixture representing a HTTP-mocked CPC in DPM mode.
 
@@ -132,8 +134,9 @@ def http_mocked_cpc_dpm(request, http_mocked_session):  # noqa: F811
 @pytest.fixture(
     scope='module'
 )
-def http_mocked_cpc_classic(request, http_mocked_session):  # noqa: F811
+def http_mocked_cpc_classic(request, http_mocked_session):
     # pylint: disable=unused-argument,redefined-outer-name
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
     Pytest fixture representing a HTTP-mocked CPC in classic mode.
 
@@ -167,8 +170,9 @@ def http_mocked_cpc_classic(request, http_mocked_session):  # noqa: F811
 @pytest.fixture(
     scope='module'
 )
-def http_mocked_lpar(request, http_mocked_cpc_classic):  # noqa: F811
+def http_mocked_lpar(request, http_mocked_cpc_classic):
     # pylint: disable=unused-argument,redefined-outer-name
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
     Pytest fixture representing a HTTP-mocked LPAR on a CPC in classic mode.
 
@@ -200,8 +204,9 @@ def http_mocked_lpar(request, http_mocked_cpc_classic):  # noqa: F811
 @pytest.fixture(
     scope='module'
 )
-def http_mocked_partition(request, http_mocked_cpc_dpm):  # noqa: F811
+def http_mocked_partition(request, http_mocked_cpc_dpm):
     # pylint: disable=unused-argument,redefined-outer-name
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
     Pytest fixture representing a HTTP-mocked Partition on a CPC in DPM mode.
 
@@ -233,8 +238,9 @@ def http_mocked_partition(request, http_mocked_cpc_dpm):  # noqa: F811
 @pytest.fixture(
     scope='module'
 )
-def http_mocked_console(request, http_mocked_session):  # noqa: F811
+def http_mocked_console(request, http_mocked_session):
     # pylint: disable=unused-argument,redefined-outer-name
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
     Pytest fixture representing a HTTP-mocked HMC console.
 
@@ -274,3 +280,17 @@ def http_mocked_console(request, http_mocked_session):  # noqa: F811
         console = consoles[0]
 
     return console
+
+
+@pytest.fixture()
+def zhmc_capture():
+    # Note: The first paragraph is shown by 'pytest --fixtures'
+    """
+    Pytest fixture that wraps testfixtures.LogCapture.
+
+    This way of defining a fixture works around the issue that when
+    using the decorator testfixtures.log_capture() instead, pytest
+    fails with "fixture 'capture' not found".
+    """
+    with LogCapture(level=logging.DEBUG) as log:
+        yield log

--- a/tests/unit/zhmcclient/test_cpc.py
+++ b/tests/unit/zhmcclient/test_cpc.py
@@ -27,11 +27,6 @@ from zhmcclient._cpc import _drop_unused_adapters_and_resources
 from zhmcclient.mock import FakedSession
 from tests.common.utils import assert_resources
 
-# pylint: disable=unused-import
-from tests.common.http_mocked_fixtures import http_mocked_session  # noqa: F401
-from tests.common.http_mocked_fixtures import http_mocked_cpc_dpm  # noqa: F401
-# pylint: enable=unused-import
-
 # Names of our faked Consoles:
 # Default console (z13)
 CONSOLE_Z13_NAME = 'console-z13'
@@ -2194,8 +2189,7 @@ class TestCpc:
     # TODO: Test for Cpc.validate_lun_path()
 
 
-def test_cpc_swap_cts(http_mocked_cpc_dpm):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def test_cpc_swap_cts(http_mocked_cpc_dpm):
     """
     Test function for Cpc.swap_current_time_server()
     """
@@ -2222,8 +2216,7 @@ def test_cpc_swap_cts(http_mocked_cpc_dpm):  # noqa: F811
         assert result is None
 
 
-def test_cpc_set_stp_config(http_mocked_cpc_dpm):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def test_cpc_set_stp_config(http_mocked_cpc_dpm):
     """
     Test function for Cpc.set_stp_config()
     """
@@ -2271,8 +2264,7 @@ def test_cpc_set_stp_config(http_mocked_cpc_dpm):  # noqa: F811
         assert result is None
 
 
-def test_cpc_change_stp_id(http_mocked_cpc_dpm):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def test_cpc_change_stp_id(http_mocked_cpc_dpm):
     """
     Test function for Cpc.change_stp_id()
     """
@@ -2299,8 +2291,7 @@ def test_cpc_change_stp_id(http_mocked_cpc_dpm):  # noqa: F811
         assert result is None
 
 
-def test_cpc_join_ctn(http_mocked_cpc_dpm):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def test_cpc_join_ctn(http_mocked_cpc_dpm):
     """
     Test function for Cpc.join_ctn()
     """
@@ -2327,8 +2318,7 @@ def test_cpc_join_ctn(http_mocked_cpc_dpm):  # noqa: F811
         assert result is None
 
 
-def test_cpc_leave_ctn(http_mocked_cpc_dpm):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def test_cpc_leave_ctn(http_mocked_cpc_dpm):
     """
     Test function for Cpc.leave_ctn()
     """
@@ -2458,10 +2448,10 @@ TESTCASES_CPC_INSTALL_AND_ACTIVATE = [
     "exp_exc_type",
     TESTCASES_CPC_INSTALL_AND_ACTIVATE)
 def test_cpc_install_and_activate(
-        http_mocked_cpc_dpm,  # noqa: F811
+        http_mocked_cpc_dpm,
         desc, input_kwargs, exp_request_body, response_status, response_body,
         exp_exc_type):
-    # pylint: disable=redefined-outer-name,unused-argument
+    # pylint: disable=unused-argument
     """
     Test function for Cpc.install_and_activate()
     """
@@ -2555,10 +2545,10 @@ TESTCASES_CPC_DELETE_RETRIEVED_INTERNAL_CODE = [
     "exp_exc_type",
     TESTCASES_CPC_DELETE_RETRIEVED_INTERNAL_CODE)
 def test_delete_retrieved_internal_code(
-        http_mocked_cpc_dpm,  # noqa: F811
+        http_mocked_cpc_dpm,
         desc, input_kwargs, exp_request_body, response_status, response_body,
         exp_exc_type):
-    # pylint: disable=redefined-outer-name,unused-argument
+    # pylint: disable=unused-argument
     """
     Test function for Cpc.delete_retrieved_internal_code()
     """

--- a/tests/unit/zhmcclient/test_logging.py
+++ b/tests/unit/zhmcclient/test_logging.py
@@ -20,7 +20,6 @@ Unit tests for _logging module.
 import re
 import logging
 import pytest
-from testfixtures import LogCapture
 
 from zhmcclient._logging import logged_api_call, get_logger
 from zhmcclient._constants import BLANKED_OUT_STRING
@@ -148,17 +147,6 @@ _EXP_LOG_MSG_ENTER_PATTERN = "Called: (.*), args: (.*), kwargs: (.*)"
 _EXP_LOG_MSG_LEAVE_PATTERN = "Return: (.*), result: (.*)"
 
 
-@pytest.fixture()
-def capture():
-    """
-    This way of defining a fixture works around the issue that when
-    using the decorator testfixtures.log_capture() instead, pytest
-    fails with "fixture 'capture' not found".
-    """
-    with LogCapture(level=logging.DEBUG) as log:
-        yield log
-
-
 #
 # Test cases
 #
@@ -194,7 +182,7 @@ def assert_log_capture(
         assert re.search(return_pattern, return_str)
 
 
-def test_1a_global_from_global(capture):
+def test_1a_global_from_global(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated global function from a global
     function."""
@@ -202,20 +190,20 @@ def test_1a_global_from_global(capture):
     call_from_global(decorated_global_function)
 
     assert_log_capture(
-        capture, func_pattern='decorated_global_function')
+        zhmc_capture, func_pattern='decorated_global_function')
 
 
-def test_1b_global_from_method(capture):
+def test_1b_global_from_method(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated global function from a method."""
 
     CallerClass().call_from_method(decorated_global_function)
 
     assert_log_capture(
-        capture, func_pattern='decorated_global_function')
+        zhmc_capture, func_pattern='decorated_global_function')
 
 
-def test_1c_global_props_args_from_global(capture):
+def test_1c_global_props_args_from_global(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated global function with properties as args,
     from a global function."""
@@ -230,12 +218,12 @@ def test_1c_global_props_args_from_global(capture):
     call_from_global(decorated_global_props_function, props)
 
     assert_log_capture(
-        capture, func_pattern='decorated_global_props_function',
+        zhmc_capture, func_pattern='decorated_global_props_function',
         args_pattern=re.escape(str(blanked_props)),
         return_pattern=re.escape(str(props)))
 
 
-def test_1c_global_props_kwargs_from_global(capture):
+def test_1c_global_props_kwargs_from_global(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated global function with properties as
     kwargs, from a global function."""
@@ -244,10 +232,10 @@ def test_1c_global_props_kwargs_from_global(capture):
                      properties={'prop1': 'value1'})
 
     assert_log_capture(
-        capture, func_pattern='decorated_global_props_function')
+        zhmc_capture, func_pattern='decorated_global_props_function')
 
 
-def test_2a_global_inner1_from_global(capture):
+def test_2a_global_inner1_from_global(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated inner function defined in a global
     function from a global function."""
@@ -257,10 +245,10 @@ def test_2a_global_inner1_from_global(capture):
     call_from_global(decorated_inner1_function)
 
     assert_log_capture(
-        capture, func_pattern='global1_function.decorated_inner1_function')
+        zhmc_capture, func_pattern='global1_function.decorated_inner1_function')
 
 
-def test_2b_global_inner1_from_method(capture):
+def test_2b_global_inner1_from_method(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated inner function defined in a global
     function from a method."""
@@ -270,10 +258,10 @@ def test_2b_global_inner1_from_method(capture):
     CallerClass().call_from_method(decorated_inner1_function)
 
     assert_log_capture(
-        capture, func_pattern='global1_function.decorated_inner1_function')
+        zhmc_capture, func_pattern='global1_function.decorated_inner1_function')
 
 
-def test_3a_global_inner2_from_global(capture):
+def test_3a_global_inner2_from_global(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated inner function defined in an inner
     function defined in a global function from a global function."""
@@ -283,10 +271,10 @@ def test_3a_global_inner2_from_global(capture):
     call_from_global(decorated_inner2_function)
 
     assert_log_capture(
-        capture, func_pattern='inner1_function.decorated_inner2_function')
+        zhmc_capture, func_pattern='inner1_function.decorated_inner2_function')
 
 
-def test_3b_global_inner1_from_method(capture):
+def test_3b_global_inner1_from_method(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated inner function defined in an inner
     function defined in a global function from a method."""
@@ -296,10 +284,10 @@ def test_3b_global_inner1_from_method(capture):
     CallerClass().call_from_method(decorated_inner2_function)
 
     assert_log_capture(
-        capture, func_pattern='inner1_function.decorated_inner2_function')
+        zhmc_capture, func_pattern='inner1_function.decorated_inner2_function')
 
 
-def test_4a_method_from_global(capture):
+def test_4a_method_from_global(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated method from a global function."""
 
@@ -309,10 +297,10 @@ def test_4a_method_from_global(capture):
     call_from_global(decorated_method, d)
 
     assert_log_capture(
-        capture, func_pattern='Decorator1Class.decorated_method')
+        zhmc_capture, func_pattern='Decorator1Class.decorated_method')
 
 
-def test_4b_method_from_method(capture):
+def test_4b_method_from_method(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated method from a method."""
 
@@ -322,10 +310,10 @@ def test_4b_method_from_method(capture):
     CallerClass().call_from_method(decorated_method, d)
 
     assert_log_capture(
-        capture, func_pattern='Decorator1Class.decorated_method')
+        zhmc_capture, func_pattern='Decorator1Class.decorated_method')
 
 
-def test_5a_method_from_global(capture):
+def test_5a_method_from_global(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated inner function defined in a method
     from a global function."""
@@ -336,10 +324,10 @@ def test_5a_method_from_global(capture):
     call_from_global(decorated_inner_function)
 
     assert_log_capture(
-        capture, func_pattern='method.decorated_inner_function')
+        zhmc_capture, func_pattern='method.decorated_inner_function')
 
 
-def test_5b_method_from_method(capture):
+def test_5b_method_from_method(zhmc_capture):
     # pylint: disable=redefined-outer-name
     """Simple test calling a decorated inner function defined in a method
     from a method."""
@@ -350,7 +338,7 @@ def test_5b_method_from_method(capture):
     CallerClass().call_from_method(decorated_inner_function)
 
     assert_log_capture(
-        capture, func_pattern='method.decorated_inner_function')
+        zhmc_capture, func_pattern='method.decorated_inner_function')
 
 
 def test_decorated_class():

--- a/tests/unit/zhmcclient/test_lpar.py
+++ b/tests/unit/zhmcclient/test_lpar.py
@@ -29,12 +29,6 @@ from zhmcclient.mock import FakedSession, LparActivateHandler, \
     LparDeactivateHandler, LparLoadHandler
 from tests.common.utils import assert_resources, assert_blanked_in_message
 
-# pylint: disable=unused-import,line-too-long
-from tests.common.http_mocked_fixtures import http_mocked_session  # noqa: F401
-from tests.common.http_mocked_fixtures import http_mocked_cpc_classic  # noqa: F401,E501
-from tests.common.http_mocked_fixtures import http_mocked_lpar  # noqa: F401
-# pylint: enable=unused-import,line-too-long
-
 
 # Object IDs and names of our faked LPARs:
 LPAR1_OID = 'lpar1-oid'
@@ -1536,8 +1530,7 @@ class TestLpar:
         assert_resources(lpars, exp_faked_lpars, prop_names)
 
 
-def test_lpar_start(http_mocked_lpar):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def test_lpar_start(http_mocked_lpar):
     """
     Test function for Lpar.start()
     """
@@ -1568,8 +1561,7 @@ def test_lpar_start(http_mocked_lpar):  # noqa: F811
         assert result_job.op_uri == exp_result_job.op_uri
 
 
-def test_lpar_stop(http_mocked_lpar):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def test_lpar_stop(http_mocked_lpar):
     """
     Test function for Lpar.stop()
     """
@@ -1604,8 +1596,7 @@ def test_lpar_stop(http_mocked_lpar):  # noqa: F811
     # TODO: Test for Lpar.reset_normal()
 
 
-def test_lpar_load_from_ftp(http_mocked_lpar):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def test_lpar_load_from_ftp(http_mocked_lpar):
     """
     Test function for Lpar.load_from_ftp()
     """

--- a/tests/unit/zhmcclient/test_os_console.py
+++ b/tests/unit/zhmcclient/test_os_console.py
@@ -23,15 +23,8 @@ import websocket
 from zhmcclient import OSConsole, Partition, OSConsoleConnectedError, \
     OSConsoleNotConnectedError
 
-# pylint: disable=unused-import,line-too-long
-from tests.common.http_mocked_fixtures import http_mocked_session  # noqa: F401
-from tests.common.http_mocked_fixtures import http_mocked_cpc_dpm  # noqa: F401
-from tests.common.http_mocked_fixtures import http_mocked_partition  # noqa: F401,E501
-# pylint: enable=unused-import,line-too-long
 
-
-def test_osc_initial_attrs(http_mocked_partition):  # noqa: F811
-    # pylint: disable=redefined-outer-name, unused-argument
+def test_osc_initial_attrs(http_mocked_partition):
     """Test initial attributes of OSConsole."""
 
     ws_timeout = 42
@@ -54,8 +47,8 @@ def test_osc_initial_attrs(http_mocked_partition):  # noqa: F811
 @mock.patch('websocket.WebSocket')
 def test_osc_connect(
         websocket_mock, create_os_websocket_mock,
-        http_mocked_partition):  # noqa: F811
-    # pylint: disable=redefined-outer-name, unused-argument
+        http_mocked_partition):
+    # pylint: disable=unused-argument
     """All tests for OSConsole.connect/disconnect/is_connected()."""
 
     create_os_websocket_mock.return_value = '/api/websocket/fake-ws1'
@@ -149,9 +142,9 @@ LPAR_OSC_RECV_ALL_TESTCASES = [
 @mock.patch('websocket.WebSocket')
 def test_osc_recv_all(
         websocket_mock, create_os_websocket_mock,
-        http_mocked_partition,  # noqa: F811
+        http_mocked_partition,
         desc, connected, recv_chunks, exp_data, exp_exc_type):
-    # pylint: disable=redefined-outer-name, unused-argument
+    # pylint: disable=unused-argument
     """All tests for OSConsole.recv_all()."""
 
     create_os_websocket_mock.return_value = '/api/websocket/fake-ws1'
@@ -276,9 +269,9 @@ LPAR_OSC_RECV_LINE_TESTCASES = [
 @mock.patch('websocket.WebSocket')
 def test_osc_recv_line(
         websocket_mock, create_os_websocket_mock,
-        http_mocked_partition,  # noqa: F811
+        http_mocked_partition,
         desc, connected, recv_chunks, exp_call_count, exp_data, exp_exc_type):
-    # pylint: disable=redefined-outer-name, unused-argument
+    # pylint: disable=unused-argument
     """All tests for OSConsole.recv_line()."""
 
     create_os_websocket_mock.return_value = '/api/websocket/fake-ws1'
@@ -359,9 +352,9 @@ LPAR_OSC_SEND_TESTCASES = [
 @mock.patch('websocket.WebSocket')
 def test_osc_send(
         websocket_mock, create_os_websocket_mock,
-        http_mocked_partition,  # noqa: F811
+        http_mocked_partition,
         desc, connected, send_data, exp_exc_type):
-    # pylint: disable=redefined-outer-name, unused-argument
+    # pylint: disable=unused-argument
     """All tests for OSConsole.send()."""
 
     create_os_websocket_mock.return_value = '/api/websocket/fake-ws1'
@@ -438,9 +431,9 @@ LPAR_OSC_EXEC_CMD_TESTCASES = [
 @mock.patch('websocket.WebSocket')
 def test_osc_exec_cmd(
         websocket_mock, create_os_websocket_mock,
-        http_mocked_partition,  # noqa: F811
+        http_mocked_partition,
         desc, connected, command, output, exp_exc_type):
-    # pylint: disable=redefined-outer-name, unused-argument
+    # pylint: disable=unused-argument
     """All tests for OSConsole.execute_command()."""
 
     create_os_websocket_mock.return_value = '/api/websocket/fake-ws1'

--- a/zhmcclient/mock/_urihandler.py
+++ b/zhmcclient/mock/_urihandler.py
@@ -3471,6 +3471,7 @@ class AdaptersHandler:
         # Create the VirtualSwitch for the new adapter
         vs_props = {
             'name': new_adapter.name,
+            'description': f"vswitch for {new_adapter.name}",
             'type': 'hipersockets',
             'backing-adapter-uri': new_adapter.uri,
             'port': 0,

--- a/zhmcclient/testutils/_cpc_fixtures.py
+++ b/zhmcclient/testutils/_cpc_fixtures.py
@@ -20,11 +20,7 @@ Pytest fixtures for CPCs.
 import pytest
 
 from .. import Client
-
-# pylint: disable=unused-import
-from ._hmc_definition_fixtures import hmc_session  # noqa: F401
 from ._hmc_inventory_file import HMCInventoryFileError
-
 
 __all__ = ['all_cpcs', 'dpm_mode_cpcs', 'classic_mode_cpcs']
 
@@ -46,89 +42,117 @@ def fixtureid_cpcs(fixture_value):
 
 
 @pytest.fixture(
-    scope='module',
+    scope='session',
     ids=fixtureid_cpcs
 )
-def all_cpcs(request, hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def all_cpcs(request, hmc_session):
+    # pylint: disable=unused-argument
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
-    Pytest fixture representing the set of all CPCs to test against, regardless
+    Pytest fixture that provides access to the CPCs to test against, regardless
     of their operational mode.
 
-    The set of CPCs to test against is defined in the ``cpcs`` variable in the
+    The CPCs to test against is defined in the ``cpcs`` variable in the
     HMC entry in the :ref:`HMC inventory file`; if that variable is omitted, it
     is the set of all managed CPCs.
-
-    A test function parameter with the name of this fixture resolves to a list
-    of :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
-    objects have the "short" set of properties from :meth:`zhmcclient.Cpc.list`.
 
     The test function is invoked just once with the list of CPCs, and the
     test function needs to loop through the CPCs (or a subset).
 
-    Because the `hmc_session` parameter of this fixture is again a fixture,
-    the :func:`zhmcclient.testutils.hmc_session`
-    function needs to be imported as well when this fixture is used.
+    The HMC is selected via the ``TESTHMC`` environment variable when running
+    pytest. If the selected HMC is a group in the HMC inventory file, the test
+    function is called once for each HMC. For details, see
+    :ref:`Running end2end tests`.
+
+    This fixture has a scope of "session", so the same HMC session is reused
+    across all test modules for the complete pytest run.
+
+    This fixture is provided in the 'zhmcclient' Python package as a pytest
+    plugin, so it is globally known to pytest and can be used without importing
+    it.
+
+    Returns:
+
+      list of :class:`zhmcclient.Cpc`: The CPCs to test against.
+      These objects have the "short" set of properties from
+      :meth:`zhmcclient.Cpc.list`.
     """
     return defined_cpcs(hmc_session, 'any')
 
 
 @pytest.fixture(
-    scope='module',
+    scope='session',
     ids=fixtureid_cpcs
 )
-def dpm_mode_cpcs(request, hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def dpm_mode_cpcs(request, hmc_session):
+    # pylint: disable=unused-argument
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
-    Pytest fixture representing the set of CPCs in DPM mode to test against.
+    Pytest fixture that provides access to the CPCs in DPM mode to test against.
 
-    The set of CPCs to test against is the subset of all CPCs to be tested that
-    is in DPM mode.
-
-    The set of all CPCs to be tested is defined in the ``cpcs`` variable in the
-    HMC entry in the :ref:`HMC inventory file`; if that variable is omitted, it
-    is the set of all managed CPCs.
-
-    A test function parameter with the name of this fixture resolves to a list
-    of :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
-    objects have the "short" set of properties from :meth:`zhmcclient.Cpc.list`.
+    The CPCs in DPM mode to test against is defined as list items in the
+    ``cpcs`` variable in the HMC entry in the :ref:`HMC inventory file`, where
+    the ``dpm_enabled`` property of the item is set to true.
 
     The test function is invoked just once with the list of CPCs, and the
     test function needs to loop through the CPCs (or a subset).
 
-    Because the `hmc_session` parameter of this fixture is again a fixture,
-    the :func:`zhmcclient.testutils.hmc_session`
-    function needs to be imported as well when this fixture is used.
+    The HMC is selected via the ``TESTHMC`` environment variable when running
+    pytest. If the selected HMC is a group in the HMC inventory file, the test
+    function is called once for each HMC. For details, see
+    :ref:`Running end2end tests`.
+
+    This fixture has a scope of "session", so the same HMC session is reused
+    across all test modules for the complete pytest run.
+
+    This fixture is provided in the 'zhmcclient' Python package as a pytest
+    plugin, so it is globally known to pytest and can be used without importing
+    it.
+
+    Returns:
+
+      list of :class:`zhmcclient.Cpc`: The CPCs in DPM mode to test against.
+      These objects have the "short" set of properties from
+      :meth:`zhmcclient.Cpc.list`.
     """
     return defined_cpcs(hmc_session, 'dpm')
 
 
 @pytest.fixture(
-    scope='module',
+    scope='session',
     ids=fixtureid_cpcs
 )
-def classic_mode_cpcs(request, hmc_session):  # noqa: F811
-    # pylint: disable=redefined-outer-name,unused-argument
+def classic_mode_cpcs(request, hmc_session):
+    # pylint: disable=unused-argument
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
-    Pytest fixture representing the set of CPCs in classic mode to test against.
+    Pytest fixture that provides access to the CPCs in classic mode to test
+    against.
 
-    The set of CPCs to test against is the subset of all CPCs to be tested that
-    is in classic mode.
-
-    The set of all CPCs to be tested is defined in the ``cpcs`` variable in the
-    HMC entry in the :ref:`HMC inventory file`; if that variable is omitted, it
-    is the set of all managed CPCs.
-
-    A test function parameter with the name of this fixture resolves to a list
-    of :class:`zhmcclient.Cpc` objects representing that set of CPCs. These
-    objects have the "short" set of properties from :meth:`zhmcclient.Cpc.list`.
+    The CPCs in classic mode to test against is defined as list items in
+    the ``cpcs`` variable in the HMC entry in the :ref:`HMC inventory file`,
+    where the ``dpm_enabled`` property of the item is omitted or set to false.
 
     The test function is invoked just once with the list of CPCs, and the
     test function needs to loop through the CPCs (or a subset).
 
-    Because the `hmc_session` parameter of this fixture is again a fixture,
-    the :func:`zhmcclient.testutils.hmc_session`
-    function needs to be imported as well when this fixture is used.
+    The HMC is selected via the ``TESTHMC`` environment variable when running
+    pytest. If the selected HMC is a group in the HMC inventory file, the test
+    function is called once for each HMC. For details, see
+    :ref:`Running end2end tests`.
+
+    This fixture has a scope of "session", so the same HMC session is reused
+    across all test modules for the complete pytest run.
+
+    This fixture is provided in the 'zhmcclient' Python package as a pytest
+    plugin, so it is globally known to pytest and can be used without importing
+    it.
+
+    Returns:
+
+      list of :class:`zhmcclient.Cpc`: The CPCs in classic mode to test against.
+      These objects have the "short" set of properties from
+      :meth:`zhmcclient.Cpc.list`.
     """
     return defined_cpcs(hmc_session, 'classic')
 

--- a/zhmcclient/testutils/_hmc_definition_fixtures.py
+++ b/zhmcclient/testutils/_hmc_definition_fixtures.py
@@ -51,46 +51,59 @@ def fixtureid_hmc_definition(fixture_value):
 
 @pytest.fixture(
     params=hmc_definitions(load=None),
-    scope='module',
+    scope='session',
     ids=fixtureid_hmc_definition
 )
 def hmc_definition(request):
+    # pylint: disable=unused-argument
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
-    Pytest fixture representing the set of HMC definitions to use for a test.
+    Pytest fixture that provides an HMC definition from the HMC inventory file.
 
-    A test function parameter with the name of this fixture resolves to the
-    :class:`~zhmcclient.testutils.HMCDefinition`
-    object of each HMC to test against.
+    The HMC is selected via the ``TESTHMC`` environment variable when running
+    pytest. If the selected HMC is a group in the HMC inventory file, the test
+    function is called once for each HMC. For details, see
+    :ref:`Running end2end tests`.
 
-    The test function is called once for each HMC, if the targeted HMC is a
-    group.
+    Returns:
+
+      :class:`~zhmcclient.testutils.HMCDefinition`: The HMC definition from the
+      HMC inventory file for the HMC to test against.
     """
     return request.param
 
 
 @pytest.fixture(
-    scope='module'
+    scope='session'
 )
 def hmc_session(request, hmc_definition):
     # pylint: disable=redefined-outer-name,unused-argument
+    # Note: The first paragraph is shown by 'pytest --fixtures'
     """
-    Pytest fixture representing the set of HMC sessions to run a test against.
+    Pytest fixture that provides a logged-on HMC session to an HMC defined in
+    the HMC inventory file.
 
-    A test function parameter with the name of this fixture resolves to the
-    :class:`zhmcclient.Session` or :class:`zhmcclient.mock.FakedSession` object
-    for each HMC to test against.
+    The HMC is selected via the ``TESTHMC`` environment variable when running
+    pytest. If the selected HMC is a group in the HMC inventory file, the test
+    function is called once for each HMC. For details, see
+    :ref:`Running end2end tests`.
 
-    The session is already logged on to the HMC.
+    Upon fixture teardown, the session is logged off from the HMC.
 
-    The session object has an additional property named ``hmc_definition``
-    that is the :class:`~zhmcclient.testutils.HMCDefinition` object for the
-    corresponding HMC definition in the :ref:`HMC inventory file`.
+    This fixture has a scope of "session", so the same HMC session is reused
+    across all test modules for the complete pytest run.
 
-    Because the `hmc_definition` parameter of this fixture is again a fixture,
-    the :func:`zhmcclient.testutils.hmc_definition` function needs to be
-    imported as well when this fixture is used.
+    This fixture is provided in the 'zhmcclient' Python package as a pytest
+    plugin, so it is globally known to pytest and can be used without importing
+    it.
 
-    Upon fixture teardown, the session is automatically logged off from the HMC.
+    Returns:
+
+      :class:`zhmcclient.Session` or :class:`zhmcclient.mock.FakedSession`:
+      A logged-on session to the HMC to test against.
+      The session object has an additional property named ``hmc_definition``
+      that is the :class:`~zhmcclient.testutils.HMCDefinition` object for the
+      corresponding HMC definition in the :ref:`HMC inventory file`.
     """
     session = setup_hmc_session(hmc_definition)
     yield session


### PR DESCRIPTION
For details, see the commit message.

This is the PR that depends on a number of the recent PRs.

The number of HMC sessions created during the end2end tests was reduced from 595 to 15:
```
$ rm -f test_session.log
$ TESTHMC=A28 TESTLOGFILE=test_session.log make end2end
$ grep "Logging on" test_session.log | wc -l
15
```