### PR TITLE
Improved checking for sensitive properties in logs

### DIFF
--- a/changes/noissue.24.feature.rst
+++ b/changes/noissue.24.feature.rst
@@ -1,0 +1,2 @@
+Improved checking for sensitive properties in logs to reduce maintenance
+effort.

--- a/tests/unit/zhmcclient/test_logging.py
+++ b/tests/unit/zhmcclient/test_logging.py
@@ -162,7 +162,7 @@ def assert_log_capture(
     enter_record = log_capture.records[0]
     assert enter_record.name == _EXP_LOGGER_NAME
     assert enter_record.levelname == _EXP_LOG_LEVEL
-    assert re.match(_EXP_LOG_MSG_ENTER_PATTERN, enter_record.msg)
+    assert re.match(_EXP_LOG_MSG_ENTER_PATTERN, enter_record.getMessage())
     func_str, args_str, kwargs_str = enter_record.args
     if func_pattern:
         assert re.search(func_pattern, func_str)
@@ -174,7 +174,7 @@ def assert_log_capture(
     leave_record = log_capture.records[1]
     assert leave_record.name == _EXP_LOGGER_NAME
     assert leave_record.levelname == _EXP_LOG_LEVEL
-    assert re.match(_EXP_LOG_MSG_LEAVE_PATTERN, leave_record.msg)
+    assert re.match(_EXP_LOG_MSG_LEAVE_PATTERN, leave_record.getMessage())
     func_str, return_str = leave_record.args
     if func_pattern:
         assert re.search(func_pattern, func_str)

--- a/zhmcclient/_activation_profile.py
+++ b/zhmcclient/_activation_profile.py
@@ -225,8 +225,7 @@ class ActivationProfileManager(BaseManager):
             list_uri, result_prop, full_properties, filter_args,
             additional_properties)
 
-    @logged_api_call(blanked_properties=['ssc-master-pw', 'zaware-master-pw'],
-                     properties_pos=1)
+    @logged_api_call
     def create(self, properties):
         """
         Create and configure an Activation Profiles on this CPC, of the profile
@@ -346,8 +345,7 @@ class ActivationProfile(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call(blanked_properties=['ssc-master-pw', 'zaware-master-pw'],
-                     properties_pos=1)
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this Activation Profile.

--- a/zhmcclient/_constants.py
+++ b/zhmcclient/_constants.py
@@ -23,6 +23,8 @@ For technical reasons, the online documentation shows these constants in the
 ``zhmcclient`` namespace and should be used from there.
 """
 
+import re
+
 __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'DEFAULT_CONNECT_RETRIES',
            'DEFAULT_HMC_PORT',
@@ -52,7 +54,9 @@ __all__ = ['DEFAULT_CONNECT_TIMEOUT',
            'HTML_REASON_OTHER',
            'STOMP_MIN_CONNECTION_CHECK_TIME',
            'DEFAULT_WS_TIMEOUT',
-           'BLANKED_OUT_STRING']
+           'BLANKED_OUT_STRING',
+           'BLANKED_OUT_PROPERTY_PATTERN',
+           'BLANKED_OUT_PROPERTY_REPLACE']
 
 
 #: Default HMC port number
@@ -210,3 +214,14 @@ DEFAULT_WS_TIMEOUT = 5
 #: Replacement string for blanked out sensitive values in log entries, such as
 #: passwords or session tokens.
 BLANKED_OUT_STRING = '********'
+
+#: Regexp pattern for properties in the JSON or dict representation string that
+#: contains sensitive data and will be blanked out in any logs.
+BLANKED_OUT_PROPERTY_PATTERN = re.compile(
+    r"""(['"])"""
+    r"""([^'"]*(authentication-code|credential|key|passcode|password|pw"""
+    r"""|secret|session))"""
+    r"""\1\s*:\s*('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|None|null)""")
+
+#: The replacement string corresponding to the regexp pattern.
+BLANKED_OUT_PROPERTY_REPLACE = rf"\1\2\1: \1{BLANKED_OUT_STRING}\1"

