### PR TITLE
Revert "SSOServerDefinition: Fixes in end2end tests (#2226)"

### DIFF
--- a/tests/end2end/test_sso_server_definition.py
+++ b/tests/end2end/test_sso_server_definition.py
@@ -69,7 +69,8 @@ SSOSRVDEF_INPUT_PROPS = {
 # Expected automatically set properties for the test instance in
 # SSOSRVDEF_INPUT_PROPS
 SSOSRVDEF_AUTO_PROPS = {
-    "logout-sso-session-on-reauthentication-failure": True,
+    "logout-url": None,
+    "logout-sso-session-on-reauthentication-failure": False,
 }
 
 
@@ -198,7 +199,12 @@ def test_ssosrvdef_crud(zhmc_logger, hmc_session):
                 ssosrvdef.properties[pn] == exp_value
             ), f"Unexpected value for property {pn!r}"
         ssosrvdef.pull_full_properties()
+        # After GET, server-controlled (auto) properties override the input
+        # values. Check only the non-auto input props here, then check auto
+        # props separately.
         for pn, exp_value in ssosrvdef_input_props.items():
+            if pn in SSOSRVDEF_AUTO_PROPS:
+                continue
             assert (
                 ssosrvdef.properties[pn] == exp_value
             ), f"Unexpected value for property {pn!r}"


### PR DESCRIPTION
This reverts commit 7b1dfc3e865d7d2fd9c62e6194001b60521e5fc8.