### PR TITLE
Ensure that tests use local files; Document test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ uninstall:
 clobber: clean
 	-$(call RM_FUNC,$(dist_files))
 	-$(call RM_R_FUNC,*.done)
-	-$(call RMDIR_FUNC,$(doc_build_dir) htmlcov htmlcov.end2end .tox)
+	-$(call RMDIR_FUNC,$(doc_build_dir) htmlcov .tox)
 	@echo "Makefile: $@ done."
 
 .PHONY: clean
@@ -672,8 +672,7 @@ endif
 
 .PHONY: test
 test: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_unit_py_files) $(test_common_py_files) $(pytest_cov_files)
-	-$(call RMDIR_R_FUNC,htmlcov)
-	pytest --color=yes $(pytest_no_log_opt) -s $(test_dir)/unit $(pytest_cov_opts) $(pytest_opts)
+	bash -c "PYTHONPATH=. pytest --color=yes $(pytest_no_log_opt) -s $(test_dir)/unit $(pytest_cov_opts) $(pytest_opts)"
 	@echo "Makefile: $@ done."
 
 .PHONY: installtest
@@ -688,15 +687,13 @@ endif
 
 .PHONY:	end2end
 end2end: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(pytest_cov_files)
-	-$(call RMDIR_R_FUNC,htmlcov.end2end)
-	bash -c "TESTEND2END_LOAD=true pytest --color=yes $(pytest_no_log_opt) -v -s $(test_dir)/end2end $(pytest_cov_opts) $(pytest_opts)"
+	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true pytest --color=yes $(pytest_no_log_opt) -v -s $(test_dir)/end2end $(pytest_cov_opts) $(pytest_opts)"
 	@echo "Makefile: $@ done."
 
 # TODO: Enable rc checking again once the remaining issues are resolved
 .PHONY:	end2end_mocked
 end2end_mocked: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(pytest_cov_files) tests/end2end/mocked_inventory.yaml tests/end2end/mocked_vault.yaml tests/end2end/mocked_hmc_z16.yaml
-	-$(call RMDIR_R_FUNC,htmlcov.end2end)
-	bash -c "TESTEND2END_LOAD=true TESTINVENTORY=tests/end2end/mocked_inventory.yaml TESTVAULT=tests/end2end/mocked_vault.yaml pytest --color=yes $(pytest_no_log_opt) -v -s $(test_dir)/end2end $(pytest_cov_opts) $(pytest_opts)"
+	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true TESTINVENTORY=tests/end2end/mocked_inventory.yaml TESTVAULT=tests/end2end/mocked_vault.yaml pytest --color=yes $(pytest_no_log_opt) -v -s $(test_dir)/end2end $(pytest_cov_opts) $(pytest_opts)"
 	@echo "Makefile: $@ done."
 
 .PHONY: authors
@@ -716,4 +713,4 @@ AUTHORS.md: _always
 
 .PHONY:	end2end_show
 end2end_show:
-	bash -c "TESTEND2END_LOAD=true $(PYTHON_CMD) -c 'from zhmcclient.testutils import print_hmc_definitions; print_hmc_definitions()'"
+	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true $(PYTHON_CMD) -c 'from zhmcclient.testutils import print_hmc_definitions; print_hmc_definitions()'"

--- a/changes/noissue.testlocal.1.feature.rst
+++ b/changes/noissue.testlocal.1.feature.rst
@@ -1,0 +1,5 @@
+Test: Added test modules 'test__import_local.py' to the unit and end2end
+tests which verify that the 'zhmcclient' modules are imported from the local
+directory. Documented in chapter "Testing" that the zhmcclient modules are
+imported from the local directory, even when the zhmcclient package is
+installed in the Python environment.

