### PR TITLE
Pinned stomp to <9 again; Other improvements for stomp

### DIFF
--- a/changes/noissue.stomp-9.cleanup.rst
+++ b/changes/noissue.stomp-9.cleanup.rst
@@ -1,0 +1,6 @@
+Changed pinning of stomp.py from <8.3.0 to <9.0.0. The 8.3.0 version is
+meanwhile yanked, but the changes in version 9.0.0 have not yet been
+accommodated in zhmcclient. In preparation of future version 9 support,
+added explicit enabling or disabling of certificate validation with stomp,
+in the :class:`zhmcclient.NotificationReceiver` and
+:class:`zhmcclient.AutoUpdater` classes.

--- a/changes/noissue.stomp-logging.feature.rst
+++ b/changes/noissue.stomp-logging.feature.rst
@@ -1,0 +1,3 @@
+Added logging before opening and closing the JMS (stomp) connection in the
+zhmcclient auto-update support, to provide context for any errors logged
+during opening and closing the connection.

--- a/changes/noissue.stomp.cleanup.rst
+++ b/changes/noissue.stomp.cleanup.rst
@@ -1,2 +1,0 @@
-Removed pinning of stomp.py to <8.3.0. The 8.3.0 version is meanwhile yanked,
-and the 9.0.0 version can now be used.

--- a/changes/noissue.stomperror.incompatible.rst
+++ b/changes/noissue.stomperror.incompatible.rst
@@ -1,0 +1,10 @@
+The :meth:`zhmcclient.AutoUpdater.open` method has been changed to no
+longer raise stomp exceptions that may occur when connecting to the HMC.
+Such exceptions are now raised as :exc:`zhmcclient.NotificationConnectionError`.
+This change affects only users who use the auto-update feature of zhmcclient
+(i.e. call the :meth:`zhmcclient.BaseResource.enable_auto_update` method) and
+handle "stomp.StompException" exceptions or their subclasses in their code.
+Such code needs to be changed to handle
+:exc:`zhmcclient.NotificationConnectionError` instead.
+Note that the :meth:`zhmcclient.NotificationReceiver.connect` method already
+raised stomp exceptions as :exc:`zhmcclient.NotificationConnectionError`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,9 @@
 requests>=2.32.4; python_version == '3.9'
 requests>=2.33.0; python_version >= '3.10'
 
-# The broken stomp-py 8.3.0 meanwhile has been yanked on Pypi
-stomp-py>=8.1.1
+# The broken stomp-py 8.3.0 meanwhile has been yanked on Pypi.
+# stomp-py 9.0.0 waits forever when connecting, see https://codeberg.org/jasonrbriggs/stomp.py/issues/453
+stomp-py>=8.1.1,<9.0.0
 
 immutabledict>=4.2.0
 nocasedict>=1.0.2

--- a/tests/unit/zhmcclient/test_auto_updater.py
+++ b/tests/unit/zhmcclient/test_auto_updater.py
@@ -213,7 +213,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             ],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for property change notification .*"
                  "resource /api/cpcs/fake-cpc1 .*"
@@ -339,7 +339,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             ],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for property change notification .*"
                  "resource /api/cpcs/fake-cpc1 .*"
@@ -407,7 +407,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             ],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for property change notification .*"
                  "resource /api/partitions/fake-part1/nics/fake-nic1 .*"
@@ -479,7 +479,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             ],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for status change notification"),
                 ('zhmcclient.jms', logging.INFO,
@@ -526,7 +526,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             'exp_resources': [],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for inventory change notification .*"
                  "resource /api/partitions/fake-part1 .*"
@@ -591,7 +591,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             ],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for inventory change notification .*"
                  "resource /api/partitions/fake-part2 .*"
@@ -640,7 +640,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             'exp_resources': [],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for inventory change notification .*"
                  "resource /api/cpcs/fake-cpc1 .*"
@@ -705,7 +705,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             ],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for inventory change notification .*"
                  "resource /api/cpcs/fake-cpc2 .*"
@@ -752,7 +752,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             'exp_resources': [],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.DEBUG,
                  "JMS message for inventory change notification .*"
                  "resource /api/partitions/fake-part1 .*"
@@ -814,7 +814,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             ],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.ERROR,
                  "JMS message for object notification .*"
                  "no 'element-uri' .*no 'object-uri'"),
