### PR TITLE
1.25: Bump bleach to 6.4.0 on python>=3.10 (#2196)

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -161,7 +161,9 @@ atomicwrites==1.4.0
 backports-abc==0.5
 backports.shutil-get-terminal-size==1.0.0
 backports.ssl-match-hostname==3.5.0.1
-bleach==3.3.0
+# bleach is used by nbconvert (Jupyter notebook)
+bleach==6.2.0; python_version == '3.9'
+bleach==6.4.0; python_version >= '3.10'
 cachetools==5.3.2
 Click==8.0.2
 clint==0.5.1


### PR DESCRIPTION
backport PR #2196 to 1.25.