### PR TITLE
Bump from jupyter_server >=2.10.0 to jupyter_server >=2.20.0 

### DIFF
--- a/changes/37.fix.rst
+++ b/changes/37.fix.rst
@@ -1,0 +1,6 @@
+Bumped ``jupyter_server`` to >=2.20.0 on Python>=3.10 to fix
+CVE-2024-35178 (GHSA-hrw6-wg82-cm62), a path traversal vulnerability
+caused by an incorrect ``startswith()`` root-directory check that
+allowed authenticated users to read, write, and delete files in sibling
+directories sharing a name prefix with the server's ``root_dir``.
+Also documented this Dependabot alert pattern in the development guide.

--- a/changes/noissue.37.fix.rst
+++ b/changes/noissue.37.fix.rst
@@ -3,4 +3,3 @@ CVE-2024-35178 (GHSA-hrw6-wg82-cm62), a path traversal vulnerability
 caused by an incorrect ``startswith()`` root-directory check that
 allowed authenticated users to read, write, and delete files in sibling
 directories sharing a name prefix with the server's ``root_dir``.
-Also documented this Dependabot alert pattern in the development guide.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -143,7 +143,7 @@ jupyter_client>=8.6.3; sys_platform != 'win32' or python_version <= '3.12'
 jupyter-console>=6.6.3; sys_platform != 'win32' or python_version <= '3.12'
 jupyter_core>=5.8.1; sys_platform != 'win32' or python_version <= '3.12'
 jupyter_server>=2.18.2; python_version == '3.9' and (sys_platform != 'win32' or python_version <= '3.12')
-jupyter_server>=2.10.0; python_version >= '3.10' and (sys_platform != 'win32' or python_version <= '3.12')
+jupyter_server>=2.20.0; python_version >= '3.10' and (sys_platform != 'win32' or python_version <= '3.12')
 jupyter>=1.1.1; sys_platform != 'win32' or python_version <= '3.12'
 jupyterlab_pygments>=0.3.0; sys_platform != 'win32' or python_version <= '3.12'
 jupyterlab_server>=2.28.0; sys_platform != 'win32' or python_version <= '3.12'

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -953,7 +953,6 @@ Dependabot alerts should be handled as follows:
       urllib3==2.6.0; python_version == '3.9'
       urllib3==2.7.0; python_version >= '3.10'
 
-
 .. _`Backporting`:
 
 Backporting

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -118,7 +118,7 @@ jupyter_client==8.6.3; sys_platform != 'win32' or python_version <= '3.12'
 jupyter-console==6.6.3; sys_platform != 'win32' or python_version <= '3.12'
 jupyter_core==5.8.1; sys_platform != 'win32' or python_version <= '3.12'
 jupyter_server==2.18.2; python_version == '3.9' and (sys_platform != 'win32' or python_version <= '3.12')
-jupyter_server==2.10.0; python_version >= '3.10' and (sys_platform != 'win32' or python_version <= '3.12')
+jupyter_server==2.20.0; python_version >= '3.10' and (sys_platform != 'win32' or python_version <= '3.12')
 jupyter==1.1.1; sys_platform != 'win32' or python_version <= '3.12'
 jupyterlab_pygments==0.3.0; sys_platform != 'win32' or python_version <= '3.12'
 jupyterlab_server==2.28.0; sys_platform != 'win32' or python_version <= '3.12'


### PR DESCRIPTION
Fixes path traversal vulnerability in jupyter_server <=2.17.0.