### PR TITLE
1.24: Fixed pip backtracking on coverage package

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -50,9 +50,9 @@ pluggy>=1.3.0
 #   Python>=3.13.
 # Note: The earlier repetition of pinnings to avoid pip backtracking no longer
 #       seems to be needed.
-coverage>=7.6.1; python_version == '3.8'
-coverage>=7.8.0; python_version >= '3.9' and python_version <= '3.12'
-coverage>=6.5.0; python_version >= '3.13'
+coverage>=7.6.1,<8.0; python_version == '3.8'
+coverage>=7.8.0,<8.0; python_version >= '3.9' and python_version <= '3.12'
+coverage>=6.5.0,<7.0; python_version >= '3.13'
 pytest-cov>=2.7.0
 coveralls>=4.0.1; python_version <= '3.12'
 coveralls>=3.3.0; python_version >= '3.13'


### PR DESCRIPTION
Rolls back PR #2024 into 1.24.