### PR TITLE
1.25: Added changelog entries for dependabot and stomp.py pinning

### DIFF
--- a/changes/noissue.deendabot.fix.rst
+++ b/changes/noissue.deendabot.fix.rst
@@ -1,0 +1,1 @@
+Fixed dependabot issues up to 2026-05-12.

--- a/changes/noissue.stomp.fix.rst
+++ b/changes/noissue.stomp.fix.rst
@@ -1,0 +1,3 @@
+Pinned the version of stomp.py to <8.3.0, because version 8.3.0 caused problems
+with the zhmcclient library, and because version 8.3.0 on Pypi has no
+corresponding changes in the source code repository of stomp.py.


### PR DESCRIPTION
Rolls back PR #2156 into 1.25.