### PR TITLE
1.24: Support for PEP-639 license

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -7,6 +7,6 @@
 
 pip>=25.0; python_version == '3.8'
 pip>=25.2; python_version >= '3.9'
-setuptools>=70.0.0
+setuptools>=77.0.3
 setuptools-scm[toml]>=9.2.0
 wheel>=0.41.3

--- a/changes/2053.cleanup.rst
+++ b/changes/2053.cleanup.rst
@@ -1,0 +1,2 @@
+Used new license format defined in PEP 639 to accommodate upcoming removal
+of support for old format.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -9,7 +9,7 @@
 
 pip==25.0; python_version == '3.8'
 pip==25.2; python_version >= '3.9'
-setuptools==70.0.0
+setuptools==77.0.3
 # Note on not specifying 'setuptools-scm[toml]': Extras cannot be in constraints files
 setuptools-scm==9.2.0
 wheel==0.41.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 requires = [
     # Keep in sync with base-requirements.txt and the base dependencies in
     # minimum-constraints-install.txt
-    "setuptools>=70.0.0",
+    "setuptools>=77.0.3",
     "setuptools-scm[toml]>=9.2.0",
     "wheel>=0.41.3"
 ]
@@ -38,10 +38,11 @@ maintainers = [
     {name = "Kathir Velusamy", email = "kathir.velu@in.ibm.com'"}
 ]
 readme = "README.md"
-license = {text = "Apache License, Version 2.0"}
+# License info in new PEP 639 format (since setuptools 77.0.3)
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 keywords = ["hmc", "client"]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",


### PR DESCRIPTION
Rolls back PR #2056 into 1.24.