### PR TITLE
1.25: Exclude stomp-py 8.3.0 from dependencies (#2146)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@
 requests>=2.32.4; python_version == '3.9'
 requests>=2.33.0; python_version >= '3.10'
 
-stomp-py>=8.1.1
+# stomp-py 8.3.0 looks broken
+stomp-py>=8.1.1,<8.3.0
 
 immutabledict>=4.2.0
 nocasedict>=1.0.2


### PR DESCRIPTION
Rolls back PR #2146 into 1.25.