### PR TITLE
1.25: Bump cryptography from 46.0.7 to 48.0.1 (#2192)

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -165,8 +165,9 @@ bleach==3.3.0
 cachetools==5.3.2
 Click==8.0.2
 clint==0.5.1
+commonmark==0.9.1
 configparser==4.0.2
-cryptography==46.0.7  # used by Authlib, which is used by safety
+cryptography==48.0.1  # used by Authlib, which is used by safety
 dataclasses==0.8
 decorator==4.0.11
 defusedxml==0.7.1


### PR DESCRIPTION
Backport PR #2192 into 1.25.