### PR TITLE
examples/install_from_ftp: align license with project

### DIFF
--- a/examples/install_from_ftp.py
+++ b/examples/install_from_ftp.py
@@ -4,7 +4,7 @@
 #
 #   Copyright Red Hat
 #
-#   SPDX-License-Identifier: GPL-2.0
+#   SPDX-License-Identifier: Apache-2.0
 #
 #   Author: Sebastian Mitterle <smitterl@redhat.com>
 


### PR DESCRIPTION
The file was accidentally licensed differently from the rest of the code. Use the same license for this script.