### PR TITLE
1.24: Fixed name length issue in end2end tests

### DIFF
--- a/changes/2014.fix.rst
+++ b/changes/2014.fix.rst
@@ -1,0 +1,2 @@
+Test: Fixed the issue with partition link name exceeding a length of 64
+in the end2end test function test_partlink_create_delete().

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -33,7 +33,7 @@ from zhmcclient.testutils import LOG_FORMAT_STRING, LOG_DATETIME_FORMAT, \
     LOG_DATETIME_TIMEZONE
 
 # Prefix used for names of resources that are created during tests
-TEST_PREFIX = 'zhmcclient_tests_end2end'
+TEST_PREFIX = 'zhmcclient_e2e'
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Rolls back PR #2037 into 1.24.