### PR TITLE
Reduced the platforms on which 'make doclinkcheck' runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -312,7 +312,8 @@ jobs:
         RUN_TYPE: ${{ steps.set-run-type.outputs.result }}
       run: |
         make bandit
-    - name: Run doclinkcheck
+    - name: Run doclinkcheck (only on ubuntu-latest, 3.14, latest)
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' && matrix.package_level == 'latest'
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
         RUN_TYPE: ${{ steps.set-run-type.outputs.result }}

--- a/changes/noissue.doclinkcheck.feature.rst
+++ b/changes/noissue.doclinkcheck.feature.rst
@@ -1,0 +1,3 @@
+Test: Reduced the platforms on which 'make doclinkcheck' runs to just
+Ubuntu, Python 3.14 and latest package levels, to run less often into
+the rate limiting of some sites that are being checked.


### PR DESCRIPTION
No review needed.