### PR TITLE
Exclude stomp-py 8.3.0 from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@
 requests>=2.32.4; python_version == '3.9'
 requests>=2.33.0; python_version >= '3.10'
 
-stomp-py>=8.1.1
+# stomp-py 8.3.0 looks broken
+stomp-py>=8.1.1,<8.3.0
 
 immutabledict>=4.2.0
 nocasedict>=1.0.2


### PR DESCRIPTION
Release 8.3.0 seems to be malfunctioning.