### PR TITLE
1.25: Test: Reduced GitHub Actions test environments (#2189)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,53 +41,18 @@ jobs:
         else \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\" ], \
-            \"python-version\": [ \"3.14\" ], \
+            \"python-version\": [ \"3.9\", \"3.14\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
                 \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.9\", \
+                \"python-version\": \"3.10\", \
                 \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.9\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.12\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.9\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.11\", \
-                \"package_level\": \"latest\" \
               }, \
               { \
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"3.14\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"windows-latest\", \
-                \"python-version\": \"3.9\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"windows-latest\", \
-                \"python-version\": \"3.9\", \
                 \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"windows-latest\", \
-                \"python-version\": \"3.14\", \
-                \"package_level\": \"minimum\" \
               }, \
               { \
                 \"os\": \"windows-latest\", \

--- a/changes/noissue.reducetests.cleanup.rst
+++ b/changes/noissue.reducetests.cleanup.rst
@@ -1,0 +1,1 @@
+Test: Reduced the GitHub Actions test environments to save resources.


### PR DESCRIPTION
Backport PR #2189 to 1.25.