### PR TITLE
1.25: Reduced commit line length checking to be done just during pull request creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
         accessToken: ${{ secrets.GITHUB_TOKEN }}
         error: Commit message has no or incorrectly formatted signed-off-by line
     - name: Check commit messages - Line length
-      if: github.event_name != 'schedule'
+      if: github.event_name == 'pull_request'
       uses: gsactions/commit-message-checker@v2
       with:
         pattern: '^.{1,80}\n\n(.{0,80}\n)*.{0,80}$'


### PR DESCRIPTION
Rolls back PR #2095 into 1.25.