### PR TITLE
Fixed safety ID issue by upgrading safety

### DIFF
--- a/.safety-policy-develop.yml
+++ b/.safety-policy-develop.yml
@@ -44,14 +44,22 @@ security:
             reason: Fixed authlib version 1.6.9 requires Python>=3.10 and is used there
         89032:
             reason: Fixed tornado version 6.5.5 requires Python>=3.10 and is used there
+        89824:
+            reason: Fixed nltk version 3.9.4 requires Python>=3.10 and is used there
         89826:
             reason: Fixed nltk version 3.9.4 requires Python>=3.10 and is used there
+        89827:
+            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
         90749:
             reason: Fixed cryptography version 46.0.6 requires Python>=3.10 and is used there
-
-        # Need to comment out SFTY IDs due to issue https://github.com/pyupio/safety/issues/847
-        # SFTY-20260218-01424:
-        #     reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
+        SFTY-20260218-01424:
+            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
+        SFTY-20260304-49322:
+            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
+        SFTY-20260320-58622:
+            reason: Fixed nltk version 3.9.4 requires Python>=3.10 and is used there
+        SFTY-20260309-65600:
+            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -32,14 +32,14 @@ security:
             reason: Fixed requests version 2.33.0 is not installable in the Python 3.9 CI environment, so Python 3.9 uses requests 2.32.4
         96886:
             reason: Fixed urllib3 version 2.7.0 requires Python>=3.10 and is used there
-
-        # Need to comment out SFTY IDs due to issue https://github.com/pyupio/safety/issues/847
-        # SFTY-20260122-20373:
-        #     reason: Fixed pytest version 9.0.3 requires Python>=3.10 and is used there
-        # SFTY-20260511-47957:
-        #     reason: Fixed urllib3 version 2.7.0 requires Python>=3.10 and is used there
-        # SFTY-20260420-60812:
-        #     reason: Fixed pip version 26.1 requires Python>=3.10 and is used there
+        SFTY-20260122-20373:
+            reason: Fixed pytest version 9.0.3 requires Python>=3.10 and is used there
+        SFTY-20260511-47957:
+            reason: Fixed urllib3 version 2.7.0 requires Python>=3.10 and is used there
+        SFTY-20260420-60812:
+            reason: Fixed pip version 26.1 requires Python>=3.10 and is used there
+        SFTY-20260427-69629:
+            reason: Fixed pip version 26.1 requires Python>=3.10 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -49,11 +49,7 @@ coveralls>=4.0.1; python_version == '3.9'
 coveralls>=4.0.2; python_version >= '3.10'
 
 # Safety CI by pyup.io
-# safety 3.6.1 fixes the issue with typer >=0.17.0, see https://github.com/pyupio/safety/issues/778
-# pydantic 2.8.0 fixes an install issue on Python 3.13.
-# pydantic 2.12.0 fixes an install issue on Python 3.14.
-# Safety 3.6.2 removed the pinning of pydantic<2.10.0,>=2.6.0.
-safety>=3.6.2
+safety>=3.8.1
 safety-schemas>=0.0.16
 dparse>=0.6.4
 ruamel.yaml>=0.19.1
@@ -61,12 +57,11 @@ Authlib>=1.6.12
 marshmallow>=3.26.2
 pydantic>=2.12.0
 pydantic_core>=2.41.1
-# safety 3.6.1 depends on typer>=0.16.0
 typer>=0.16.0
 typer-cli>=0.16.0
 typer-slim>=0.16.0
-# safety 3.4.0 depends on psutil~=6.1.0
-psutil~=6.1.0
+# safety 3.8.1 depends on ruststore>=0.10.4 only on Python>=3.10
+truststore>=0.10.4; python_version >= '3.10'
 
 # Bandit checker
 bandit>=1.7.8
@@ -136,7 +131,7 @@ jupyter_client>=8.6.3; sys_platform != 'win32' or python_version <= '3.12'
 jupyter-console>=6.6.3; sys_platform != 'win32' or python_version <= '3.12'
 jupyter_core>=5.8.1; sys_platform != 'win32' or python_version <= '3.12'
 jupyter_server>=2.18.2; python_version == '3.9' and (sys_platform != 'win32' or python_version <= '3.12')
