### PR TITLE
Support for checking blanked-out sensitive properties in end2end log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ help:
 	@echo "  build             - Build the distribution files in: $(dist_dir)"
 	@echo "  builddoc          - Build documentation in: $(doc_build_dir)"
 	@echo "  all               - Do all of the above"
-	@echo "  end2end           - Run end2end tests (adds to coverage results)"
+	@echo "  end2end           - Run end2end tests (adds to coverage results, checks blanked-out properties in log)"
 	@echo "  end2end_show      - Show HMCs defined for end2end tests"
 	@echo "  end2end_check     - Check access to all HMCs defined in your HMC inventory file for end2end tests"
 	@echo "  authors           - Generate AUTHORS.md file from git log"
@@ -703,8 +703,10 @@ endif
 
 .PHONY:	end2end
 end2end: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(package_py_files) $(test_end2end_py_files) $(test_common_py_files) $(coverage_config_file)
-	bash -c "PYTHONPATH=. TESTEND2END_LOAD=true coverage run --append -m pytest -v -m 'not check_hmcs' $(pytest_general_opts) $(pytest_test_opts) $(test_dir)/end2end"
+	-$(call RM_FUNC,end2end.log)
+	bash -c "PYTHONPATH=. TESTLOGFILE=end2end.log TESTEND2END_LOAD=true coverage run --append -m pytest -v -m 'not check_hmcs' $(pytest_general_opts) $(pytest_test_opts) $(test_dir)/end2end"
 	coverage html
+	tools/check_blanked.py end2end.log
 	@echo "Makefile: $@ done."
 
 # TODO: Enable rc checking again once the remaining issues are resolved

--- a/changes/noissue.25.feature.rst
+++ b/changes/noissue.25.feature.rst
@@ -1,0 +1,3 @@
+Test: Added support for checking blanked-out sensitive properties in the
+zhmcclient log file created during the end2end tests, by adding a new
+script tools/check_blanked.py, and running it during "make end2end".

--- a/tools/check_blanked.py
+++ b/tools/check_blanked.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+"""
+Check that certain properties in the specified zhmcclient log file have a
+blanked-out value.
+"""
+
+import sys
+import re
+import argparse
+from zhmcclient import BLANKED_OUT_STRING
+
+
+# Ends of property names that are checked for being blanked out.
+# Keep in sync with BLANKED_OUT_PROPERTY_PATTERN in zhmcclient/_constants.py.
+PROPERTY_NAME_ENDS = [
+    "authentication-code",
+    "credential",
+    "key",
+    "passcode",
+    "password",
+    "pw",
+    "secret",
+    "session",
+    "Session"
+]
+
+# Pattern for matching a single property name and value
+PROPERTY_PATTERN = re.compile(
+    rf"""(['"])([^'"]*({'|'.join(PROPERTY_NAME_ENDS)}))\1"""
+    r"""\s*:\s*"""
+    r"""('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|None|null)"""
+)
+
+
+def parse_args():
+    """
+    Parse input arguments
+    """
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=f"""
+Check that certain properties in the specified zhmcclient log file have a
+blanked-out value.
+
+The properties that are checked are those whose names end with:
+
+  {'\n  '.join(PROPERTY_NAME_ENDS)}
+
+The following syntax forms for the properties in the file are supported:
+
+  'name': 'value'
+  'name': "value"
+  "name": 'value'
+  "name": "value"
+""")
+
+    parser.add_argument(dest="file", metavar='FILE',
+                        help="Path name of the zhmcclient log file to be "
+                        "checked")
+
+    return parser.parse_args(sys.argv[1:])
+
+
+def main():
+    """
+    Main function
+    """
+    args = parse_args()
+    file = args.file
+    print(f"Checking blanked properties in file: {file}")
+
+    checked_pnames = set()
+    rc = 0
+    with open(file, "r", encoding="utf-8") as fp:
+        for lineno, line in enumerate(fp, start=1):
+            for match in PROPERTY_PATTERN.finditer(line):
+                pname = match.group(2)
+                pvalue = match.group(4).strip('"').strip("'")
+                checked_pnames.add(pname)
+                if pvalue != BLANKED_OUT_STRING:
+                    rc = 1
+                    print(f"{file}({lineno}): Found property {pname!r} with "
+                          f"non-blanked value {pvalue!r}")
+
+    print("The file contains the following blanked properties: "
+          f"{', '.join(checked_pnames)}")
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I have tested this on T224 with a subset of the end2end tests:
```
TESTCASES=test_user.py make end2end
```