### PR TITLE
1.25: Fixed the commit title length check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: gsactions/commit-message-checker@v2
       with:
-        pattern: '^.{1,80}\n\n(.{0,80}\n)*.{0,80}$'
+        pattern: '^.{1,80}( \(#[\d]+\))?\n\n(.{0,80}\n)*.{0,80}$'
         flags: ''
         excludeDescription: true
         excludeTitle: true

--- a/changes/noissue.29.fix.rst
+++ b/changes/noissue.29.fix.rst
@@ -1,0 +1,2 @@
+Fixed the check for the maximum length of the commit message title to
+tolerate squash merges, which add the PR number at the end of the line.


### PR DESCRIPTION
Rolls back PR #2145 into 1.25.