-jupyter_server>=2.10.0; python_version >= '3.10' and (sys_platform != 'win32' or python_version <= '3.12')
+jupyter_server>=2.20.0; python_version >= '3.10' and (sys_platform != 'win32' or python_version <= '3.12')
 jupyter>=1.1.1; sys_platform != 'win32' or python_version <= '3.12'
 jupyterlab_pygments>=0.3.0; sys_platform != 'win32' or python_version <= '3.12'
 jupyterlab_server>=2.28.0; sys_platform != 'win32' or python_version <= '3.12'

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -40,7 +40,7 @@ coveralls==4.0.1; python_version == '3.9'
 coveralls==4.0.2; python_version >= '3.10'
 
 # Safety CI by pyup.io
-safety==3.6.2
+safety==3.8.1
 safety-schemas==0.0.16
 dparse==0.6.4
 ruamel.yaml==0.19.1
@@ -51,8 +51,7 @@ pydantic_core==2.41.1
 typer==0.16.0
 typer-cli==0.16.0
 typer-slim==0.16.0
-psutil==6.1.0
-truststore==0.9.1
+truststore==0.10.4; python_version >= '3.10'
 
 # Bandit checker
 bandit==1.7.8
@@ -111,7 +110,7 @@ jupyter_client==8.6.3; sys_platform != 'win32' or python_version <= '3.12'
 jupyter-console==6.6.3; sys_platform != 'win32' or python_version <= '3.12'
 jupyter_core==5.8.1; sys_platform != 'win32' or python_version <= '3.12'
 jupyter_server==2.18.2; python_version == '3.9' and (sys_platform != 'win32' or python_version <= '3.12')
-jupyter_server==2.10.0; python_version >= '3.10' and (sys_platform != 'win32' or python_version <= '3.12')
+jupyter_server==2.20.0; python_version >= '3.10' and (sys_platform != 'win32' or python_version <= '3.12')
 jupyter==1.1.1; sys_platform != 'win32' or python_version <= '3.12'
 jupyterlab_pygments==0.3.0; sys_platform != 'win32' or python_version <= '3.12'
 jupyterlab_server==2.28.0; sys_platform != 'win32' or python_version <= '3.12'
@@ -202,15 +201,14 @@ mdurl==0.1.2
 mistune==3.2.1
 nest-asyncio==1.5.4
 nest-asyncio2==1.7.2
-# nltk 3.9.3 fixes CVE-2025-14009
-# Need to comment out nltk==3.9.2 due to issue https://github.com/pyupio/safety/issues/847
-# nltk==3.9.2; python_version == '3.9'
+nltk==3.9.2; python_version == '3.9'
 nltk==3.9.4; python_version >= '3.10'
 overrides==7.7.0
 pandocfilters==1.4.1
 parso==0.8.7
 pexpect==4.3.1
 prompt_toolkit==3.0.52
+psutil==6.1.0
 pure_eval==0.2.3
 pycparser==2.23
 pyproject-api==1.6.1  # used by tox since its 4.0.0

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -7,8 +7,7 @@
 
 # Base dependencies
 
-# Need to comment out pip==26.0.1 due to issue https://github.com/pyupio/safety/issues/847
-# pip==26.0.1; python_version == '3.9'
+pip==26.0.1; python_version == '3.9'
 pip==26.1; python_version >= '3.10'
 setuptools==78.1.1
 # Note on not specifying 'setuptools-scm[toml]': Extras cannot be in constraints files
@@ -38,16 +37,14 @@ websocket-client==1.8.0
 
 certifi==2024.07.04
 
-# Need to comment out urllib3==2.6.3 due to issue https://github.com/pyupio/safety/issues/847
-# urllib3==2.6.3; python_version == '3.9'
+urllib3==2.6.3; python_version == '3.9'
 urllib3==2.7.0; python_version >= '3.10'
 
 
 # Direct dependencies for install of extra 'testutils' (must be consistent with extra-testutils-requirements)
 
 # Used by zhmcclient.testutils
-# Need to comment out pytest==8.4.0 due to issue https://github.com/pyupio/safety/issues/847
-# pytest==8.4.0; python_version == '3.9'
+pytest==8.4.0; python_version == '3.9'
 pytest==9.0.3; python_version >= '3.10'
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with requirements.txt)


### PR DESCRIPTION
safety 3.8.1 has fixed issue https://github.com/pyupio/safety/issues/847, so we can now enable the dependencies and safety IDs again that we had to comment out due to that issue.