--- a/zhmcclient/_ldap_server_definition.py
+++ b/zhmcclient/_ldap_server_definition.py
@@ -152,7 +152,7 @@ class LdapServerDefinitionManager(BaseManager):
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
-    @logged_api_call(blanked_properties=['bind-password'], properties_pos=1)
+    @logged_api_call
     def create(self, properties):
         """
         Create a new LDAP Server Definition in this HMC.
@@ -258,7 +258,7 @@ class LdapServerDefinition(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call(blanked_properties=['bind-password'], properties_pos=1)
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this LDAP Server Definitions.

--- a/zhmcclient/_logging.py
+++ b/zhmcclient/_logging.py
@@ -73,12 +73,14 @@ Examples:
       logging.basicConfig(format=format_string, level=logging.DEBUG)
 """
 
+import re
 import logging
 import inspect
 import functools
 from collections.abc import Mapping, Sequence
 
-from ._constants import API_LOGGER_NAME, BLANKED_OUT_STRING
+from ._constants import API_LOGGER_NAME, BLANKED_OUT_STRING, \
+    BLANKED_OUT_PROPERTY_PATTERN, BLANKED_OUT_PROPERTY_REPLACE
 
 __all__ = []
 
@@ -114,6 +116,8 @@ def logged_api_call(
 
     The logger's name is the dotted module name of the module defining the
     decorated function (e.g. 'zhmcclient._cpc').
+
+    The values of sensitive properties will be blanked out.
 
     Parameters:
 
@@ -277,22 +281,43 @@ def logged_api_call(
                         blanked_dict(args[properties_pos])
             return tuple(logged_args), logged_kwargs
 
+        def log_repr(obj, name, trunc):
+            """
+            Return a Python repr() representation of the object, with
+            sensitive properties blanked out.
+            """
+            obj_str = log_escaped(repr(obj))
+            obj_str = re.sub(BLANKED_OUT_PROPERTY_PATTERN,
+                             BLANKED_OUT_PROPERTY_REPLACE, obj_str)
+            obj_len = len(obj_str)
+            if obj_len > trunc > 0:
+                obj_str = (f"{name} (first {trunc} B of {obj_len} B): "
+                           f"{obj_str[0:trunc]} ...(truncated)")
+            else:
+                obj_str = f"{name}: {obj_str}"
+            return obj_str
+
         def log_call(args, kwargs):
             """
             Log the call to the API function.
             """
-            logged_args, logged_kwargs = blanked_args(args, kwargs)
-            logger.debug("Called: %s, args: %.500s, kwargs: %.500s",
-                         apifunc_str,
-                         log_escaped(repr(logged_args)),
-                         log_escaped(repr(logged_kwargs)))
+            trunc = 500
+            # We are calling log_trunc() also on args, because their values
+            # (in theory) may contain dicts with sensitive properties.
+            _args, _kwargs = blanked_args(args, kwargs)
+            args_str = log_repr(_args, "args", trunc)
+            kwargs_str = log_repr(_kwargs, "kwargs", trunc)
+            logger.debug("Called: %s, %s, %s",
+                         apifunc_str, args_str, kwargs_str)
 
         def log_return(result):
             """
             Log the return from the API function.
             """
-            logger.debug("Return: %s, result: %.1000s",
-                         apifunc_str, log_escaped(repr(result)))
+            trunc = 1000
+            result_str = log_repr(result, "result", trunc)
+            logger.debug("Return: %s, %s",
+                         apifunc_str, result_str)
 
         @functools.wraps(func)
         def log_api_call(*args, **kwargs):

--- a/zhmcclient/_lpar.py
+++ b/zhmcclient/_lpar.py
@@ -188,8 +188,7 @@ class Lpar(BaseResource):
             f"got {type(manager)}")
         super().__init__(manager, uri, name, properties)
 
-    @logged_api_call(blanked_properties=['ssc-master-pw', 'zaware-master-pw'],
-                     properties_pos=1)
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this LPAR.

--- a/zhmcclient/_mfa_server_definition.py
+++ b/zhmcclient/_mfa_server_definition.py
@@ -152,7 +152,7 @@ class MfaServerDefinitionManager(BaseManager):
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
-    @logged_api_call(blanked_properties=['bind-password'], properties_pos=1)
+    @logged_api_call
     def create(self, properties):
         """
         Create a new MFA Server Definition in this HMC.
@@ -258,7 +258,7 @@ class MfaServerDefinition(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call(blanked_properties=['bind-password'], properties_pos=1)
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this MFA Server Definitions.

--- a/zhmcclient/_partition.py
+++ b/zhmcclient/_partition.py
@@ -178,8 +178,7 @@ class PartitionManager(BaseManager):
             list_uri, result_prop, full_properties, filter_args,
             additional_properties)
 
-    @logged_api_call(blanked_properties=['boot-ftp-password', 'ssc-master-pw'],
-                     properties_pos=1)
+    @logged_api_call
     def create(self, properties):
         """
         Create and configure a Partition in this CPC.
@@ -703,8 +702,7 @@ class Partition(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call(blanked_properties=['boot-ftp-password', 'ssc-master-pw'],
-                     properties_pos=1)
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this Partition.

--- a/zhmcclient/_session.py
+++ b/zhmcclient/_session.py
@@ -20,6 +20,7 @@ Session class: A session to the HMC, optionally in context of an HMC user.
 import json
 import time
 import re
+import logging
 from copy import copy
 from collections.abc import Iterable
 import requests
@@ -38,7 +39,8 @@ from ._constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_CONNECT_RETRIES, \
     DEFAULT_OPERATION_TIMEOUT, DEFAULT_STATUS_TIMEOUT, \
     DEFAULT_NAME_URI_CACHE_TIMETOLIVE, DEFAULT_LOG_CONTENT_TRUNCATE, \
     HMC_LOGGER_NAME, HTML_REASON_WEB_SERVICES_DISABLED, HTML_REASON_OTHER, \
-    DEFAULT_HMC_PORT, BLANKED_OUT_STRING
+    DEFAULT_HMC_PORT, BLANKED_OUT_STRING, BLANKED_OUT_PROPERTY_PATTERN, \
+    BLANKED_OUT_PROPERTY_REPLACE
 from ._utils import repr_obj_id
 from ._version import __version__
 
@@ -52,15 +54,6 @@ _STD_HEADERS = {
     'Content-type': 'application/json',
     'Accept': '*/*'
 }
-
-# Properties whose values are always blanked out in the HMC log entries
-BLANKED_OUT_PROPERTIES = [
-    'boot-ftp-password',    # partition create/update
-    'bind-password',        # LDAP server def. create/update
-    'ssc-master-pw',        # image profile cr/upd, part. cr/upd, LPAR upd
-    'password',             # user create/update
-    'zaware-master-pw',     # image profile create/update, LPAR update
-]
 
 # Name of the HMC property indicating internal inconsistencies
 IMPLEMENTATION_ERRORS_PROP = "@@implementation-errors"
@@ -961,6 +954,8 @@ class Session:
         """
         Log the HTTP request of an HMC REST API call, at the debug level.
 
+        The values of sensitive properties will be blanked out.
+
         Parameters:
 
           method (:term:`string`): HTTP method name in upper case, e.g. 'GET'
@@ -976,58 +971,52 @@ class Session:
             determining the length from the content string
         """
 
-        content_msg = None
-        if content is not None:
-            if isinstance(content, bytes):
-                content = content.decode('utf-8', errors='ignore')
-            assert isinstance(content, str)
-            if content_len is None:
-                content_len = len(content)  # may change after JSON conversion
-            try:
-                content_dict = json2dict(content)
-            except ValueError:
-                # If the content is not JSON, we assume it does not contain
-                # structured data such as a password or session IDs.
-                pass
-            else:
-                for pname in BLANKED_OUT_PROPERTIES:
-                    if pname in content_dict:
-                        content_dict[pname] = BLANKED_OUT_STRING
-                content = dict2json(content_dict)
-            trunc = self._retry_timeout_config.log_content_truncate
-            if content_len > trunc > 0:
-                content_label = f"content(first {trunc} B of {content_len} B)"
-                content_msg = content[0:trunc] + '...(truncated)'
-            else:
-                content_label = f'content({content_len} B)'
-                content_msg = content
-        else:
-            content_label = 'content'
-            content_msg = content
+        if HMC_LOGGER.isEnabledFor(logging.DEBUG):
 
-        if resource:
-            names = []
-            res_class = resource.manager.class_name
-            while resource:
-                # Using resource.name gets into an infinite recursion when
-                # the resource name is not present, due to pulling the
-                # properties in that case. We take the careful approach.
-                name_prop = resource.manager.name_prop
-                name = resource.properties.get(name_prop, '<unknown>')
-                names.insert(0, name)
-                resource = resource.manager.parent
-            res_str = f" ({res_class} {'.'.join(names)})"
-        else:
-            res_str = ""
+            if content is not None:
+                if isinstance(content, bytes):
+                    content = content.decode('utf-8', errors='ignore')
+                assert isinstance(content, str)
+                # Length may change after conversion to unicode string
+                content_len = len(content)
+                content = re.sub(BLANKED_OUT_PROPERTY_PATTERN,
+                                 BLANKED_OUT_PROPERTY_REPLACE, content)
+                trunc = self._retry_timeout_config.log_content_truncate
+                if content_len > trunc > 0:
+                    content_str = (f"content(first {trunc} B of {content_len} "
+                                   f"B): {repr(content[0:trunc])} "
+                                   "...(truncated)'")
+                else:
+                    content_str = f"content({content_len} B): {repr(content)}"
+            else:
+                content_str = f"content: {repr(content)}"
 
-        HMC_LOGGER.debug("Request: %s %s%s, headers: %r, %s: %r",
-                         method, url, res_str, _headers_for_logging(headers),
-                         content_label, content_msg)
+            if resource:
+                names = []
+                res_class = resource.manager.class_name
+                while resource:
+                    # Using resource.name gets into an infinite recursion when
+                    # the resource name is not present, due to pulling the
+                    # properties in that case. We take the careful approach.
+                    name_prop = resource.manager.name_prop
+                    name = resource.properties.get(name_prop, '<unknown>')
+                    names.insert(0, name)
+                    resource = resource.manager.parent
+                res_str = f" ({res_class} {'.'.join(names)})"
+            else:
+                res_str = ""
+
+            HMC_LOGGER.debug("Request: %s %s%s, headers: %r, %s",
+                             method, url, res_str,
+                             _headers_for_logging(headers),
+                             content_str)
 
     def _log_http_response(
             self, method, url, resource, status, headers=None, content=None):
         """
         Log the HTTP response of an HMC REST API call, at the debug level.
+
+        The values of sensitive properties will be blanked out.
 
         Parameters:
 
@@ -1043,64 +1032,51 @@ class Session:
             response (byte string or unicode string)
         """
 
-        if content is not None:
-            if isinstance(content, bytes):
-                content = content.decode('utf-8')
-            assert isinstance(content, str)
-            content_len = len(content)  # may change after JSON conversion
-            try:
-                content_dict = json2dict(content)
-            except ValueError:
-                # If the content is not JSON (e.g. response from metrics
-                # context retrieval), we assume it does not contain structured
-                # data such as a password or session IDs.
-                pass
-            else:
-                if 'request-headers' in content_dict:
-                    headers_dict = content_dict['request-headers']
-                    if 'x-api-session' in headers_dict:
-                        headers_dict['x-api-session'] = BLANKED_OUT_STRING
-                if 'api-session' in content_dict:
-                    content_dict['api-session'] = BLANKED_OUT_STRING
-                if 'session-credential' in content_dict:
-                    content_dict['session-credential'] = BLANKED_OUT_STRING
-                content = dict2json(content_dict)
-            if status >= 400:
-                content_label = 'content'
-                content_msg = content
-            else:
-                trunc = self._retry_timeout_config.log_content_truncate
-                if content_len > trunc > 0:
-                    content_label = \
-                        f"content(first {trunc} B of {content_len} B)"
-                    content_msg = content[0:trunc] + '...(truncated)'
+        if HMC_LOGGER.isEnabledFor(logging.DEBUG):
+
+            if content is not None:
+                if isinstance(content, bytes):
+                    content = content.decode('utf-8')
+                assert isinstance(content, str)
+                # Length may change after conversion to unicode string
+                content_len = len(content)
+                content = re.sub(BLANKED_OUT_PROPERTY_PATTERN,
+                                 BLANKED_OUT_PROPERTY_REPLACE, content)
+                if status >= 400:
+                    content_str = f"content: {repr(content)}"
                 else:
-                    content_label = f'content({len(content)} B)'
-                    content_msg = content
-        else:
-            content_label = 'content'
-            content_msg = content
+                    trunc = self._retry_timeout_config.log_content_truncate
+                    if content_len > trunc > 0:
+                        content_str = (f"content(first {trunc} B of "
+                                       f"{content_len} B): "
+                                       f"{repr(content[0:trunc])} "
+                                       "...(truncated)'")
+                    else:
+                        content_str = (f"content({content_len} B): "
+                                       f"{repr(content)}")
+            else:
+                content_str = f"content: {repr(content)}"
 
-        if resource:
-            names = []
-            res_class = resource.manager.class_name
-            while resource:
-                # Using resource.name gets into an infinite recursion when
-                # the resource name is not present, due to pulling the
-                # properties in that case. We take the careful approach.
-                name_prop = resource.manager.name_prop
-                name = resource.properties.get(name_prop, '<unknown>')
-                names.insert(0, name)
-                resource = resource.manager.parent
-            res_str = f" ({res_class} {'.'.join(names)})"
-        else:
-            res_str = ""
+            if resource:
+                names = []
+                res_class = resource.manager.class_name
+                while resource:
+                    # Using resource.name gets into an infinite recursion when
+                    # the resource name is not present, due to pulling the
+                    # properties in that case. We take the careful approach.
+                    name_prop = resource.manager.name_prop
+                    name = resource.properties.get(name_prop, '<unknown>')
+                    names.insert(0, name)
+                    resource = resource.manager.parent
+                res_str = f" ({res_class} {'.'.join(names)})"
+            else:
+                res_str = ""
 
-        HMC_LOGGER.debug("Respons: %s %s%s, status: %s, "
-                         "headers: %r, %s: %r",
-                         method, url, res_str, status,
-                         _headers_for_logging(headers),
-                         content_label, content_msg)
+            HMC_LOGGER.debug("Respons: %s %s%s, status: %s, "
+                             "headers: %r, %s",
+                             method, url, res_str, status,
+                             _headers_for_logging(headers),
+                             content_str)
 
     @logged_api_call
     def get(self, uri, resource=None, logon_required=True, renew_session=True):

--- a/zhmcclient/_sso_server_definition.py
+++ b/zhmcclient/_sso_server_definition.py
@@ -152,7 +152,7 @@ class SSOServerDefinitionManager(BaseManager):
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
-    @logged_api_call(blanked_properties=['client-secret'], properties_pos=1)
+    @logged_api_call
     def create(self, properties):
         """
         Create a new SSO Server Definition in this HMC.
@@ -258,7 +258,7 @@ class SSOServerDefinition(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call(blanked_properties=['client-secret'], properties_pos=1)
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this SSO Server Definitions.

--- a/zhmcclient/_user.py
+++ b/zhmcclient/_user.py
@@ -150,7 +150,7 @@ class UserManager(BaseManager):
         return self._list_with_operation(
             list_uri, result_prop, full_properties, filter_args, None)
 
-    @logged_api_call(blanked_properties=['password'], properties_pos=1)
+    @logged_api_call
     def create(self, properties):
         """
         Create a new User in this HMC.
@@ -257,7 +257,7 @@ class User(BaseResource):
             self.get_properties_local(self.manager._name_prop, None))
         self.cease_existence_local()
 
-    @logged_api_call(blanked_properties=['password'], properties_pos=1)
+    @logged_api_call
     def update_properties(self, properties):
         """
         Update writeable properties of this User.


### PR DESCRIPTION
For details, see the commit message. It is helpful to first read the commit message before reviewing the code.

Does not need to be rolled back to 1.25 because the only newly blanked-out property is `client-secret` in `SSOServerDefinition` which has not yet been released.