@@ -846,7 +846,7 @@ TESTCASES_AUTO_UPDATER_ALL = [
             'exp_resources': [],
             'exp_log_entries': [
                 ('zhmcclient.jms', logging.INFO,
-                 "JMS session .* established"),
+                 "JMS session .* opened"),
                 ('zhmcclient.jms', logging.WARNING,
                  "JMS message for notification of type job-completion .*"
                  "is ignored"),

--- a/tests/unit/zhmcclient/test_utils.py
+++ b/tests/unit/zhmcclient/test_utils.py
@@ -31,7 +31,7 @@ from zhmcclient.mock import FakedSession
 from zhmcclient import Client, FilterConversionError
 from zhmcclient._utils import datetime_from_timestamp, \
     timestamp_from_datetime, datetime_to_isoformat, datetime_from_isoformat, \
-    matches_filters, divide_filter_args, tzlocal
+    matches_filters, divide_filter_args, tzlocal, parse_version
 
 # datetime.fromisoformnat() supports 'hhmm' without colon as timezone offset
 ISOFORMAT_SUPPORTS_HHMM = tuple(map(int, sys.version_info[:2])) >= (3, 11)
@@ -1212,5 +1212,87 @@ def test_divide_filter_args(
 
         # The function to be tested
         result = divide_filter_args(query_props, filter_args)
+
+        assert result == exp_result
+
+
+TESTCASES_PARSE_VERSION = [
+    # Test cases for test_parse_version().
+    # Each list item is a tuple defining a testcase in the following format:
+    # - desc (str): Testcase description
+    # - version_str (str): Input version string
+    # - exp_result (tuple: Expected return value
+    # - exp_exc_type: Expected exception type raised from method to be tested,
+    #   or None for success.
+    # - exp_exc_pattern: Regex pattern to check exception message,
+    #   or None for success.
+
+    (
+        "None is not allowed",
+        None,
+        None,
+        AttributeError,
+        "'NoneType' object has no attribute 'split'"
+    ),
+    (
+        "Empty string",
+        "",
+        ("",),
+        None,
+        None
+    ),
+    (
+        "Only major version as a decimal string",
+        "9",
+        (9,),
+        None,
+        None
+    ),
+    (
+        "Major, minor, patch version as decimal strings",
+        "9.1.7",
+        (9, 1, 7),
+        None,
+        None
+    ),
+    (
+        "Additional fourth version part as a decimal string",
+        "9.1.7.42",
+        (9, 1, 7, 42),
+        None,
+        None
+    ),
+    (
+        "Major, minor, patch version followed by non-integer string",
+        "9.1.7.a1",
+        (9, 1, 7, "a1"),
+        None,
+        None
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, version_str, exp_result, exp_exc_type, exp_exc_pattern",
+    TESTCASES_PARSE_VERSION)
+def test_parse_version(
+        desc, version_str, exp_result, exp_exc_type, exp_exc_pattern):
+    # pylint: disable=unused-argument
+    """
+    Test function for parse_version().
+    """
+
+    if exp_exc_type:
+        with pytest.raises(exp_exc_type) as exc_info:
+
+            # Execute the code to be tested
+            parse_version(version_str)
+
+        exc = exc_info.value
+        assert re.search(exp_exc_pattern, str(exc))
+    else:
+
+        # The function to be tested
+        result = parse_version(version_str)
 
         assert result == exp_result

--- a/zhmcclient/_auto_updater.py
+++ b/zhmcclient/_auto_updater.py
@@ -32,11 +32,13 @@ from ._constants import DEFAULT_STOMP_PORT, JMS_LOGGER_NAME, \
     DEFAULT_STOMP_HEARTBEAT_SEND_CYCLE, DEFAULT_STOMP_HEARTBEAT_RECEIVE_CYCLE, \
     DEFAULT_STOMP_HEARTBEAT_RECEIVE_CHECK
 from ._utils import RC_CPC, RC_CHILDREN_CLIENT, RC_CHILDREN_CPC, \
-    RC_CHILDREN_CONSOLE, get_stomp_rt_kwargs, get_headers_message
+    RC_CHILDREN_CONSOLE, get_stomp_rt_kwargs, get_headers_message, \
+    parse_version
 from ._client import Client
 from ._manager import BaseManager
 from ._resource import BaseResource
 from ._notification import StompRetryTimeoutConfig, validate_cert_hostname
+from ._exceptions import NotificationConnectionError
 
 __all__ = ['AutoUpdater']
 
@@ -148,7 +150,15 @@ class AutoUpdater:
 
         If the session does not yet have an object notification topic set,
         the session is logged on.
+
+        Raises:
+
+            NotificationConnectionError: STOMP connection failed.
         """
+        JMS_LOGGER.info(
+            "Opening JMS session for object notification topic '%s'",
+            self._session.object_topic)
+
         if not self._session.object_topic:
             self._session.logon()  # This sets actual_host
 
@@ -163,22 +173,47 @@ class AutoUpdater:
             ca_cert = self._session.verify_cert
         else:
             ca_cert = None
+        # Before version 9 of stomp.py, the enablement of certificate
+        # validation was derived from the 'ca_certs' parameter.
+        # Starting with version 9 of stomp.py, a new parameter 'verify' with
+        # a default of True has been added to explicitly control the enablement.
         if ca_cert:
             JMS_LOGGER.info(
                 "Enabling certificate validation with CA path: %s", ca_cert)
+            if parse_version(self._stomp.__version__) >= (9, 0):
+                set_kwargs['verify'] = True
             set_kwargs['ca_certs'] = ca_cert
+            # Note: According to https://docs.python.org/3/library/ssl.html#
+            # ssl.SSLSocket.do_handshake, hostname validation is performed by
+            # OpenSSL since Python 3.7. However, this does not work with
+            # stomp.py for some reason. Therefore, we perform hostname
+            # validation ourselves.
             set_kwargs['cert_validator'] = validate_cert_hostname
         else:
             JMS_LOGGER.warning("Certificate validation is disabled")
+            if parse_version(self._stomp.__version__) >= (9, 0):
+                set_kwargs['verify'] = False
         self._conn.set_ssl(
             for_hosts=[(self._session.actual_host, DEFAULT_STOMP_PORT)],
             **set_kwargs)
 
         listener = _UpdateListener(self, self._session)
         self._conn.set_listener('', listener)
-        # pylint: disable=protected-access
-        self._conn.connect(self._session.userid, self._session._password,
-                           wait=True)
+
+        JMS_LOGGER.debug("Connecting via STOMP to the HMC")
+
+        try:
+            # wait=True causes the connection to be retried for some times
+            # and finally raises stomp.ConnectFailedException
+            # pylint: disable=protected-access
+            self._conn.connect(self._session.userid, self._session._password,
+                               wait=True)
+        except (self._stomp.exception.StompException, OSError) as exc:
+            msg = f"STOMP connection failed: {exc.__class__.__name__}: {exc}"
+            JMS_LOGGER.error(msg)
+            raise NotificationConnectionError(msg) from exc
+
+        JMS_LOGGER.debug("STOMP connection successfully established")
 
         dest = "/topic/" + self._session.object_topic
         self._conn.subscribe(destination=dest, id=self._sub_id, ack='auto')
@@ -187,7 +222,7 @@ class AutoUpdater:
 
         JMS_LOGGER.info(
             "JMS session for object notification topic '%s' has been "
-            "established", self._session.object_topic)
+            "opened", self._session.object_topic)
 
     def close(self):
         """
@@ -196,12 +231,16 @@ class AutoUpdater:
         This implicitly unsubscribes from the object notification topic this
         auto updater was created for.
         """
+        JMS_LOGGER.info(
+            "Closing JMS session for object notification topic '%s'",
+            self._session.object_topic)
+
         self._conn.disconnect()
         self._conn = None
 
         JMS_LOGGER.info(
             "JMS session for object notification topic '%s' has been "
-            "disconnected", self._session.object_topic)
+            "closed", self._session.object_topic)
 
     def is_open(self):
         """

--- a/zhmcclient/_notification.py
+++ b/zhmcclient/_notification.py
@@ -97,7 +97,7 @@ from ._constants import DEFAULT_STOMP_PORT, DEFAULT_STOMP_CONNECT_TIMEOUT, \
 from ._exceptions import NotificationJMSError, NotificationParseError, \
     SubscriptionNotFound, NotificationConnectionError, \
     NotificationSubscriptionError
-from ._utils import get_stomp_rt_kwargs, get_headers_message
+from ._utils import get_stomp_rt_kwargs, get_headers_message, parse_version
 from ._vendor.python.ssl import match_hostname, CertificateError
 
 __all__ = ['NotificationReceiver', 'StompRetryTimeoutConfig']
@@ -425,9 +425,15 @@ class NotificationReceiver:
             ca_cert = self._verify_cert
         else:
             ca_cert = None
+        # Before version 9 of stomp.py, the enablement of certificate
+        # validation was derived from the 'ca_certs' parameter.
+        # Starting with version 9 of stomp.py, a new parameter 'verify' with
+        # a default of True has been added to explicitly control the enablement.
         if ca_cert:
             JMS_LOGGER.info(
                 "Enabling certificate validation with CA path: %s", ca_cert)
+            if parse_version(self._stomp.__version__) >= (9, 0):
+                set_kwargs['verify'] = True
             set_kwargs['ca_certs'] = ca_cert
             # Note: According to https://docs.python.org/3/library/ssl.html#
             # ssl.SSLSocket.do_handshake, hostname validation is performed by
@@ -437,22 +443,25 @@ class NotificationReceiver:
             set_kwargs['cert_validator'] = validate_cert_hostname
         else:
             JMS_LOGGER.warning("Certificate validation is disabled")
+            if parse_version(self._stomp.__version__) >= (9, 0):
+                set_kwargs['verify'] = False
         self._conn.set_ssl(for_hosts=[(self._host, self._port)], **set_kwargs)
         listener = _NotificationListener(self._handover_queue)
         self._conn.set_listener('', listener)
 
         connected = self.is_connected()
-        JMS_LOGGER.info(
+        JMS_LOGGER.debug(
             "Connecting via STOMP to the HMC (currently connected: %s)",
             connected)
         try:
             # wait=True causes the connection to be retried for some times
             # and finally raises stomp.ConnectFailedException
             self._conn.connect(self._userid, self._password, wait=True)
-        except Exception as exc:
+        except (self._stomp.exception.StompException, OSError) as exc:
             msg = f"STOMP connection failed: {exc.__class__.__name__}: {exc}"
-            JMS_LOGGER.warning(msg)
+            JMS_LOGGER.error(msg)
             raise NotificationConnectionError(msg)
+
         JMS_LOGGER.info("STOMP connection successfully established")
 
         for topic_name in self._topic_names:
@@ -505,7 +514,7 @@ class NotificationReceiver:
             self._conn.subscribe(destination=dest, id=id_value, ack='auto')
         except Exception as exc:
             msg = f"STOMP subscription failed: {exc.__class__.__name__}: {exc}"
-            JMS_LOGGER.warning(msg)
+            JMS_LOGGER.error(msg)
             raise NotificationSubscriptionError(msg)
         return id_value
 
@@ -543,7 +552,7 @@ class NotificationReceiver:
             msg = (
                 f"STOMP unsubscription failed: {exc.__class__.__name__}: "
                 f"{exc}")
-            JMS_LOGGER.warning(msg)
+            JMS_LOGGER.error(msg)
             raise NotificationSubscriptionError(msg)
 
     @logged_api_call
@@ -1008,7 +1017,7 @@ class _NotificationListener:
         """
         _, message = get_headers_message(frame_args)
         if message is None and DEBUG_HEARTBEATS:
-            JMS_LOGGER.info("Sending STOMP heartbeat to HMC")
+            JMS_LOGGER.debug("Sending STOMP heartbeat to HMC")
 
     def on_heartbeat(self):
         # pylint: disable=no-self-use
@@ -1016,7 +1025,7 @@ class _NotificationListener:
         Event method that gets called when a STOMP heartbeat has been received.
         """
         if DEBUG_HEARTBEATS:
-            JMS_LOGGER.info("Received STOMP heartbeat from HMC")
+            JMS_LOGGER.debug("Received STOMP heartbeat from HMC")
 
     def on_receiver_loop_completed(self, *frame_args):
         """

--- a/zhmcclient/_resource.py
+++ b/zhmcclient/_resource.py
@@ -693,6 +693,7 @@ class BaseResource:
           :exc:`~zhmcclient.AuthError`
           :exc:`~zhmcclient.ConnectionError`
           :exc:`~zhmcclient.CeasedExistence`
+          :exc:`~zhmcclient.NotificationConnectionError`
         """
         if not self._auto_update:
             session = self.manager.session

--- a/zhmcclient/_utils.py
+++ b/zhmcclient/_utils.py
@@ -886,3 +886,31 @@ def get_headers_message(frame_args):
     if message == '':
         message = None
     return headers, message
+
+
+def parse_version(version_str):
+    """
+    Parse a version string into its dot-separated parts and return a tuple of
+    the parts.
+
+    The version string may contain integer and non-integer parts. Any integer
+    parts are returned as int-typed values.
+
+    This function has been added because Python has no built-in support for
+    version parsing and to avoid a dependency on an additional package
+    such as "packaging".
+
+    Parameters:
+      version_str (str): Version string.
+
+    Returns:
+      tuple: Version parts.
+    """
+    ret = []
+    for part in version_str.split("."):
+        try:
+            part = int(part)
+        except ValueError:
+            pass
+        ret.append(part)
+    return tuple(ret)


### PR DESCRIPTION
For details, see the commit message.

I tested this with the test_auto_update.py end2end test against the HMC of B151.

The remaining issues with stomp version 9 are documented in  https://codeberg.org/jasonrbriggs/stomp.py/issues/453

Note: After merging this PR, reopen the linked issue again.