### PR TITLE
1.26: Addressed safety issues; Added missing deps

### DIFF
--- a/.safety-policy-develop.yml
+++ b/.safety-policy-develop.yml
@@ -52,16 +52,16 @@ security:
             reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
         90749:
             reason: Fixed cryptography version 46.0.6 requires Python>=3.10 and is used there
-        SFTY-20260218-01424:
-            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
         SFTY-20260122-20373:
             reason: Fixed pytest version 9.0.3 requires Python>=3.10 and is used there
+        SFTY-20260218-01424:
+            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
         SFTY-20260304-49322:
+            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
+        SFTY-20260309-65600:
             reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
         SFTY-20260320-58622:
             reason: Fixed nltk version 3.9.4 requires Python>=3.10 and is used there
-        SFTY-20260309-65600:
-            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
         SFTY-20260420-60812:
             reason: Fixed pip version 26.1 requires Python>=3.10 and is used there
         SFTY-20260427-69629:
@@ -90,14 +90,16 @@ security:
             reason: Fixed nltk version 3.10.0 requires Python>=3.10 and is used there
         SFTY-20260729-70233:
             reason: Fixed pip version 26.2 requires Python>=3.10 and is used there
-        SFTY-20260731-78787:
+        SFTY-20260731-71411:
             reason: Fixed nltk version 3.9.4 requires Python>=3.10 and is used there
         SFTY-20260731-74449:
             reason: Fixed nltk version 3.9.4 requires Python>=3.10 and is used there
-        SFTY-20260731-71411:
+        SFTY-20260731-78787:
             reason: Fixed nltk version 3.9.4 requires Python>=3.10 and is used there
         SFTY-20260731-83123:
             reason: Fixed nltk version 3.9.4 requires Python>=3.10 and is used there
+        SFTY-20260813-62140:
+            reason: Fixed nltk version 3.10.0 requires Python>=3.10 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -189,6 +189,7 @@ httpcore==1.0.9
 httpx==0.28.1
 imagesize==1.3.0
 importlib-resources==5.12.0; python_version <= '3.11'  # Python 3.12 has importlib-resources 5.12
+installer==1.0.1; python_version >= '3.10'
 isoduration==20.11.0
 jedi==0.19.2
 Jinja2==3.1.6
@@ -203,8 +204,13 @@ matplotlib-inline==0.2.2
 mdurl==0.1.2
 mistune==3.3.0
 mypy_extensions==1.1.0
-nab-project==0.0.15
-nab-provider==0.0.15
+nab-index==0.0.17; python_version >= '3.10'
+nab-markersets==0.0.17; python_version >= '3.10'
+nab-project==0.0.17; python_version >= '3.10'
+nab-provider==0.0.17; python_version >= '3.10'
+nab-python==0.0.13; python_version >= '3.10'
+nab-resolver==0.0.17; python_version >= '3.10'
+nab==0.0.17; python_version >= '3.10'
 nest-asyncio==1.5.4
 nest-asyncio2==1.7.2
 nltk==3.9.2; python_version == '3.9'
@@ -252,7 +258,3 @@ webcolors==24.11.1
 webencodings==0.5.1
 widgetsnbextension==4.0.14
 zipp==3.20.0
-installer==1.0.1; python_version >= '3.10'  # Used by pipdeptree>=4.0.0
-nab-index==0.0.11; python_version >= '3.10'  # Used by pipdeptree>=4.0.0
-nab-python==0.0.11; python_version >= '3.10'  # Used by pipdeptree>=4.0.0
-nab-resolver==0.0.11; python_version >= '3.10'  # Used by pipdeptree>=4.0.0


### PR DESCRIPTION
Backports PR #2283 into 1.26.