--- a/changes/noissue.testlocal.2.feature.rst
+++ b/changes/noissue.testlocal.2.feature.rst
@@ -1,0 +1,2 @@
+Docs: Added a chapter "Test coverage" to the development section, which
+describes how test coverage is traced and reported.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -119,6 +119,9 @@ To run the unit tests in the currently active Python environment, issue:
 
     $ make test
 
+The unit tests import the zhmcclient modules from the local directory, even
+when the zhmcclient package is installed in the Python environment.
+
 By default, all unit tests are run. The ``TESTCASES`` environment variable can
 be used to limit the testcases that are run. Its value is passed to the ``-k``
 option of the ``pytest`` command.
@@ -179,6 +182,9 @@ To run the end2end tests in the currently active Python environment, issue:
 
     $ make end2end
 
+The end2end tests import the zhmcclient modules from the local directory, even
+when the zhmcclient package is installed in the Python environment.
+
 By default, the HMC inventory file named ``.zhmc_inventory.yaml`` in
 the home directory of the current user is used. A different path name can
 be specified with the ``TESTINVENTORY`` environment variable.
@@ -231,6 +237,9 @@ These mock environments can be used to run the end2end tests against, by executi
 
     $ make end2end_mocked
 
+The end2end tests import the zhmcclient modules from the local directory, even
+when the zhmcclient package is installed in the Python environment.
+
 
 .. _`Enabling logging during end2end tests`:
 
@@ -270,6 +279,27 @@ or, shorter:
 .. code-block:: text
 
     $ export ZHMC_LOG=all=debug
+
+
+.. _`Test coverage`:
+
+Test coverage
+^^^^^^^^^^^^^
+
+When unit or end2end tests are run locally, the pytest-cov plugin of pytest
+traces coverage data and adds that to the local ``.coverage`` file. Each test
+run adds data to that file.
+
+At the end of a test run, pytest creates a HMTL formatted coverage report in
+the ``htmlcov`` directory. That report contains the data from the ``.coverage``
+file, and thus represents all prior test runs since that file was created.
+If you want to see just the coverage caused by a single test run, remove
+the ``.coverage`` file manually, or run ``make clean``.
+
+When the tests are run in GitHub Actions, the same mechanism is used, and in
+addition the coverage data is reported to
+https://coveralls.io/github/zhmcclient/python-zhmcclient. The PR is updated
+with a comment linking to the coveralls.io data for the PR.
 
 
 .. _`HMC inventory file`:

--- a/tests/end2end/test__import_local.py
+++ b/tests/end2end/test__import_local.py
@@ -1,0 +1,32 @@
+# Copyright 2025 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test that zhmcclient is imported from the local file system.
+"""
+
+
+import os
+import zhmcclient
+
+
+def test_import_local():
+    """
+    Test that zhmcclient is imported from the local file system.
+    """
+    my_dir = os.path.dirname(__file__)
+    exp_zhmcclient_dir = os.path.abspath(
+        os.path.join(my_dir, '..', '..', 'zhmcclient'))
+    zhmcclient_dir = os.path.abspath(os.path.dirname(zhmcclient.__file__))
+    assert zhmcclient_dir == exp_zhmcclient_dir

--- a/tests/unit/test__import_local.py
+++ b/tests/unit/test__import_local.py
@@ -1,0 +1,32 @@
+# Copyright 2025 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test that zhmcclient is imported from the local file system.
+"""
+
+
+import os
+import zhmcclient
+
+
+def test_import_local():
+    """
+    Test that zhmcclient is imported from the local file system.
+    """
+    my_dir = os.path.dirname(__file__)
+    exp_zhmcclient_dir = os.path.abspath(
+        os.path.join(my_dir, '..', '..', 'zhmcclient'))
+    zhmcclient_dir = os.path.abspath(os.path.dirname(zhmcclient.__file__))
+    assert zhmcclient_dir == exp_zhmcclient_dir


### PR DESCRIPTION
For details, see the commit message.

I wanted to have the ensurance for local files because during the development of PR #2016, the files were partly not imported locally.