### PR TITLE
1.24: examples/install_from_ftp: align license with project (#2040)

### DIFF
--- a/examples/install_from_ftp.py
+++ b/examples/install_from_ftp.py
@@ -4,7 +4,7 @@
 #
 #   Copyright Red Hat
 #
-#   SPDX-License-Identifier: GPL-2.0
+#   SPDX-License-Identifier: Apache-2.0
 #
 #   Author: Sebastian Mitterle <smitterl@redhat.com>
 


### PR DESCRIPTION
Rolls back PR #2040 into 1.24.